### PR TITLE
Update bundler to 2.2.20

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,4 +210,4 @@ RUBY VERSION
    ruby 3.0.1p64
 
 BUNDLED WITH
-   2.2.15
+   2.2.20


### PR DESCRIPTION
## Context

Heroku gave a warning about Bundler having been updated last time I deployed.

## Changes

* Update Bundler