### PR TITLE
Fix bug where notes not getting updated on master list items when regular list items changed

### DIFF
--- a/app/models/shopping_list_item.rb
+++ b/app/models/shopping_list_item.rb
@@ -60,7 +60,7 @@ class ShoppingListItem < ApplicationRecord
       item_on_master_list.destroy!
     else
       if notes.present?
-        new_notes = item_on_master_list.notes.gsub(/#{notes}/, '').gsub(/^ ?\-\- /, '').gsub(/ \-\- ?$/, '')
+        new_notes = item_on_master_list.notes.sub(/#{notes}/, '').gsub(/^ ?\-\- /, '').gsub(/ \-\- ?$/, '')
       end
 
       new_notes = nil unless defined?(new_notes) && new_notes.present?

--- a/app/models/shopping_list_item.rb
+++ b/app/models/shopping_list_item.rb
@@ -35,7 +35,7 @@ class ShoppingListItem < ApplicationRecord
   private
 
   def add_to_master_list
-    new_attrs = self.attributes.reject { |key, value| ['shopping_list_id', :shopping_list_id, 'id', :id].include?(key) }
+    new_attrs = reject_non_public_attrs(self.attributes)
     ShoppingListItem.create_or_combine!(**new_attrs, shopping_list: master_list)
   end
 
@@ -114,5 +114,10 @@ class ShoppingListItem < ApplicationRecord
 
   def master_list
     @master_list ||= user.master_shopping_list
+  end
+
+  def reject_non_public_attrs(attrs)
+    non_public_attrs = [:id, 'id', :shopping_list_id, 'shopping_list_id', :created_at, 'created_at', :updated_at, 'updated_at']
+    attrs.reject { |key, value| non_public_attrs.include?(key) }
   end
 end

--- a/app/models/shopping_list_item.rb
+++ b/app/models/shopping_list_item.rb
@@ -56,20 +56,18 @@ class ShoppingListItem < ApplicationRecord
   def adjust_master_list_after_destroy
     item_on_master_list = master_list.shopping_list_items.find_by_description(description)
 
-    if item_on_master_list.quantity == quantity
-      item_on_master_list.destroy!
-    else
-      if notes.present?
-        new_notes = item_on_master_list.notes.sub(/#{notes}/, '').gsub(/^ ?\-\- /, '').gsub(/ \-\- ?$/, '')
-      end
+    item_on_master_list.destroy! && return if item_on_master_list.quantity == quantity
 
-      new_notes = nil unless defined?(new_notes) && new_notes.present?
-
-      item_on_master_list.update!(
-        quantity: item_on_master_list.quantity - quantity,
-        notes: new_notes || item_on_master_list.notes
-      )
+    if notes.present?
+      new_notes = item_on_master_list.notes.sub(/#{notes}/, '').gsub(/^ ?\-\- /, '').gsub(/ \-\- ?$/, '')
     end
+
+    new_notes = nil unless defined?(new_notes) && new_notes.present?
+
+    item_on_master_list.update!(
+      quantity: item_on_master_list.quantity - quantity,
+      notes: new_notes || item_on_master_list.notes
+    )
   end
 
   def prevent_changed_description

--- a/app/models/shopping_list_item.rb
+++ b/app/models/shopping_list_item.rb
@@ -15,9 +15,9 @@ class ShoppingListItem < ApplicationRecord
   delegate :user, to: :shopping_list
 
   def self.create_or_combine!(attrs)
-    list = attrs[:shopping_list] || ShoppingList.find(attrs[:shopping_list_id])
+    shopping_list = attrs[:shopping_list] || ShoppingList.find(attrs[:shopping_list_id])
     desc = (attrs[:description] || attrs['description'])&.humanize
-    existing_item = list.shopping_list_items.find_by_description(desc)
+    existing_item = shopping_list.shopping_list_items.find_by_description(desc)
 
     if existing_item.nil?
       create!(attrs)
@@ -45,9 +45,12 @@ class ShoppingListItem < ApplicationRecord
     # The new value will never be zero because there will be a validation error before saving if the
     # new quantity value is zero. On the client side, when a user enters a quantity of zero, the client
     # should implement logic to make a DELETE request on the list item instead.
-    delta_quantity = saved_change_to_attribute(:quantity).last - saved_change_to_attribute(:quantity).first
     item_on_master_list = master_list.shopping_list_items.find_by_description(description)
-    item_on_master_list.update!(quantity: item_on_master_list.quantity + delta_quantity)
+
+    item_on_master_list.update!(
+      quantity: item_on_master_list.quantity + delta_quantity,
+      notes: update_combined_note_values(item_on_master_list.notes, *saved_change_to_attribute(:notes))
+    )
   end
 
   def adjust_master_list_after_destroy
@@ -56,7 +59,16 @@ class ShoppingListItem < ApplicationRecord
     if item_on_master_list.quantity == quantity
       item_on_master_list.destroy!
     else
-      item_on_master_list.update!(quantity: item_on_master_list.quantity - quantity)
+      if notes.present?
+        new_notes = item_on_master_list.notes.gsub(/#{notes}/, '').gsub(/^ ?\-\- /, '').gsub(/ \-\- ?$/, '')
+      end
+
+      new_notes = nil unless defined?(new_notes) && new_notes.present?
+
+      item_on_master_list.update!(
+        quantity: item_on_master_list.quantity - quantity,
+        notes: new_notes || item_on_master_list.notes
+      )
     end
   end
 
@@ -70,6 +82,34 @@ class ShoppingListItem < ApplicationRecord
 
   def shopping_list_is_master_list?
     self.shopping_list.master == true
+  end
+
+  def delta_quantity
+    saved_change_to_attribute(:quantity).present? ? 
+      saved_change_to_attribute(:quantity).last - saved_change_to_attribute(:quantity).first :
+      0
+  end
+
+  # When updating the notes on a regular list item, we also want to update
+  # the value on the corresponding master list. The issue is that the notes
+  # on a master list item consists of the combined notes fields of all regular
+  # list items matching that description. We only want to update the note
+  # that's being changed.
+  #
+  # All args to this method are strings. "combined_value" is the existing
+  # value of the notes on the master list. "old_value" is the original value
+  # of the note being changed, and "new_value" is the new value. The "notes"
+  # field of the master list item is set to the returned value in the
+  # #adjust_master_list_after_update method.
+  #
+  def update_combined_note_values(combined_value = nil, old_value = nil, new_value = nil)
+    return new_value unless combined_value.present?
+
+    if old_value.present? && combined_value =~ /#{old_value}/
+      combined_value.sub(old_value, new_value.to_s).gsub(/^ ?\-\- /, '').gsub(/ \-\- ?$/, '')
+    elsif old_value.blank?
+      [combined_value, new_value].join(' -- ').gsub(/^ ?\-\- /, '').gsub(/ \-\- ?$/, '')
+    end
   end
 
   def master_list

--- a/spec/models/shopping_list_item_spec.rb
+++ b/spec/models/shopping_list_item_spec.rb
@@ -86,13 +86,18 @@ RSpec.describe ShoppingListItem, type: :model do
       end
 
       context 'when there is a matching item on the master list' do
-        subject(:create_item) { create(:shopping_list_item, description: 'Ebony sword', quantity: 2, shopping_list: shopping_list) }
+        subject(:create_item) { create(:shopping_list_item, description: 'Ebony sword', quantity: 2, notes: 'notes 2', shopping_list: shopping_list) }
 
-        let!(:item_on_master_list) { create(:shopping_list_item, description: 'Ebony sword', quantity: 1, shopping_list: master_list) }
+        let!(:item_on_master_list) { create(:shopping_list_item, description: 'Ebony sword', quantity: 1, notes: 'notes 1', shopping_list: master_list) }
 
         it 'updates the quantity on the master list' do
           create_item
           expect(item_on_master_list.reload.quantity).to eq 3
+        end
+
+        it 'concatenates the notes fields' do
+          create_item
+          expect(item_on_master_list.reload.notes).to eq 'notes 1 -- notes 2'
         end
       end
     end

--- a/spec/models/shopping_list_item_spec.rb
+++ b/spec/models/shopping_list_item_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe ShoppingListItem, type: :model do
     end
 
     context 'when updating an existing list item' do
-      let!(:list_item) { create(:shopping_list_item, description: 'Ebony sword', quantity: 2, shopping_list: shopping_list) }
+      let!(:list_item) { create(:shopping_list_item, description: 'Ebony sword', quantity: 2, notes: 'notes 1', shopping_list: shopping_list) }
       
       context 'when incrementing the quantity' do
         subject(:update_item) { list_item.update!(quantity: 3) }
@@ -122,6 +122,58 @@ RSpec.describe ShoppingListItem, type: :model do
           expect(master_list.shopping_list_items.find_by(description: 'Ebony sword').quantity).to eq 1
         end
       end
+
+      context 'when changing the notes' do
+        subject(:update_item) { list_item.update!(notes: 'new notes') }
+
+        let(:master_list_item) { list_item.user.master_shopping_list.shopping_list_items.find_by_description('Ebony sword') }
+
+        context 'when the master list has a combined notes value from multiple items' do
+          before do
+            other_list = create(:shopping_list, user: list_item.user)
+            create(:shopping_list_item, description: 'Ebony sword', notes: 'notes 2', quantity: 1, shopping_list: other_list)
+          end
+
+          context 'when the new notes value is not empty' do
+            it 'changes the notes specified while leaving other notes intact' do
+              update_item
+              expect(master_list.shopping_list_items.find_by(description: 'Ebony sword').notes).to eq 'new notes -- notes 2'
+            end
+          end
+
+          context 'when the new notes value is empty' do
+            subject(:update_item) { list_item.update!(notes: nil) }
+
+            it 'removes the corresponding note from the master list' do
+              update_item
+              expect(master_list_item.reload.notes).to eq 'notes 2'
+            end 
+          end
+        end
+
+        context 'when the old notes value is nil' do
+          subject(:update_item) { list_item.update!(notes: 'new notes') }
+
+          let!(:list_item) { create(:shopping_list_item, description: 'Ebony sword', notes: nil) }
+
+          it 'updates the notes to the new notes value' do
+            update_item
+            expect(master_list_item.reload.notes).to eq 'new notes'
+          end
+        end
+
+        context 'when the master list matches the old notes value multiple times' do
+          before do
+            other_list = create(:shopping_list, user: list_item.user)
+            create(:shopping_list_item, shopping_list: other_list, description: 'Ebony sword', notes: list_item.notes)
+          end
+
+          it 'only changes one of the occurrences' do
+            update_item
+            expect(master_list_item.reload.notes).to eq 'new notes -- notes 1'
+          end
+        end
+      end
     end
 
     context 'when destroying a list item' do
@@ -131,7 +183,6 @@ RSpec.describe ShoppingListItem, type: :model do
       let(:master_list_item) { master_list.shopping_list_items.find_by_description('Ebony sword') }
 
       context 'when the new quantity on the master list is greater than 0' do
-
         before do
           master_list_item.update!(quantity: 3)
         end
@@ -145,6 +196,42 @@ RSpec.describe ShoppingListItem, type: :model do
       context 'when the new quantity on the master list is 0' do
         it 'removes the item from the master list' do
           expect { destroy_item }.to change(master_list.shopping_list_items, :count).from(1).to(0)
+        end
+      end
+
+      context 'when neither list item has notes' do
+        before do
+          # so the master list item doesn't get deleted too
+          master_list_item.update!(quantity: 3)
+        end
+
+        it "doesn't change the notes field on the master list" do
+          destroy_item
+          expect(master_list_item.reload.notes).to be nil
+        end
+      end
+
+      context 'when the master list item has notes but the item being destroyed does not' do
+        before do
+          list_item.update!(notes: nil)
+          master_list_item.update!(notes: 'some notes', quantity: 3)
+        end
+
+        it "doesn't change the notes value on the master list" do
+          destroy_item
+          expect(master_list_item.reload.notes).to eq 'some notes'
+        end
+      end
+
+      context 'when the destroyed item has notes and the master list has combined notes with other items' do
+        before do
+          list_item.update!(notes: 'other notes')
+          master_list_item.update!(notes: 'some notes -- other notes', quantity: 3)
+        end
+
+        it 'removes the notes from the master list along with any leading/trailing whitespace or dashes' do
+          destroy_item
+          expect(master_list_item.reload.notes).to eq 'some notes'
         end
       end
     end


### PR DESCRIPTION
## Context

[**Combine notes fields from regular shopping items on master list**](https://trello.com/c/4yLo85Ub/2-combine-notes-fields-from-regular-shopping-list-items-on-master-list)

We were losing notes on regular list items because they weren't being added to master list notes when added to the master list. We needed to change this behaviour:

### When a New Regular List Item Is Created

The master list should add that item's "notes" value, if any, to its own, separated from existing values with ` -- `.

### When a Regular Item Is Updated

The logic goes like this:
```
if regular item notes are unchanged
  do nothing
elsif regular item notes are changed from nil to a value
  concatenate the value to the master list item notes value, separated by ` -- `
elsif regular item notes are changed from a value to nil/empty
  remove that value from the master list item, also removing any leading or trailing ` -- `
elsif regular item notes are changed from one value to another
  change that value in the master list item notes as well, taking care to only replace the first occurrence
  (since the master list could have multiple note values that are the same associated with different items)
```

### When a Regular Item Is Destroyed

The logic goes like this:
```
if regular_item.notes.blank?
  do nothing
elsif master_list_item.notes == regular_list_item.notes
  set master_list_item notes to nil
else
  remove first instance of regular_list_item.notes value from master_list_item.notes, along with
  any leading or trailing ` -- `
```

### Considerations

No `notes` value should ever begin or end with ` -- `. It is possible users would add this value to the beginning or end of their notes and that could throw a wrench in things but such is life.

## Changes

* Lots of tests
* Modify `ShoppingListItem` code to effect changes explained under 'Context'