### PR TITLE
Add response body to 404 responses for shopping lists

### DIFF
--- a/app/controllers/shopping_lists_controller.rb
+++ b/app/controllers/shopping_lists_controller.rb
@@ -53,7 +53,7 @@ class ShoppingListsController < ApplicationController
   def set_shopping_list
     @shopping_list = current_user.shopping_lists.includes(:shopping_list_items).find(params[:id])
   rescue ActiveRecord::RecordNotFound
-    head :not_found
+    render json: { error: "Shopping list id=#{params[:id]} not found"}, status: :not_found
   end
 
   def prevent_action_on_master_list

--- a/docs/api/resources/shopping-lists.md
+++ b/docs/api/resources/shopping-lists.md
@@ -160,6 +160,14 @@ Authorization: Bearer xxxxxxxxxxxx
 
 404 Not Found
 
+#### Example Body
+
+```json
+{
+  "error": "Shopping list id=17264 not found"
+}
+```
+
 ## POST /shopping_lists
 
 Creates a new shopping list for the authenticated user. If the user does not already have a master list, a master list will also be created automatically. The response includes the newly created shopping list.
@@ -325,7 +333,12 @@ Unprocessable entity due to attempting to update a master list or convert a regu
 }
 ```
 
-No response body is returned for a 404 response.
+Not found:
+```json
+{
+  "error": "Shopping list id=2385 not found"
+}
+```
 
 ## DELETE /shopping_lists/:id
 
@@ -375,7 +388,7 @@ If the resource deleted was the user's last regular list, the master list will a
 
 ### Error Responses
 
-If the specified list does not exist or does not belong to the authenticated user, a 404 response will be returned. If the specified list is a master list, a 405 response will be returned. Error responses do not return data.
+If the specified list does not exist or does not belong to the authenticated user, a 404 response will be returned. If the specified list is a master list, a 405 response will be returned.
 
 #### Statuses
 
@@ -384,7 +397,12 @@ If the specified list does not exist or does not belong to the authenticated use
 
 #### Example Body
 
-No response body will be returned with a 404 response.
+For a 404 response:
+```json
+{
+  "error": "Shopping list id=8245 not found"
+}
+```
 
 For a 405 response:
 ```json

--- a/docs/api/resources/shopping-lists.md
+++ b/docs/api/resources/shopping-lists.md
@@ -315,7 +315,7 @@ Content-Type: application/json
 
 #### Example Bodies
 
-Unprocessable entity due to title uniqueness constraint:
+For a 422 response due to title uniqueness constraint:
 ```json
 {
   "errors": {
@@ -324,7 +324,7 @@ Unprocessable entity due to title uniqueness constraint:
 }
 ```
 
-Unprocessable entity due to attempting to update a master list or convert a regular list to a master list:
+For a 422 response due to attempting to update a master list or convert a regular list to a master list:
 ```json
 {
   "errors": {
@@ -333,7 +333,7 @@ Unprocessable entity due to attempting to update a master list or convert a regu
 }
 ```
 
-Not found:
+For a 404 response:
 ```json
 {
   "error": "Shopping list id=2385 not found"

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -134,9 +134,9 @@ RSpec.describe "ShoppingLists", type: :request do
         expect(response.status).to eq 404
       end
 
-      it 'does not return any data' do
+      it 'returns an error message indicating the list was not found' do
         get_shopping_list
-        expect(response.body).to be_empty
+        expect(JSON.parse(response.body)).to eq({ 'error' => "Shopping list id=#{shopping_list_id} not found" })
       end
     end
 
@@ -162,9 +162,9 @@ RSpec.describe "ShoppingLists", type: :request do
         expect(response.status).to eq 404
       end
 
-      it 'does not return any data' do
+      it 'returns an error message indicating the list was not found' do
         get_shopping_list
-        expect(response.body).to be_empty
+        expect(JSON.parse(response.body)).to eq({ 'error' => "Shopping list id=#{shopping_list_id} not found" })
       end
     end
 
@@ -264,7 +264,7 @@ RSpec.describe "ShoppingLists", type: :request do
 
         it "doesn't return data" do
           update_shopping_list
-          expect(response.body).to be_empty
+          expect(JSON.parse(response.body)).to eq({ 'error' => "Shopping list id=#{shopping_list_id} not found" })
         end
       end
 
@@ -394,7 +394,7 @@ RSpec.describe "ShoppingLists", type: :request do
 
         it "doesn't return data" do
           update_shopping_list
-          expect(response.body).to be_empty
+          expect(JSON.parse(response.body)).to eq({ 'error' => "Shopping list id=#{shopping_list_id} not found" })
         end
       end
 
@@ -467,7 +467,7 @@ RSpec.describe "ShoppingLists", type: :request do
         expect(response.status).to eq 401
       end
 
-      it 'does not return any user data' do
+      it 'returns an error body indicating authorisation failed' do
         get_index
         expect(JSON.parse(response.body)).to eq({ 'error' => 'Google OAuth token validation failed' })
       end
@@ -495,7 +495,7 @@ RSpec.describe "ShoppingLists", type: :request do
 
       it 'returns all shopping lists belonging to the authenticated user' do
         get_index
-        expect(JSON.parse(response.body)).to eq JSON.parse(authenticated_user.shopping_lists.master_first.to_json(include: :shopping_list_items))
+        expect(JSON.parse(response.body)).to eq JSON.parse(authenticated_user.shopping_lists.master_first .to_json(include: :shopping_list_items))
       end
 
       it 'returns status 200' do
@@ -551,9 +551,9 @@ RSpec.describe "ShoppingLists", type: :request do
         expect(response.status).to eq 404
       end
 
-      it 'does not return any data' do
+      it 'returns an error message indicating the list was not found' do
         delete_shopping_list
-        expect(response.body).to be_empty
+        expect(JSON.parse(response.body)).to eq({ 'error' => "Shopping list id=#{shopping_list_id} not found" })
       end
 
       it 'does not delete any shopping lists' do
@@ -583,9 +583,9 @@ RSpec.describe "ShoppingLists", type: :request do
         expect(response.status).to eq 404
       end
 
-      it 'does not return any data' do
+      it 'returns an error message indicating the list was not found' do
         delete_shopping_list
-        expect(response.body).to be_empty
+        expect(JSON.parse(response.body)).to eq({ 'error' => "Shopping list id=#{shopping_list_id} not found" })
       end
     end
 


### PR DESCRIPTION
## Context

Currently, when a user requests a nonexistent shopping list, the 404 response returns no data. It would be better to standardise the API to return error responses including response bodies with an `"error"` or `"errors"` key, and the front end will expect an error response to be rendered to improve error handling.

## Changes

* Add response body `{"error":"Shopping list id=#{params[:id]} not found"}` to 404 responses from the ShoppingListsController
* Update specs to expect the body
* Update API docs with 404 body examples