### PR TITLE
Flesh out shopping list model functionality and API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,79 @@
-# Skyrim Inventory Management
+# Skyrim Inventory Management API
 
-Skyrim Inventory Management is a fully featured Rails app enabling users to manage inventory across multiple properties in Skyrim.
+[Skyrim Inventory Management](https://sim.danascheider.com) is a fully featured, split-stack Rails/React app enabling users to manage inventory and tasks across multiple properties in Skyrim. The back end API found in this repo is hosted on [Heroku](https://heroku.com) at https://sim-api.danascheider.com. 
+
+## Disclaimer
+
+This application is my hobby project intended for my personal use and all other users should use at their own risk. There are no admin users who can fix anything you break about your own account or data, so if you fuck something up, consider it fucked. I do have certain access to data on account of being able to access the logs and database directly through Heroku, but don't count on my help for anything because (1) I can't guarantee I can do anything about your specific problem and (2) I don't have the bandwidth or executive function to consistently and promptly act in a support capacity on this app for other users. I'll help if I can because I'm not an asshole but I'm not making any promises. In particular, note that I do not keep backup data, nor does this app do [soft deletes](https://www.dailysmarty.com/posts/how-to-soft-delete-in-rails). Any data you delete is gone forever.
+
+## Authentication
+
+Skyrim Inventory Management uses [Sign In With Google](https://developers.google.com/identity/sign-in/web/sign-in) to handle authentication. Indeed, I undertook development of this app with a primary goal of learning to implement OAuth/Sign In With Google on a split-stack app. All API routes are authenticated and resources are automatically scoped to the authenticated user. Sessions are maintained on the [front end](https://github.com/danascheider/skyrim_inventory_management_frontend) and the Google OAuth token is verified by the back end on each request using the wonderfully user-friendly [google-id-token](https://github.com/google/google-id-token) gem. The API itself is stateless--it keeps no user session data and each request has to be individually authenticated.
+
+Authentication is handled using the Google-issued OAuth token as a [bearer token](https://oauth.net/2/bearer-tokens/#:~:text=Bearer%20Tokens%20are%20the%20predominant,such%20as%20JSON%20Web%20Tokens.). The token is included in the `Authorization` header on every API request. The token is verified in a `before_action` defined on the `ApplicationController`, and a 401 response is sent from that `before_action` if the token isn't present, can't be verified, or has expired. If the front-end receives a 401 response from the server, it invalidates the token and the user has to log in again.
+
+Users are uniquely identified by the email address associated with the Google account they use to sign in. The API does not intelligently link accounts if a user has logged in under multiple Google accounts at different times - each account they log in with will have its own SIM user and no access to resources associated with other accounts.
+
+### Authenticating Resources
+
+All resources are scoped to the currently authenticated user. Requesting a resource that doesn't belong to the authenticated user will result in a 404, not a 401. So, if User 1 owns the `ShoppingList` with ID 24, requesting `/shopping_lists/24` with User 2's token will simply result in the resource not being found, and not in a 401 response.
+
+## Resources
+
+### Users
+
+All resources are scoped to the user authenticated during a given request. Profile information for users is automatically updated with data returned from Google on token verification. The profile stores only the user's name, email, and profile image URL from Google. Of these, email is king: a user's email cannot be changed and if, for some reason, Google returns a different email, a new user account will be created with no association to the original one. The user's `uid` is also set to their email.
+
+There are no admin users or other special user accounts and thus no way to view data for users other than the one authenticated in the current request.
+
+#### Schema
+
+```
+id: integer, primary key, unique, not null
+uid: string, unique, not null
+email: string, unique, not null, generally equal to `uid`
+image_url: string or null
+name: string or null
+```
+
+### Shopping Lists
+
+Shopping lists provide a flexible way to track which items you need. The only property of a shopping list is its `"user_id"`. Every shopping list has many [shopping list items](/#shopping-list-items), which are included in `GET` requests that return that list.
+
+#### Schema
+
+```
+id: integer, primary key, unique, not null
+user_id: integer, foreign key, not null
+master: boolean, only one master allowed per user
+title: string, unique per user, default value of 'Master' if master and 'My List n' otherwise
+```
+
+#### Master Shopping Lists
+
+Users can have multiple shopping lists. In the future, each list will correspond to a location or property where the items are needed. For example, a user might need 10 iron ingots at Heljarchen Hall and 4 iron ingots at Lakeview Manor. In this case, the user might have a shopping list for Heljarchen Hall including 10 iron ingots and another list for Lakeview Manor including 4 iron ingots.
+
+It is also useful to know the total quantity of an item that a user needs. For this reason, every user also has a master list that is created when the user creates their first shopping list. This list is automatically updated to include all shopping list items on any of the user's other lists. If there are items with the same (case-insensitive) `description` on multiple lists, those items will be combined into a single item on the master list with the `quantity` being the sum of the quantities specified on each other list where the item occurs. Every time an item is added, updated, or removed from another list, the master list is automatically updated to reflect changes to the items or quantities.
+
+The title of all master shopping lists is "Master". Master lists can be retrieved through the API but cannot be created, updated, or destroyed, including adding or removing items, as these functions are all handled automatically.
+
+### Shopping List Items
+
+Shopping list items have three properties: a text `description`, an integer `quantity`, and text `notes`. To provide maximum flexibility, there are no restrictions on the `description` field - it can be any description of an item needed and doesn't have to be in terms that are specific or meaningful to the game. Examples could be:
+
+* "Unenchanted ebony sword"
+* "Item with Fortify Carry Weight enchantment"
+* "Necklace with Resist Frost enchantment"
+* "Helmet or circlet"
+* "Iron, steel, or imperial sword"
+* "Ingredient with Fortify Sneak property"
+
+#### Schema
+
+```
+id: integer, primary key, unique, not null
+shopping_list_id: integer, foreign key, not null
+description: string, unique on each shopping list, not null
+quantity: integer, not null
+notes: string
+```

--- a/app/controllers/shopping_lists_controller.rb
+++ b/app/controllers/shopping_lists_controller.rb
@@ -9,7 +9,7 @@ class ShoppingListsController < ApplicationController
     shopping_list = current_user.shopping_lists.new
 
     if shopping_list.save
-      render json: shopping_list, status: :created
+      render json: { shopping_list: shopping_list, master_list: current_user.master_shopping_list }, status: :created
     else
       head :unprocessable_entity
     end

--- a/app/controllers/shopping_lists_controller.rb
+++ b/app/controllers/shopping_lists_controller.rb
@@ -2,7 +2,7 @@
 
 class ShoppingListsController < ApplicationController
   def index
-    render json: current_user.shopping_lists, status: :ok
+    render json: current_user.shopping_lists.includes(:shopping_list_items), status: :ok
   end
 
   def create
@@ -18,7 +18,7 @@ class ShoppingListsController < ApplicationController
   def show
     shopping_list = current_user.shopping_lists.find(params[:id])
 
-    render json: shopping_list, status: :ok
+    render json: shopping_list.to_json(include: :shopping_list_items), status: :ok
   rescue ActiveRecord::RecordNotFound
     head :not_found
   end

--- a/app/controllers/shopping_lists_controller.rb
+++ b/app/controllers/shopping_lists_controller.rb
@@ -26,7 +26,7 @@ class ShoppingListsController < ApplicationController
   def destroy
     shopping_list = current_user.shopping_lists.find(params[:id])
     shopping_list.destroy!
-    head :no_content
+    render json: { master_list: current_user.master_shopping_list }, status: :ok
   rescue ActiveRecord::RecordNotFound
     head :not_found
   end

--- a/app/controllers/shopping_lists_controller.rb
+++ b/app/controllers/shopping_lists_controller.rb
@@ -16,9 +16,9 @@ class ShoppingListsController < ApplicationController
   end
 
   def show
-    shopping_list = current_user.shopping_lists.find(params[:id])
+    shopping_list = current_user.shopping_lists.includes(:shopping_list_items).find(params[:id])
 
-    render json: shopping_list.to_json(include: :shopping_list_items), status: :ok
+    render json: shopping_list.to_json, status: :ok
   rescue ActiveRecord::RecordNotFound
     head :not_found
   end

--- a/app/controllers/shopping_lists_controller.rb
+++ b/app/controllers/shopping_lists_controller.rb
@@ -2,7 +2,7 @@
 
 class ShoppingListsController < ApplicationController
   def index
-    render json: current_user.shopping_lists.includes(:shopping_list_items), status: :ok
+    render json: current_user.shopping_lists.to_json(include: :shopping_list_items), status: :ok
   end
 
   def create

--- a/app/controllers/shopping_lists_controller.rb
+++ b/app/controllers/shopping_lists_controller.rb
@@ -35,7 +35,11 @@ class ShoppingListsController < ApplicationController
       end
     else
       shopping_list.destroy!
-      render json: { master_list: current_user.master_shopping_list }, status: :ok
+      if current_user.master_shopping_list.present? # if this was their last regular list the master will have been destroyed
+        render json: { master_list: current_user.master_shopping_list }, status: :ok
+      else
+        head :no_content
+      end
     end
   rescue ActiveRecord::RecordNotFound
     head :not_found

--- a/app/controllers/shopping_lists_controller.rb
+++ b/app/controllers/shopping_lists_controller.rb
@@ -2,7 +2,7 @@
 
 class ShoppingListsController < ApplicationController
   def index
-    render json: current_user.shopping_lists, status: :ok
+    render json: current_user.shopping_lists.to_json(include: :shopping_list_items), status: :ok
   end
 
   def create
@@ -16,7 +16,7 @@ class ShoppingListsController < ApplicationController
   end
 
   def show
-    shopping_list = current_user.shopping_lists.find(params[:id])
+    shopping_list = current_user.shopping_lists.includes(:shopping_list_items).find(params[:id])
 
     render json: shopping_list, status: :ok
   rescue ActiveRecord::RecordNotFound

--- a/app/controllers/shopping_lists_controller.rb
+++ b/app/controllers/shopping_lists_controller.rb
@@ -2,7 +2,7 @@
 
 class ShoppingListsController < ApplicationController
   def index
-    render json: current_user.shopping_lists.to_json(include: :shopping_list_items), status: :ok
+    render json: current_user.shopping_lists, status: :ok
   end
 
   def create
@@ -16,7 +16,7 @@ class ShoppingListsController < ApplicationController
   end
 
   def show
-    shopping_list = current_user.shopping_lists.includes(:shopping_list_items).find(params[:id])
+    shopping_list = current_user.shopping_lists.find(params[:id])
 
     render json: shopping_list, status: :ok
   rescue ActiveRecord::RecordNotFound

--- a/app/controllers/shopping_lists_controller.rb
+++ b/app/controllers/shopping_lists_controller.rb
@@ -9,7 +9,7 @@ class ShoppingListsController < ApplicationController
     shopping_list = current_user.shopping_lists.new
 
     if shopping_list.save
-      render json: { shopping_list: shopping_list, master_list: current_user.master_shopping_list }, status: :created
+      render json: shopping_list, status: :created
     else
       head :unprocessable_entity
     end

--- a/app/controllers/shopping_lists_controller.rb
+++ b/app/controllers/shopping_lists_controller.rb
@@ -25,8 +25,18 @@ class ShoppingListsController < ApplicationController
 
   def destroy
     shopping_list = current_user.shopping_lists.find(params[:id])
-    shopping_list.destroy!
-    render json: { master_list: current_user.master_shopping_list }, status: :ok
+
+    if shopping_list.master
+      if current_user.shopping_lists.count == 1 # if they don't have other lists allow it
+        shopping_list.destroy!
+        head :no_content
+      else
+        head :method_not_allowed
+      end
+    else
+      shopping_list.destroy!
+      render json: { master_list: current_user.master_shopping_list }, status: :ok
+    end
   rescue ActiveRecord::RecordNotFound
     head :not_found
   end

--- a/app/controllers/shopping_lists_controller.rb
+++ b/app/controllers/shopping_lists_controller.rb
@@ -6,7 +6,7 @@ class ShoppingListsController < ApplicationController
   end
 
   def create
-    shopping_list = current_user.shopping_lists.new
+    shopping_list = current_user.shopping_lists.new(shopping_list_params)
 
     if shopping_list.save
       render json: shopping_list, status: :created
@@ -43,5 +43,11 @@ class ShoppingListsController < ApplicationController
     end
   rescue ActiveRecord::RecordNotFound
     head :not_found
+  end
+
+  private
+
+  def shopping_list_params
+    params[:shopping_list].present? ? params.require(:shopping_list).permit(:title) : {}
   end
 end

--- a/app/controllers/shopping_lists_controller.rb
+++ b/app/controllers/shopping_lists_controller.rb
@@ -6,19 +6,31 @@ class ShoppingListsController < ApplicationController
   end
 
   def create
-    shopping_list = current_user.shopping_lists.new(shopping_list_params)
+    shopping_list = current_user.shopping_lists.new(shopping_list_create_params)
 
     if shopping_list.save
       render json: shopping_list, status: :created
     else
-      head :unprocessable_entity
+      render json: { errors: shopping_list.errors }, status: :unprocessable_entity
     end
   end
 
   def show
     shopping_list = current_user.shopping_lists.includes(:shopping_list_items).find(params[:id])
 
-    render json: shopping_list.to_json, status: :ok
+    render json: shopping_list, status: :ok
+  rescue ActiveRecord::RecordNotFound
+    head :not_found
+  end
+
+  def update
+    shopping_list = current_user.shopping_lists.find(params[:id])
+
+    if shopping_list.update(shopping_list_update_params)
+      render json: shopping_list, status: :ok
+    else
+      render json: { errors: shopping_list.errors }, status: :unprocessable_entity
+    end
   rescue ActiveRecord::RecordNotFound
     head :not_found
   end
@@ -47,7 +59,11 @@ class ShoppingListsController < ApplicationController
 
   private
 
-  def shopping_list_params
+  def shopping_list_create_params
     params[:shopping_list].present? ? params.require(:shopping_list).permit(:title) : {}
+  end
+  
+  def shopping_list_update_params
+    params.require(:shopping_list).permit(:title)
   end
 end

--- a/app/controllers/verifications_controller.rb
+++ b/app/controllers/verifications_controller.rb
@@ -8,6 +8,6 @@ class VerificationsController < ApplicationController
   # token has been verified server-side and that there is
   # a corresponding user in the system.
   def verify_token
-    head :created
+    head :no_content
   end
 end

--- a/app/models/shopping_list.rb
+++ b/app/models/shopping_list.rb
@@ -5,6 +5,7 @@ class ShoppingList < ApplicationRecord
   has_many :shopping_list_items, dependent: :destroy
 
   validate :one_master_list_per_user
+  validates :title, uniqueness: { scope: :user_id }
 
   before_create :set_default_title, if: :master_or_title_blank?
   after_create :ensure_master_list_present
@@ -27,8 +28,8 @@ class ShoppingList < ApplicationRecord
     self.title = if master == true
       'Master'
     else
-      list_count = user.shopping_lists.where(master: false).count
-      "My List #{list_count + 1}"
+      highest_number = user.shopping_lists.where("title like '%My List%'").pluck(:title).map { |title| title.gsub('My List ', '').to_i }.max || 0
+      "My List #{highest_number + 1}"
     end
   end
 

--- a/app/models/shopping_list.rb
+++ b/app/models/shopping_list.rb
@@ -9,6 +9,8 @@ class ShoppingList < ApplicationRecord
 
   before_create :set_default_title, if: :master_or_title_blank?
   after_create :ensure_master_list_present
+  before_destroy :ensure_not_master, if: :other_lists_present?
+  after_destroy :destroy_master_list, unless: :other_lists_present?
 
   private
 
@@ -35,5 +37,17 @@ class ShoppingList < ApplicationRecord
 
   def master_or_title_blank?
     master == true || title.blank?
+  end
+
+  def ensure_not_master
+    throw :abort if master == true
+  end
+
+  def destroy_master_list
+    user.master_shopping_list&.destroy!
+  end
+
+  def other_lists_present?
+    user.shopping_lists.where(master: false).count > 0
   end
 end

--- a/app/models/shopping_list.rb
+++ b/app/models/shopping_list.rb
@@ -6,6 +6,7 @@ class ShoppingList < ApplicationRecord
 
   validate :one_master_list_per_user
 
+  before_create :set_default_title, if: :master_or_title_blank?
   after_create :ensure_master_list_present
 
   private
@@ -18,7 +19,20 @@ class ShoppingList < ApplicationRecord
 
   def ensure_master_list_present
     if user.master_shopping_list.nil?
-      user.shopping_lists.create!(master: true)
+      user.shopping_lists.create!(master: true, title: 'Master')
     end
+  end
+
+  def set_default_title
+    self.title = if master == true
+      'Master'
+    else
+      list_count = user.shopping_lists.where(master: false).count
+      "My List #{list_count + 1}"
+    end
+  end
+
+  def master_or_title_blank?
+    master == true || title.blank?
   end
 end

--- a/app/models/shopping_list.rb
+++ b/app/models/shopping_list.rb
@@ -6,11 +6,19 @@ class ShoppingList < ApplicationRecord
 
   validate :one_master_list_per_user
 
+  after_create :ensure_master_list_present
+
   private
 
   def one_master_list_per_user
     if master == true && user.master_shopping_list && user.master_shopping_list != self
       errors.add(:master, 'user can only have one master shopping list')
+    end
+  end
+
+  def ensure_master_list_present
+    if user.master_shopping_list.nil?
+      user.shopping_lists.create!(master: true)
     end
   end
 end

--- a/app/models/shopping_list.rb
+++ b/app/models/shopping_list.rb
@@ -3,4 +3,14 @@
 class ShoppingList < ApplicationRecord
   belongs_to :user
   has_many :shopping_list_items, dependent: :destroy
+
+  validate :one_master_list_per_user
+
+  private
+
+  def one_master_list_per_user
+    if master == true && user.master_shopping_list && user.master_shopping_list != self
+      errors.add(:master, 'user can only have one master shopping list')
+    end
+  end
 end

--- a/app/models/shopping_list.rb
+++ b/app/models/shopping_list.rb
@@ -12,6 +12,11 @@ class ShoppingList < ApplicationRecord
   before_destroy :ensure_not_master, if: :other_lists_present?
   after_destroy :destroy_master_list, unless: :other_lists_present?
 
+  def to_json(opts = {})
+    opts.merge!({ include: :shopping_list_items }) unless opts.has_key?(:include)
+    super(opts)
+  end
+
   private
 
   def one_master_list_per_user

--- a/app/models/shopping_list_item.rb
+++ b/app/models/shopping_list_item.rb
@@ -7,7 +7,7 @@ class ShoppingListItem < ApplicationRecord
   validates :quantity, presence: true, numericality: { only_integer: true, greater_than: 0 }
 
   before_save :humanize_description
-  before_save :prevent_changed_description
+  before_update :prevent_changed_description
   after_create :add_to_master_list, unless: :shopping_list_is_master_list?
   after_update :adjust_master_list_after_update, unless: :shopping_list_is_master_list?
   after_destroy :adjust_master_list_after_destroy, unless: :shopping_list_is_master_list?

--- a/app/models/shopping_list_item.rb
+++ b/app/models/shopping_list_item.rb
@@ -57,7 +57,6 @@ class ShoppingListItem < ApplicationRecord
   end
 
   def prevent_changed_description
-    return true if new_record?
     throw :abort if description_changed?
   end
 

--- a/app/models/shopping_list_item.rb
+++ b/app/models/shopping_list_item.rb
@@ -2,4 +2,74 @@
 
 class ShoppingListItem < ApplicationRecord
   belongs_to :shopping_list
+
+  validates :description, presence: true
+  validates :quantity, presence: true, numericality: { only_integer: true, greater_than: 0 }
+
+  before_save :humanize_description
+  before_save :prevent_changed_description
+  after_create :add_to_master_list, unless: :shopping_list_is_master_list?
+  after_update :adjust_master_list_after_update, unless: :shopping_list_is_master_list?
+  after_destroy :adjust_master_list_after_destroy, unless: :shopping_list_is_master_list?
+
+  delegate :user, to: :shopping_list
+
+  def self.create_or_combine!(attrs)
+    list = attrs[:shopping_list] || ShoppingList.find(attrs[:shopping_list_id])
+    desc = (attrs[:description] || attrs['description'])&.humanize
+    existing_item = list.shopping_list_items.find_by_description(desc)
+
+    if existing_item.nil?
+      create!(attrs)
+    else
+      qty = attrs[:quantity] || attrs['quantity'] || 1
+      new_quantity = existing_item.quantity + qty
+      existing_item.update!(quantity: new_quantity)
+    end
+  end
+
+  private
+
+  def add_to_master_list
+    new_attrs = self.attributes.reject { |key, value| ['shopping_list_id', :shopping_list_id, 'id', :id].include?(key) }
+    ShoppingListItem.create_or_combine!(**new_attrs, shopping_list: master_list)
+  end
+
+  def adjust_master_list_after_update
+    # Any item being updated (as opposed to created) will already be represented on the master list.
+    # So we just need to find the item on the master list and add delta_quantity to its quantity value.
+    # The new value will never be zero because there will be a validation error before saving if the
+    # new quantity value is zero. On the client side, when a user enters a quantity of zero, the client
+    # should implement logic to make a DELETE request on the list item instead.
+    delta_quantity = saved_change_to_attribute(:quantity).last - saved_change_to_attribute(:quantity).first
+    item_on_master_list = master_list.shopping_list_items.find_by_description(description)
+    item_on_master_list.update!(quantity: item_on_master_list.quantity + delta_quantity)
+  end
+
+  def adjust_master_list_after_destroy
+    item_on_master_list = master_list.shopping_list_items.find_by_description(description)
+
+    if item_on_master_list.quantity == quantity
+      item_on_master_list.destroy!
+    else
+      item_on_master_list.update!(quantity: item_on_master_list.quantity - quantity)
+    end
+  end
+
+  def prevent_changed_description
+    return true if new_record?
+    throw :abort if description_changed?
+  end
+
+  def humanize_description
+    self.description = description.humanize
+  end
+
+  def shopping_list_is_master_list?
+    self.shopping_list.master == true
+  end
+
+  def master_list
+    @master_list ||= user.master_shopping_list
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,4 +15,8 @@ class User < ApplicationRecord
       user.save!
     end
   end
+
+  def master_shopping_list
+    shopping_lists.find_by(master: true)
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   get '/auth/verify_token', to: 'verifications#verify_token', as: 'verify_token'
   get '/users/current', to: 'users#current', as: 'current_user'
 
-  resources :shopping_lists, only: %i[index show create destroy]
+  resources :shopping_lists
 
   get '/privacy', to: 'utilities#privacy'
   get '/tos', to: 'utilities#tos'

--- a/db/migrate/20210619015003_add_master_to_shopping_lists.rb
+++ b/db/migrate/20210619015003_add_master_to_shopping_lists.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMasterToShoppingLists < ActiveRecord::Migration[6.1]
+  def change
+    add_column :shopping_lists, :master, :boolean, default: false
+  end
+end

--- a/db/migrate/20210619225944_add_title_to_shopping_lists.rb
+++ b/db/migrate/20210619225944_add_title_to_shopping_lists.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddTitleToShoppingLists < ActiveRecord::Migration[6.1]
+  def change
+    add_column :shopping_lists, :title, :string, null: false
+    add_index :shopping_lists, %i[user_id title], unique: true
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_18_040219) do
+ActiveRecord::Schema.define(version: 2021_06_19_015003) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 2021_06_18_040219) do
     t.integer "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "master", default: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_19_015003) do
+ActiveRecord::Schema.define(version: 2021_06_19_225944) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,6 +29,8 @@ ActiveRecord::Schema.define(version: 2021_06_19_015003) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "master", default: false
+    t.string "title", null: false
+    t.index ["user_id", "title"], name: "index_shopping_lists_on_user_id_and_title", unique: true
   end
 
   create_table "users", force: :cascade do |t|

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,15 @@
+# API Documentation
+
+Skyrim Inventory Management API offers a range of endpoints allowing users to store, retrieve, and remove data about their inventory and tasks.
+
+## Endpoints
+
+All endpoints accept and return JSON bodies only. Unless otherwise specified, all endpoints are authenticated using an `Authorization` header including the bearer token from Google OAuth. The API is stateless and all requests must be authenticated individually. Requests including a request body should include a `Content-Type` header set to `"application/json"`.
+
+Authorization is handled in a `before_action` on the `ApplicationController`. Unless otherwise indicated, error statuses for all resources can include any of the error statuses the [`GET /auth/verify`](/docs/api/resources/authorization.md) returns.
+
+## Resources
+
+* [Authorization](/docs/api/resources/authorization.md)
+* [Users](/docs/api/resources/users.md)
+* [Shopping Lists](/docs/api/resources/shopping-lists.md)

--- a/docs/api/resources/authorization.md
+++ b/docs/api/resources/authorization.md
@@ -1,0 +1,47 @@
+# Authorization
+
+Skyrim Inventory Management uses [Sign In With Google](https://developers.google.com/identity/sign-in/web/sign-in) to authenticate users. Session data is stored on the [front end](https://github.com/danascheider/skyrim_inventory_management_frontend) and the API verifies the OAuth token on each request. On initial sign-in, the client should make a request to [GET /auth/verify_token](#get-auth-verify_token) with the bearer token from Google included in the authorization header.
+
+## Contents
+
+* [`GET /auth/verify_token`](#get-authverifytoken)
+
+## GET /auth/verify_token
+
+This endpoint verifies user tokens on initial sign-in and ensures that the user has an up-to-date account or profile on the server. The account is created or updated using the profile data returned from Google, not with client-provided data. Users are uniquely identified by the email that Google returns on token verification. If a user signs in with a different Google account, or if Google returns a different email address for some reason, a separate account will be created with the new email and will not be linked to the user's original account. Users must keep track of which account they've used to sign in.
+
+### Example Request
+
+```
+GET /auth/verify_token
+Authorization: Bearer xxxxxxxxxxxxx
+```
+
+### Successful Responses
+
+#### Status
+
+204 No Content
+
+### Error Responses
+
+#### Status
+
+401 Unauthorized
+
+#### Example Bodies
+
+OAuth token validation failure:
+```json
+{
+  "error": "Google OAuth token validation failed"
+}
+```
+
+Failed certificate validation:
+```json
+{
+  "error": "Invalid OAuth certificate"
+}
+```
+

--- a/docs/api/resources/shopping-lists.md
+++ b/docs/api/resources/shopping-lists.md
@@ -1,0 +1,364 @@
+# Shopping Lists
+
+Shopping lists represent lists of items a user needs in the game. Users can have different lists corresponding to different property locations. Users with shopping lists also have a master list that includes the combined list items and quantities from all their other lists. Master lists are created, updated, and destroyed automatically. They cannot be directly interacted with via the API, except to retrieve them.
+
+Each list contains list items, which are returned with each response that includes the list.
+
+Like other resources in SIM, shopping lists are scoped to the authenticated user. There is no way to retrieve shopping lists for any other user through the API.
+
+## Endpoints
+
+* [`GET /shopping_lists`](#get-shoppinglists)
+* [`GET /shopping_lists/:id`](#get-shoppinglistsid)
+* [`POST /shopping_lists`](#post-shoppinglists)
+* [`PUT|PATCH /shopping_lists/:id`](#patch-shoppinglistsid)
+* [`DELETE /shopping_lists/:id`](#delete-shoppinglistsid)
+
+## GET /shopping_lists
+
+Returns all shopping lists owned by the authenticated user.
+
+### Example Request
+
+```
+GET /shopping_lists
+Authorization: Bearer xxxxxxxxxxxxx
+```
+
+### Successful Responses
+
+#### Status
+
+200 OK
+
+#### Example Bodies
+
+For a user with no lists:
+```json
+[]
+```
+For a user with multiple lists:
+```json
+[
+  {
+    "id": 43,
+    "user_id": 8234,
+    "master": true,
+    "title": "Master",
+    "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "shopping_list_items": [
+      {
+        "shopping_list_id": 43,
+        "description": "Unenchanted ebony sword",
+        "quantity": 1,
+        "notes": "Need an unenchanted sword to start Companions questline",
+        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      },
+      {
+        "shopping_list_id": 43,
+        "description": "Iron ingot",
+        "quantity": 4,
+        "notes": "3 locks -- 2 hinges",
+        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      }
+    ]
+  },
+  {
+    "id": 46,
+    "user_id": 8234,
+    "master": false,
+    "title": "Lakeview Manor",
+    "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "shopping_list_items": [
+      {
+        "shopping_list_id": 46,
+        "description": "Unenchanted ebony sword",
+        "quantity": 1,
+        "notes": "Need an unenchanted sword to start Companions questline",
+        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      },
+      {
+        "shopping_list_id": 46,
+        "description": "Iron ingot",
+        "quantity": 3,
+        "notes": "3 locks",
+        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      }
+    ]
+  },
+  {
+    "id": 52,
+    "user_id": 8234,
+    "master": false,
+    "title": "Severin Manor",
+    "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "shopping_list_items": [
+      {
+        "shopping_list_id": 52,
+        "description": "Iron ingot",
+        "quantity": 1,
+        "notes": "2 hinges",
+        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      }
+    ]
+  }
+]
+```
+
+## GET /shopping_lists/:id
+
+Returns the shopping list with the given ID, if it exists and belongs to the authenticated user. The response includes any list items on the given shopping list. If the shopping list exists but does not belong to the authenticated user, a 404 error response will be returned.
+
+### Example Request
+
+```
+GET /shopping_lists/24
+Authorization: Bearer xxxxxxxxxxxx
+```
+
+### Successful Responses
+
+#### Status
+
+200 OK
+
+#### Example Body
+
+```json
+{
+  "id": 4,
+  "user_id": 6,
+  "master": false,
+  "title": "My List 1",
+  "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+  "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+  "shopping_list_items": [
+    {
+      "id": 1,
+      "shopping_list_id": 4,
+      "description": "Ebony sword",
+      "quantity": 2,
+      "notes": "One to enchant with Absorb Health, one to enchant with Soul Trap",
+      "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+      "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+    }
+  ]
+}
+```
+
+### Error Responses
+
+#### Status
+
+404 Not Found
+
+## POST /shopping_lists
+
+Creates a new shopping list for the authenticated user. If the user does not already have a master list, a master list will also be created automatically. The response includes the newly created shopping list.
+
+The request does not have to include a body. If it does, the body should include a `"shopping_list"` object with an optional `"title"` key, the only attribute that can be set on the shopping list via request data. If you don't include a title, your list will be titled "My List n", where _n_ is an integer equal to the highest numbered default list title you have. For example, if you have lists titled "My List 1", "My List 3", and "My List 4", your new list will be titled "My List 5".
+
+Each list title must be unique for the authenticated user. So, multiple users can have lists called "My List 1", but if you have such a list and attempt to create a new list with the same title, the API will return an error.
+
+### Example Requests
+
+Request specifying a title:
+```
+POST /shopping_lists
+Authorization: Bearer xxxxxxxxxx
+Content-Type: application/json
+{
+  "shopping_list": {
+    "title": "Custom Title"
+  }
+}
+```
+
+Request not specifying a title (list will be given a default title as defined above):
+```
+POST /shopping_lists
+Authorization: Bearer xxxxxxxxxx
+Content-Type: application/json
+{}
+```
+
+### Success Responses
+
+#### Status
+
+201 Created
+
+#### Example Body
+
+```json
+{
+  "id": 4,
+  "user_id": 6,
+  "master": false,
+  "title": "My List 1",
+  "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+  "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+  "shopping_list_items": []
+}
+```
+
+### Error Responses
+
+#### Status
+
+422 Unprocessable Entity
+
+#### Example Body
+
+```json
+{
+  "errors": {
+    "title": ["has already been taken"]
+  }
+}
+```
+
+## PATCH /shopping_lists/:id
+
+If the specified shopping list exists, belongs to the authenticated user, and is not a master list, updates the title and returns the shopping list. Title is the only shopping list attribute that can be modified using this endpoint. This endpoint also supports the `PUT` method.
+
+### Example Requests
+
+Requests must include a `"shopping_list"` object with a `"title"` key.
+
+Using a `PATCH` request:
+```
+PATCH /shopping_lists/3
+Authorization: Bearer xxxxxxxxxx
+Content-Type: application/json
+{
+  "shopping_list": {
+    "title": "New List Title"
+  }
+}
+```
+
+Using a `PUT` request:
+```
+PUT /shopping_lists/3
+Authorization: Bearer xxxxxxxxxxx
+Content-Type: application/json
+{
+  "shopping_list": {
+    "title": "New List Title"
+  }
+}
+```
+
+### Success Response
+
+#### Status
+
+200 OK
+
+#### Example Body
+
+```json
+{
+  "id": 834,
+  "user_id": 16,
+  "master": false,
+  "title": "New List Title",
+  "created_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00",
+  "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+  "shopping_list_items": [
+    {
+      "id": 32,
+      "shopping_list_id": 834,
+      "description": "Ebony sword",
+      "quantity": 1,
+      "notes": "To enchant with Soul Trap",
+      "created_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00",
+      "updated_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00"
+    }
+  ]
+}
+```
+
+### Error Responses
+
+#### Statuses
+
+422 Unprocessable Entity
+404 Not Found
+
+#### Example Bodies
+
+Unprocessable Entity:
+```json
+{
+  "errors": {
+    "title": ["has already been taken"]
+  }
+}
+```
+
+No response body is returned for a 404 response.
+
+## DELETE /shopping_lists/:id
+
+Destroys the given shopping list if it exists and belongs to the authenticated user. If the list to be destroyed is the user's only regular (non-master) shopping list, the master list will also be destroyed.
+
+### Example Request
+
+```
+DELETE /shopping_lists/428
+Authorization: Bearer xxxxxxxxxxxx
+```
+
+### Success Response
+
+#### Statuses
+
+204 No Content
+200 OK
+
+#### Example Body
+
+If the resource deleted was the user's last regular list, the master list will also be destroyed and no content will be returned in the response. If the user had at least one other regular list (as well as a master list), then the master list will be returned with its values updated to reflect removal of the items on the list that was deleted.
+
+```json
+{
+  "master_list": {
+    "id": 834,
+    "user_id": 16,
+    "master": true,
+    "title": "Master",
+    "created_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00",
+    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "shopping_list_items": [
+      {
+        "id": 32,
+        "shopping_list_id": 834,
+        "description": "Ebony sword",
+        "quantity": 1,
+        "notes": "To enchant with Soul Trap",
+        "created_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      }
+    ] 
+  }
+}
+```
+
+### Error Responses
+
+If the specified list does not exist or does not belong to the authenticated user, a 404 response will be returned. If the specified list is a master list, a 405 response will be returned. Error responses do not return data.
+
+#### Statuses
+
+404 Not Found
+405 Method Not Allowed

--- a/docs/api/resources/users.md
+++ b/docs/api/resources/users.md
@@ -1,0 +1,36 @@
+# Users
+
+Skyrim Inventory Management offers only one route for retrieving user profile data. There are no admin users or endpoints to retrieve data for multiple or unauthenticated users. Additionally, there is no way to modify user profile data through the API. User data is populated through the Sign In With Google verification API. Users wishing to update their profiles in SIM should update the Google profile they use to log in.
+
+## Endpoints
+
+* [`GET /users/current`](#get-userscurrent)
+
+## GET /users/current
+
+Returns the user authenticated with the bearer token included in the `Authorization` header. Error responses are the same as for the `GET /auth/verify_token` endpoint.
+
+### Example Request
+
+```
+GET /users/current
+Authorization: Bearer xxxxxxxxx
+```
+
+### Successful Responses
+
+#### Status
+
+200 OK
+
+#### Example Body
+
+```json
+{
+  "id": 241,
+  "uid": "janedoe@gmail.com",
+  "email": "janedoe@gmail.com",
+  "image_url": "https://example.googleusercontent.com",
+  "name": "Jane Doe"
+}
+```

--- a/spec/factories/shopping_lists.rb
+++ b/spec/factories/shopping_lists.rb
@@ -9,5 +9,15 @@ FactoryBot.define do
 
       title { 'Master' }
     end
+
+    factory :shopping_list_with_list_items do
+      transient do
+        list_item_count { 2 }
+      end
+
+      after(:build, :create) do |list, evaluator|
+        create_list(:shopping_list_item, evaluator.list_item_count, shopping_list: list)
+      end
+    end
   end
 end

--- a/spec/factories/shopping_lists.rb
+++ b/spec/factories/shopping_lists.rb
@@ -4,8 +4,12 @@ FactoryBot.define do
   factory :shopping_list do
     user
 
+    sequence(:title) { |n| "My List #{n}" }
+
     factory :master_shopping_list do
       master { true }
+
+      title { 'Master' }
     end
   end
 end

--- a/spec/factories/shopping_lists.rb
+++ b/spec/factories/shopping_lists.rb
@@ -3,5 +3,9 @@
 FactoryBot.define do
   factory :shopping_list do
     user
+
+    factory :master_shopping_list do
+      master { true }
+    end
   end
 end

--- a/spec/factories/shopping_lists.rb
+++ b/spec/factories/shopping_lists.rb
@@ -4,8 +4,6 @@ FactoryBot.define do
   factory :shopping_list do
     user
 
-    sequence(:title) { |n| "My List #{n}" }
-
     factory :master_shopping_list do
       master { true }
 

--- a/spec/models/shopping_list_item_spec.rb
+++ b/spec/models/shopping_list_item_spec.rb
@@ -3,5 +3,126 @@
 require 'rails_helper'
 
 RSpec.describe ShoppingListItem, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'delegation' do
+    subject(:owner) { list_item.user }
+
+    let(:list_item) { create(:shopping_list_item) }
+
+    describe '#user' do
+      it 'returns the owner of its ShoppingList' do
+        expect(owner).to eq(list_item.shopping_list.user)
+      end
+    end
+  end
+
+  describe '::create_or_combine!' do
+    context 'when there is an existing item on the same list with the same description' do
+      subject(:create_item) { described_class.create_or_combine!(description: 'existing item', quantity: 1, shopping_list: shopping_list) }
+
+      let!(:shopping_list) { create(:shopping_list) }
+      let!(:existing_item) { create(:shopping_list_item, description: 'Existing item', quantity: 2, shopping_list: shopping_list) }
+
+      it "doesn't create a new list item" do
+        expect { create_item }.not_to change(shopping_list.shopping_list_items, :count)
+      end
+
+      it 'adds the quantity to the existing item' do
+        create_item
+        expect(existing_item.reload.quantity).to eq 3
+      end
+    end
+  end
+
+  describe '#update!' do
+    let!(:list_item) { create(:shopping_list_item, quantity: 1) }
+
+    context 'when updating quantity' do
+      subject(:update_item) { list_item.update!(quantity: 4) }
+
+      it 'updates as normal' do
+        expect { update_item }.to change(list_item, :quantity).from(1).to(4)
+      end
+    end
+
+    context 'when updating description' do
+      subject(:update_item) { list_item.update!(description: 'Something else') }
+
+      it 'raises an error' do
+        expect { update_item }.to raise_error(ActiveRecord::RecordNotSaved)
+      end
+    end
+  end
+
+  describe 'updating the master list' do
+    let(:shopping_list) { create(:shopping_list) }
+    let(:master_list) { shopping_list.user.master_shopping_list }
+
+    context 'when creating a new list item' do
+      subject(:create_item) { create(:shopping_list_item, shopping_list: shopping_list) }
+
+      context 'when there is no matching item already on the master list' do
+        it 'adds the same item to the master list' do
+          expect { create_item }.to change(master_list.shopping_list_items, :count).from(0).to(1)
+        end
+      end
+
+      context 'when there is a matching item on the master list' do
+        subject(:create_item) { create(:shopping_list_item, description: 'Ebony sword', quantity: 2, shopping_list: shopping_list) }
+
+        let!(:item_on_master_list) { create(:shopping_list_item, description: 'Ebony sword', quantity: 1, shopping_list: master_list) }
+
+        it 'updates the quantity on the master list' do
+          create_item
+          expect(item_on_master_list.reload.quantity).to eq 3
+        end
+      end
+    end
+
+    context 'when updating an existing list item' do
+      let!(:list_item) { create(:shopping_list_item, description: 'Ebony sword', quantity: 2, shopping_list: shopping_list) }
+      
+      context 'when incrementing the quantity' do
+        subject(:update_item) { list_item.update!(quantity: 3) }
+
+        it 'increases the quantity on the master list' do
+          update_item
+          expect(master_list.shopping_list_items.find_by(description: 'Ebony sword').quantity).to eq 3
+        end
+      end
+
+      context 'when decrementing the quantity' do
+        subject(:update_item) { list_item.update!(quantity: 1) }
+
+        it 'decreases the quantity on the master list' do
+          update_item
+          expect(master_list.shopping_list_items.find_by(description: 'Ebony sword').quantity).to eq 1
+        end
+      end
+    end
+
+    context 'when destroying a list item' do
+      subject(:destroy_item) { list_item.destroy! }
+
+      let!(:list_item) { create(:shopping_list_item, description: 'Ebony sword', quantity: 2, shopping_list: shopping_list) }
+      let(:master_list_item) { master_list.shopping_list_items.find_by_description('Ebony sword') }
+
+      context 'when the new quantity on the master list is greater than 0' do
+
+        before do
+          master_list_item.update!(quantity: 3)
+        end
+
+        it 'adjusts the quantity on the master list' do
+          destroy_item
+          expect(master_list_item.reload.quantity).to eq 1
+        end
+      end
+
+      context 'when the new quantity on the master list is 0' do
+        it 'removes the item from the master list' do
+          expect { destroy_item }.to change(master_list.shopping_list_items, :count).from(1).to(0)
+        end
+      end
+    end
+  end
 end

--- a/spec/models/shopping_list_spec.rb
+++ b/spec/models/shopping_list_spec.rb
@@ -43,6 +43,57 @@ RSpec.describe ShoppingList, type: :model do
     end
   end
 
+  describe 'setting a default title' do
+    let(:user) { create(:user) }
+
+    # I don't use FactoryBot to create the models in the subject blocks because
+    # it sets values for certain attributes and I don't want those to get in the way.
+    context 'when the list is not a master list' do
+      context 'when the user has set a title' do
+        subject(:title) { user.shopping_lists.create!(title: 'Heljarchen Hall').title }
+
+        let(:user) { create(:user) }
+
+        it 'keeps the title the user has set' do
+          expect(title).to eq 'Heljarchen Hall'
+        end
+      end
+
+      context 'when the user has not set a title' do
+        subject(:title) { user.shopping_lists.create!.title }
+
+        before do
+          # Create lists for a different user to make sure the name of this user's
+          # list isn't affected by them
+          create_list(:shopping_list, 2)
+          create_list(:shopping_list, 2, user: user)
+        end
+
+        it 'sets the title based on how many regular lists the user has' do
+          expect(title).to eq 'My List 3'
+        end
+      end
+    end
+
+    context 'when the list is a master list' do
+      context 'when the user has set a title' do
+        subject(:title) { user.shopping_lists.create!(master: true, title: 'Something other than master').title }
+        
+        it 'overrides the title the user has set' do
+          expect(title).to eq 'Master'
+        end
+      end
+
+      context 'when the user has not set a title' do
+        subject(:title) { user.shopping_lists.create!(master: true).title }
+
+        it 'sets the title to "Master"' do
+          expect(title).to eq 'Master'
+        end
+      end
+    end
+  end
+
   describe 'after create hook' do
     subject(:create_shopping_list) { create(:shopping_list, user: user) }
 

--- a/spec/models/shopping_list_spec.rb
+++ b/spec/models/shopping_list_spec.rb
@@ -3,5 +3,74 @@
 require 'rails_helper'
 
 RSpec.describe ShoppingList, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'validations' do
+    describe 'master lists' do
+      context 'when there are no master lists' do
+        let(:user) { create(:user) }
+        let(:master_list) { build(:master_shopping_list, user: user) }
+
+        it 'is valid' do
+          expect(master_list).to be_valid
+        end
+      end
+
+      context 'when there is an existing master list belonging to another user' do
+        let(:user) { create(:user) }
+        let(:master_list) { build(:master_shopping_list, user: user) }
+
+        before do
+          create(:master_shopping_list)
+        end
+
+        it 'is valid' do
+          expect(master_list).to be_valid
+        end
+      end
+
+      context 'when the user already has a master list' do
+        let(:user) { create(:user) }
+        let(:master_list) { build(:master_shopping_list, user: user) }
+
+        before do
+          create(:master_shopping_list, user: user)
+        end
+
+        it 'is invalid', :aggregate_failures do
+          expect(master_list).not_to be_valid
+          expect(master_list.errors[:master]).to eq ['user can only have one master shopping list']
+        end
+      end
+    end
+  end
+
+  describe 'after create hook' do
+    subject(:create_shopping_list) { create(:shopping_list, user: user) }
+
+    let(:user) { create(:user) }
+
+    context 'when the user has an existing master list' do
+      before do
+        create(:master_shopping_list, user: user)
+      end
+
+      it "doesn't raise a validation error" do
+        expect { create_shopping_list }.not_to raise_error
+      end
+  
+      it "doesn't create another master list" do
+        expect { create_shopping_list }.to change(user.shopping_lists, :count).from(1).to(2)
+      end
+    end
+
+    context "when the user doesn't have a master list yet" do
+      it 'creates two lists' do
+        expect { create_shopping_list }.to change(user.shopping_lists, :count).from(0).to(2)
+      end
+
+      it 'creates a master list' do
+        create_shopping_list
+        expect(user.master_shopping_list).not_to be nil
+      end
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe :user, type: :model do
+  subject(:user) { create(:user) }
+
+  describe '#master_shopping_list' do
+    context 'when the user has a master shopping list' do
+      let!(:master_list) { create(:master_shopping_list, user: user) }
+
+      it 'returns the master list' do
+        expect(user.master_shopping_list).to eq master_list
+      end
+    end
+
+    context 'when the user has no master shopping list' do
+      it 'returns nil' do
+        expect(user.master_shopping_list).to be nil
+      end
+    end
+  end
+end

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -213,7 +213,7 @@ RSpec.describe "ShoppingLists", type: :request do
 
       it 'returns all shopping lists belonging to the authenticated user' do
         get_index
-        expect(response.body).to eq authenticated_user.shopping_lists.to_json
+        expect(response.body).to eq authenticated_user.shopping_lists.to_json(include: :shopping_list_items)
       end
 
       it 'returns status 200' do

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "ShoppingLists", type: :request do
 
       context 'when all goes well' do
         it 'creates a new shopping list' do
-          expect { create_shopping_list }.to change(ShoppingList, :count).from(0).to(1)
+          expect { create_shopping_list }.to change(ShoppingList, :count).from(0).to(2) # because of the master list
         end
 
         it 'creates the list for the logged-in user' do
@@ -41,7 +41,7 @@ RSpec.describe "ShoppingLists", type: :request do
 
         it 'returns the new list' do
           create_shopping_list
-          expect(response.body).to eq ShoppingList.last.to_json
+          expect(response.body).to eq({ shopping_list: user.shopping_lists.first, master_list: user.master_shopping_list }.to_json)
         end
 
         it 'returns status 201' do
@@ -326,7 +326,7 @@ RSpec.describe "ShoppingLists", type: :request do
       end
 
       it 'deletes the shopping list' do
-        expect { delete_shopping_list }.to change(ShoppingList, :count).from(1).to(0)
+        expect { delete_shopping_list }.to change(ShoppingList, :count).from(2).to(1) # will initially be 2 because master list
       end
     end
   end

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -328,6 +328,16 @@ RSpec.describe "ShoppingLists", type: :request do
       it 'deletes the shopping list' do
         expect { delete_shopping_list }.to change(ShoppingList, :count).from(2).to(1) # will initially be 2 because master list
       end
+
+      it 'returns the master list' do
+        delete_shopping_list
+        expect(response.body).to eq({ master_list: user.master_shopping_list }.to_json)
+      end
+
+      it 'returns status 200' do
+        delete_shopping_list
+        expect(response.status).to eq 200
+      end
     end
   end
 end

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe "ShoppingLists", type: :request do
 
     context 'when authenticated and the shopping list exists' do
       let(:user) { create(:user) }
-      let(:shopping_list) { create(:shopping_list, user: user) }
+      let(:shopping_list) { create(:shopping_list_with_list_items, list_item_count: 2, user: user) }
       let(:shopping_list_id) { shopping_list.id }
       let(:validator) { instance_double(GoogleIDToken::Validator, check: validation_data) }
 
@@ -164,9 +164,9 @@ RSpec.describe "ShoppingLists", type: :request do
         allow(GoogleIDToken::Validator).to receive(:new).and_return(validator)
       end
 
-      it 'returns the shopping list' do
+      it 'returns the shopping list with its list items' do
         get_shopping_list
-        expect(response.body).to eq shopping_list.to_json
+        expect(response.body).to eq shopping_list.to_json(include: :shopping_list_items)
       end
     end
   end
@@ -206,7 +206,7 @@ RSpec.describe "ShoppingLists", type: :request do
       before do
         allow(GoogleIDToken::Validator).to receive(:new).and_return(validator)
 
-        create_list(:shopping_list, 3, user: authenticated_user)
+        create_list(:shopping_list_with_list_items, 3, list_item_count: 2, user: authenticated_user)
         unauthenticated_user = create(:user)
         create_list(:shopping_list, 3, user: unauthenticated_user)
       end

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "ShoppingLists", type: :request do
 
         it 'returns the new list' do
           create_shopping_list
-          expect(response.body).to eq({ shopping_list: user.shopping_lists.first, master_list: user.master_shopping_list }.to_json)
+          expect(response.body).to eq(user.shopping_lists.first.to_json)
         end
 
         it 'returns status 201' do

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "ShoppingLists", type: :request do
   end
 
   describe 'POST /shopping_lists' do
-    subject(:create_shopping_list) { post '/shopping_lists', params: {}, headers: headers }
+    subject(:create_shopping_list) { post '/shopping_lists', params: '{ "shopping_list": {} }', headers: headers }
 
     context 'when authenticated' do
       let!(:user) { create(:user) }
@@ -51,13 +51,17 @@ RSpec.describe "ShoppingLists", type: :request do
       end
 
       context 'when something goes wrong' do
-        before do
-          allow_any_instance_of(ShoppingList).to receive(:save).and_return(nil)
-        end
+        subject(:create_shopping_list) { post '/shopping_lists', params: "{ \"shopping_list\": { \"title\": \"#{existing_list.title}\" } }", headers: headers }
+        let(:existing_list) { create(:shopping_list, user: user) }
 
         it 'returns status 422' do
           create_shopping_list
           expect(response.status).to eq 422
+        end
+
+        it "doesn't return any data" do
+          create_shopping_list
+          expect(response.body).to be_empty
         end
       end
     end

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -389,7 +389,7 @@ RSpec.describe "ShoppingLists", type: :request do
 
       it 'returns all shopping lists belonging to the authenticated user' do
         get_index
-        expect(response.body).to eq authenticated_user.shopping_lists.to_json(include: :shopping_list_items)
+        expect(JSON.parse(response.body)).to eq JSON.parse(authenticated_user.shopping_lists.to_json(include: :shopping_list_items))
       end
 
       it 'returns status 200' do

--- a/spec/requests/verifications_spec.rb
+++ b/spec/requests/verifications_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Verifications", type: :request do
       allow(GoogleIDToken::Validator).to receive(:new).and_return(validator)
     end
 
-    it 'returns status 201' do
+    it 'returns status 204' do
       verify_token
       expect(response.status).to eq 204
     end

--- a/spec/requests/verifications_spec.rb
+++ b/spec/requests/verifications_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Verifications", type: :request do
 
     it 'returns status 201' do
       verify_token
-      expect(response.status).to eq 201
+      expect(response.status).to eq 204
     end
 
     context 'when no existing user matches' do


### PR DESCRIPTION
## Context

Users need to be able to manage their shopping lists through the API. This PR adds resource routes for shopping lists.

## Changes

### General

* Change response code from verifications controller to 204 instead of 201 since the resource may have been created previously

### Shopping List Model

* Add `master` column to database to establish concept of master list
* Add `title` column to database so users can differentiate lists
* Add validations:
  * One and only one master list per user
  * Uniqueness of title scoped to user
* Add callbacks:
  * Set default title on master lists or lists where no title has been specified
  * Create master list after creation of regular list if no master list exists yet
  * Prevent master list from being destroyed unless it is the user's only shopping list
  * Destroy master list automatically when the user destroys their last regular shopping list
* Overwrite `#to_json` method to include shopping list item children unless otherwise specified

### Shopping List Routes

* Add RESTful resource routes for shopping lists (index/create/show/update/destroy)

### Shopping List Item Model

* Add validations:
  * Validate description presence
  * Validate that quantity is present and is an integer greater than 0
* Add callbacks:
  * Before save, call `humanize` on description value to normalise and facilitate combining similar values on master lists
  * Abort save if description is being changed
  * Update master list items/quantities when list item is created, updated, or destroyed
* Add delegator so `:user` can be called directly on a list item

### User Model

* Add `#master_shopping_list` method to avoid having to use `shopping_lists.find_by(master: true)`

### Docs and Testing

* Add detailed API documentation
* Update factories for shopping lists
* Add and update tests