### PR TITLE
Return shopping lists master first

### DIFF
--- a/app/controllers/shopping_lists_controller.rb
+++ b/app/controllers/shopping_lists_controller.rb
@@ -6,7 +6,7 @@ class ShoppingListsController < ApplicationController
   before_action :prevent_destroy_master_list, only: :destroy
 
   def index
-    render json: current_user.shopping_lists.to_json(include: :shopping_list_items), status: :ok
+    render json: current_user.shopping_lists.master_first.to_json(include: :shopping_list_items), status: :ok
   end
 
   def create

--- a/app/models/shopping_list.rb
+++ b/app/models/shopping_list.rb
@@ -12,6 +12,9 @@ class ShoppingList < ApplicationRecord
   before_destroy :ensure_not_master, if: :other_lists_present?
   after_destroy :destroy_master_list, unless: :other_lists_present?
 
+  scope :master_first, -> { order(master: :desc) }
+
+
   def to_json(opts = {})
     opts.merge!({ include: :shopping_list_items }) unless opts.has_key?(:include)
     super(opts)

--- a/docs/api/resources/shopping-lists.md
+++ b/docs/api/resources/shopping-lists.md
@@ -16,7 +16,7 @@ Like other resources in SIM, shopping lists are scoped to the authenticated user
 
 ## GET /shopping_lists
 
-Returns all shopping lists owned by the authenticated user.
+Returns all shopping lists owned by the authenticated user. The master shopping list will be returned first.
 
 ### Example Request
 

--- a/spec/models/shopping_list_spec.rb
+++ b/spec/models/shopping_list_spec.rb
@@ -3,6 +3,20 @@
 require 'rails_helper'
 
 RSpec.describe ShoppingList, type: :model do
+  describe 'scopes' do
+    describe '::master_first' do
+      subject(:master_first) { user.shopping_lists.master_first.to_a }
+
+      let!(:user) { create(:user) }
+      let!(:master_list) { create(:master_shopping_list, user: user) }
+      let!(:shopping_list) { create(:shopping_list, user: user) }
+
+      it 'returns the shopping lists with the master list first' do
+        expect(master_first).to eq([master_list, shopping_list])
+      end
+    end
+  end
+
   describe 'validations' do
     describe 'master lists' do
       context 'when there are no master lists' do

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -495,7 +495,7 @@ RSpec.describe "ShoppingLists", type: :request do
 
       it 'returns all shopping lists belonging to the authenticated user' do
         get_index
-        expect(JSON.parse(response.body)).to eq JSON.parse(authenticated_user.shopping_lists.to_json(include: :shopping_list_items))
+        expect(JSON.parse(response.body)).to eq JSON.parse(authenticated_user.shopping_lists.master_first.to_json(include: :shopping_list_items))
       end
 
       it 'returns status 200' do


### PR DESCRIPTION
## Context

[**Make sure master list is returned first from API**](https://trello.com/c/jgpzHKaz/12-make-sure-master-list-is-returned-first-from-api)

When a user views their shopping lists in the UI, they should see the master list at the top. Currently, since the master list is created in the `after_create` hook of the user's first regular list, the master list will effectively never be at the top (unless the user deletes the list that is before it).

## Changes

* Add `master_first` scope to the `ShoppingList` model that returns shopping lists with the master list(s) first
* Use the `master_first` scope when returning shopping lists from the `GET /shopping_lists` endpoint
* Add and update tests
* Update docs