### PR TITLE
Ensure shopping lists are returned in the order they should appear in the UI

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+<!-- These are basic changes that should be included in all PRs. Your PR may benefit -->
+
+## Context
+
+[**Trello Card Title**](link)
+
+Please link the Trello card above, but also explain key context and reason(s) for the change here in case the link breaks in the future or the reader doesn't have access to Trello. Links to documentation, blog posts, or other materials that would help users understand the problem being solved are also helpful here.
+
+## Changes
+
+Summary of the changes you've made, preferably in the form of a bulleted list
+
+### Required Changes
+
+* [ ] Added and updated RSpec tests as appropriate
+* [ ] Added and updated API docs and developer docs as appropriate
+
+## Considerations
+
+Explain any design or implementation decisions you've made here, as well as any alternatives you considered or tried. Justify your approach. Include links to any blog posts, documentation, or other materials readers may find useful to understand your implementation or the alternatives.

--- a/app/controllers/shopping_lists_controller.rb
+++ b/app/controllers/shopping_lists_controller.rb
@@ -6,7 +6,7 @@ class ShoppingListsController < ApplicationController
   before_action :prevent_destroy_master_list, only: :destroy
 
   def index
-    render json: current_user.shopping_lists.master_first.to_json(include: :shopping_list_items), status: :ok
+    render json: current_user.shopping_lists.index_order.to_json(include: :shopping_list_items), status: :ok
   end
 
   def create

--- a/app/models/shopping_list.rb
+++ b/app/models/shopping_list.rb
@@ -26,7 +26,7 @@ class ShoppingList < ApplicationRecord
   after_destroy :destroy_master_list, unless: :other_lists_present?
 
   scope :master_first, -> { order(master: :desc) }
-  scope :index_order, -> { master_first.order(created_at: :desc) }
+  scope :index_order, -> { master_first.order(updated_at: :desc) }
 
 
   def to_json(opts = {})

--- a/app/models/shopping_list.rb
+++ b/app/models/shopping_list.rb
@@ -26,6 +26,7 @@ class ShoppingList < ApplicationRecord
   after_destroy :destroy_master_list, unless: :other_lists_present?
 
   scope :master_first, -> { order(master: :desc) }
+  scope :index_order, -> { master_first.order(created_at: :desc) }
 
 
   def to_json(opts = {})

--- a/docs/api/resources/shopping-lists.md
+++ b/docs/api/resources/shopping-lists.md
@@ -26,7 +26,7 @@ Like other resources in SIM, shopping lists are scoped to the authenticated user
 
 ## GET /shopping_lists
 
-Returns all shopping lists owned by the authenticated user. The master shopping list will be returned first, followed by the user's other shopping lists in reverse chronological order by `created_at` (i.e., the lists that were created most recently will be on top).
+Returns all shopping lists owned by the authenticated user. The master shopping list will be returned first, followed by the user's other shopping lists in reverse chronological order by `updated_at` (i.e., the lists that were edited most recently will be on top).
 
 ### Example Request
 

--- a/docs/api/resources/shopping-lists.md
+++ b/docs/api/resources/shopping-lists.md
@@ -26,7 +26,7 @@ Like other resources in SIM, shopping lists are scoped to the authenticated user
 
 ## GET /shopping_lists
 
-Returns all shopping lists owned by the authenticated user. The master shopping list will be returned first.
+Returns all shopping lists owned by the authenticated user. The master shopping list will be returned first, followed by the user's other shopping lists in reverse chronological order by `created_at` (i.e., the lists that were created most recently will be on top).
 
 ### Example Request
 

--- a/spec/models/shopping_list_spec.rb
+++ b/spec/models/shopping_list_spec.rb
@@ -25,8 +25,12 @@ RSpec.describe ShoppingList, type: :model do
       let!(:shopping_list2) { create(:shopping_list, user: user) }
       let!(:shopping_list3) { create(:shopping_list, user: user) }
 
+      before do
+        shopping_list2.update!(title: 'Windstad Manor')
+      end
+
       it 'is in reverse chronological order with master before anything' do
-        expect(index_order).to eq([master_list, shopping_list3, shopping_list2, shopping_list1])
+        expect(index_order).to eq([master_list, shopping_list2, shopping_list3, shopping_list1])
       end
     end
   end

--- a/spec/models/shopping_list_spec.rb
+++ b/spec/models/shopping_list_spec.rb
@@ -15,6 +15,20 @@ RSpec.describe ShoppingList, type: :model do
         expect(master_first).to eq([master_list, shopping_list])
       end
     end
+
+    describe '::index_order' do
+      subject(:index_order) { user.shopping_lists.index_order.to_a }
+
+      let!(:user) { create(:user) }
+      let!(:master_list) { create(:master_shopping_list, user: user) }
+      let!(:shopping_list1) { create(:shopping_list, user: user) }
+      let!(:shopping_list2) { create(:shopping_list, user: user) }
+      let!(:shopping_list3) { create(:shopping_list, user: user) }
+
+      it 'is in reverse chronological order with master before anything' do
+        expect(index_order).to eq([master_list, shopping_list3, shopping_list2, shopping_list1])
+      end
+    end
   end
 
   describe 'validations' do

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -505,7 +505,7 @@ RSpec.describe "ShoppingLists", type: :request do
 
       it 'returns all shopping lists belonging to the authenticated user' do
         get_index
-        expect(JSON.parse(response.body)).to eq JSON.parse(authenticated_user.shopping_lists.master_first .to_json(include: :shopping_list_items))
+        expect(JSON.parse(response.body)).to eq JSON.parse(authenticated_user.shopping_lists.index_order.to_json(include: :shopping_list_items))
       end
 
       it 'returns status 200' do

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -498,9 +498,11 @@ RSpec.describe "ShoppingLists", type: :request do
       before do
         allow(GoogleIDToken::Validator).to receive(:new).and_return(validator)
 
-        create_list(:shopping_list_with_list_items, 3, list_item_count: 2, user: authenticated_user)
+        user_list = create_list(:shopping_list_with_list_items, 3, list_item_count: 2, user: authenticated_user)
         unauthenticated_user = create(:user)
         create_list(:shopping_list, 3, user: unauthenticated_user)
+
+        user_list[1].update!(title: 'New title')   
       end
 
       it 'returns all shopping lists belonging to the authenticated user' do


### PR DESCRIPTION
## Context

[**Ensure that shopping lists are returned most recent first (after master)**](https://trello.com/c/OR5vOBit/45-ensure-that-shopping-lists-are-returned-most-recent-first-after-master)

Currently, when the client requests `GET /shopping_lists`, lists are returned master list first, followed by the rest of the lists in chronological order. However, it would be better UX to have the most recently created list come first after the master list - i.e., to put the lists in reverse chronological order.

## Changes

* Add `::index_order` scope that puts shopping lists in reverse chronological order (other than the master list, which always comes first)
* Add and update specs to incorporate this scope
* Update API docs