### PR TITLE
Create route for shopping list items

### DIFF
--- a/app/controllers/shopping_list_items_controller.rb
+++ b/app/controllers/shopping_list_items_controller.rb
@@ -3,21 +3,16 @@
 class ShoppingListItemsController < ApplicationController
   before_action :set_shopping_list_item, only: %i[update destroy]
   before_action :set_shopping_list, only: %i[create]
-  # TODO: make sure list items are on lists belonging to the current user
+
   # TODO: prevent master list item from being edited or destroyed directly
-  # TODO: create_or_combine route?
+  # TODO: create_or_combine?
 
   # Error cases:
   #   * Shopping list doesn't exist
   #   * Shopping list is master list
   #   * Invalid attributes for shopping list item
-  #   * Error updating items on master list
-  #
-  # Stuff to figure out:
-  #   * What should we return data-wise to make sure the front end 
-  #     gets both the new item and the update to the item on the master
-  #     list? The easiest thing for the front end would be to just
-  #     replace both lists.
+  #   * Error updating items on master list (shouldn't happen if regular list item attrs are valid)
+
   def create
     item = @shopping_list.shopping_list_items.new(list_item_params)
 
@@ -43,6 +38,8 @@ class ShoppingListItemsController < ApplicationController
 
   def set_shopping_list
     @shopping_list ||= current_user.shopping_lists.find(params[:shopping_list_id])
+
+    render json: { error: 'Cannot manage master shopping list items directly.' }, status: :method_not_allowed if @shopping_list.master
   rescue ActiveRecord::RecordNotFound
     head :not_found
   end

--- a/app/controllers/shopping_list_items_controller.rb
+++ b/app/controllers/shopping_list_items_controller.rb
@@ -4,15 +4,6 @@ class ShoppingListItemsController < ApplicationController
   before_action :set_shopping_list_item, only: %i[update destroy]
   before_action :set_shopping_list, only: %i[create]
 
-  # TODO: prevent master list item from being edited or destroyed directly
-
-  # Error cases:
-  #   * Shopping list doesn't exist
-  #   * Shopping list is master list
-  #   * Invalid attributes for shopping list item
-  #   * Error updating existing item on master list (won't happen if regular
-  #     list item attrs are valid)
-
   def create
     item = @shopping_list.shopping_list_items.combine_or_new(list_item_params)
 

--- a/app/controllers/shopping_list_items_controller.rb
+++ b/app/controllers/shopping_list_items_controller.rb
@@ -9,6 +9,8 @@ class ShoppingListItemsController < ApplicationController
 
     if item.save
       master_list_item = @shopping_list.master_list.shopping_list_items.find_by_description(item.description)
+
+      @shopping_list.touch
       
       render json: [master_list_item, item], status: :created
     else

--- a/app/controllers/shopping_list_items_controller.rb
+++ b/app/controllers/shopping_list_items_controller.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class ShoppingListItemsController < ApplicationController
+  before_action :set_shopping_list_item, only: %i[update destroy]
+  before_action :set_shopping_list, only: %i[create]
+  # TODO: make sure list items are on lists belonging to the current user
+  # TODO: prevent master list item from being edited or destroyed directly
+  # TODO: create_or_combine route?
+
+  # Error cases:
+  #   * Shopping list doesn't exist
+  #   * Shopping list is master list
+  #   * Invalid attributes for shopping list item
+  #   * Error updating items on master list
+  #
+  # Stuff to figure out:
+  #   * What should we return data-wise to make sure the front end 
+  #     gets both the new item and the update to the item on the master
+  #     list? The easiest thing for the front end would be to just
+  #     replace both lists.
+  def create
+    item = @shopping_list.shopping_list_items.new(list_item_params)
+
+    if item.save
+      master_list_item = @shopping_list.master_list.shopping_list_items.find_by_description(item.description)
+      
+      render json: [master_list_item, item], status: :created
+    else
+      render json: { errors: item.errors }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def list_item_params
+    params.require(:shopping_list_item).permit(
+      :description,
+      :quantity,
+      :notes,
+      :shopping_list_id
+    )
+  end
+
+  def set_shopping_list
+    @shopping_list ||= current_user.shopping_lists.find(params[:shopping_list_id])
+  rescue ActiveRecord::RecordNotFound
+    head :not_found
+  end
+
+  def set_shopping_list_item
+    @shopping_list_item ||= ShoppingListItem.find(params[:id])
+  end
+end

--- a/app/controllers/shopping_list_items_controller.rb
+++ b/app/controllers/shopping_list_items_controller.rb
@@ -5,16 +5,16 @@ class ShoppingListItemsController < ApplicationController
   before_action :set_shopping_list, only: %i[create]
 
   # TODO: prevent master list item from being edited or destroyed directly
-  # TODO: create_or_combine?
 
   # Error cases:
   #   * Shopping list doesn't exist
   #   * Shopping list is master list
   #   * Invalid attributes for shopping list item
-  #   * Error updating items on master list (shouldn't happen if regular list item attrs are valid)
+  #   * Error updating existing item on master list (won't happen if regular
+  #     list item attrs are valid)
 
   def create
-    item = @shopping_list.shopping_list_items.new(list_item_params)
+    item = @shopping_list.shopping_list_items.combine_or_new(list_item_params)
 
     if item.save
       master_list_item = @shopping_list.master_list.shopping_list_items.find_by_description(item.description)

--- a/app/controllers/shopping_lists_controller.rb
+++ b/app/controllers/shopping_lists_controller.rb
@@ -61,19 +61,19 @@ class ShoppingListsController < ApplicationController
 
   def prevent_setting_master
     if shopping_list_params.fetch(:master, nil) == true
-      render json: { errors: { master: ['cannot create or update a master shopping list through the API'] } }, status: :unprocessable_entity
+      render json: { errors: { master: ['cannot manually create or update a master shopping list'] } }, status: :unprocessable_entity
     end
   end
 
   def prevent_update_master_list
     if @shopping_list.master == true
-      render json: { error: 'cannot update a master shopping list through the API' }, status: :method_not_allowed
+      render json: { error: 'Cannot manually update a master shopping list' }, status: :method_not_allowed
     end
   end
 
   def prevent_destroy_master_list
     if @shopping_list.master == true
-      render json: { error: 'cannot destroy a master shopping list through the API' }, status: :method_not_allowed
+      render json: { error: 'Cannot manually destroy a master shopping list' }, status: :method_not_allowed
     end
   end
 end

--- a/app/models/shopping_list.rb
+++ b/app/models/shopping_list.rb
@@ -28,10 +28,14 @@ class ShoppingList < ApplicationRecord
   scope :master_first, -> { order(master: :desc) }
   scope :index_order, -> { master_first.order(updated_at: :desc) }
 
-
   def to_json(opts = {})
     opts.merge!({ include: :shopping_list_items }) unless opts.has_key?(:include)
     super(opts)
+  end
+
+  # TODO: Tests
+  def master_list
+    user.master_shopping_list
   end
 
   private

--- a/app/models/shopping_list.rb
+++ b/app/models/shopping_list.rb
@@ -4,7 +4,7 @@ require 'titlecase'
 
 class ShoppingList < ApplicationRecord
   belongs_to :user
-  has_many :shopping_list_items, dependent: :destroy
+  has_many :shopping_list_items, ->{ index_order }, dependent: :destroy
 
   validate :one_master_list_per_user
   validate :only_master_list_named_master

--- a/app/models/shopping_list.rb
+++ b/app/models/shopping_list.rb
@@ -33,7 +33,6 @@ class ShoppingList < ApplicationRecord
     super(opts)
   end
 
-  # TODO: Tests
   def master_list
     user.master_shopping_list
   end

--- a/app/models/shopping_list_item.rb
+++ b/app/models/shopping_list_item.rb
@@ -14,6 +14,8 @@ class ShoppingListItem < ApplicationRecord
 
   delegate :user, to: :shopping_list
 
+  scope :index_order, -> { order(updated_at: :desc) }
+
   def self.create_or_combine!(attrs)
     shopping_list = attrs[:shopping_list] || ShoppingList.find(attrs[:shopping_list_id])
     desc = (attrs[:description] || attrs['description'])&.humanize

--- a/app/models/shopping_list_item.rb
+++ b/app/models/shopping_list_item.rb
@@ -32,7 +32,7 @@ class ShoppingListItem < ApplicationRecord
       notes = attrs[:notes] || attrs['notes'] || ''
 
       new_quantity = existing_item.quantity + qty
-      new_notes = existing_item.notes =~ /#{notes}/i ? existing_item.notes : [existing_item.notes, notes].join(' -- ')
+      new_notes = [existing_item.notes, notes].join(' -- ')
 
       existing_item.assign_attributes(quantity: new_quantity, notes: new_notes)
       existing_item

--- a/app/models/shopping_list_item.rb
+++ b/app/models/shopping_list_item.rb
@@ -16,21 +16,26 @@ class ShoppingListItem < ApplicationRecord
 
   scope :index_order, -> { order(updated_at: :desc) }
 
-  def self.create_or_combine!(attrs)
+  def self.combine_or_create!(attrs)
+    combine_or_new(attrs).save!
+  end
+
+  def self.combine_or_new(attrs)
     shopping_list = attrs[:shopping_list] || ShoppingList.find(attrs[:shopping_list_id])
     desc = (attrs[:description] || attrs['description'])&.humanize
     existing_item = shopping_list.shopping_list_items.find_by_description(desc)
 
     if existing_item.nil?
-      create!(attrs)
+      new attrs
     else
       qty = attrs[:quantity] || attrs['quantity'] || 1
-      notes = attrs[:notes] || attrs['notes']
+      notes = attrs[:notes] || attrs['notes'] || ''
 
       new_quantity = existing_item.quantity + qty
-      new_notes = [existing_item.notes, notes].join(' -- ')
+      new_notes = existing_item.notes =~ /#{notes}/i ? existing_item.notes : [existing_item.notes, notes].join(' -- ')
 
-      existing_item.update!(quantity: new_quantity, notes: new_notes)
+      existing_item.assign_attributes(quantity: new_quantity, notes: new_notes)
+      existing_item
     end
   end
 
@@ -38,7 +43,7 @@ class ShoppingListItem < ApplicationRecord
 
   def add_to_master_list
     new_attrs = reject_non_public_attrs(self.attributes)
-    ShoppingListItem.create_or_combine!(**new_attrs, shopping_list: master_list)
+    ShoppingListItem.combine_or_create!(**new_attrs, shopping_list: master_list)
   end
 
   def adjust_master_list_after_update

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,9 @@ Rails.application.routes.draw do
   get '/auth/verify_token', to: 'verifications#verify_token', as: 'verify_token'
   get '/users/current', to: 'users#current', as: 'current_user'
 
-  resources :shopping_lists
+  resources :shopping_lists do
+    resources :shopping_list_items, shallow: true, except: %i[index show]
+  end
 
   get '/privacy', to: 'utilities#privacy'
   get '/tos', to: 'utilities#tos'

--- a/docs/api/resources/shopping-list-items.md
+++ b/docs/api/resources/shopping-list-items.md
@@ -18,7 +18,7 @@ If the client requests a new list item be created on a user's regular list, one 
 * If there is an item with the same (case-insensitive) `description` on the master list, then that item will be updated:
   * The description will not be changed
   * The quantity will be increased by the quantity of the new list item
-  * The notes will be aggregated: if the notes for the new item are not the same as the ones on the existing master list item, the new notes will be appended to the existing ones separated by ` -- `.
+  * The notes for the two items will be concatenated and separated by ` -- `
 
 ### Updating a List Item
 

--- a/docs/api/resources/shopping-list-items.md
+++ b/docs/api/resources/shopping-list-items.md
@@ -1,0 +1,127 @@
+# Shopping List Items
+
+Shopping list items represent the items on a user's [shopping lists](/docs/api/resources/shopping-lists.md). Shopping list items on regular lists can be created, updated, and destroyed through the API. Shopping list items on the user's master shopping list are managed automatically as the items on their other lists change. Each shopping list item belongs to a particular list and will be destroyed if the list is destroyed.
+
+There are no read routes (`GET /shopping_list_items`, `GET /shopping_list/:id/shopping_list_items`, or `GET /shopping_list_items/:id`) for shopping list items since all shopping list items are returned with the lists they are on when requests are made to the list routes. There are, however, routes to create, update, and destroy shopping list items.
+
+All requests to shopping list item endpoints must be [authenticated](/docs/api/resources/authorization.md).
+
+## Automatically Managed Master Lists
+
+Skyrim Inventory Management makes use of automatically managed master lists to help users track an aggregate of what items they need for different properties. The master list is created automatically when the client creates a user's first regular shopping list, and is destroyed automatically when the client deletes the user's last regular shopping list. When items are added, updated, or destroyed from any of a user's regular lists, master list items are updated as described in this section.
+
+### Creating a New List Item
+
+If the client requests a new list item be created on a user's regular list, one of the following things will happen:
+
+* If there is not an item with the same (case-insensitive) `description` on the master list, then an item with the same `description`, `quantity`, and `notes` will be created on the master list.
+* If there is an item with the same (case-insensitive) `description` on the master list, then that item will be updated:
+  * The description will not be changed
+  * The quantity will be increased by the quantity of the new list item
+  * The notes will be aggregated: if the notes for the new item are not the same as the ones on the existing master list item, the new notes will be appended to the existing ones separated by ` -- `.
+
+### Updating a List Item
+
+When a client updates a list item on a user's regular list, one or more of the following things will happen:
+
+* If the quantity is increased, the quantity of the item on the master list will be increased by the same amount
+* If the quantity is decreased, the quantity of the item on the master list will be decreased by the same amount
+* If the notes are changed, SIM will ensure that the new notes are reflected in the master list item
+
+### Destroying a List Item
+
+When a client destroys a list item on a user's regular shopping list, one of the following things will happen:
+
+* If the quantity of the item on the user's master shopping list is higher than the quantity of the item deleted (i.e., if there is another matching item on a different list), the master list item's quantity will be decreased by the amount of the quantity of the deleted item.
+* If the quantity on the user's master shopping list is equal to the quantity of the item deleted (i.e., if there is not another matching item on a different list), the item on the master shopping list will be deleted as well.
+
+## Endpoints
+
+The following endpoints are available to manage shopping list items:
+
+* [`POST /shopping_lists/:id/shopping_list_items`](#post-shoppinglistsidshoppinglistitems)
+
+## POST /shopping_lists/:id/shopping_list_items
+
+If the shopping list with the given ID exists, belongs to the authenticated user, is not a master shopping list, and does not have an existing shopping list item with the same (case-insensitive) description, creates a shopping list item on the given list. If all these conditions are met but the list does have an existing shopping list item with a matching description, it updates the quantity and notes on the existing item.
+
+In both cases, the user's master list is also updated to reflect the new quantity and notes.
+
+Requests must specify a `description` and an integer `quantity` greater than 0. The optional `notes` field is an arbitrary string where users can keep any reminders of what the item will be used for or other useful notes.
+
+A successful response will return a JSON array of two items. The first item is the item from the user's master list that has been added or updated as a result of the request. The second item is the item created or updated from the client's request.
+
+### Example Request
+
+```
+POST /shopping_lists/72/shopping_list_items
+Authorization: Bearer xxxxxxxxxxx
+Content-Type: application/json
+{
+  "description": "Ebony sword",
+  "quantity": 7,
+  "notes": "To enchant with 'Absorb Health'"
+}
+```
+
+### Success Responses
+
+#### Statuses
+
+* 200 OK
+
+#### Example Body
+
+```json
+[
+  {
+    "id": 87,
+    "shopping_list_id": 238,
+    "description": "Ebony sword",
+    "quantity": 9,
+    "notes": "To sell -- To enchant with 'Absorb Health'",
+    "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "updated_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00"
+  },
+  {
+    "id": 126,
+    "shopping_list_id": 237,
+    "description": "Ebony sword",
+    "quantity": 7,
+    "notes": "To enchant with 'Absorb Health'",
+    "created_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00",
+    "updated_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00"
+  }
+]
+```
+
+### Error Responses
+
+Several error responses are posssible.
+
+#### Statuses
+
+* 404 Not Found
+* 405 Method Not Allowed
+* 422 Unprocessable Entity
+
+#### Example Bodies
+
+No body will be returned with a 404 error, which is returned if the specified shopping list doesn't exist or doesn't belong to the authenticated user.
+
+A 405 error, which is returned if the specified shopping list is a master shopping list, comes with the following body:
+```json
+{
+  "error": "Cannot manage master shopping list items directly."
+}
+```
+
+A 422 error, returned as a result of a validation error, includes whichever errors prevented the list item from being created:
+```json
+{
+  "errors": {
+    "quantity": ["must be a number", "must be greater than zero"],
+    "description": ["is required"]
+  }
+}
+```

--- a/docs/api/resources/shopping-lists.md
+++ b/docs/api/resources/shopping-lists.md
@@ -351,8 +351,9 @@ Content-Type: application/json
 
 #### Statuses
 
-422 Unprocessable Entity
-404 Not Found
+* 422 Unprocessable Entity
+* 405 Method Not Allowed
+* 404 Not Found
 
 #### Example Bodies
 
@@ -365,12 +366,10 @@ For a 422 response due to title uniqueness constraint:
 }
 ```
 
-For a 422 response due to attempting to update a master list or convert a regular list to a master list:
+For a 405 response due to attempting to update a master list or convert a regular list to a master list:
 ```json
 {
-  "errors": {
-    "master": ["cannot create or update a master shopping list through the API"]
-  }
+  "error": "cannot update a master shopping list through the API"
 }
 ```
 
@@ -396,8 +395,8 @@ Authorization: Bearer xxxxxxxxxxxx
 
 #### Statuses
 
-204 No Content
-200 OK
+* 204 No Content
+* 200 OK
 
 #### Example Body
 
@@ -433,8 +432,8 @@ If the specified list does not exist or does not belong to the authenticated use
 
 #### Statuses
 
-404 Not Found
-405 Method Not Allowed
+* 404 Not Found
+* 405 Method Not Allowed
 
 #### Example Body
 

--- a/docs/api/resources/shopping-lists.md
+++ b/docs/api/resources/shopping-lists.md
@@ -382,7 +382,7 @@ For a 404 response:
 
 ## DELETE /shopping_lists/:id
 
-Destroys the given shopping list if it exists and belongs to the authenticated user. If the list to be destroyed is the user's only regular (non-master) shopping list, the master list will also be destroyed.
+Destroys the given shopping list, and any shopping list items on it, if it exists and belongs to the authenticated user. If the list to be destroyed is the user's only regular (non-master) shopping list, the master list will also be destroyed.
 
 ### Example Request
 

--- a/spec/models/shopping_list_item_spec.rb
+++ b/spec/models/shopping_list_item_spec.rb
@@ -81,15 +81,6 @@ RSpec.describe ShoppingListItem, type: :model do
         expect(combine_or_new).to eq existing_item
         expect(combine_or_new.notes).to eq 'notes 1 -- notes 2'
       end
-
-      context 'when the notes are the same' do
-        subject(:combine_or_new) { described_class.combine_or_new(description: 'existing item', quantity: 1, shopping_list: shopping_list, notes: 'notes 1') }
-
-        it "doesn't duplicate the notes field", :aggregate_failures do
-          expect(combine_or_new).to eq existing_item
-          expect(combine_or_new.notes).to eq 'notes 1'
-        end
-      end
     end
 
     context 'when there is not an existing item on the same list with that description' do
@@ -214,6 +205,18 @@ RSpec.describe ShoppingListItem, type: :model do
           it 'updates the notes to the new notes value' do
             update_item
             expect(master_list_item.reload.notes).to eq 'new notes'
+          end
+        end
+
+        context 'when the master list matches the old notes value multiple times' do
+          before do
+            other_list = create(:shopping_list, user: list_item.user)
+            create(:shopping_list_item, shopping_list: other_list, description: 'Ebony sword', notes: list_item.notes)
+          end
+
+          it 'only changes one of the occurrences' do
+            update_item
+            expect(master_list_item.reload.notes).to eq 'new notes -- notes 1'
           end
         end
       end

--- a/spec/models/shopping_list_item_spec.rb
+++ b/spec/models/shopping_list_item_spec.rb
@@ -15,6 +15,24 @@ RSpec.describe ShoppingListItem, type: :model do
     end
   end
 
+  describe 'scopes' do
+    describe '::index_order' do
+      let!(:list_item1) { create(:shopping_list_item) }
+      let!(:list_item2) { create(:shopping_list_item, shopping_list: list) }
+      let!(:list_item3) { create(:shopping_list_item, shopping_list: list) }
+
+      let(:list) { list_item1.shopping_list }
+
+      before do
+        list_item2.update!(quantity: 3)
+      end
+
+      it 'returns the list items in descending chronological order by updated_at' do
+        expect(list.shopping_list_items.index_order.to_a).to eq([list_item2, list_item3, list_item1])
+      end
+    end
+  end
+
   describe '::create_or_combine!' do
     context 'when there is an existing item on the same list with the same description' do
       subject(:create_or_combine) { described_class.create_or_combine!(description: 'existing item', quantity: 1, shopping_list: shopping_list, notes: 'notes 2') }

--- a/spec/models/shopping_list_spec.rb
+++ b/spec/models/shopping_list_spec.rb
@@ -194,7 +194,22 @@ RSpec.describe ShoppingList, type: :model do
     end
   end
 
-  describe 'tt'
+  describe 'relations' do
+    subject(:items) { shopping_list.shopping_list_items }
+
+    let(:shopping_list) { create(:shopping_list) }
+    let!(:item1) { create(:shopping_list_item, shopping_list: shopping_list) }
+    let!(:item2) { create(:shopping_list_item, shopping_list: shopping_list) }
+    let!(:item3) { create(:shopping_list_item, shopping_list: shopping_list) }
+
+    before do
+      item2.update!(quantity: 2)
+    end
+
+    it 'keeps child models in descending order of updated_at' do
+      expect(shopping_list.shopping_list_items.to_a).to eq([item2, item3, item1])
+    end
+  end
 
   describe 'after create hook' do
     subject(:create_shopping_list) { create(:shopping_list, user: user) }

--- a/spec/models/shopping_list_spec.rb
+++ b/spec/models/shopping_list_spec.rb
@@ -128,7 +128,16 @@ RSpec.describe ShoppingList, type: :model do
     end
   end
 
-  
+  describe '#master_list' do
+    let!(:user) { create(:user) }
+    let!(:master_list) { create(:master_shopping_list, user: user) }
+    let(:shopping_list) { create(:shopping_list, user: user) }
+
+    it "returns the user's master list" do
+      expect(shopping_list.master_list).to eq master_list
+    end
+  end
+
   describe 'title transformations' do
     describe 'setting a default title' do
       let(:user) { create(:user) }

--- a/spec/requests/shopping_list_items_spec.rb
+++ b/spec/requests/shopping_list_items_spec.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'ShoppingListItems', type: :request do
+  let(:headers) do
+    {
+      'Content-Type' => 'application/json',
+      'Authorization' => 'Bearer xxxxxxx'
+    }
+  end
+
+  describe 'POST /shopping_lists/:id/shopping_list_items' do
+    subject(:create_item) do
+      post "/shopping_lists/#{shopping_list.id}/shopping_list_items",
+           params: params,
+           headers: headers
+    end
+
+    let(:shopping_list) { create(:shopping_list) }
+    
+    context 'when authenticated' do
+      let!(:user) { shopping_list.user }
+      
+      let(:validation_data) do
+        {
+          'exp' => (Time.now + 1.year).to_i,
+          'email' => user.email,
+          'name' => user.name
+        }
+      end
+      
+      let(:validator) { instance_double(GoogleIDToken::Validator, check: validation_data) }
+      
+      before do
+        allow(GoogleIDToken::Validator).to receive(:new).and_return(validator)
+      end
+      
+      context 'when all goes well' do
+        let(:params) { "{\"shopping_list_item\":{\"description\":\"Corundum ingot\",\"quantity\":5,\"notes\":\"To make locks\",\"shopping_list_id\":#{shopping_list.id}}}" }
+
+        it 'creates a new shopping list item on the shopping list' do
+          expect { create_item }.to change(shopping_list.shopping_list_items, :count).from(0).to(1)
+        end
+
+        context 'when the master list has no items on it' do
+          let(:master_list) { user.master_shopping_list }
+
+          it 'adds the item to the master list' do
+            expect { create_item }.to change(ShoppingListItem, :count).from(0).to(2)
+          end
+
+          it 'assigns the right attributes' do
+            create_item
+            item = shopping_list.shopping_list_items.last
+            expect(master_list.shopping_list_items.last.attributes).to include(
+              'description' => item.description,
+              'quantity' => item.quantity,
+              'notes' => item.notes
+            )
+          end
+
+          it 'returns the master list item and the regular list item' do
+            create_item
+            expect(response.body).to eq([master_list.shopping_list_items.last, shopping_list.shopping_list_items.last].to_json)
+          end
+
+          it 'returns status 201' do
+            create_item
+            expect(response.status).to eq 201
+          end
+        end
+
+        context 'when the master list has a matching item' do
+          let(:master_list) { user.master_shopping_list }
+
+          before do
+            second_list = user.shopping_lists.create!(title: 'Proudspire Manor')
+            second_list.shopping_list_items.create!(
+              description: 'Corundum ingot',
+              quantity: 1,
+              notes: 'some other notes'
+            )
+          end
+
+          it 'updates the item on the master list', :aggregate_failures do
+            create_item
+            expect(master_list.shopping_list_items.count).to eq 1
+            expect(master_list.shopping_list_items.last.attributes).to include(
+              'description' => 'Corundum ingot',
+              'quantity' => 6,
+              'notes' => 'some other notes -- To make locks'
+            )
+          end
+
+          it 'returns the master list item and the regular list item' do
+            create_item
+            expect(response.body).to eq([master_list.shopping_list_items.last, shopping_list.shopping_list_items.last].to_json)
+          end
+
+          it 'returns status 201' do
+            create_item
+            expect(response.status).to eq 201
+          end
+        end
+      end
+
+      context 'when the shopping list belongs to a different user' do
+        let(:user) { create(:user) }
+        let(:params) { "{\"shopping_list_item\":{\"description\":\"Corundum ingot\",\"quantity\":5,\"notes\":\"To make locks\",\"shopping_list_id\":#{shopping_list.id}}}" }
+
+        it 'returns 404' do
+          create_item
+          expect(response.status).to eq 404
+        end
+
+        it 'does not return content' do
+          create_item
+          expect(response.body).to be_empty
+        end
+      end
+
+      context 'when the shopping list does not exist' do
+        subject(:create_item) do
+          post '/shopping_lists/838934/shopping_list_items',
+               params: params,
+               headers: headers
+        end
+
+        let(:params) { "{\"shopping_list_item\":{\"description\":\"Corundum ingot\",\"quantity\":5,\"notes\":\"To make locks\",\"shopping_list_id\":#{shopping_list.id}}}" }
+
+        it 'returns 404' do
+          create_item
+          expect(response.status).to eq 404
+        end
+
+        it 'returns no body' do
+          create_item
+          expect(response.body).to be_empty
+        end
+      end
+
+      context 'when the params are invalid' do
+        let(:params) { "{\"shopping_list_item\":{\"description\":\"Corundum ingot\",\"quantity\":\"foooo\",\"notes\":\"To make locks\",\"shopping_list_id\":#{shopping_list.id}}}" }
+
+        it 'returns 422' do
+          create_item
+          expect(response.status).to eq 422
+        end
+
+        it 'returns the validation errors' do
+          create_item
+          expect(JSON.parse(response.body)).to eq({
+            'errors' => {
+              'quantity' => ['is not a number']
+            }
+          })
+        end
+      end
+    end
+
+    context 'when unauthenticated' do
+      let(:params) { "{\"shopping_list_item\":{\"description\":\"Corundum ingot\",\"quantity\":4,\"notes\":\"To make locks\",\"shopping_list_id\":#{shopping_list.id}}}" }
+
+      it 'returns 401' do
+        create_item
+        expect(response.status).to eq 401
+      end
+
+      it 'returns a helpful error' do
+        create_item
+        expect(JSON.parse(response.body)).to eq({ 'error' => 'Google OAuth token validation failed' })
+      end
+    end
+  end
+end

--- a/spec/requests/shopping_list_items_spec.rb
+++ b/spec/requests/shopping_list_items_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
             expect(shopping_list.shopping_list_items.first.attributes).to include(
               'description' => 'Corundum ingot',
               'quantity' => 7,
-              'notes' => 'To make locks'
+              'notes' => 'To make locks -- To make locks'
             )
           end
         end

--- a/spec/requests/shopping_list_items_spec.rb
+++ b/spec/requests/shopping_list_items_spec.rb
@@ -140,6 +140,16 @@ RSpec.describe 'ShoppingListItems', type: :request do
         end
       end
 
+      context 'when the shopping list is a master list' do
+        let(:shopping_list) { create(:master_shopping_list) }
+        let(:params) { "{\"shopping_list_item\":{\"description\":\"Corundum ingot\",\"quantity\":5,\"notes\":\"To make locks\",\"shopping_list_id\":#{shopping_list.id}}}" }
+
+        it 'returns status 405' do
+          create_item
+          expect(response.status).to eq 405
+        end
+      end
+
       context 'when the params are invalid' do
         let(:params) { "{\"shopping_list_item\":{\"description\":\"Corundum ingot\",\"quantity\":\"foooo\",\"notes\":\"To make locks\",\"shopping_list_id\":#{shopping_list.id}}}" }
 

--- a/spec/requests/shopping_list_items_spec.rb
+++ b/spec/requests/shopping_list_items_spec.rb
@@ -103,6 +103,25 @@ RSpec.describe 'ShoppingListItems', type: :request do
             expect(response.status).to eq 201
           end
         end
+
+        context 'when the new item matches an existing item on the list' do
+          before do
+            shopping_list.shopping_list_items.create!(description: 'Corundum ingot', quantity: 2, notes: 'To make locks')
+          end
+
+          it "doesn't create a new item" do
+            expect { create_item }.not_to change(shopping_list.shopping_list_items, :count)
+          end
+
+          it 'updates the existing item' do
+            create_item
+            expect(shopping_list.shopping_list_items.first.attributes).to include(
+              'description' => 'Corundum ingot',
+              'quantity' => 7,
+              'notes' => 'To make locks'
+            )
+          end
+        end
       end
 
       context 'when the shopping list belongs to a different user' do

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
         it 'returns a helpful error body' do
           create_shopping_list
-          expect(JSON.parse(response.body)).to eq({ 'errors' => { 'master' => ['cannot create or update a master shopping list through the API'] } })
+          expect(JSON.parse(response.body)).to eq({ 'errors' => { 'master' => ['cannot manually create or update a master shopping list'] } })
         end
       end
     end
@@ -296,7 +296,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
         it 'returns a helpful error body' do
           update_shopping_list
-          expect(JSON.parse(response.body)).to eq({ 'error' => 'cannot update a master shopping list through the API' })
+          expect(JSON.parse(response.body)).to eq({ 'error' => 'Cannot manually update a master shopping list' })
         end
       end
 
@@ -318,7 +318,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
         it 'returns a helpful error body' do
           update_shopping_list
-          expect(JSON.parse(response.body)).to eq({ 'errors' => { 'master' => ['cannot create or update a master shopping list through the API'] } })
+          expect(JSON.parse(response.body)).to eq({ 'errors' => { 'master' => ['cannot manually create or update a master shopping list'] } })
         end
       end
     end
@@ -426,7 +426,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
         it 'returns a helpful error body' do
           update_shopping_list
-          expect(JSON.parse(response.body)).to eq({ 'error' => 'cannot update a master shopping list through the API' })
+          expect(JSON.parse(response.body)).to eq({ 'error' => 'Cannot manually update a master shopping list' })
         end
       end
 
@@ -448,7 +448,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
         it 'returns a helpful error body' do
           update_shopping_list
-          expect(JSON.parse(response.body)).to eq({ 'errors' => { 'master' => ['cannot create or update a master shopping list through the API'] } })
+          expect(JSON.parse(response.body)).to eq({ 'errors' => { 'master' => ['cannot manually create or update a master shopping list'] } })
         end
       end
     end
@@ -688,7 +688,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
         it 'returns a helpful error body' do
           delete_shopping_list
-          expect(response.body).to eq({ error: 'cannot destroy a master shopping list through the API' }.to_json)
+          expect(response.body).to eq({ error: 'Cannot manually destroy a master shopping list' }.to_json)
         end
       end
     end

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -289,14 +289,14 @@ RSpec.describe 'ShoppingLists', type: :request do
           expect(shopping_list.reload.title).to eq 'Master'
         end
 
-        it 'returns status 422' do
+        it 'returns status 405 (method not allowed)' do
           update_shopping_list
-          expect(response.status).to eq 422
+          expect(response.status).to eq 405
         end
 
         it 'returns a helpful error body' do
           update_shopping_list
-          expect(JSON.parse(response.body)).to eq({ 'errors' => { 'master' => ['cannot create or update a master shopping list through the API'] } })
+          expect(JSON.parse(response.body)).to eq({ 'error' => 'cannot update a master shopping list through the API' })
         end
       end
 
@@ -419,14 +419,14 @@ RSpec.describe 'ShoppingLists', type: :request do
           expect(shopping_list.reload.title).to eq 'Master'
         end
 
-        it 'returns status 422' do
+        it 'returns status 405' do
           update_shopping_list
-          expect(response.status).to eq 422
+          expect(response.status).to eq 405
         end
 
         it 'returns a helpful error body' do
           update_shopping_list
-          expect(JSON.parse(response.body)).to eq({ 'errors' => { 'master' => ['cannot create or update a master shopping list through the API'] } })
+          expect(JSON.parse(response.body)).to eq({ 'error' => 'cannot update a master shopping list through the API' })
         end
       end
 

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe "ShoppingLists", type: :request do
+RSpec.describe 'ShoppingLists', type: :request do
   let(:headers) do
     {
       'Content-Type' => 'application/json',


### PR DESCRIPTION
## Context

[**Routes for managing shopping list items**](https://trello.com/c/K4501FRt/18-routes-for-managing-shopping-list-items)

This is the first of three PRs for this card, which is turning out to be pretty complicated due to the aggregation and syncing behaviour of shopping lists. (There is a [card](https://trello.com/c/1gjVL1ix/62-use-controller-services-to-handle-complex-shopping-list-logic) to refactor this logic using controller services and it is next in the queue.)

Because there is turning out to be a lot to these routes, I've decided to break it down into three PRs - one for creating, one for updating, and one for destroying.

## Changes

* Create a `ShoppingListItemsController` with a `create` route for shopping list items
* Modify `ShoppingListController` behaviour by returning a 405 Method Not Allowed status when a user tries to update a master list
* Change `combine_or_create!` method to a new `combine_or_create!` method that calls save on the output of `combine_or_new`
* Create `:index_order` scope for `ShoppingListItem` so it appears in descending chronological order by `:updated_at`
* Ensure `:updated_at` timestamp is [updated on shopping list](https://trello.com/c/5DEczwm5/56-consider-shopping-list-updated-when-items-added-removed-or-edited) when an item is added to it

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

Like other API endpoints in SIM dealing with lists, this was complicated by the automatic aggregation and syncing that goes on between a user's shopping lists in SIM. The traditional REST behaviour - taking a POST request and returning the object created - was not going to work given that each request creates or updates at least two list items. I made a couple of major decisions here:

1. Items on the same shopping list with the same description will be combined instead of a new item being created.
2. The response body will be a JSON array containing first the created or updated _master_ list item, then the created or updated _regular_ item.

The first of these is kind of essential given the way master lists currently work. Either list items are aggregated or they aren't. The only reason for there to be separate list items for the same in-game items is if they are on separate lists. Otherwise, combine them, preserving the notes for both. Any other way risks things getting messy. If there are multiple items by the same name on a regular list, can there be multiple items by the same name on a master list?

Frankly, I would prefer to have list behaviour controlled by some `ListOrchestrator` object that each user would have that knows what lists it has and what items are on those lists and combines them on the master list. But I'm not sure how to make that compatible with ActiveRecord given there isn't a need to keep such an orchestrator in the database. That's why I'm looking at controller services. I may even implement them before I do the rest of these routes.

As for point 2, there was no way to make this RESTful because SIM shopping lists don't act like RESTful resources. So it was best to think about:

* The needs of the front end
* What would result in the least data being transferred from the server to the client

I didn't feel comfortable with a `shopping_list_items` route returning an entire shopping list. I thought it would be better to keep the response scoped to the list item and just return both of the ones that were created or changed. I also changed the status code to 200 instead of 201 to reflect that the resources may or may not, in fact, have been created.

### Updating Shopping List Models

There is a [card](https://trello.com/c/5DEczwm5/56-consider-shopping-list-updated-when-items-added-removed-or-edited) for making sure that shopping list `:updated_at` values are set to `Time.now` whenever a shopping list item is added, updated, or removed from that list. The reason for this work is that we want the shopping list the user interacted with most recently to appear at the top on their dashboard. It seemed logical to begin that work now and took very little time, so I went ahead and implemented that.

I made a couple of decisions around this logic:

1. **The master list's `:updated_at` value will not be changed**
  Because the master list already always appears at the top of the user's dashboard, there is no need to update its `:updated_at` to make sure it's at the top. (It also wouldn't hurt to update it - it'd have no effect on the user whatsoever.) Not updating it avoids an additional database call (theoretically, we could update both in one database call but it would involve a raw SQL query consisting of a few different statements together - in other words, not a one-liner. Not only that, but we'd have to control even more master list logic inside the `ShoppingListItem` class, with even more `after_create` (etc.) hooks. It seemed better for shopping list items to be as unaware of shopping list logic as possible - especially as we migrate to [controller services](https://trello.com/c/1gjVL1ix/62-use-controller-services-to-handle-complex-shopping-list-logic) to handle this sort of logic instead of the models themselves - which brings me to my next point:
2. **This functionality will be the responsibility of the controller instead of the model**
  I made this decision for three reasons: (1) the purpose of this change is primarily UX - from the standpoint of the internal API, it doesn't matter if `:updated_at` is changed, (2) it makes it simpler to move this sort of logic to controller services and 
 `lib` modules, and (3) it facilitated decision 1.