### PR TITLE
Return error responses when attempting to create, update, or destroy master lists through the API

### DIFF
--- a/app/controllers/shopping_lists_controller.rb
+++ b/app/controllers/shopping_lists_controller.rb
@@ -57,8 +57,8 @@ class ShoppingListsController < ApplicationController
   end
 
   def prevent_action_on_master_list
-    if @shopping_list.master == true || params[:shopping_list]&.fetch(:master, nil) == true
-      render json: { errors: { master: ['cannot create or update a master shopping list through API'] } }, status: :unprocessable_entity
+    if @shopping_list&.master == true || params[:shopping_list]&.fetch(:master, nil) == true
+      render json: { errors: { master: ['cannot create or update a master shopping list through the API'] } }, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/shopping_lists_controller.rb
+++ b/app/controllers/shopping_lists_controller.rb
@@ -58,7 +58,7 @@ class ShoppingListsController < ApplicationController
 
   def prevent_action_on_master_list
     if @shopping_list&.master == true || params[:shopping_list]&.fetch(:master, nil) == true
-      render json: { error: 'cannot create or update a master shopping list through API' }, status: :unprocessable_entity
+      render json: { errors: { master: ['cannot create or update a master shopping list through API'] } }, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/shopping_lists_controller.rb
+++ b/app/controllers/shopping_lists_controller.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class ShoppingListsController < ApplicationController
+  before_action :set_shopping_list, only: %i[show update destroy]
+  before_action :prevent_action_on_master_list, only: %i[create update]
+  before_action :prevent_destroy_master_list, only: :destroy
+
   def index
     render json: current_user.shopping_lists.to_json(include: :shopping_list_items), status: :ok
   end
@@ -16,45 +20,24 @@ class ShoppingListsController < ApplicationController
   end
 
   def show
-    shopping_list = current_user.shopping_lists.includes(:shopping_list_items).find(params[:id])
-
-    render json: shopping_list, status: :ok
-  rescue ActiveRecord::RecordNotFound
-    head :not_found
+    render json: @shopping_list, status: :ok
   end
 
   def update
-    shopping_list = current_user.shopping_lists.find(params[:id])
-
-    if shopping_list.update(shopping_list_update_params)
-      render json: shopping_list, status: :ok
+    if @shopping_list.update(shopping_list_update_params)
+      render json: @shopping_list, status: :ok
     else
-      render json: { errors: shopping_list.errors }, status: :unprocessable_entity
+      render json: { errors: @shopping_list.errors }, status: :unprocessable_entity
     end
-  rescue ActiveRecord::RecordNotFound
-    head :not_found
   end
 
   def destroy
-    shopping_list = current_user.shopping_lists.find(params[:id])
-
-    if shopping_list.master
-      if current_user.shopping_lists.count == 1 # if they don't have other lists allow it
-        shopping_list.destroy!
-        head :no_content
-      else
-        head :method_not_allowed
-      end
+    @shopping_list.destroy!
+    if current_user.master_shopping_list.present? # if this was their last regular list the master will have been destroyed
+      render json: { master_list: current_user.master_shopping_list }, status: :ok
     else
-      shopping_list.destroy!
-      if current_user.master_shopping_list.present? # if this was their last regular list the master will have been destroyed
-        render json: { master_list: current_user.master_shopping_list }, status: :ok
-      else
-        head :no_content
-      end
+      head :no_content
     end
-  rescue ActiveRecord::RecordNotFound
-    head :not_found
   end
 
   private
@@ -65,5 +48,23 @@ class ShoppingListsController < ApplicationController
   
   def shopping_list_update_params
     params.require(:shopping_list).permit(:title)
+  end
+
+  def set_shopping_list
+    @shopping_list = current_user.shopping_lists.includes(:shopping_list_items).find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    head :not_found
+  end
+
+  def prevent_action_on_master_list
+    if @shopping_list&.master == true || params[:shopping_list]&.fetch(:master, nil) == true
+      render json: { error: 'cannot create or update a master shopping list through API' }, status: :unprocessable_entity
+    end
+  end
+
+  def prevent_destroy_master_list
+    if @shopping_list.master == true
+      render json: { error: 'cannot destroy a master shopping list through the API' }, status: :method_not_allowed
+    end
   end
 end

--- a/app/controllers/shopping_lists_controller.rb
+++ b/app/controllers/shopping_lists_controller.rb
@@ -57,7 +57,7 @@ class ShoppingListsController < ApplicationController
   end
 
   def prevent_action_on_master_list
-    if @shopping_list&.master == true || params[:shopping_list]&.fetch(:master, nil) == true
+    if @shopping_list.master == true || params[:shopping_list]&.fetch(:master, nil) == true
       render json: { errors: { master: ['cannot create or update a master shopping list through API'] } }, status: :unprocessable_entity
     end
   end

--- a/docs/api/resources/shopping-lists.md
+++ b/docs/api/resources/shopping-lists.md
@@ -1,6 +1,6 @@
 # Shopping Lists
 
-Shopping lists represent lists of items a user needs in the game. Users can have different lists corresponding to different property locations. Users with shopping lists also have a master list that includes the combined list items and quantities from all their other lists. Master lists are created, updated, and destroyed automatically. They cannot be directly interacted with via the API, except to retrieve them.
+Shopping lists represent lists of items a user needs in the game. Users can have different lists corresponding to different property locations. Users with shopping lists also have a master list that includes the combined list items and quantities from all their other lists. Master lists are created, updated, and destroyed automatically. They cannot be created, updated, or destroyed through the API (including to change attributes or to add, remove, or update list items).
 
 Each list contains list items, which are returned with each response that includes the list.
 
@@ -216,12 +216,22 @@ Content-Type: application/json
 
 422 Unprocessable Entity
 
-#### Example Body
+#### Example Bodies
 
+If duplicate title is given:
 ```json
 {
   "errors": {
     "title": ["has already been taken"]
+  }
+}
+```
+
+If request attempts to create a master list:
+```json
+{
+  "errors": {
+    "master": ["cannot create or update a master shopping list through API"]
   }
 }
 ```
@@ -297,11 +307,20 @@ Content-Type: application/json
 
 #### Example Bodies
 
-Unprocessable Entity:
+Unprocessable entity due to title uniqueness constraint:
 ```json
 {
   "errors": {
     "title": ["has already been taken"]
+  }
+}
+```
+
+Unprocessable entity due to attempting to update a master list or convert a regular list to a master list:
+```json
+{
+  "errors": {
+    "master": ["cannot create or update a master shopping list through API"]
   }
 }
 ```
@@ -362,3 +381,14 @@ If the specified list does not exist or does not belong to the authenticated use
 
 404 Not Found
 405 Method Not Allowed
+
+#### Example Body
+
+No response body will be returned with a 404 response.
+
+For a 405 response:
+```json
+{
+  "error": "cannot destroy a master shopping list through the API"
+}
+```

--- a/docs/api/resources/shopping-lists.md
+++ b/docs/api/resources/shopping-lists.md
@@ -231,7 +231,7 @@ If request attempts to create a master list:
 ```json
 {
   "errors": {
-    "master": ["cannot create or update a master shopping list through API"]
+    "master": ["cannot create or update a master shopping list through the API"]
   }
 }
 ```
@@ -320,7 +320,7 @@ Unprocessable entity due to attempting to update a master list or convert a regu
 ```json
 {
   "errors": {
-    "master": ["cannot create or update a master shopping list through API"]
+    "master": ["cannot create or update a master shopping list through the API"]
   }
 }
 ```

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "ShoppingLists", type: :request do
 
         it 'returns a helpful error body' do
           create_shopping_list
-          expect(JSON.parse(response.body)).to eq({ 'error' => 'cannot create or update a master shopping list through API' })
+          expect(JSON.parse(response.body)).to eq({ 'errors' => { 'master' => ['cannot create or update a master shopping list through API'] } })
         end
       end
     end
@@ -286,7 +286,7 @@ RSpec.describe "ShoppingLists", type: :request do
 
         it 'returns a helpful error body' do
           update_shopping_list
-          expect(JSON.parse(response.body)).to eq({ 'error' => 'cannot create or update a master shopping list through API' })
+          expect(JSON.parse(response.body)).to eq({ 'errors' => { 'master' => ['cannot create or update a master shopping list through API'] } })
         end
       end
 
@@ -308,7 +308,7 @@ RSpec.describe "ShoppingLists", type: :request do
 
         it 'returns a helpful error body' do
           update_shopping_list
-          expect(JSON.parse(response.body)).to eq({ 'error' => 'cannot create or update a master shopping list through API' })
+          expect(JSON.parse(response.body)).to eq({ 'errors' => { 'master' => ['cannot create or update a master shopping list through API'] } })
         end
       end
     end
@@ -416,7 +416,7 @@ RSpec.describe "ShoppingLists", type: :request do
 
         it 'returns a helpful error body' do
           update_shopping_list
-          expect(JSON.parse(response.body)).to eq({ 'error' => 'cannot create or update a master shopping list through API' })
+          expect(JSON.parse(response.body)).to eq({ 'errors' => { 'master' => ['cannot create or update a master shopping list through API'] } })
         end
       end
 
@@ -438,7 +438,7 @@ RSpec.describe "ShoppingLists", type: :request do
 
         it 'returns a helpful error body' do
           update_shopping_list
-          expect(JSON.parse(response.body)).to eq({ 'error' => 'cannot create or update a master shopping list through API' })
+          expect(JSON.parse(response.body)).to eq({ 'errors' => { 'master' => ['cannot create or update a master shopping list through API'] } })
         end
       end
     end

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "ShoppingLists", type: :request do
 
         it 'returns a helpful error body' do
           create_shopping_list
-          expect(JSON.parse(response.body)).to eq({ 'errors' => { 'master' => ['cannot create or update a master shopping list through API'] } })
+          expect(JSON.parse(response.body)).to eq({ 'errors' => { 'master' => ['cannot create or update a master shopping list through the API'] } })
         end
       end
     end
@@ -286,7 +286,7 @@ RSpec.describe "ShoppingLists", type: :request do
 
         it 'returns a helpful error body' do
           update_shopping_list
-          expect(JSON.parse(response.body)).to eq({ 'errors' => { 'master' => ['cannot create or update a master shopping list through API'] } })
+          expect(JSON.parse(response.body)).to eq({ 'errors' => { 'master' => ['cannot create or update a master shopping list through the API'] } })
         end
       end
 
@@ -308,7 +308,7 @@ RSpec.describe "ShoppingLists", type: :request do
 
         it 'returns a helpful error body' do
           update_shopping_list
-          expect(JSON.parse(response.body)).to eq({ 'errors' => { 'master' => ['cannot create or update a master shopping list through API'] } })
+          expect(JSON.parse(response.body)).to eq({ 'errors' => { 'master' => ['cannot create or update a master shopping list through the API'] } })
         end
       end
     end
@@ -416,7 +416,7 @@ RSpec.describe "ShoppingLists", type: :request do
 
         it 'returns a helpful error body' do
           update_shopping_list
-          expect(JSON.parse(response.body)).to eq({ 'errors' => { 'master' => ['cannot create or update a master shopping list through API'] } })
+          expect(JSON.parse(response.body)).to eq({ 'errors' => { 'master' => ['cannot create or update a master shopping list through the API'] } })
         end
       end
 
@@ -438,7 +438,7 @@ RSpec.describe "ShoppingLists", type: :request do
 
         it 'returns a helpful error body' do
           update_shopping_list
-          expect(JSON.parse(response.body)).to eq({ 'errors' => { 'master' => ['cannot create or update a master shopping list through API'] } })
+          expect(JSON.parse(response.body)).to eq({ 'errors' => { 'master' => ['cannot create or update a master shopping list through the API'] } })
         end
       end
     end


### PR DESCRIPTION
## Context

Master shopping lists are managed automatically. Users can create, update, or destroy regular shopping lists and master lists will be created, updated, or destroyed accordingly. Allowing master lists to be created, modified, or destroyed via the API could really throw a wrench in this process. We want to remove access to master lists via POST, PATCH, PUT, and DELETE requests and only allow GET requests on these resources.

## Changes

* Ensure master shopping lists cannot be directly created, updated, or destroyed via API requests
* Update docs to clarify this and provide examples of error responses
* Add and update specs