### PR TITLE
Concatenate notes fields when combining items on shopping lists

### DIFF
--- a/app/models/shopping_list_item.rb
+++ b/app/models/shopping_list_item.rb
@@ -23,8 +23,12 @@ class ShoppingListItem < ApplicationRecord
       create!(attrs)
     else
       qty = attrs[:quantity] || attrs['quantity'] || 1
+      notes = attrs[:notes] || attrs['notes']
+
       new_quantity = existing_item.quantity + qty
-      existing_item.update!(quantity: new_quantity)
+      new_notes = [existing_item.notes, notes].join(' -- ')
+
+      existing_item.update!(quantity: new_quantity, notes: new_notes)
     end
   end
 


### PR DESCRIPTION
## Context

[**Determine if create_or_combine! handles notes correctly**](https://trello.com/c/3of9tyIB/5-determine-if-createorcombine-handles-notes-correctly)

We realised that when the SIM backend decides a "new" shopping list item should actually be combined with an existing one, the application throws out any notes the user added to the new item. These should not be thrown out but should also be added to the existing list item.

## Changes

* Concatenate notes for new list item when combining that item with an existing item.
* Add tests for this functionality
* Add tests for case where new list item should be created