### PR TITLE
Massive refactor moving to controller services and MasterListable concern

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Shopping list items have three properties: a text `description`, an integer `qua
 
 ```
 id: integer, primary key, unique, not null
-shopping_list_id: integer, foreign key, not null
+list_id: integer, foreign key, not null
 description: string, unique on each shopping list, not null
 quantity: integer, not null
 notes: string

--- a/app/controller_services/application_controller/authorization_service.rb
+++ b/app/controller_services/application_controller/authorization_service.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'service/unauthorized_result'
+
+class ApplicationController < ActionController::API
+  class AuthorizationService
+    def initialize(controller, token)
+      @controller = controller
+      @token = token
+    end
+
+    def perform
+      validator = GoogleIDToken::Validator.new
+      payload = validator.check(token, configatron.google_oauth_client_id)
+
+      if current?(payload['exp'])
+        controller.current_user = User.create_or_update_for_google(payload)
+        return
+      end
+
+      Service::UnauthorizedResult.new(errors: ['Expired authentication token. Try logging out and logging in again'])
+    rescue GoogleIDToken::ValidationError => e
+      Rails.logger.error "Token validation failed -- #{e.message}"
+      Service::UnauthorizedResult.new(errors: ['Google OAuth token validation failed'])
+    rescue GoogleIDToken::CertificateError => e
+      Rails.logger.error "Problem with OAuth certificate -- #{e.message}"
+      Service::UnauthorizedResult.new(errors: ['Invalid OAuth certificate'])
+    end
+
+    private
+
+    def current?(seconds_since_unix_epoch)
+      Time.at(seconds_since_unix_epoch) >= Time.now
+    end
+
+    attr_reader :controller, :token
+  end
+end

--- a/app/controller_services/shopping_list_items_controller/create_service.rb
+++ b/app/controller_services/shopping_list_items_controller/create_service.rb
@@ -31,7 +31,7 @@ class ShoppingListItemsController < ApplicationController
           Service::OKResult.new(resource: [master_list_item, item])
         end
       else
-        Service::UnprocessableEntityResult.new(errors: assemble_error_messages(item.errors))
+        Service::UnprocessableEntityResult.new(errors: item.error_array)
       end
     rescue ActiveRecord::RecordNotFound
       Service::NotFoundResult.new
@@ -47,10 +47,6 @@ class ShoppingListItemsController < ApplicationController
 
     def master_list
       shopping_list.master_list
-    end
-
-    def assemble_error_messages(errors)
-      errors.map { |error| "#{error.attribute.capitalize} #{error.message}" }
     end
   end
 end

--- a/app/controller_services/shopping_list_items_controller/create_service.rb
+++ b/app/controller_services/shopping_list_items_controller/create_service.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'service/created_result'
+require 'service/not_found_result'
+require 'service/unprocessable_entity_result'
+require 'service/method_not_allowed_result'
+require 'service/ok_result'
+
+class ShoppingListItemsController < ApplicationController
+  class CreateService
+    MASTER_LIST_ERROR = 'Cannot manually manage items on a master shopping list'
+
+    def initialize(user, list_id, params)
+      @user = user
+      @list_id = list_id
+      @params = params
+    end
+
+    def perform
+      return Service::MethodNotAllowedResult.new(errors: [MASTER_LIST_ERROR]) if shopping_list.master == true
+
+      preexisting_item = shopping_list.list_items.find_by(description: params[:description])
+      item = ShoppingListItem.combine_or_new(params.merge(list_id: list_id))
+
+      if item.save
+        shopping_list.touch
+        master_list_item = master_list.add_item_from_child_list(item)
+        if preexisting_item.blank?
+          Service::CreatedResult.new(resource: [master_list_item, item])
+        else
+          Service::OKResult.new(resource: [master_list_item, item])
+        end
+      else
+        Service::UnprocessableEntityResult.new(errors: assemble_error_messages(item.errors))
+      end
+    rescue ActiveRecord::RecordNotFound
+      Service::NotFoundResult.new
+    end
+
+    private
+
+    attr_reader :user, :list_id, :params
+
+    def shopping_list
+      @shopping_list ||= user.shopping_lists.find(list_id)
+    end
+
+    def master_list
+      shopping_list.master_list
+    end
+
+    def assemble_error_messages(errors)
+      errors.map { |error| "#{error.attribute.capitalize} #{error.message}" }
+    end
+  end
+end

--- a/app/controller_services/shopping_lists_controller/create_service.rb
+++ b/app/controller_services/shopping_lists_controller/create_service.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'service/created_result'
+require 'service/unprocessable_entity_result'
+
+class ShoppingListsController < ApplicationController
+  class CreateService
+    MASTER_LIST_ERROR = 'Cannot manually create a master shopping list'
+
+    def initialize(user, params)
+      @user = user
+      @params = params
+    end
+
+    def perform
+      return Service::UnprocessableEntityResult.new(errors: [MASTER_LIST_ERROR]) if params[:master]
+
+      shopping_list = user.shopping_lists.new(params)
+
+      if shopping_list.save
+        resource = new_master_list&.save ? [user.master_shopping_list, shopping_list] : shopping_list
+        Service::CreatedResult.new(resource: resource)
+      else
+        Service::UnprocessableEntityResult.new(errors: assemble_error_messages(shopping_list.errors))
+      end
+    end
+
+    private
+
+    attr_reader :user, :params
+
+    def assemble_error_messages(data)
+      data.map { |error| "#{error.attribute.capitalize} #{error.message}" }
+    end
+
+    def new_master_list
+      return user.shopping_lists.new(master: true, title: 'Master') if user.master_shopping_list.nil?
+    end
+  end
+end

--- a/app/controller_services/shopping_lists_controller/create_service.rb
+++ b/app/controller_services/shopping_lists_controller/create_service.rb
@@ -23,17 +23,13 @@ class ShoppingListsController < ApplicationController
         resource = preexisting_master_list ? shopping_list : [user.master_shopping_list, shopping_list]
         Service::CreatedResult.new(resource: resource)
       else
-        Service::UnprocessableEntityResult.new(errors: assemble_error_messages(shopping_list.errors))
+        Service::UnprocessableEntityResult.new(errors: shopping_list.error_array)
       end
     end
 
     private
 
     attr_reader :user, :params
-
-    def assemble_error_messages(data)
-      data.map { |error| "#{error.attribute.capitalize} #{error.message}" }
-    end
 
     def new_master_list
       return user.shopping_lists.new(master: true, title: 'Master') if user.master_shopping_list.nil?

--- a/app/controller_services/shopping_lists_controller/create_service.rb
+++ b/app/controller_services/shopping_lists_controller/create_service.rb
@@ -30,9 +30,5 @@ class ShoppingListsController < ApplicationController
     private
 
     attr_reader :user, :params
-
-    def new_master_list
-      return user.shopping_lists.new(master: true, title: 'Master') if user.master_shopping_list.nil?
-    end
   end
 end

--- a/app/controller_services/shopping_lists_controller/create_service.rb
+++ b/app/controller_services/shopping_lists_controller/create_service.rb
@@ -16,9 +16,11 @@ class ShoppingListsController < ApplicationController
       return Service::UnprocessableEntityResult.new(errors: [MASTER_LIST_ERROR]) if params[:master]
 
       shopping_list = user.shopping_lists.new(params)
+      preexisting_master_list = user.master_shopping_list
 
       if shopping_list.save
-        resource = new_master_list&.save ? [user.master_shopping_list, shopping_list] : shopping_list
+        # Check if the master shopping list is newly created and return it too if so
+        resource = preexisting_master_list ? shopping_list : [user.master_shopping_list, shopping_list]
         Service::CreatedResult.new(resource: resource)
       else
         Service::UnprocessableEntityResult.new(errors: assemble_error_messages(shopping_list.errors))

--- a/app/controller_services/shopping_lists_controller/create_service.rb
+++ b/app/controller_services/shopping_lists_controller/create_service.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 require 'service/created_result'
+require 'service/not_found_result'
 require 'service/unprocessable_entity_result'
+require 'service/method_not_allowed_result'
+require 'service/ok_result'
 
 class ShoppingListsController < ApplicationController
   class CreateService

--- a/app/controller_services/shopping_lists_controller/destroy_service.rb
+++ b/app/controller_services/shopping_lists_controller/destroy_service.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'service/no_content_result'
+require 'service/method_not_allowed_result'
+require 'service/not_found_result'
+require 'service/ok_result'
+
+class ShoppingListsController < ApplicationController
+  class DestroyService
+    MASTER_LIST_ERROR = 'Cannot manually delete a master shopping list'
+
+    def initialize(user, list_id)
+      @user = user
+      @list_id = list_id
+    end
+
+    def perform
+      return Service::MethodNotAllowedResult.new(errors: [MASTER_LIST_ERROR]) if shopping_list.master == true
+
+      master_list = destroy_and_update_master_list_items
+      master_list.nil? ? Service::NoContentResult.new : Service::OKResult.new(resource: master_list)
+    rescue ActiveRecord::RecordNotFound
+      Service::NotFoundResult.new
+    end
+
+    private
+
+    attr_reader :user, :list_id
+
+    def shopping_list
+      @shopping_list ||= user.shopping_lists.find(list_id)
+    end
+
+    def destroy_and_update_master_list_items
+      master_list = shopping_list.master_list
+
+      list_items = shopping_list.list_items.map(&:attributes)
+
+      # If shopping_list is the user's last regular shopping list, this will also
+      # destroy their master list
+      shopping_list.destroy!
+      
+      if master_list&.persisted?
+        list_items.each { |item_attributes| master_list.remove_item_from_child_list(item_attributes) }
+        master_list
+      end
+    end
+  end
+end

--- a/app/controller_services/shopping_lists_controller/index_service.rb
+++ b/app/controller_services/shopping_lists_controller/index_service.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'service/ok_result'
+
+class ShoppingListsController < ApplicationController
+  class IndexService
+    def initialize(user)
+      @user = user
+    end
+
+    def perform
+      Service::OKResult.new(resource: user.shopping_lists.index_order)
+    end
+
+    private
+
+    attr_reader :user
+  end
+end

--- a/app/controller_services/shopping_lists_controller/update_service.rb
+++ b/app/controller_services/shopping_lists_controller/update_service.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'service/ok_result'
+require 'service/method_not_allowed_result'
+require 'service/not_found_result'
+require 'service/unprocessable_entity_result'
+
+class ShoppingListsController < ApplicationController
+  class UpdateService
+    MASTER_LIST_ERROR = 'Cannot manually update a master shopping list'
+    DISALLOWED_UPDATE_ERROR = 'Cannot make a regular shopping list a master list'
+
+    def initialize(user, list_id, params)
+      @user = user
+      @list_id = list_id
+      @params = params
+    end
+
+    def perform
+      return Service::MethodNotAllowedResult.new(errors: [MASTER_LIST_ERROR]) if shopping_list.master == true
+      return Service::UnprocessableEntityResult.new(errors: [DISALLOWED_UPDATE_ERROR]) if params[:master] == true
+
+      if shopping_list.update(params)
+        Service::OKResult.new(resource: shopping_list)
+      else
+        Service::UnprocessableEntityResult.new(errors: assemble_error_messages(shopping_list.errors))
+      end
+    rescue ActiveRecord::RecordNotFound
+      Service::NotFoundResult.new
+    end
+
+    private
+
+    attr_reader :user, :list_id, :params
+
+    def assemble_error_messages(data)
+      data.map { |error| "#{error.attribute.capitalize} #{error.message}" }
+    end
+
+
+    def shopping_list
+      @shopping_list ||= user.shopping_lists.find(list_id)
+    end
+  end
+end

--- a/app/controller_services/shopping_lists_controller/update_service.rb
+++ b/app/controller_services/shopping_lists_controller/update_service.rb
@@ -23,7 +23,7 @@ class ShoppingListsController < ApplicationController
       if shopping_list.update(params)
         Service::OKResult.new(resource: shopping_list)
       else
-        Service::UnprocessableEntityResult.new(errors: assemble_error_messages(shopping_list.errors))
+        Service::UnprocessableEntityResult.new(errors: shopping_list.error_array)
       end
     rescue ActiveRecord::RecordNotFound
       Service::NotFoundResult.new
@@ -32,11 +32,6 @@ class ShoppingListsController < ApplicationController
     private
 
     attr_reader :user, :list_id, :params
-
-    def assemble_error_messages(data)
-      data.map { |error| "#{error.attribute.capitalize} #{error.message}" }
-    end
-
 
     def shopping_list
       @shopping_list ||= user.shopping_lists.find(list_id)

--- a/app/controller_services/users_controller/show_service.rb
+++ b/app/controller_services/users_controller/show_service.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'service/ok_result'
+
+class UsersController < ApplicationController
+  class ShowService
+    def initialize(user)
+      @user = user
+    end
+
+    def perform
+      Service::OKResult.new(resource: user)
+    end
+
+    private
+
+    attr_reader :user
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,8 @@ class ApplicationController < ActionController::API
 
   def validate_google_oauth_token
     result = AuthorizationService.new(self, id_token).perform
-    ::Controller::Response.new(self, result).execute unless result.nil?
+
+    ::Controller::Response.new(self, result).execute if result.present?
   end
 
   def id_token

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,40 +1,23 @@
 # frozen_string_literal: true
 
+require 'controller/response'
+
 class ApplicationController < ActionController::API
   before_action :validate_google_oauth_token
 
-  attr_reader :current_user
+  # Had to make this a public attr_accessor so it can be set within the
+  # ApplicationController::AuthorizationService. This value should not
+  # be set anywhere outside of either that class or this one.
+  attr_accessor :current_user
 
   private
 
   def validate_google_oauth_token
-    validator = GoogleIDToken::Validator.new
-    payload = validator.check(id_token, configatron.google_oauth_client_id)
-
-    if current?(payload['exp'])
-      @current_user = User.create_for_google(payload)
-    else
-      Rails.logger.error('User authenticated with expired token')
-      @current_user = nil
-      render json: { error: 'Expired authentication token. Try logging out and logging in again.' }, status: :unauthorized
-    end
-  rescue GoogleIDToken::ValidationError => e
-    Rails.logger.error "Unsuccessful login attempt -- token validation failed: #{e.message}"
-    render json: { error: 'Google OAuth token validation failed' }, status: :unauthorized
-  rescue GoogleIDToken::CertificateError => e
-    Rails.logger.error "Unsuccessful login attempt -- problem with certificate: #{e.message}"
-    render json: { error: 'Invalid OAuth certificate' }, status: :unauthorized
+    result = AuthorizationService.new(self, id_token).perform
+    ::Controller::Response.new(self, result).execute unless result.nil?
   end
 
   def id_token
     request.headers['Authorization']&.gsub('Bearer ', '')
-  end
-
-  def oauth_audience
-    request.headers['X-Oauth-Aud']
-  end
-
-  def current?(seconds_since_unix_epoch)
-    Time.at(seconds_since_unix_epoch) >= Time.now
   end
 end

--- a/app/controllers/shopping_list_items_controller.rb
+++ b/app/controllers/shopping_list_items_controller.rb
@@ -5,10 +5,11 @@ class ShoppingListItemsController < ApplicationController
   before_action :set_shopping_list, only: %i[create]
 
   def create
-    item = @shopping_list.shopping_list_items.combine_or_new(list_item_params)
+    item = @shopping_list.list_items.combine_or_new(list_item_params)
 
     if item.save
-      master_list_item = @shopping_list.master_list.shopping_list_items.find_by_description(item.description)
+      @shopping_list.master_list.add_item_from_child_list(item)
+      master_list_item = @shopping_list.master_list.list_items.find_by(description: item.description)
 
       @shopping_list.touch
       
@@ -25,7 +26,7 @@ class ShoppingListItemsController < ApplicationController
       :description,
       :quantity,
       :notes,
-      :shopping_list_id
+      :list_id
     )
   end
 

--- a/app/controllers/shopping_lists_controller.rb
+++ b/app/controllers/shopping_lists_controller.rb
@@ -4,7 +4,7 @@ require 'controller/response'
 
 class ShoppingListsController < ApplicationController
   before_action :set_shopping_list, only: %i[show update destroy]
-  before_action :prevent_setting_master, only: %i[create update]
+  before_action :prevent_setting_master, only: %i[update]
   before_action :prevent_update_master_list, only: :update
   before_action :prevent_destroy_master_list, only: :destroy
 
@@ -15,19 +15,9 @@ class ShoppingListsController < ApplicationController
   end
 
   def create
-    shopping_list = current_user.shopping_lists.new(shopping_list_params)
+    result = CreateService.new(current_user, shopping_list_params).perform
 
-    if shopping_list.save
-      resp_body = [shopping_list]
-
-      if (shopping_list.created_at - current_user.master_shopping_list.created_at).abs < 1.second
-        resp_body.unshift(current_user.master_shopping_list)
-      end
-
-      render json: resp_body, status: :created
-    else
-      render json: { errors: shopping_list.errors }, status: :unprocessable_entity
-    end
+    ::Controller::Response.new(self, result).execute
   end
 
   def show

--- a/app/controllers/shopping_lists_controller.rb
+++ b/app/controllers/shopping_lists_controller.rb
@@ -45,18 +45,6 @@ class ShoppingListsController < ApplicationController
     render json: { error: "Shopping list id=#{params[:id]} not found"}, status: :not_found
   end
 
-  def prevent_setting_master
-    if shopping_list_params.fetch(:master, nil) == true
-      render json: { errors: { master: ['cannot manually create or update a master shopping list'] } }, status: :unprocessable_entity
-    end
-  end
-
-  def prevent_update_master_list
-    if @shopping_list.master == true
-      render json: { error: 'Cannot manually update a master shopping list' }, status: :method_not_allowed
-    end
-  end
-
   def prevent_destroy_master_list
     if @shopping_list.master == true
       render json: { error: 'Cannot manually destroy a master shopping list' }, status: :method_not_allowed

--- a/app/controllers/shopping_lists_controller.rb
+++ b/app/controllers/shopping_lists_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'controller/response'
+
 class ShoppingListsController < ApplicationController
   before_action :set_shopping_list, only: %i[show update destroy]
   before_action :prevent_setting_master, only: %i[create update]
@@ -7,7 +9,9 @@ class ShoppingListsController < ApplicationController
   before_action :prevent_destroy_master_list, only: :destroy
 
   def index
-    render json: current_user.shopping_lists.index_order.to_json(include: :shopping_list_items), status: :ok
+    result = IndexService.new(current_user).perform
+
+    ::Controller::Response.new(self, result).execute
   end
 
   def create

--- a/app/controllers/shopping_lists_controller.rb
+++ b/app/controllers/shopping_lists_controller.rb
@@ -3,9 +3,6 @@
 require 'controller/response'
 
 class ShoppingListsController < ApplicationController
-  before_action :set_shopping_list, only: %i[destroy]
-  before_action :prevent_destroy_master_list, only: :destroy
-
   def index
     result = IndexService.new(current_user).perform
 
@@ -25,29 +22,14 @@ class ShoppingListsController < ApplicationController
   end
 
   def destroy
-    @shopping_list.destroy!
-    if current_user.master_shopping_list.present? # if this was their last regular list the master will have been destroyed
-      render json: { master_list: current_user.master_shopping_list }, status: :ok
-    else
-      head :no_content
-    end
+    result = DestroyService.new(current_user, params[:id]).perform
+
+    ::Controller::Response.new(self, result).execute
   end
 
   private
 
   def shopping_list_params
     params[:shopping_list].present? ? params.require(:shopping_list).permit(:title, :master) : {}
-  end
-
-  def set_shopping_list
-    @shopping_list = current_user.shopping_lists.includes(:shopping_list_items).find(params[:id])
-  rescue ActiveRecord::RecordNotFound
-    render json: { error: "Shopping list id=#{params[:id]} not found"}, status: :not_found
-  end
-
-  def prevent_destroy_master_list
-    if @shopping_list.master == true
-      render json: { error: 'Cannot manually destroy a master shopping list' }, status: :method_not_allowed
-    end
   end
 end

--- a/app/controllers/shopping_lists_controller.rb
+++ b/app/controllers/shopping_lists_controller.rb
@@ -3,9 +3,7 @@
 require 'controller/response'
 
 class ShoppingListsController < ApplicationController
-  before_action :set_shopping_list, only: %i[show update destroy]
-  before_action :prevent_setting_master, only: %i[update]
-  before_action :prevent_update_master_list, only: :update
+  before_action :set_shopping_list, only: %i[destroy]
   before_action :prevent_destroy_master_list, only: :destroy
 
   def index
@@ -20,16 +18,10 @@ class ShoppingListsController < ApplicationController
     ::Controller::Response.new(self, result).execute
   end
 
-  def show
-    render json: @shopping_list, status: :ok
-  end
-
   def update
-    if @shopping_list.update(shopping_list_params)
-      render json: @shopping_list, status: :ok
-    else
-      render json: { errors: @shopping_list.errors }, status: :unprocessable_entity
-    end
+    result = UpdateService.new(current_user, params[:id], shopping_list_params).perform
+    
+    ::Controller::Response.new(self, result).execute
   end
 
   def destroy

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+require 'controller/response'
+
 class UsersController < ApplicationController
   # current_user is set in the before_action that verifies the
   # user's OAuth token from Google.
   def current
-    render json: current_user, status: :ok
+    result = ShowService.new(current_user).perform
+
+    ::Controller::Response.new(self, result).execute
   end
 end

--- a/app/controllers/utilities_controller.rb
+++ b/app/controllers/utilities_controller.rb
@@ -17,7 +17,12 @@ class UtilitiesController < ApplicationController
     Thank you for using Skyrim Inventory Management. This app was intended
     for my personal use and offers no guarantees of security, privacy, or
     fitness for any purpose. We do not share your data with any third
-    parties except Google as needed for authentication.
+    parties except Google as needed for authentication. (More accurately,
+    Google shares information with us.) The personal information we keep
+    about you is your name, your email, and your Google profile image, all
+    of which we get from Google when you log in. That means the name, email,
+    and profile image we have on file for you will be the ones associated
+    with the Google account you use to log in. 
   HEREDOC
 
   TOS = <<~HEREDOC

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,7 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  def error_array
+    errors.map { |error| "#{error.attribute.capitalize} #{error.message}"}
+  end
 end

--- a/app/models/concerns/master_listable.rb
+++ b/app/models/concerns/master_listable.rb
@@ -77,6 +77,8 @@ module MasterListable
       existing_item.notes = extract_notes(attrs['notes'], existing_item.notes)
       existing_item.save!
     end
+
+    existing_item
   end
 
   def update_item_from_child_list(description, delta_quantity, old_notes, new_notes)
@@ -91,6 +93,7 @@ module MasterListable
     existing_item.quantity += delta_quantity
     existing_item.notes = existing_item.sub(old_notes, new_notes)
     existing_item.save!
+    existing_item
   end
 
   def extract_notes(notes, existing)

--- a/app/models/concerns/master_listable.rb
+++ b/app/models/concerns/master_listable.rb
@@ -78,7 +78,7 @@ module MasterListable
       existing_item.save!
     end
 
-    existing_item
+    existing_item&.persisted? ? existing_item : nil
   end
 
   def update_item_from_child_list(description, delta_quantity, old_notes, new_notes)
@@ -157,7 +157,7 @@ module MasterListable
   end
 
   def list_item_class_name
-    raise NotImplementedError, 'Classes including MasterListable must implement a list_item_class_name method.'
+    raise NotImplementedError, 'Classes including MasterListable must implement a class method :list_item_class_name.'
   end
 
   def master_has_other_children?

--- a/app/models/concerns/master_listable.rb
+++ b/app/models/concerns/master_listable.rb
@@ -91,7 +91,12 @@ module MasterListable
     end
 
     existing_item.quantity += delta_quantity
-    existing_item.notes = existing_item.notes&.sub(old_notes.to_s, new_notes.to_s).presence || new_notes
+    existing_item.notes = if old_notes.nil? && new_notes.present?
+                            [existing_item.notes.to_s, new_notes.to_s].join(' -- ')
+                          else
+                            existing_item.notes&.sub(/#{old_notes}/, new_notes.to_s).presence || new_notes
+                          end
+
     existing_item.save!
     existing_item
   end

--- a/app/models/concerns/master_listable.rb
+++ b/app/models/concerns/master_listable.rb
@@ -46,13 +46,13 @@ module MasterListable
     validate :not_named_master,             unless: :is_master_list?
     validate :ensure_master_list_is_master, unless: :is_master_list?
 
-    before_create :create_master_list,            unless: :is_master_list?
-    before_validation :set_master_list,           unless: :is_master_list?
+    before_create :create_master_list,    unless: :is_master_list?
+    before_validation :set_master_list,   unless: :is_master_list?
     before_save :abort_if_master_changed
-    before_save :remove_master_list_id,           if: :is_master_list?
-    before_save :set_title_to_master,             if: :is_master_list?
-    before_destroy :abort_if_master,              if: :has_child_lists?
-    after_destroy :destroy_master_list,           unless: -> { is_master_list? || master_has_other_children? }
+    before_save :remove_master_list_id,   if: :is_master_list?
+    before_save :set_title_to_master,     if: :is_master_list?
+    before_destroy :abort_if_master,      if: :has_child_lists?
+    after_destroy :destroy_master_list,   unless: -> { is_master_list? || master_has_other_children? }
   end
 
   def add_item_from_child_list(item)
@@ -102,7 +102,7 @@ module MasterListable
   end
 
   def extract_notes(notes, existing)
-    return existing unless notes && existing =~ /#{notes}/
+    return existing unless notes && existing.to_s =~ /#{notes}/
 
     existing.sub(notes, '')
   end

--- a/app/models/concerns/master_listable.rb
+++ b/app/models/concerns/master_listable.rb
@@ -91,7 +91,7 @@ module MasterListable
     end
 
     existing_item.quantity += delta_quantity
-    existing_item.notes = existing_item.sub(old_notes, new_notes)
+    existing_item.notes = existing_item.notes&.sub(old_notes.to_s, new_notes.to_s).presence || new_notes
     existing_item.save!
     existing_item
   end

--- a/app/models/concerns/master_listable.rb
+++ b/app/models/concerns/master_listable.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+# There is always a risk with concerns that they will not ultimately provide
+# the flexibility that is needed in a complex application. However, there are
+# going to be a few models - InventoryList would be another one coming up - that
+# will require master list behaviour, which is pretty complex logically, and it
+# seems reasonable not to duplicate that logic too much (or split it across too
+# many classes or modules).
+#
+# One of the main ways that model concerns limit flexibility is by making certain
+# assumptions about the database schema or methods defined in the models that
+# include them. That said, here are some of those assumptions.
+#
+# The database schema for a MasterListable model has a few requirements. It must
+# contain the following columns:
+# 
+#    | Column         | Type    | Constraints                 |
+#    | -------------- | ------- | --------------------------- |
+#    | title          | string  | null: false                 |
+#    | master         | boolean | null: false, default: false |
+#    | master_list_id | integer |                             |
+#    | user_id        | integer | null: false                 |
+#
+# There are a few other assumptions made:
+# - There is a `#list_item_class_name` method defined. For a `ShoppingList` model,
+#   this would be `'ShoppingListItem'`.
+# - There is a scope on the child model class called `:index_order` that defines
+#   the order in which the child models should appear. For example, `ShoppingListItem`
+#   models are in descending `:updated_at` order.
+
+module MasterListable
+  extend ActiveSupport::Concern
+
+  class MasterListError < StandardError; end
+  
+  included do
+    belongs_to :user
+    has_many :list_items, -> { index_order }, class_name: self.list_item_class_name, dependent: :destroy, foreign_key: :list_id
+    belongs_to :master_list, class_name: self.to_s, foreign_key: :master_list_id, optional: true
+    has_many :child_lists, class_name: self.to_s, foreign_key: :master_list_id, inverse_of: :master_list
+
+    scope :master_first, -> { order(master: :desc) }
+    scope :includes_items, -> { includes(:list_items) }
+
+    validate :one_master_list_per_user,     if: :is_master_list?
+    validate :not_named_master,             unless: :is_master_list?
+    validate :ensure_master_list_is_master, unless: :is_master_list?
+
+    before_create :create_master_list,            unless: :is_master_list?
+    before_validation :set_master_list,           unless: :is_master_list?
+    before_save :abort_if_master_changed
+    before_save :remove_master_list_id,           if: :is_master_list?
+    before_save :set_title_to_master,             if: :is_master_list?
+    before_destroy :abort_if_master,              if: :has_child_lists?
+    after_destroy :destroy_master_list,           unless: -> { is_master_list? || master_has_other_children? }
+  end
+
+  def add_item_from_child_list(item)
+    raise MasterListError, 'add_item_from_child_list method only available on master lists' unless is_master_list?
+
+    list_items.combine_or_create!(public_list_item_attrs(item).merge('list_id' => id))
+  end
+
+  def remove_item_from_child_list(attrs)
+    raise MasterListError, 'remove_item_from_child_list method only available on master lists' unless is_master_list?
+
+    existing_item = list_items.find_by(description: attrs['description'])
+
+    if existing_item.nil? || existing_item.quantity < attrs['quantity']
+      raise MasterListError, 'item passed to remove_item_from_child_list method is not represented on the master list'
+    end
+
+    if existing_item.quantity == attrs['quantity']
+      existing_item.destroy!
+    else
+      existing_item.quantity -= attrs['quantity']
+      existing_item.notes = extract_notes(attrs['notes'], existing_item.notes)
+      existing_item.save!
+    end
+  end
+
+  def update_item_from_child_list(description, delta_quantity, old_notes, new_notes)
+    raise MasterListError, 'update_item_from_child_list method only available on master lists' unless is_master_list?
+
+    existing_item = list_items.find_by(description: description)
+
+    if existing_item.nil? || delta_quantity < (-existing_item.quantity)
+      raise MasterListError, 'invalid data to update master list item'
+    end
+
+    existing_item.quantity += delta_quantity
+    existing_item.notes = existing_item.sub(old_notes, new_notes)
+    existing_item.save!
+  end
+
+  def extract_notes(notes, existing)
+    return existing unless notes && existing =~ /#{notes}/
+
+    existing.sub(notes, '')
+  end
+
+  def ensure_master_list_is_master
+    if master_list&.master != true
+      errors.add(:master_list, 'must be a master list')
+    end
+  end
+
+  def set_master_list
+    self.master_list ||= self.class.find_or_create_by!(user: user, master: true)
+  end
+
+  def create_master_list
+    self.class.find_or_create_by!(user: user, master: true)
+  end
+
+  def set_title_to_master
+    self.title = 'Master'
+  end
+
+  def abort_if_master_changed
+    throw :abort if master_changed? && !new_record?
+    true
+  end
+
+  def public_list_item_attrs(item)
+    private_attrs = [:id, 'id', :created_at, 'created_at', :updated_at, 'updated_at']
+
+    item.attributes.reject { |key, value| private_attrs.include?(key) }
+  end
+
+  def abort_if_master
+    throw :abort if is_master_list?
+  end
+
+  def not_named_master
+    errors.add(:title, 'cannot be "Master"') if title&.downcase == 'master'
+  end
+
+  def one_master_list_per_user
+    scope = self.class.where(user: user, master: true)
+
+    if scope.count > 1 || (scope.count > 0 && !scope.include?(self))
+      errors.add(:master, 'can only be one list per user')
+    end
+  end
+
+  def remove_master_list_id
+    self.master_list_id = nil
+    true
+  end
+
+  def destroy_master_list
+    master_list.destroy!
+  end
+
+  def list_item_class_name
+    raise NotImplementedError, 'Classes including MasterListable must implement a list_item_class_name method.'
+  end
+
+  def master_has_other_children?
+    # since this is called in an after_destroy hook, any children the
+    # master list still has are "other" children
+    master_list.child_lists.any?
+  end
+
+  def is_master_list?
+    master == true
+  end
+
+  def has_child_lists?
+    child_lists.any?
+  end
+end

--- a/app/models/shopping_list.rb
+++ b/app/models/shopping_list.rb
@@ -26,7 +26,8 @@ class ShoppingList < ApplicationRecord
   after_destroy :destroy_master_list, unless: :other_lists_present?
 
   scope :master_first, -> { order(master: :desc) }
-  scope :index_order, -> { master_first.order(updated_at: :desc) }
+  scope :index_order, -> { includes_items.master_first.order(updated_at: :desc) }
+  scope :includes_items, -> { includes(:shopping_list_items) }
 
   def to_json(opts = {})
     opts.merge!({ include: :shopping_list_items }) unless opts.has_key?(:include)

--- a/app/models/shopping_list.rb
+++ b/app/models/shopping_list.rb
@@ -3,12 +3,6 @@
 require 'titlecase'
 
 class ShoppingList < ApplicationRecord
-  belongs_to :user
-  has_many :shopping_list_items, ->{ index_order }, dependent: :destroy
-
-  validate :one_master_list_per_user
-  validate :only_master_list_named_master
-
   # Titles have to be unique per user as described in the API docs. They also can only
   # contain alphanumeric characters and spaces with no special characters or whitespace
   # other than spaces. Leading or trailing whitespace is stripped anyway so the validation
@@ -19,62 +13,28 @@ class ShoppingList < ApplicationRecord
                       message: 'can only include alphanumeric characters and spaces'
                     }
 
-  before_save :set_default_title, if: :master_or_title_blank?
-  before_save :titleize_title
-  before_destroy :ensure_not_master, if: :other_lists_present?
-  after_destroy :destroy_master_list, unless: :other_lists_present?
+  before_save :format_title
 
-  scope :master_first, -> { order(master: :desc) }
+  # This has to be defined before including MasterListable because its `included` block
+  # calls this method.
+  def self.list_item_class_name
+    'ShoppingListItem'
+  end
+
+  include MasterListable
+
   scope :index_order, -> { includes_items.master_first.order(updated_at: :desc) }
-  scope :includes_items, -> { includes(:shopping_list_items) }
-
-  def to_json(opts = {})
-    opts.merge!({ include: :shopping_list_items }) unless opts.has_key?(:include)
-    super(opts)
-  end
-
-  def master_list
-    user.master_shopping_list
-  end
 
   private
 
-  def one_master_list_per_user
-    if master == true && user.master_shopping_list && user.master_shopping_list != self
-      errors.add(:master, 'user can only have one master shopping list')
-    end
-  end
+  def format_title
+    return if master
 
-  def only_master_list_named_master
-    errors.add(:title, "cannot be \"#{title}\" for a regular shopping list") if title =~ /^master$/i && !master
-  end
-
-  def set_default_title
-    self.title = if master == true
-      'Master'
-    else
+    if title.blank?
       highest_number = user.shopping_lists.where("title like '%My List%'").pluck(:title).map { |title| title.gsub('My List ', '').to_i }.max || 0
-      "My List #{highest_number + 1}"
+      self.title = "My List #{highest_number + 1}"
+    else
+      self.title = Titlecase.titleize(title.strip)
     end
-  end
-  
-  def titleize_title
-    self.title = Titlecase.titleize(title.strip)
-  end
-
-  def master_or_title_blank?
-    master == true || title.blank?
-  end
-
-  def ensure_not_master
-    throw :abort if master == true
-  end
-
-  def destroy_master_list
-    user.master_shopping_list&.destroy!
-  end
-
-  def other_lists_present?
-    user.shopping_lists.where(master: false).count > 0
   end
 end

--- a/app/models/shopping_list.rb
+++ b/app/models/shopping_list.rb
@@ -21,7 +21,6 @@ class ShoppingList < ApplicationRecord
 
   before_save :set_default_title, if: :master_or_title_blank?
   before_save :titleize_title
-  after_create :ensure_master_list_present
   before_destroy :ensure_not_master, if: :other_lists_present?
   after_destroy :destroy_master_list, unless: :other_lists_present?
 
@@ -48,12 +47,6 @@ class ShoppingList < ApplicationRecord
 
   def only_master_list_named_master
     errors.add(:title, "cannot be \"#{title}\" for a regular shopping list") if title =~ /^master$/i && !master
-  end
-
-  def ensure_master_list_present
-    if user.master_shopping_list.nil?
-      user.shopping_lists.create!(master: true, title: 'Master')
-    end
   end
 
   def set_default_title

--- a/app/models/shopping_list_item.rb
+++ b/app/models/shopping_list_item.rb
@@ -29,10 +29,11 @@ class ShoppingListItem < ApplicationRecord
       new attrs
     else
       qty = attrs[:quantity] || attrs['quantity'] || 1
-      notes = attrs[:notes] || attrs['notes'] || ''
+      new_notes = attrs[:notes] || attrs['notes']
+      old_notes = existing_item.notes
 
       new_quantity = existing_item.quantity + qty
-      new_notes = [existing_item.notes, notes].join(' -- ')
+      new_notes = [old_notes, new_notes].compact.join(' -- ').presence
 
       existing_item.assign_attributes(quantity: new_quantity, notes: new_notes)
       existing_item

--- a/app/models/shopping_list_item.rb
+++ b/app/models/shopping_list_item.rb
@@ -2,9 +2,8 @@
 
 class ShoppingListItem < ApplicationRecord
   belongs_to :list, class_name: 'ShoppingList'
-  
 
-  validates :description, presence: true
+  validates :description, presence: true, uniqueness: { scope: :list_id }
   validates :quantity, presence: true, numericality: { only_integer: true, greater_than: 0 }
 
   before_save :humanize_description
@@ -16,7 +15,9 @@ class ShoppingListItem < ApplicationRecord
   scope :index_order, -> { order(updated_at: :desc) }
 
   def self.combine_or_create!(attrs)
-    combine_or_new(attrs).save!
+    obj = combine_or_new(attrs)
+    obj.save!
+    obj
   end
 
   def self.combine_or_new(attrs)

--- a/app/models/shopping_list_item.rb
+++ b/app/models/shopping_list_item.rb
@@ -1,18 +1,17 @@
 # frozen_string_literal: true
 
 class ShoppingListItem < ApplicationRecord
-  belongs_to :shopping_list
+  belongs_to :list, class_name: 'ShoppingList'
+  
 
   validates :description, presence: true
   validates :quantity, presence: true, numericality: { only_integer: true, greater_than: 0 }
 
   before_save :humanize_description
+  before_save :clean_up_notes
   before_update :prevent_changed_description
-  after_create :add_to_master_list, unless: :shopping_list_is_master_list?
-  after_update :adjust_master_list_after_update, unless: :shopping_list_is_master_list?
-  after_destroy :adjust_master_list_after_destroy, unless: :shopping_list_is_master_list?
 
-  delegate :user, to: :shopping_list
+  delegate :user, to: :list
 
   scope :index_order, -> { order(updated_at: :desc) }
 
@@ -21,9 +20,9 @@ class ShoppingListItem < ApplicationRecord
   end
 
   def self.combine_or_new(attrs)
-    shopping_list = attrs[:shopping_list] || ShoppingList.find(attrs[:shopping_list_id])
+    shopping_list = attrs[:list] || attrs['list'] || ShoppingList.find(attrs[:list_id] || attrs['list_id'])
     desc = (attrs[:description] || attrs['description'])&.humanize
-    existing_item = shopping_list.shopping_list_items.find_by_description(desc)
+    existing_item = shopping_list.list_items.find_by_description(desc)
 
     if existing_item.nil?
       new attrs
@@ -41,42 +40,6 @@ class ShoppingListItem < ApplicationRecord
 
   private
 
-  def add_to_master_list
-    new_attrs = reject_non_public_attrs(self.attributes)
-    ShoppingListItem.combine_or_create!(**new_attrs, shopping_list: master_list)
-  end
-
-  def adjust_master_list_after_update
-    # Any item being updated (as opposed to created) will already be represented on the master list.
-    # So we just need to find the item on the master list and add delta_quantity to its quantity value.
-    # The new value will never be zero because there will be a validation error before saving if the
-    # new quantity value is zero. On the client side, when a user enters a quantity of zero, the client
-    # should implement logic to make a DELETE request on the list item instead.
-    item_on_master_list = master_list.shopping_list_items.find_by_description(description)
-
-    item_on_master_list.update!(
-      quantity: item_on_master_list.quantity + delta_quantity,
-      notes: update_combined_note_values(item_on_master_list.notes, *saved_change_to_attribute(:notes))
-    )
-  end
-
-  def adjust_master_list_after_destroy
-    item_on_master_list = master_list.shopping_list_items.find_by_description(description)
-
-    item_on_master_list.destroy! && return if item_on_master_list.quantity == quantity
-
-    if notes.present?
-      new_notes = item_on_master_list.notes.sub(/#{notes}/, '').gsub(/^ ?\-\- /, '').gsub(/ \-\- ?$/, '')
-    end
-
-    new_notes = nil unless defined?(new_notes) && new_notes.present?
-
-    item_on_master_list.update!(
-      quantity: item_on_master_list.quantity - quantity,
-      notes: new_notes || item_on_master_list.notes
-    )
-  end
-
   def prevent_changed_description
     throw :abort if description_changed?
   end
@@ -85,44 +48,8 @@ class ShoppingListItem < ApplicationRecord
     self.description = description.humanize
   end
 
-  def shopping_list_is_master_list?
-    self.shopping_list.master == true
-  end
-
-  def delta_quantity
-    saved_change_to_attribute(:quantity).present? ? 
-      saved_change_to_attribute(:quantity).last - saved_change_to_attribute(:quantity).first :
-      0
-  end
-
-  # When updating the notes on a regular list item, we also want to update
-  # the value on the corresponding master list. The issue is that the notes
-  # on a master list item consists of the combined notes fields of all regular
-  # list items matching that description. We only want to update the note
-  # that's being changed.
-  #
-  # All args to this method are strings. "combined_value" is the existing
-  # value of the notes on the master list. "old_value" is the original value
-  # of the note being changed, and "new_value" is the new value. The "notes"
-  # field of the master list item is set to the returned value in the
-  # #adjust_master_list_after_update method.
-  #
-  def update_combined_note_values(combined_value = nil, old_value = nil, new_value = nil)
-    return new_value unless combined_value.present?
-
-    if old_value.present? && combined_value =~ /#{old_value}/
-      combined_value.sub(old_value, new_value.to_s).gsub(/^ ?\-\- /, '').gsub(/ \-\- ?$/, '')
-    elsif old_value.blank?
-      [combined_value, new_value].join(' -- ').gsub(/^ ?\-\- /, '').gsub(/ \-\- ?$/, '')
-    end
-  end
-
-  def master_list
-    @master_list ||= user.master_shopping_list
-  end
-
-  def reject_non_public_attrs(attrs)
-    non_public_attrs = [:id, 'id', :shopping_list_id, 'shopping_list_id', :created_at, 'created_at', :updated_at, 'updated_at']
-    attrs.reject { |key, value| non_public_attrs.include?(key) }
+  def clean_up_notes
+    return true unless notes
+    self.notes = notes.strip.gsub(/^(\-\- )*/, '').gsub(/( \-\-)*$/, '').gsub(/( \-\- ){2,}/, ' -- ')
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
 
   has_many :shopping_lists, dependent: :destroy
 
-  def self.create_for_google(data)
+  def self.create_or_update_for_google(data)
     where(uid: data['email']).first_or_initialize.tap do |user|
       user.uid = data['email']
       user.email = data['email']

--- a/db/migrate/20210704215647_add_master_list_id_to_shopping_lists.rb
+++ b/db/migrate/20210704215647_add_master_list_id_to_shopping_lists.rb
@@ -1,0 +1,5 @@
+class AddMasterListIdToShoppingLists < ActiveRecord::Migration[6.1]
+  def change
+    add_column :shopping_lists, :master_list_id, :integer
+  end
+end

--- a/db/migrate/20210705020129_change_shopping_list_id_to_list_id_on_shopping_list_items.rb
+++ b/db/migrate/20210705020129_change_shopping_list_id_to_list_id_on_shopping_list_items.rb
@@ -1,0 +1,5 @@
+class ChangeShoppingListIdToListIdOnShoppingListItems < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :shopping_list_items, :shopping_list_id, :list_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_19_225944) do
+ActiveRecord::Schema.define(version: 2021_07_05_020129) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "shopping_list_items", force: :cascade do |t|
-    t.integer "shopping_list_id", null: false
+    t.integer "list_id", null: false
     t.string "description", null: false
     t.string "notes"
     t.integer "quantity", default: 1, null: false
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 2021_06_19_225944) do
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "master", default: false
     t.string "title", null: false
+    t.integer "master_list_id"
     t.index ["user_id", "title"], name: "index_shopping_lists_on_user_id_and_title", unique: true
   end
 

--- a/docs/api/resources/authorization.md
+++ b/docs/api/resources/authorization.md
@@ -17,7 +17,7 @@ GET /auth/verify_token
 Authorization: Bearer xxxxxxxxxxxxx
 ```
 
-### Successful Responses
+### Success Responses
 
 #### Status
 

--- a/docs/api/resources/shopping-list-items.md
+++ b/docs/api/resources/shopping-list-items.md
@@ -76,7 +76,7 @@ Content-Type: application/json
 [
   {
     "id": 87,
-    "shopping_list_id": 238,
+    "list_id": 238,
     "description": "Ebony sword",
     "quantity": 9,
     "notes": "To sell -- To enchant with 'Absorb Health'",
@@ -85,7 +85,7 @@ Content-Type: application/json
   },
   {
     "id": 126,
-    "shopping_list_id": 237,
+    "list_id": 237,
     "description": "Ebony sword",
     "quantity": 7,
     "notes": "To enchant with 'Absorb Health'",

--- a/docs/api/resources/shopping-list-items.md
+++ b/docs/api/resources/shopping-list-items.md
@@ -10,23 +10,25 @@ All requests to shopping list item endpoints must be [authenticated](/docs/api/r
 
 Skyrim Inventory Management makes use of automatically managed master lists to help users track an aggregate of what items they need for different properties. The master list is created automatically when the client creates a user's first regular shopping list, and is destroyed automatically when the client deletes the user's last regular shopping list. When items are added, updated, or destroyed from any of a user's regular lists, master list items are updated as described in this section.
 
+(Ensuring automatic management of master lists does require some work on the part of SIM developers. If you are working on lists in SIM and would like information on how to keep them synced, head over to the [`MasterListable` docs](/docs/master-lists.md).)
+
 ### Creating a New List Item
 
 If the client requests a new list item be created on a user's regular list, one of the following things will happen:
 
 * If there is not an item with the same (case-insensitive) `description` on the master list, then an item with the same `description`, `quantity`, and `notes` will be created on the master list.
 * If there is an item with the same (case-insensitive) `description` on the master list, then that item will be updated:
-  * The description will not be changed
-  * The quantity will be increased by the quantity of the new list item
-  * The notes for the two items will be concatenated and separated by ` -- `
+  * The `description` will not be changed
+  * The `quantity` will be increased by the quantity of the new list item
+  * The `notes` for the two items, if any, will be concatenated and separated by ` -- `
 
 ### Updating a List Item
 
 When a client updates a list item on a user's regular list, one or more of the following things will happen:
 
-* If the quantity is increased, the quantity of the item on the master list will be increased by the same amount
-* If the quantity is decreased, the quantity of the item on the master list will be decreased by the same amount
-* If the notes are changed, SIM will ensure that the new notes are reflected in the master list item
+* If the `quantity` is increased, the `quantity` of the item on the master list will be increased by the same amount
+* If the `quantity` is decreased, the `quantity` of the item on the master list will be decreased by the same amount
+* If the `notes` are changed, SIM will ensure that the new (or added or removed) `notes` are reflected in the master list item
 
 ### Destroying a List Item
 
@@ -41,11 +43,18 @@ The following endpoints are available to manage shopping list items:
 
 * [`POST /shopping_lists/:id/shopping_list_items`](#post-shoppinglistsidshoppinglistitems)
 
-## POST /shopping_lists/:id/shopping_list_items
+## POST /shopping_lists/:shopping_list_id/shopping_list_items
 
-If the shopping list with the given ID exists, belongs to the authenticated user, is not a master shopping list, and does not have an existing shopping list item with the same (case-insensitive) description, creates a shopping list item on the given list. If all these conditions are met but the list does have an existing shopping list item with a matching description, it updates the quantity and notes on the existing item.
+If the shopping list with the given ID exists, belongs to the authenticated user, is not a master shopping list, and does not have an existing shopping list item with the same (case-insensitive) description, Creates a shopping list item on the given list if the shopping list with the given ID:
 
-In both cases, the user's master list is also updated to reflect the new quantity and notes.
+1. Exists
+2. Belongs to the authenticated user
+3. Is not a master list AND
+4. Does not have an existing shopping list item with the same description
+
+If the first three conditions are met but the list does have an existing shopping list item with a matching description, `quantity` and `notes` are updated on the existing item to aggregate the values.
+
+In both cases, the user's master list is also updated to reflect the new `quantity` and `notes`.
 
 Requests must specify a `description` and an integer `quantity` greater than 0. The optional `notes` field is an arbitrary string where users can keep any reminders of what the item will be used for or other useful notes.
 
@@ -97,7 +106,7 @@ Content-Type: application/json
 
 ### Error Responses
 
-Several error responses are posssible.
+Three error responses are possible.
 
 #### Statuses
 
@@ -112,16 +121,19 @@ No body will be returned with a 404 error, which is returned if the specified sh
 A 405 error, which is returned if the specified shopping list is a master shopping list, comes with the following body:
 ```json
 {
-  "error": "Cannot manage master shopping list items directly."
+  "errors": [
+    "Cannot manually manage items on a master shopping list"
+  ]
 }
 ```
 
 A 422 error, returned as a result of a validation error, includes whichever errors prevented the list item from being created:
 ```json
 {
-  "errors": {
-    "quantity": ["must be a number", "must be greater than zero"],
-    "description": ["is required"]
-  }
+  "errors": [
+    "Quantity must be a number",
+    "Quantity must be greater than zero",
+    "Description is required"
+  ]
 }
 ```

--- a/docs/api/resources/shopping-lists.md
+++ b/docs/api/resources/shopping-lists.md
@@ -37,9 +37,9 @@ Authorization: Bearer xxxxxxxxxxxxx
 
 ### Successful Responses
 
-#### Status
+#### Statuses
 
-200 OK
+* 200 OK
 
 #### Example Bodies
 
@@ -80,6 +80,7 @@ For a user with multiple lists:
     "id": 46,
     "user_id": 8234,
     "master": false,
+    "master_list_id": 43,
     "title": "Lakeview Manor",
     "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
     "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
@@ -106,6 +107,7 @@ For a user with multiple lists:
     "id": 52,
     "user_id": 8234,
     "master": false,
+    "master_list_id": 43,
     "title": "Severin Manor",
     "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
     "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
@@ -121,61 +123,6 @@ For a user with multiple lists:
     ]
   }
 ]
-```
-
-## GET /shopping_lists/:id
-
-Returns the shopping list with the given ID, if it exists and belongs to the authenticated user. The response includes any list items on the given shopping list. If the shopping list exists but does not belong to the authenticated user, a 404 error response will be returned.
-
-### Example Request
-
-```
-GET /shopping_lists/24
-Authorization: Bearer xxxxxxxxxxxx
-```
-
-### Successful Responses
-
-#### Status
-
-200 OK
-
-#### Example Body
-
-```json
-{
-  "id": 4,
-  "user_id": 6,
-  "master": false,
-  "title": "My List 1",
-  "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-  "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-  "list_items": [
-    {
-      "id": 1,
-      "list_id": 4,
-      "description": "Ebony sword",
-      "quantity": 2,
-      "notes": "One to enchant with Absorb Health, one to enchant with Soul Trap",
-      "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-      "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
-    }
-  ]
-}
-```
-
-### Error Responses
-
-#### Status
-
-404 Not Found
-
-#### Example Body
-
-```json
-{
-  "error": "Shopping list id=17264 not found"
-}
 ```
 
 ## POST /shopping_lists
@@ -216,9 +163,9 @@ Content-Type: application/json
 
 ### Success Responses
 
-#### Status
+#### Statuses
 
-201 Created
+* 201 Created
 
 #### Example Bodies
 
@@ -229,6 +176,7 @@ When there hasn't been a master list created:
     "id": 4,
     "user_id": 6,
     "master": false,
+    "master_list_id": 3,
     "title": "My List 1",
     "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
     "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
@@ -241,7 +189,7 @@ When the master list has also been created:
 ```json
 [
   {
-    "id": 5,
+    "id": 4,
     "user_id": 6,
     "master": true,
     "title": "Master",
@@ -249,9 +197,10 @@ When the master list has also been created:
     "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
   },
   {
-    "id": 4,
+    "id": 5,
     "user_id": 6,
     "master": false,
+    "master_list_id": 4,
     "title": "My List 1",
     "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
     "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
@@ -270,18 +219,18 @@ When the master list has also been created:
 If duplicate title is given:
 ```json
 {
-  "errors": {
-    "title": ["has already been taken"]
-  }
+  "errors": [
+    "Title has already been taken"
+  ]
 }
 ```
 
 If request attempts to create a master list:
 ```json
 {
-  "errors": {
-    "master": ["cannot create or update a master shopping list through the API"]
-  }
+  "errors": [
+    "Cannot manually create a master shopping list"
+  ]
 }
 ```
 
@@ -319,9 +268,9 @@ Content-Type: application/json
 
 ### Success Response
 
-#### Status
+#### Statuses
 
-200 OK
+* 200 OK
 
 #### Example Body
 
@@ -330,6 +279,7 @@ Content-Type: application/json
   "id": 834,
   "user_id": 16,
   "master": false,
+  "master_list_id": 833,
   "title": "New List Title",
   "created_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00",
   "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
@@ -360,25 +310,22 @@ Content-Type: application/json
 For a 422 response due to title uniqueness constraint:
 ```json
 {
-  "errors": {
-    "title": ["has already been taken"]
-  }
+  "errors": [
+    "Title has already been taken"
+  ]
 }
 ```
 
 For a 405 response due to attempting to update a master list or convert a regular list to a master list:
 ```json
 {
-  "error": "cannot update a master shopping list through the API"
+  "errors": [
+    "Cannot manually update a master shopping list"
+  ]
 }
 ```
 
-For a 404 response:
-```json
-{
-  "error": "Shopping list id=2385 not found"
-}
-```
+For a 404 response, no response body is returned.
 
 ## DELETE /shopping_lists/:id
 
@@ -435,18 +382,15 @@ If the specified list does not exist or does not belong to the authenticated use
 * 404 Not Found
 * 405 Method Not Allowed
 
-#### Example Body
+#### Example Bodies
 
-For a 404 response:
-```json
-{
-  "error": "Shopping list id=8245 not found"
-}
-```
+For a 404 response, no response body will be returned
 
 For a 405 response:
 ```json
 {
-  "error": "cannot destroy a master shopping list through the API"
+  "errors": [
+    "Cannot manually delete a master shopping list"
+  ]
 }
 ```

--- a/docs/api/resources/shopping-lists.md
+++ b/docs/api/resources/shopping-lists.md
@@ -35,7 +35,7 @@ GET /shopping_lists
 Authorization: Bearer xxxxxxxxxxxxx
 ```
 
-### Successful Responses
+### Success Responses
 
 #### Statuses
 

--- a/docs/api/resources/shopping-lists.md
+++ b/docs/api/resources/shopping-lists.md
@@ -57,9 +57,9 @@ For a user with multiple lists:
     "title": "Master",
     "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
     "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "shopping_list_items": [
+    "list_items": [
       {
-        "shopping_list_id": 43,
+        "list_id": 43,
         "description": "Unenchanted ebony sword",
         "quantity": 1,
         "notes": "Need an unenchanted sword to start Companions questline",
@@ -67,7 +67,7 @@ For a user with multiple lists:
         "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
       },
       {
-        "shopping_list_id": 43,
+        "list_id": 43,
         "description": "Iron ingot",
         "quantity": 4,
         "notes": "3 locks -- 2 hinges",
@@ -83,9 +83,9 @@ For a user with multiple lists:
     "title": "Lakeview Manor",
     "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
     "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "shopping_list_items": [
+    "list_items": [
       {
-        "shopping_list_id": 46,
+        "list_id": 46,
         "description": "Unenchanted ebony sword",
         "quantity": 1,
         "notes": "Need an unenchanted sword to start Companions questline",
@@ -93,7 +93,7 @@ For a user with multiple lists:
         "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
       },
       {
-        "shopping_list_id": 46,
+        "list_id": 46,
         "description": "Iron ingot",
         "quantity": 3,
         "notes": "3 locks",
@@ -109,9 +109,9 @@ For a user with multiple lists:
     "title": "Severin Manor",
     "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
     "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "shopping_list_items": [
+    "list_items": [
       {
-        "shopping_list_id": 52,
+        "list_id": 52,
         "description": "Iron ingot",
         "quantity": 1,
         "notes": "2 hinges",
@@ -150,10 +150,10 @@ Authorization: Bearer xxxxxxxxxxxx
   "title": "My List 1",
   "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
   "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-  "shopping_list_items": [
+  "list_items": [
     {
       "id": 1,
-      "shopping_list_id": 4,
+      "list_id": 4,
       "description": "Ebony sword",
       "quantity": 2,
       "notes": "One to enchant with Absorb Health, one to enchant with Soul Trap",
@@ -232,7 +232,7 @@ When there hasn't been a master list created:
     "title": "My List 1",
     "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
     "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "shopping_list_items": []
+    "list_items": []
   }
 ]
 ```
@@ -333,10 +333,10 @@ Content-Type: application/json
   "title": "New List Title",
   "created_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00",
   "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-  "shopping_list_items": [
+  "list_items": [
     {
       "id": 32,
-      "shopping_list_id": 834,
+      "list_id": 834,
       "description": "Ebony sword",
       "quantity": 1,
       "notes": "To enchant with Soul Trap",
@@ -411,10 +411,10 @@ If the resource deleted was the user's last regular list, the master list will a
     "title": "Master",
     "created_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00",
     "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "shopping_list_items": [
+    "list_items": [
       {
         "id": 32,
-        "shopping_list_id": 834,
+        "list_id": 834,
         "description": "Ebony sword",
         "quantity": 1,
         "notes": "To enchant with Soul Trap",

--- a/docs/api/resources/shopping-lists.md
+++ b/docs/api/resources/shopping-lists.md
@@ -261,9 +261,9 @@ When the master list has also been created:
 
 ### Error Responses
 
-#### Status
+#### Statuses
 
-422 Unprocessable Entity
+* 422 Unprocessable Entity
 
 #### Example Bodies
 

--- a/docs/api/resources/users.md
+++ b/docs/api/resources/users.md
@@ -17,7 +17,7 @@ GET /users/current
 Authorization: Bearer xxxxxxxxx
 ```
 
-### Successful Responses
+### Success Responses
 
 #### Status
 

--- a/docs/controller-services.md
+++ b/docs/controller-services.md
@@ -53,9 +53,4 @@ end
 
 ## Standardised Responses
 
-Now, all error responses from the API, if they have body content, will return a JSON object with a single key, `"errors"`, and a list of error messages. For ActiveRecord models, this means you will need to assemble the messages from validation errors. Existing controller services use a method that maps the messages properly:
-```ruby
-def assemble_error_messages(errors)
-  errors.map { |error| "#{error.attribute.capitalize} #{error.message}" }
-end
-```
+Now, all error responses from the API, if they have body content, will return a JSON object with a single key, `"errors"`, and a list of error messages. There is now an `#error_array` method defined on `ApplicationRecord` that assembles normal ActiveRecord validation errors into such an array.

--- a/docs/controller-services.md
+++ b/docs/controller-services.md
@@ -1,0 +1,61 @@
+# Controller Services
+
+The SIM back end uses a controller service pattern to extract heavy controller logic. This pattern is easy to use once you have learnt it. There are three key components: the service class, the result object, and the response object.
+
+## The Service Class
+
+A service class lives in the `/app/controller_services` directory, in a subdirectory for the controller it serves. Consistent with [Zeitwerk](https://medium.com/cedarcode/understanding-zeitwerk-in-rails-6-f168a9f09a1f) requirements, the service classes are namespaced under the controller itself. For example, `/app/controller_services/users_controller/show_service.rb` contains a class called `UsersController::ShowService`.
+
+The service class is instantiated with exactly the data it needs to figure out what kind of response to make (i.e., status code) and what the payload should be. It has a single instance method, `perform`, that identifies the correct type of response and returns a result object with the response type and payload.
+
+## The Result Object
+
+Results objects live in the `/lib/service` directory. There is a base `Service::Result` class that serves as a parent class to the subclasses used by the service classes. Each result object defines a `status` method that is set to a symbol representing an HTTP status, such as `:no_content` or `:unprocessable_entity`. Any result object can be instantiated with a `:resource` or `:errors`. A `:resource` is any JSON string, array, or object (represented using Ruby data structures). Errors are an array of strings describing the errors that occurred. If a result object does not have a `:resource` or `:errors` object defined, the response will include no data (i.e., will call `head` instead of `render` on the controller).
+
+Existing result classes are:
+
+* `Service::OKResult`
+* `Service::CreatedResult`
+* `Service::NoContentResult`
+* `Service::UnauthorizedResult`
+* `Service::NotFoundResult`
+* `Service::MethodNotAllowedResult`
+* `Service::UnprocessableEntityResult`
+
+An example of their use might be (inside a controller service's `#perform` method):
+```ruby
+def perform
+  return Service::NotFoundResult.new(errors: ['Could not find shopping list']) unless shopping_list.present?
+end
+```
+
+## The Response Object
+
+The `Controller::Response` object lives in the `/lib/controller` directory. The response takes a controller and a result object as an argument and makes the response indicated in the result object using the controller passed in. This usually happens in the controller itself:
+
+```ruby
+# /app/controllers/shopping_lists_controller.rb
+
+require 'controller/response'
+
+class ShoppingListsController < ApplicationController
+  def create
+    # The CreateService needs to know who to create a list for and what
+    # params to do it with. If successful, it will return a
+    # Service::CreatedResponse object.
+    result = CreateService.new(current_user, shopping_list_params).perform
+    
+    # Renders the right JSON response and status code
+    response = ::Controller::Response.new(self, result).execute
+  end
+end
+```
+
+## Standardised Responses
+
+Now, all error responses from the API, if they have body content, will return a JSON object with a single key, `"errors"`, and a list of error messages. For ActiveRecord models, this means you will need to assemble the messages from validation errors. Existing controller services use a method that maps the messages properly:
+```ruby
+def assemble_error_messages(errors)
+  errors.map { |error| "#{error.attribute.capitalize} #{error.message}" }
+end
+```

--- a/docs/master-lists.md
+++ b/docs/master-lists.md
@@ -1,0 +1,246 @@
+# Master Lists
+
+## Contents
+
+* [Overview](#overview)
+* [Glossary](#glossary)
+* [Database Requirements](#database-requirements)
+* [Master List Behaviour](#master-list-behaviour)
+  * [Creation and Destruction of Master Lists](#creation-and-destruction-of-master-lists)
+  * [Updating Master Lists](#updating-master-lists)
+    * [Adding an Item to a Child List](#adding-an-item-to-a-child-list)
+    * [Removing an Item from a Child List](#removing-an-item-from-a-child-list)
+    * [Editing an Item on a Child List](#editing-an-item-on-a-child-list)
+* [List Model Requirements](#list-model-requirements)
+* [List Item Model Requirements](#list-item-model-requirements)
+* [MasterListable](#masterlistable)
+  * [Associations](#associations)
+  * [Scopes](#scopes)
+  * [Validations](#validations)
+  * [Hooks](#hooks)
+  * [Methods](#methods)
+
+## Overview
+
+Skyrim Inventory Management makes use of a concept called "master lists". A model that represents a list of other models (e.g., `ShoppingList`, which is a list of `ShoppingListItem` models) can include the `MasterListable` module to incorporate master list behaviour. Currently, the only such class is `ShoppingList`, so that will be used as the example here, but there are other models in the pipeline that will incorporate this behaviour as well.
+
+A master list is a list that tracks and aggregates data from other lists (the child lists). When an item is added, removed, or modified on a child list, the corresponding item is added, removed, or modified on the master list as well.
+
+Above where you include `MasterListable` in the model code, you will need to define a class method called `self.list_item_class_name` that is the class name, as a string, of the class the list items for this type of list belong to:
+
+```ruby
+class ShoppingList < ApplicationRecord
+  def self.list_item_class_name
+    'ShoppingListItem'
+  end
+
+  include MasterListable
+end
+```
+
+## Glossary
+
+* **Master List:** A list that tracks and aggregates data from a collection of regular lists of the same class. A master list is differentiated from a regular list by its `master` attribute, which is set to `true`. A user can have only one master list for each list class.
+* **Regular List:** Any list that is not a master list.
+* **Child List:** A regular list belonging to a particular master list.
+* **Should/Must:** Used in this document to describe things you will need to implement for models that include master list behaviour.
+* **Is/Does/Will:** Used in this document to describe behaviour provided out of the box by the `MasterListable` module.
+
+## Database Requirements
+
+The database schema for all models that include the `MasterListable` module must meet certain requirements:
+
+| Column Name | Type | Constraints | Notes |
+| ----------- | ---- | ----------- | ----- |
+| `master`      | boolean | default: false | Indicates whether the list is a master list |
+| `master_list_id` | integer | | Reference to the master list (if this list is not a master list) |
+| `user_id` | integer | NOT NULL | Reference to the user whose lists these are |
+| `title` | string | NOT NULL | The title of the list (will be set to "Master" for master lists) |
+
+The database schema for all child models (i.e., list items for a given list type) must also meet certain requirements:
+
+| Column Name | Type | Constraints | Notes |
+| ----------- | ---- | ----------- | ----- |
+| `list_id`      | integer | NOT NULL | The list to which the item belongs |
+| `description` | string | | The item's title or description |
+| `quantity` | integer | NOT NULL, default: 1 | The quantity of the item |
+| `notes` | string | | Any notes about the item |
+
+**The list item's description should be unique per list and not editable.** List items are uniquely identified on the master list by their descriptions. There should be a validation in place to make sure that descriptions cannot be changed.
+
+## Master List Behaviour
+
+Master list behaviour is complex and involves both list items and the lists themselves.
+
+### Creation and Destruction of Master Lists
+
+Best practice for master lists is to never create or update a master list manually. The `MasterListable` concern ensures that master lists are created and destroyed automatically.
+
+When a user creates their first regular list, a master list will be automatically created for them and set as that list's master list. Subsequent lists of the same class belonging to the same user should be created with that as the master list:
+```ruby
+user.master_shopping_list.child_lists.create!(title: 'My Title')
+```
+
+When a user destroys a regular list, and it is their last regular list of that class, the master list will also be destroyed.
+
+### Updating Master Lists
+
+The `MasterListable` module does not automatically update a master list when an item is added, removed, or modified on a child list, however, it does provide methods that you can use to do this updating. Updating is a core feature of master lists but fully implementing it in the models proved too magical and was leading to a lot of complexity in the code.
+
+#### Adding an Item to a Child List
+
+When an item is added to a regular list, the corresponding master list should also be updated. This can be done using the `#add_item_from_child_list` method, which handles all logic around adding items. This method will raise a `MasterListError` if it is called on a regular list.
+```ruby
+master_list.add_item_from_child_list(item)
+```
+
+There are two possible cases: there is an item already on the master list with the same description as the item being added, or there is not.
+
+##### When There Is No Exising Item
+
+If there is no item with the same description on the master list already, one should be created on the master list with the same attributes.
+
+##### When There Is an Existing Item
+
+If there is an item with the same description on the master list already, that item will be updated as follows:
+
+1. The `quantity` of the item on the master list will be increased by the quantity of the item being added.
+2. The `notes` of the item on the master list will be concatenated with the new item's notes, separated with ` -- `
+
+#### Removing an Item from a Child List
+
+When an item is removed from a regular list, the corresponding master list should also be updated. this can be done using the `#remove_item_from_child_list` method, which handles all logic around removing items. This method will raise a `MasterListError` if it is called on a regular list.
+```ruby
+master_list.remove_item_from_child_list(item)
+```
+
+There are two possible cases:
+
+1. The item on the master list has the same quantity as the item being removed (meaning there is no other item with the same `description` on any of the master list's children).
+2. The item on the master list has a quantity greater than that of the item being removed (meaning there's another item with the same `description` on another one of the master list's children).
+
+If the item passed in is not on the master list, or if its quantity is greater than the quantity on the master list, a `MasterListError` will be raised.
+
+##### When the Quantity Is Equal
+
+When the quantity of an item on the master list is equal to the quantity of the list item being removed, the item is removed from the master list.
+
+##### When the Quantity Is Greater
+
+When the quantity of an item on the master list is greater than the quantity of the list item being removed, the quantity and notes are updated on the master list item.
+
+The quantity of the master list item is reduced by the amount of the quantity of the item being removed. The notes are also updated to remove the notes associated with the item being removed. For example, if the master list item's notes are `"notes 1 -- notes 2"` and the item being removed has notes `"notes 1"`, then the notes should be changed to `" -- notes 2"`. These straggling values can be cleaned up in the [list item model](#list-item-model-requirements).
+
+#### Editing an Item on a Child List
+
+There are two values that can be edited on a child list item: `notes` and `quantity`. One or both may be updated at a given time. The master list values can be updated using the `#update_item_from_child_list` method. In order to call this method, you'll need to know four things:
+
+* The `description` of the item being edited (to find on the master list - remember that description should not be editable)
+* The change in quantity, if any (should be negative if the quantity was reduced, positive if it was increased, and zero if it did not change)
+* The old `notes` value
+* The new `notes` value
+
+The method will raise a `MasterListError` if called on a regular list or if the item being edited does not appear on the master list.
+
+##### Updating the Quantity
+
+Once the item is found on the master list, its `quantity` will be _increased_ by the value of the `delta_quantity` argument passed in. It is important that this value be negative if the `quantity` is to be reduced.
+
+##### Updating the Notes
+
+Once the item is found on the master list, its `notes` value will be updated if there is a difference between the old and new values passed in. If the old value is changed, it will be replaced in the master list item notes. If the value is changed to a blank or `nil` value, then the old value will be removed from the master list item notes.
+
+## List Model Requirements
+
+Before including the `MasterListable` module in your class, you will need to define the `list_item_class_name` class method. The method definition will need to be above where you include the module since it is used in the module's `included` block.
+
+## List Item Model Requirements
+
+Each list item model should implement `combine_or_new` and `combine_or_create!` methods. These methods look for a model on the same list matching the description passed in as an attribute. If no item on the same list matches that description, a new one is instantiated (or created). If there is a matching item on the same list, the quantity passed in should be added to the existing item's quantities and the notes fields on the existing and new items should be updated to aggregate the notes for both items.
+
+List items also need a way to clean up automatically edited `notes` values. This should be done in a `before_save` hook and should account for the following cases:
+
+* Leading `" -- "` (should be removed)
+* Trailing `" -- "` (should be removed)
+* Multiple `" -- "` next to each other in the middle of the list (should be turned into just one separator)
+
+For example:
+
+* `" -- notes 2"` should be changed to `"notes 2"`
+* `"notes 1 -- "` should be changed to  `"notes 1"`
+* `"notes 1 --  -- notes 3"` should be changeed to `"notes 1 -- notes 3"`
+
+Finally, list items need an `::index_order` scope to indicate how they should be returned with the list they're on (for the `ShoppingListItem` model, this order is descending `:updated_at` order).
+
+In the future, these behaviours will probably also be extracted to an abstract class or another concern. For now, you can see a reference implementation [here](/app/models/shopping_list_item.rb).
+
+## MasterListable
+
+The `MasterListable` module provides master list functionality to a list model. It adds the following out of the box.
+
+### Associations
+
+* Association to `:user` (`belongs_to :user`)
+* Association to `:master_list` (`belongs_to :master_list, foreign_key: :master_list_id`)
+* Association to `:child_lists` (`has_many :child_lists`)
+
+Note that the `:master_list` and `:child_lists` associated both belong to the same class as the master list.
+
+### Scopes
+
+* `::master_first` (returns lists with the master list first)
+* `::includes_items` (includes list items with the list)
+
+### Validations
+
+The `MasterListable` concern validates that no list that is not a master list can be named "Master". List names are case-insensitive so this applies to any casing. Titles may contain "master" (with any casing) as long as they don't consist entirely of that word.
+
+The concern also includes a validation verifying that the user has only one master list.
+
+Finally, there are validations ensuring that the master list is present for any regular list and that the list set as master list is, in fact, a master list.
+
+### Hooks
+
+The `MasterListable` concern introduces several hooks to manage master list behaviour.
+
+#### before_validation
+
+Before a regular list is created, if the user does not have an existing master list, the master list is created and set as the master list for the regular list being created. This hook only runs for regular lists and nothing happens if the master list already exists or the list is being updated as opposed to created.
+
+#### before_save
+
+The `#abort_if_master_changed` hook ensures that the `master` status of a list cannot be changed once the list has been created.
+
+The `#remove_master_list_id` hook ensures that master lists do not belong to master lists.
+
+The `#set_title_to_master` hook sets the title to "Master" if the list is a master list.
+
+#### before_destroy
+
+The `#abort_if_master` hook prevents master lists that have extant children from being destroyed.
+
+
+#### after_destroy
+
+The `#destroy_master_list` hook ensures that master lists are destroyed when their last child is.
+
+### Methods
+
+#### `#add_item_from_child_list(item)`
+
+Should be called on a master list any time an item is added to one of its child lists. Handles logic for creating or combining list items on the master list. Raises a `MasterListError` if called on a regular list.
+
+#### `#remove_item_from_child_list(item)`
+
+Should be called on a master list any time an item is removed/destroyed from one of its child lists. Handles logic for removing or updating list items on the master list. Raises a `MasterListError` if called on a regular list.
+
+#### `update_item_from_child_list(description, delta_quantity, old_notes, new_notes)`
+
+Should be called on a master list any time an item is updated on a child list. Raises a `MasterListError` if called on a regular list. Handles logic for updating items that already exist on a child list.
+
+Arguments:
+
+* `description`: The `description` of the item that has been changed (descriptions are not editable).
+* `delta_quantity`: The difference between the new and old quantity on the updated item. Should be negative if the new quantity is lower and positive if it is higher.
+* `old_notes`: The previous `notes` value of the item that has been changed
+* `new_notes`: Thee updated `notes` value of the item that has been changed

--- a/lib/controller/response.rb
+++ b/lib/controller/response.rb
@@ -9,20 +9,12 @@ module Controller
     end
 
     def execute
-      if result.unauthorized?
-        controller.head :unauthorized
-      elsif result.not_found?
-        controller.head :not_found
-      elsif result.method_not_allowed?
-        controller.render json: { errors: result.errors }, status: :method_not_allowed
-      elsif result.unprocessable_entity?
-        controller.render json: { errors: result.errors }, status: :unprocessable_entity
-      elsif result.ok?
-        controller.render json: result.resource, status: :ok
-      elsif result.created?
-        controller.render json: result.resource, status: :created
-      elsif result.no_content?
-        controller.head :no_content
+      if result.errors.blank? && result.resource.blank?
+        controller.head result.status
+      elsif result.errors.any?
+        controller.render json: { errors: result.errors }, status: result.status
+      else
+        controller.render json: result.resource, status: result.status
       end
     end
 

--- a/lib/controller/response.rb
+++ b/lib/controller/response.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Controller
+  class Response
+    def initialize(controller, result, options = {})
+      @controller = controller
+      @result = result
+      @options = options
+    end
+
+    def execute
+      if result.unauthorized?
+        controller.head :unauthorized
+      elsif result.not_found?
+        controller.head :not_found
+      elsif result.method_not_allowed?
+        controller.render json: { errors: result.errors }, status: :method_not_allowed
+      elsif result.unprocessable_entity?
+        controller.render json: { errors: result.errors }, status: :unprocessable_entity
+      elsif result.ok?
+        controller.render json: result.resource, status: :ok
+      elsif result.created?
+        controller.render json: result.resource, status: :created
+      elsif result.no_content?
+        controller.head :no_content
+      end
+    end
+
+    private
+
+    attr_reader :controller, :result, :options
+  end
+end

--- a/lib/service/created_result.rb
+++ b/lib/service/created_result.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'service/result'
+
+module Service
+  class CreatedResult < Result
+    def status
+      :created
+    end
+  end
+end

--- a/lib/service/method_not_allowed_result.rb
+++ b/lib/service/method_not_allowed_result.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'service/result'
+
+module Service
+  class MethodNotAllowedResult < Result
+    def status
+      :method_not_allowed
+    end
+  end
+end

--- a/lib/service/no_content_result.rb
+++ b/lib/service/no_content_result.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'service/result'
+
+module Service
+  class NoContentResult < Result
+    def status
+      :no_content
+    end
+  end
+end

--- a/lib/service/not_found_result.rb
+++ b/lib/service/not_found_result.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'service/result'
+
+module Service
+  class NotFoundResult < Result
+    def status
+      :not_found
+    end
+  end
+end

--- a/lib/service/ok_result.rb
+++ b/lib/service/ok_result.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'service/result'
+
+module Service
+  class OKResult < Result
+    def status
+      :ok
+    end
+  end
+end

--- a/lib/service/result.rb
+++ b/lib/service/result.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Service
+  class Result
+    attr_reader :errors, :resource
+
+    def initialize(options)
+      @errors = []
+
+      options.each do |key, value|
+        if [:error, 'error', :errors, 'errors'].include?(key)
+          @errors = [value].flatten
+        elsif [:resource, 'resource'].include?(key)
+          @resource = value
+        end
+      end
+    end
+
+    ############################################################
+    ### PUBLIC INSTANCE METHODS                              ###
+    ### Instance methods all return false on the base class. ###
+    ### These should be set to the appropriate values for    ###
+    ### each subclass.                                       ###
+    ############################################################
+
+    # These methods are blanket methods indicating whether a request
+    # was successful or not. One of these methods will be set to `true`
+    # in each subclass. One of the methods below will additionally be
+    # set to true to indicate the nature of the success or failure
+    # response.
+
+    def success?
+      false
+    end
+
+    def failure?
+      false
+    end
+
+    # These methods indicate the specific type (i.e., status code) of
+    # success response. One of these will be overridden to be `true` in
+    # each subclass that represents a successful response.
+
+    def ok? # 200
+      false
+    end
+
+    def created? # 201
+      false
+    end
+
+    def no_content? # 204
+      false
+    end
+
+
+    # These methods indicate the specific type of error response. One
+    # of these will be overridden to be `true` in each subclass that
+    # represents an error response.
+
+    def unauthorized? # 401
+      false
+    end
+
+    def not_found? # 404
+      false
+    end
+
+    def method_not_allowed? # 405
+      false
+    end
+
+    def unprocessable_entity? # 422
+      false
+    end
+  end
+end

--- a/lib/service/result.rb
+++ b/lib/service/result.rb
@@ -16,5 +16,9 @@ module Service
         end
       end
     end
+
+    def status
+      raise NotImplementedError
+    end
   end
 end

--- a/lib/service/result.rb
+++ b/lib/service/result.rb
@@ -4,7 +4,7 @@ module Service
   class Result
     attr_reader :errors, :resource, :status
 
-    def initialize(options)
+    def initialize(options = {})
       @errors = []
       @status = options[:status] || :ok
 

--- a/lib/service/result.rb
+++ b/lib/service/result.rb
@@ -2,10 +2,11 @@
 
 module Service
   class Result
-    attr_reader :errors, :resource
+    attr_reader :errors, :resource, :status
 
     def initialize(options)
       @errors = []
+      @status = options[:status] || :ok
 
       options.each do |key, value|
         if [:error, 'error', :errors, 'errors'].include?(key)
@@ -14,64 +15,6 @@ module Service
           @resource = value
         end
       end
-    end
-
-    ############################################################
-    ### PUBLIC INSTANCE METHODS                              ###
-    ### Instance methods all return false on the base class. ###
-    ### These should be set to the appropriate values for    ###
-    ### each subclass.                                       ###
-    ############################################################
-
-    # These methods are blanket methods indicating whether a request
-    # was successful or not. One of these methods will be set to `true`
-    # in each subclass. One of the methods below will additionally be
-    # set to true to indicate the nature of the success or failure
-    # response.
-
-    def success?
-      false
-    end
-
-    def failure?
-      false
-    end
-
-    # These methods indicate the specific type (i.e., status code) of
-    # success response. One of these will be overridden to be `true` in
-    # each subclass that represents a successful response.
-
-    def ok? # 200
-      false
-    end
-
-    def created? # 201
-      false
-    end
-
-    def no_content? # 204
-      false
-    end
-
-
-    # These methods indicate the specific type of error response. One
-    # of these will be overridden to be `true` in each subclass that
-    # represents an error response.
-
-    def unauthorized? # 401
-      false
-    end
-
-    def not_found? # 404
-      false
-    end
-
-    def method_not_allowed? # 405
-      false
-    end
-
-    def unprocessable_entity? # 422
-      false
     end
   end
 end

--- a/lib/service/unauthorized_result.rb
+++ b/lib/service/unauthorized_result.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'service/result'
+
+module Service
+  class UnauthorizedResult < Result
+    def status
+      :unauthorized
+    end
+  end
+end

--- a/lib/service/unprocessable_entity_result.rb
+++ b/lib/service/unprocessable_entity_result.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'service/result'
+
+module Service
+  class UnprocessableEntityResult < Result
+    def status
+      :unprocessable_entity
+    end
+  end
+end

--- a/spec/controller_services/application_controller/authorization_service_spec.rb
+++ b/spec/controller_services/application_controller/authorization_service_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'service/unauthorized_result'
+
+RSpec.describe ApplicationController::AuthorizationService do
+  describe '#perform' do
+    subject(:perform) { described_class.new(controller, 'xxxxxxxxxxxxxx').perform }
+
+    let(:controller) { instance_double(ApplicationController) }
+    let(:validator) { instance_double(GoogleIDToken::Validator, check: payload) }
+
+    before do
+      allow(GoogleIDToken::Validator).to receive(:new).and_return(validator)
+    end
+
+    context 'when the token is valid' do
+      let(:user) { create(:user, name: 'Jane Doe', email: 'jane.doe@gmail.com', uid: 'jane.doe@gmail.com') }
+      let(:payload) do
+        {
+          'exp' => (Time.now + 1.day).to_i,
+          'email' => 'jane.doe@gmail.com',
+          'name' => 'Jane Doe',
+          'picture' => nil
+        }
+      end
+
+      before do
+        allow(User).to receive(:create_or_update_for_google).and_return(user)
+        allow(controller).to receive(:current_user=)
+      end
+
+      it 'creates or updates the user' do
+        perform
+        expect(User).to have_received(:create_or_update_for_google).with(payload)
+      end
+
+      it 'sets the current user' do
+        perform
+        expect(controller).to have_received(:current_user=).with(user)
+      end
+
+      it 'returns nil' do
+        expect(perform).to be nil
+      end
+    end
+
+    context 'when the token is invalid' do
+      let(:payload) do
+        {
+          'exp' => (Time.now - 1.day).to_i,
+          'email' => 'jane.doe@gmail.com',
+          'name' => 'Jane Doe',
+          'picture' => nil
+        }
+      end
+
+      before do
+        allow(controller).to receive(:current_user=)
+      end
+
+      it 'does not set the current user' do
+        perform
+        expect(controller).not_to have_received(:current_user=)
+      end
+
+      it 'returns an UnauthorizedResult' do
+        expect(perform).to be_a(Service::UnauthorizedResult)
+      end
+    end
+
+    context 'when validation raises a GoogleIDToken::ValidationError' do
+      let(:payload) { {} }
+
+      before do
+        allow(validator).to receive(:check).and_raise(GoogleIDToken::ValidationError)
+        allow(Rails.logger).to receive(:error)
+        allow(controller).to receive(:current_user=)
+      end
+
+      it 'does not set the current user' do
+        perform
+        expect(controller).not_to have_received(:current_user=)
+      end
+
+      it 'logs the error message' do
+        perform
+        expect(Rails.logger).to have_received(:error).with('Token validation failed -- GoogleIDToken::ValidationError')
+      end
+
+      it 'returns an UnauthorizedResult' do
+        expect(perform).to be_a(Service::UnauthorizedResult)
+      end
+    end
+
+    context 'when validation raises a GoogleIDToken::CertificateError' do
+      let(:payload) { {} }
+
+      before do
+        allow(validator).to receive(:check).and_raise(GoogleIDToken::CertificateError)
+        allow(Rails.logger).to receive(:error)
+        allow(controller).to receive(:current_user=)
+      end
+
+      it 'does not set the current user' do
+        perform
+        expect(controller).not_to have_received(:current_user=)
+      end
+
+      it 'logs the error message' do
+        perform
+        expect(Rails.logger).to have_received(:error).with('Problem with OAuth certificate -- GoogleIDToken::CertificateError')
+      end
+
+      it 'returns an UnauthorizedResult' do
+        expect(perform).to be_a(Service::UnauthorizedResult)
+      end
+    end
+  end
+end

--- a/spec/controller_services/shopping_list_items_controller/create_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/create_service_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'service/created_result'
+require 'service/not_found_result'
+require 'service/unprocessable_entity_result'
+require 'service/method_not_allowed_result'
+require 'service/ok_result'
+
+RSpec.describe ShoppingListItemsController::CreateService do
+  describe '#perform' do
+    subject(:perform) { described_class.new(user, shopping_list.id, params).perform }
+
+    let(:user) { create(:user) }
+
+    context 'when all goes well' do
+      let!(:master_list) { create(:master_shopping_list, user: user) }
+      let!(:shopping_list) { create(:shopping_list, user: user, master_list: master_list) }
+      let(:params) { { 'description' => 'Necklace', 'quantity' => 2, 'notes' => 'Hello world' } }
+
+      before do
+        allow(user.shopping_lists).to receive(:find).and_return(shopping_list)
+        allow(shopping_list).to receive(:master_list).and_return(master_list)
+        allow(master_list).to receive(:add_item_from_child_list)
+      end
+
+      it 'adds a list item to the given list', :aggregate_failures do
+        expect { perform }.to change(shopping_list.list_items, :count).from(0).to(1)
+      end
+
+      it 'assigns the correct values' do
+        perform
+        expect(shopping_list.list_items.last.attributes).to include(**params)
+      end
+
+      it 'updates the master list', :aggregate_failures do
+        perform
+        expect(master_list).to have_received(:add_item_from_child_list)
+      end
+
+      it 'returns a Service::CreatedResult' do
+        expect(perform).to be_a(Service::CreatedResult)
+      end
+
+      it 'returns both the created list item and master list item' do
+        expect(perform.resource).to eq([master_list.list_items.last, shopping_list.list_items.last])
+      end
+    end
+
+    context 'when the list does not exist' do
+      let(:shopping_list) { double("list that doesn't exist", id: 348) }
+      let(:params) { { 'description' => 'Necklace', 'quantity' => 2, 'notes' => 'Hello world' } }
+
+      it 'returns a Service::NotFoundResult' do
+        expect(perform).to be_a(Service::NotFoundResult)
+      end
+    end
+
+    context 'when the list does not belong to the user' do
+      let!(:shopping_list) { create(:shopping_list) }
+      let(:params) { { description: 'Necklace', quantity: 2, notes: 'Hello world' } }
+
+      it 'returns a Service::NotFoundResult' do
+        expect(perform).to be_a(Service::NotFoundResult)
+      end
+    end
+
+    context 'when there is a duplicate description' do
+      let!(:master_list) { create(:master_shopping_list, user: user) }
+      let!(:shopping_list) { create(:shopping_list, user: user, master_list: master_list) }
+      let(:params) { { description: 'Necklace', quantity: 2, notes: 'Hello world' } }
+
+      before do
+        shopping_list.list_items.create!(description: 'Necklace', quantity: 1, notes: 'To enchant')
+        master_list.add_item_from_child_list(shopping_list.list_items.last)
+      end
+
+      it 'combines the item with an existing one' do
+        expect { perform }.not_to change(shopping_list.list_items, :count)
+      end
+
+      it 'returns a Service::OKResult' do
+        expect(perform).to be_a(Service::OKResult)
+      end
+
+      it 'sets the list items' do
+        expect(perform.resource).to eq([master_list.list_items.last, shopping_list.list_items.last])
+      end
+    end
+
+    context 'when the params are invalid' do
+      let!(:shopping_list) { create(:shopping_list, user: user) }
+      let(:params) { { description: 'Necklace', quantity: -1, notes: 'invalid quantity' } }
+
+      it 'returns a Service::UnprocessableEntityResult' do
+        expect(perform).to be_a(Service::UnprocessableEntityResult)
+      end
+
+      it 'sets the errors' do
+        expect(perform.errors).to eq(['Quantity must be greater than 0'])
+      end
+    end
+
+    context 'when the list is a master list' do
+      let!(:shopping_list) { create(:master_shopping_list, user: user) }
+      let(:params) { { description: 'Necklace', quantity: 1, notes: 'this should not work' } }
+
+      it 'returns a Service::MethodNotAllowedResult' do
+        expect(perform).to be_a(Service::MethodNotAllowedResult)
+      end
+
+      it 'sets the errors' do
+        expect(perform.errors).to eq(['Cannot manually manage items on a master shopping list'])
+      end
+    end
+  end
+end

--- a/spec/controller_services/shopping_lists_controller/create_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/create_service_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'service/created_result'
+require 'service/unprocessable_entity_result'
+
+RSpec.describe ShoppingListsController::CreateService do
+  describe '#perform' do
+    subject(:perform) { described_class.new(user, params).perform }
+    
+    let(:user) { create(:user) }
+
+    context 'when the request tries to create a master list' do
+      let(:params) do
+        {
+          title: 'Master',
+          master: true
+        }
+      end
+
+      it 'returns a Service::UnprocessableEntityResult' do
+        expect(perform).to be_a(Service::UnprocessableEntityResult)
+      end
+
+      it 'sets an error' do
+        expect(perform.errors).to eq(['Cannot manually create a master shopping list'])
+      end
+    end
+
+    context 'when params are valid' do
+      let(:params) { { title: 'Proudspire Manor' } }
+
+      context 'when the user has a master shopping list' do
+        before do
+          create(:master_shopping_list, user: user)
+        end
+
+        it 'creates a shopping list for the given user' do
+          expect { perform }.to change(user.shopping_lists, :count).from(1).to(2)
+        end
+
+        it 'returns a Service::CreatedResult' do
+          expect(perform).to be_a(Service::CreatedResult)
+        end
+
+        it 'sets the resource to the created list' do
+          expect(perform.resource).to eq user.shopping_lists.last
+        end
+      end
+
+      context "when the user doesn't have a master shopping list" do
+        it 'creates two lists' do
+          expect { perform }.to change(user.shopping_lists, :count).from(0).to(2)
+        end
+
+        it 'creates a master shopping list for the given user' do
+          perform
+          expect(user.master_shopping_list).to be_present
+        end
+
+        it 'creates a regular shopping list for the given user' do
+          perform
+          expect(user.shopping_lists.first.title).to eq 'Proudspire Manor'
+        end
+
+        it 'returns a Service::CreatedResult' do
+          expect(perform).to be_a(Service::CreatedResult)
+        end
+
+        it 'sets the resource to include both lists' do
+          expect(perform.resource).to eq([user.master_shopping_list, user.shopping_lists.first])
+        end
+      end
+    end
+
+    context 'when params are invalid' do
+      let(:params) { { title: '|nvalid Tit|e' } }
+
+      it 'does not create a shopping list' do
+        expect { perform }.not_to change(user.shopping_lists, :count)
+      end
+
+      it 'returns a Service::UnprocessableEntityResult' do
+        expect(perform).to be_a(Service::UnprocessableEntityResult)
+      end
+
+      it 'sets the errors' do
+        expect(perform.errors).to eq(['Title can only include alphanumeric characters and spaces'])
+      end
+    end
+  end
+end

--- a/spec/controller_services/shopping_lists_controller/create_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/create_service_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe ShoppingListsController::CreateService do
 
         it 'creates a regular shopping list for the given user' do
           perform
-          expect(user.shopping_lists.first.title).to eq 'Proudspire Manor'
+          expect(user.shopping_lists.last.title).to eq 'Proudspire Manor'
         end
 
         it 'returns a Service::CreatedResult' do
@@ -68,7 +68,7 @@ RSpec.describe ShoppingListsController::CreateService do
         end
 
         it 'sets the resource to include both lists' do
-          expect(perform.resource).to eq([user.master_shopping_list, user.shopping_lists.first])
+          expect(perform.resource).to eq([user.master_shopping_list, user.shopping_lists.last])
         end
       end
     end

--- a/spec/controller_services/shopping_lists_controller/destroy_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/destroy_service_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'service/no_content_result'
+require 'service/method_not_allowed_result'
+require 'service/not_found_result'
+require 'service/ok_result'
+
+RSpec.describe ShoppingListsController::DestroyService do
+  describe '#perform' do
+    subject(:perform) { described_class.new(user, shopping_list.id).perform }
+
+    let(:user) { create(:user) }
+
+    context 'when all goes well' do
+      let!(:shopping_list) { create(:shopping_list_with_list_items, user: user) }
+
+      context 'when the user has additional regular lists' do
+        let!(:master_list) { user.master_shopping_list }
+        let!(:third_list) { create(:shopping_list, user: user, master_list: master_list) }
+
+        before do
+          shopping_list.list_items.each do |list_item|
+            master_list.add_item_from_child_list(list_item)
+          end
+        end
+
+        it 'destroys the shopping list' do
+          expect { perform }.to change(user.shopping_lists, :count).from(3).to(2)
+        end
+
+        it 'returns a Service::OKResult' do
+          expect(perform).to be_a(Service::OKResult)
+        end
+
+        it 'sets the resource as the master list' do
+          expect(perform.resource).to eq master_list
+        end
+
+        describe 'updating the master list' do
+          before do
+            items = create_list(:shopping_list_item, 2, list: third_list)
+            items.each { |item| master_list.add_item_from_child_list(item) }
+
+            # Because in the code it finds the shopping list by ID and then gets the master list
+            # off that instance, the tests don't have access to the instance of the master list that
+            # the method is actually being called on, so we have to resort to this hack.
+            allow(user.shopping_lists).to receive(:find).and_return(shopping_list)
+            allow(shopping_list).to receive(:master_list).and_return(master_list)
+            allow(master_list).to receive(:remove_item_from_child_list).twice
+          end
+
+          it 'calls #remove_item_from_child_list for each item', :aggregate_failures do
+            perform
+
+            shopping_list.list_items.each do |item|
+              puts master_list.inspect
+              expect(master_list).to have_received(:remove_item_from_child_list).with(item.attributes)
+            end
+          end
+        end
+      end
+
+      context "when this is the user's last regular list" do
+        before do
+          shopping_list.list_items.each do |item|
+            shopping_list.master_list.add_item_from_child_list(item)
+          end
+        end
+
+        it 'destroys the master list too' do
+          expect { perform }.to change(user.shopping_lists, :count).from(2).to(0)
+        end
+
+        it 'returns a Service::NoContentResult' do
+          expect(perform).to be_a(Service::NoContentResult)
+        end
+      end
+    end
+
+    context 'when the list is a master list' do
+      let!(:shopping_list) { create(:master_shopping_list, user: user) }
+
+      it 'returns a Service::MethodNotAllowedResult' do
+        expect(perform).to be_a(Service::MethodNotAllowedResult)
+      end
+
+      it 'sets the errors' do
+        expect(perform.errors).to eq(['Cannot manually delete a master shopping list'])
+      end
+    end
+
+    context 'when the list does not belong to the user' do
+      let(:shopping_list) { create(:shopping_list) }
+
+      it 'returns a Service::NotFoundResult' do
+        expect(perform).to be_a(Service::NotFoundResult)
+      end
+    end
+
+    context 'when the list does not exist' do
+      let(:shopping_list) { double('list that does not exist', id: 838) }
+
+      it 'returns a Service::NotFoundResult' do
+        expect(perform).to be_a(Service::NotFoundResult)
+      end
+    end
+  end
+end

--- a/spec/controller_services/shopping_lists_controller/index_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/index_service_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'service/ok_result'
+
+RSpec.describe ShoppingListsController::IndexService do
+  describe '#perform' do
+    subject(:perform) { described_class.new(user).perform }
+
+    let(:user) { create(:user) }
+
+    context 'when the user has no shopping lists' do
+      it 'returns a Service::OKResult' do
+        expect(perform).to be_a(Service::OKResult)
+      end
+
+      it 'sets the resource to be an empty array' do
+        expect(perform.resource).to eq []
+      end
+    end
+
+    context 'when the user has shopping lists' do
+      let!(:master_list) { create(:master_shopping_list, user: user) }
+      let!(:lists) { create_list(:shopping_list_with_list_items, 2, user: user) }
+
+      it 'returns a Service::OKResult' do
+        expect(perform).to be_a(Service::OKResult)
+      end
+
+      it "sets the resource to the user's shopping lists" do
+        expect(perform.resource).to eq user.shopping_lists.index_order
+      end
+    end
+  end
+end

--- a/spec/controller_services/shopping_lists_controller/update_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/update_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ShoppingListsController::UpdateService do
     let(:user) { create(:user) }
     
     context 'when all goes well' do
-      let(:shopping_list) { create(:shopping_list, user: user) }
+      let(:shopping_list) { create(:shopping_list, user: user, master_list_id: master_list.id) }
       let(:params) { { title: 'My New Title' } }
 
       it 'updates the shopping list' do

--- a/spec/controller_services/shopping_lists_controller/update_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/update_service_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'service/ok_result'
+require 'service/method_not_allowed_result'
+require 'service/not_found_result'
+require 'service/unprocessable_entity_result'
+
+RSpec.describe ShoppingListsController::UpdateService do
+  describe '#perform' do
+    subject(:perform) { described_class.new(user, shopping_list.id, params).perform }
+    
+    let!(:master_list) { create(:master_shopping_list, user: user) }
+    let(:user) { create(:user) }
+    
+    context 'when all goes well' do
+      let(:shopping_list) { create(:shopping_list, user: user) }
+      let(:params) { { title: 'My New Title' } }
+
+      it 'updates the shopping list' do
+        perform
+        expect(shopping_list.reload.title).to eq 'My New Title'
+      end
+
+      it 'returns a Service::OKResult' do
+        expect(perform).to be_a(Service::OKResult)
+      end
+
+      it 'sets the resource to the updated shopping list' do
+        expect(perform.resource).to eq shopping_list
+      end
+    end
+
+    context 'when the params are invalid' do
+      let(:shopping_list) { create(:shopping_list, user: user) }
+      let(:params) { { title: '|nvalid Tit|e' } }
+
+      it 'returns a Service::UnprocessableEntityResult' do
+        expect(perform).to be_a(Service::UnprocessableEntityResult)
+      end
+
+      it 'sets the errors' do
+        expect(perform.errors).to eq(['Title can only include alphanumeric characters and spaces'])
+      end
+    end
+
+    context 'when the shopping list does not belong to the user' do
+      let(:shopping_list) { create(:shopping_list) }
+      let(:params) { { title: 'Valid New Title' } }
+      
+      it 'returns a Service::NotFoundResult' do
+        expect(perform).to be_a(Service::NotFoundResult)
+      end
+    end
+
+    context 'when the shopping list is a master shopping list' do
+      let(:shopping_list) { master_list }
+      let(:params) { { title: 'New Title' } }
+
+      it 'returns a Service::MethodNotAllowedResult' do
+        expect(perform).to be_a(Service::MethodNotAllowedResult)
+      end
+
+      it 'sets the error message' do
+        expect(perform.errors).to eq(['Cannot manually update a master shopping list'])
+      end
+    end
+
+    context 'when the request tries to set master to true' do
+      let(:shopping_list) { create(:shopping_list, user: user) }
+      let(:params) { { master: true } }
+
+      it 'returns a Service::UnprocessableEntityResult' do
+        expect(perform).to be_a(Service::UnprocessableEntityResult)
+      end
+
+      it 'sets the error message' do
+        expect(perform.errors).to eq(['Cannot make a regular shopping list a master list'])
+      end
+    end
+  end
+end

--- a/spec/controller_services/users_controller/show_service_spec.rb
+++ b/spec/controller_services/users_controller/show_service_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'service/ok_result'
+
+RSpec.describe UsersController::ShowService do
+  describe '#perform' do
+    subject(:perform) { described_class.new(user).perform }
+
+    let(:user) { create(:user) }
+
+    it 'returns a Service::OKResult' do
+      expect(perform).to be_a(Service::OKResult)
+    end
+
+    it 'includes the payload' do
+      expect(perform.resource).to eq(user)
+    end
+  end
+end

--- a/spec/factories/shopping_list_items.rb
+++ b/spec/factories/shopping_list_items.rb
@@ -2,9 +2,9 @@
 
 FactoryBot.define do
   factory :shopping_list_item do
-    shopping_list
+    association :list, factory: :shopping_list
 
-    description { 'Necklace' }
+    sequence(:description) { |n| "Item #{n}" }
     quantity { 1 }
   end
 end

--- a/spec/factories/shopping_lists.rb
+++ b/spec/factories/shopping_lists.rb
@@ -10,6 +10,8 @@ FactoryBot.define do
       master { true }
 
       title { 'Master' }
+      master_list_id { nil }
+
     end
 
     factory :shopping_list_with_list_items do
@@ -17,8 +19,8 @@ FactoryBot.define do
         list_item_count { 2 }
       end
 
-      after(:build, :create) do |list, evaluator|
-        create_list(:shopping_list_item, evaluator.list_item_count, shopping_list: list)
+      after(:create) do |list, evaluator|
+        create_list(:shopping_list_item, evaluator.list_item_count, list: list)
       end
     end
   end

--- a/spec/lib/controller/response_spec.rb
+++ b/spec/lib/controller/response_spec.rb
@@ -1,0 +1,184 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'service/result'
+require 'controller/response'
+
+RSpec.describe Controller::Response do
+  describe '#execute' do
+    subject(:execute) { described_class.new(controller, result, options).execute }
+
+    context 'when the response status is 401' do
+      let(:controller) { instance_double(VerificationsController, head: nil) }
+      let(:options) { {} }
+      let(:result) do
+        instance_double(Service::Result,
+          unauthorized?: true,
+          not_found?: false,
+          method_not_allowed?: false,
+          errors: []
+        )
+      end
+
+      it 'returns a 401 response with no response body' do
+        execute
+        expect(controller).to have_received(:head).with(:unauthorized)
+      end
+    end
+
+    context 'when the response status is 404' do
+      let(:controller) { instance_double(ShoppingListsController, head: nil) }
+      let(:options) { {} }
+      let(:result) do
+        instance_double(Service::Result,
+          unauthorized?: false,
+          not_found?: true,
+          method_not_allowed?: false,
+          errors: []
+        )
+      end
+
+      it 'returns a 404 error with no response body' do
+        execute
+        expect(controller).to have_received(:head).with(:not_found)
+      end
+    end
+
+    context 'when the response status is 405' do
+      let(:controller) { instance_double(ShoppingListsController, render: nil) }
+      let(:errors) { ['Cannot manually update a master shopping list'] }
+      let(:options) { {} }
+      let(:result) do
+        instance_double(Service::Result,
+          unauthorized?: false,
+          not_found?: false,
+          method_not_allowed?: true,
+          errors: errors
+        )
+      end
+
+      it 'returns a 405 error with the errors' do
+        execute
+        expect(controller).to have_received(:render).with(json: { errors: errors }, status: :method_not_allowed)
+      end
+    end
+
+    context 'when the response status is 422' do
+      let(:controller) { instance_double(ShoppingListsController, render: nil) }
+      let(:options) { {} }
+      let(:errors) { ['Title is already taken', 'Cannot manually create or update a master list'] }
+      let(:result) do
+        instance_double(Service::Result,
+          unauthorized?: false,
+          not_found?: false,
+          method_not_allowed?: false,
+          unprocessable_entity?: true,
+          errors: errors
+        )
+      end
+
+      it 'renders the errors' do
+        execute
+        expect(controller).to have_received(:render).with(json: { errors: errors }, status: :unprocessable_entity)
+      end
+    end
+
+    context 'when the response status is 200' do
+      let(:controller) { instance_double(ShoppingListsController, render: nil) }
+      let(:options) { {} }
+
+      let(:resource) do
+        {
+          id: 927,
+          user_id: 72,
+          title: 'My List 2',
+          created_at: Time.now - 2.days,
+          updated_at: Time.now
+        }
+      end
+
+      let(:result) do
+        instance_double(Service::Result,
+          unauthorized?: false,
+          not_found?: false,
+          method_not_allowed?: false,
+          unprocessable_entity?: false,
+          ok?: true,
+          resource: resource
+        )
+      end
+
+      it 'renders the resource' do
+        execute
+        expect(controller).to have_received(:render).with(json: resource, status: :ok)
+      end
+    end
+
+    context 'when the response status is 201' do
+      let(:controller) { instance_double(ShoppingListItemsController, render: nil) }
+      let(:options) { {} }
+
+      let(:resource) do
+        [
+          {
+            id: 927,
+            shopping_list_id: 72,
+            description: 'Ebony sword',
+            quantity: 2,
+            notes: nil,
+            created_at: Time.now - 2.days,
+            updated_at: Time.now
+          },
+          {
+            id: 926,
+            shopping_list_id: 75,
+            description: 'Ebony sword',
+            quantity: 1,
+            notes: nil,
+            created_at: Time.now,
+            updated_at: Time.now
+          }            
+        ]
+      end
+
+      let(:result) do
+        instance_double(Service::Result,
+          unauthorized?: false,
+          not_found?: false,
+          method_not_allowed?: false,
+          unprocessable_entity?: false,
+          ok?: false,
+          created?: true,
+          resource: resource
+        )
+      end
+
+      it 'renders the resource' do
+        execute
+        expect(controller).to have_received(:render).with(json: resource, status: :created)
+      end
+    end
+
+    context 'when the response status is 204' do
+      let(:controller) { instance_double(ShoppingListItemsController, head: nil) }
+      let(:options) { {} }
+
+      let(:result) do
+        instance_double(Service::Result,
+          unauthorized?: false,
+          not_found?: false,
+          method_not_allowed?: false,
+          unprocessable_entity?: false,
+          ok?: false,
+          created?: false,
+          no_content?: true
+        )
+      end
+
+      it 'renders the resource' do
+        execute
+        expect(controller).to have_received(:head).with(:no_content)
+      end
+    end
+  end
+end

--- a/spec/lib/controller/response_spec.rb
+++ b/spec/lib/controller/response_spec.rb
@@ -2,6 +2,8 @@
 
 require 'rails_helper'
 require 'service/result'
+require 'service/ok_result'
+require 'service/no_content_result'
 require 'controller/response'
 
 RSpec.describe Controller::Response do
@@ -11,7 +13,7 @@ RSpec.describe Controller::Response do
     context 'when the result has no resource and the errors are empty' do
       let(:controller) { instance_double(VerificationsController, head: nil) }
       let(:options) { {} }
-      let(:result) { instance_double(Service::Result, status: :no_content, resource: nil, errors: []) }
+      let(:result) { Service::NoContentResult.new(resource: nil, errors: []) }
 
       it 'returns the status with no response body' do
         execute
@@ -22,13 +24,7 @@ RSpec.describe Controller::Response do
     context 'when there is a resource' do
       let(:controller) { instance_double(ShoppingListsController, render: nil) }
       let(:options) { {} }
-      let(:result) do
-        instance_double(Service::Result,
-          resource: resource,
-          status: :ok,
-          errors: []
-        )
-      end
+      let(:result) { Service::OKResult.new(resource: resource) }
 
       let(:resource) do
         {

--- a/spec/lib/controller/response_spec.rb
+++ b/spec/lib/controller/response_spec.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'service/result'
 require 'service/ok_result'
 require 'service/no_content_result'
+require 'service/method_not_allowed_result'
+require 'service/unprocessable_entity_result'
 require 'controller/response'
 
 RSpec.describe Controller::Response do
@@ -46,13 +47,7 @@ RSpec.describe Controller::Response do
       let(:controller) { instance_double(ShoppingListsController, render: nil) }
       let(:errors) { ['Cannot manually update a master shopping list'] }
       let(:options) { {} }
-      let(:result) do
-        instance_double(Service::Result,
-          status: :method_not_allowed,
-          resource: nil,
-          errors: errors
-        )
-      end
+      let(:result) { Service::MethodNotAllowedResult.new(errors: errors) }
 
       it 'renders the errors with the result status' do
         execute
@@ -65,13 +60,7 @@ RSpec.describe Controller::Response do
         let(:controller) { instance_double(ShoppingListsController, render: nil) }
         let(:options) { {} }
         let(:errors) { ['Title is already taken', 'Cannot manually create or update a master list'] }
-        let(:result) do
-          instance_double(Service::Result,
-            status: :unprocessable_entity,
-            errors: errors,
-            resource: { foo: 'foo', bar: 'bar' }
-          )
-        end
+        let(:result) { Service::UnprocessableEntityResult.new(errors: errors, resource: { foo: 'bar' }) }
 
         it 'renders the errors' do
           execute

--- a/spec/lib/controller/response_spec.rb
+++ b/spec/lib/controller/response_spec.rb
@@ -8,84 +8,27 @@ RSpec.describe Controller::Response do
   describe '#execute' do
     subject(:execute) { described_class.new(controller, result, options).execute }
 
-    context 'when the response status is 401' do
+    context 'when the result has no resource and the errors are empty' do
       let(:controller) { instance_double(VerificationsController, head: nil) }
       let(:options) { {} }
+      let(:result) { instance_double(Service::Result, status: :no_content, resource: nil, errors: []) }
+
+      it 'returns the status with no response body' do
+        execute
+        expect(controller).to have_received(:head).with(:no_content)
+      end
+    end
+
+    context 'when there is a resource' do
+      let(:controller) { instance_double(ShoppingListsController, render: nil) }
+      let(:options) { {} }
       let(:result) do
         instance_double(Service::Result,
-          unauthorized?: true,
-          not_found?: false,
-          method_not_allowed?: false,
+          resource: resource,
+          status: :ok,
           errors: []
         )
       end
-
-      it 'returns a 401 response with no response body' do
-        execute
-        expect(controller).to have_received(:head).with(:unauthorized)
-      end
-    end
-
-    context 'when the response status is 404' do
-      let(:controller) { instance_double(ShoppingListsController, head: nil) }
-      let(:options) { {} }
-      let(:result) do
-        instance_double(Service::Result,
-          unauthorized?: false,
-          not_found?: true,
-          method_not_allowed?: false,
-          errors: []
-        )
-      end
-
-      it 'returns a 404 error with no response body' do
-        execute
-        expect(controller).to have_received(:head).with(:not_found)
-      end
-    end
-
-    context 'when the response status is 405' do
-      let(:controller) { instance_double(ShoppingListsController, render: nil) }
-      let(:errors) { ['Cannot manually update a master shopping list'] }
-      let(:options) { {} }
-      let(:result) do
-        instance_double(Service::Result,
-          unauthorized?: false,
-          not_found?: false,
-          method_not_allowed?: true,
-          errors: errors
-        )
-      end
-
-      it 'returns a 405 error with the errors' do
-        execute
-        expect(controller).to have_received(:render).with(json: { errors: errors }, status: :method_not_allowed)
-      end
-    end
-
-    context 'when the response status is 422' do
-      let(:controller) { instance_double(ShoppingListsController, render: nil) }
-      let(:options) { {} }
-      let(:errors) { ['Title is already taken', 'Cannot manually create or update a master list'] }
-      let(:result) do
-        instance_double(Service::Result,
-          unauthorized?: false,
-          not_found?: false,
-          method_not_allowed?: false,
-          unprocessable_entity?: true,
-          errors: errors
-        )
-      end
-
-      it 'renders the errors' do
-        execute
-        expect(controller).to have_received(:render).with(json: { errors: errors }, status: :unprocessable_entity)
-      end
-    end
-
-    context 'when the response status is 200' do
-      let(:controller) { instance_double(ShoppingListsController, render: nil) }
-      let(:options) { {} }
 
       let(:resource) do
         {
@@ -97,87 +40,47 @@ RSpec.describe Controller::Response do
         }
       end
 
-      let(:result) do
-        instance_double(Service::Result,
-          unauthorized?: false,
-          not_found?: false,
-          method_not_allowed?: false,
-          unprocessable_entity?: false,
-          ok?: true,
-          resource: resource
-        )
-      end
-
-      it 'renders the resource' do
+      it 'renders the resource with the result status' do
         execute
         expect(controller).to have_received(:render).with(json: resource, status: :ok)
       end
     end
 
-    context 'when the response status is 201' do
-      let(:controller) { instance_double(ShoppingListItemsController, render: nil) }
+    context 'when there are errors' do
+      let(:controller) { instance_double(ShoppingListsController, render: nil) }
+      let(:errors) { ['Cannot manually update a master shopping list'] }
       let(:options) { {} }
-
-      let(:resource) do
-        [
-          {
-            id: 927,
-            shopping_list_id: 72,
-            description: 'Ebony sword',
-            quantity: 2,
-            notes: nil,
-            created_at: Time.now - 2.days,
-            updated_at: Time.now
-          },
-          {
-            id: 926,
-            shopping_list_id: 75,
-            description: 'Ebony sword',
-            quantity: 1,
-            notes: nil,
-            created_at: Time.now,
-            updated_at: Time.now
-          }            
-        ]
-      end
-
       let(:result) do
         instance_double(Service::Result,
-          unauthorized?: false,
-          not_found?: false,
-          method_not_allowed?: false,
-          unprocessable_entity?: false,
-          ok?: false,
-          created?: true,
-          resource: resource
+          status: :method_not_allowed,
+          resource: nil,
+          errors: errors
         )
       end
 
-      it 'renders the resource' do
+      it 'renders the errors with the result status' do
         execute
-        expect(controller).to have_received(:render).with(json: resource, status: :created)
+        expect(controller).to have_received(:render).with(json: { errors: errors }, status: :method_not_allowed)
       end
     end
 
-    context 'when the response status is 204' do
-      let(:controller) { instance_double(ShoppingListItemsController, head: nil) }
-      let(:options) { {} }
+    describe 'unexpected cases' do
+      context 'when there is a resource and errors' do
+        let(:controller) { instance_double(ShoppingListsController, render: nil) }
+        let(:options) { {} }
+        let(:errors) { ['Title is already taken', 'Cannot manually create or update a master list'] }
+        let(:result) do
+          instance_double(Service::Result,
+            status: :unprocessable_entity,
+            errors: errors,
+            resource: { foo: 'foo', bar: 'bar' }
+          )
+        end
 
-      let(:result) do
-        instance_double(Service::Result,
-          unauthorized?: false,
-          not_found?: false,
-          method_not_allowed?: false,
-          unprocessable_entity?: false,
-          ok?: false,
-          created?: false,
-          no_content?: true
-        )
-      end
-
-      it 'renders the resource' do
-        execute
-        expect(controller).to have_received(:head).with(:no_content)
+        it 'renders the errors' do
+          execute
+          expect(controller).to have_received(:render).with(json: { errors: errors }, status: :unprocessable_entity)
+        end
       end
     end
   end

--- a/spec/lib/created_result_spec.rb
+++ b/spec/lib/created_result_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'service/created_result'
+
+RSpec.describe Service::CreatedResult do
+  subject(:result) { described_class.new(options) }
+
+  let(:options) do
+    {
+      resource: { foo: 'bar' }
+    }
+  end
+
+  describe '#status' do
+    it 'is :created' do
+      expect(result.status).to eq :created
+    end
+  end
+end

--- a/spec/lib/service/method_not_allowed_result_spec.rb
+++ b/spec/lib/service/method_not_allowed_result_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'service/method_not_allowed_result'
+
+RSpec.describe Service::MethodNotAllowedResult do
+  subject(:result) { described_class.new(errors: ['Cannot manually update a master list']) }
+
+  describe '#status' do
+    it 'is :method_not_allowed' do
+      expect(result.status).to eq :method_not_allowed
+    end
+  end
+end

--- a/spec/lib/service/no_content_result_spec.rb
+++ b/spec/lib/service/no_content_result_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'service/no_content_result'
+
+RSpec.describe Service::NoContentResult do
+  subject(:result) { described_class.new(options) }
+
+  let(:options) do
+    {}
+  end
+
+  describe '#status' do
+    it 'is :no_content' do
+      expect(result.status).to eq :no_content
+    end
+  end
+end

--- a/spec/lib/service/not_found_result_spec.rb
+++ b/spec/lib/service/not_found_result_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'service/not_found_result'
+
+RSpec.describe Service::NotFoundResult do
+  subject(:result) { described_class.new({}) }
+
+  describe '#status' do
+    it 'is :not_found' do
+      expect(result.status).to eq :not_found
+    end
+  end
+end

--- a/spec/lib/service/ok_result_spec.rb
+++ b/spec/lib/service/ok_result_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'service/ok_result'
+
+RSpec.describe Service::OKResult do
+  subject(:result) { described_class.new(options) }
+
+  let(:options) do
+    {
+      resource: { foo: 'bar' }
+    }
+  end
+
+  describe '#status' do
+    it 'is :ok' do
+      expect(result.status).to eq :ok
+    end
+  end
+end

--- a/spec/lib/service/result_spec.rb
+++ b/spec/lib/service/result_spec.rb
@@ -6,6 +6,12 @@ RSpec.describe Service::Result do
   subject(:result) { described_class.new(options) }
 
   describe 'initialisation' do
+    let(:options) { { status: :unprocessable_entity, errors: ['Title is already taken'] } }
+
+    it 'sets the status' do
+      expect(result.status).to eq :unprocessable_entity
+    end
+
     context 'when a resource is given' do
       let(:options) do
         {
@@ -67,64 +73,6 @@ RSpec.describe Service::Result do
 
       it 'sets the errors to an empty array' do
         expect(result.errors).to eq []
-      end
-    end
-  end
-
-  describe 'instance methods' do
-    let(:options) { {} }
-
-    describe '#success?' do
-      it 'is false on the base class' do
-        expect(result.success?).to be false
-      end
-    end
-
-    describe '#failure?' do
-      it 'is false on the base class' do
-        expect(result.failure?).to be false
-      end
-    end
-
-    describe '#ok?' do
-      it 'is false on the base class' do
-        expect(result.ok?).to be false
-      end
-    end
-
-    describe '#created?' do
-      it 'is false on the base class' do
-        expect(result.created?).to be false
-      end
-    end
-
-    describe '#no_content?' do
-      it 'is false on the base class' do
-        expect(result.no_content?).to be false
-      end
-    end
-
-    describe '#unauthorized?' do
-      it 'is false on the base class' do
-        expect(result.unauthorized?).to be false
-      end
-    end
-
-    describe '#not_found?' do
-      it 'is false on the base class' do
-        expect(result.not_found?).to be false
-      end
-    end
-
-    describe '#method_not_allowed?' do
-      it 'is false on the base class' do
-        expect(result.method_not_allowed?).to be false
-      end
-    end
-
-    describe '#unprocessable_entity?' do
-      it 'is false on the base class' do
-        expect(result.unprocessable_entity?).to be false
       end
     end
   end

--- a/spec/lib/service/result_spec.rb
+++ b/spec/lib/service/result_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require 'service/result'
+
+RSpec.describe Service::Result do
+  subject(:result) { described_class.new(options) }
+
+  describe 'initialisation' do
+    context 'when a resource is given' do
+      let(:options) do
+        {
+          resource: {
+            id: 32,
+            uid: 'jane.doe@gmail.com',
+            email: 'jane.doe@gmail.com',
+            name: 'Jane Doe',
+            image_url: nil
+          }
+        }
+      end
+
+      it 'sets the resource if one is given' do
+        expect(result.resource).to eq({
+                                        id: 32,
+                                        uid: 'jane.doe@gmail.com',
+                                        email: 'jane.doe@gmail.com',
+                                        name: 'Jane Doe',
+                                        image_url: nil
+                                      })
+      end
+    end
+
+    context 'when no resource is given' do
+      let(:options) { {} }
+
+      it 'sets the resource to nil' do
+        expect(result.resource).to be nil
+      end
+    end
+
+    context 'when there are errors' do
+      let(:options) do
+        {
+          errors: ['foo', ['bar', ['baz', 'qux']]]
+        }
+      end
+
+      it 'sets the errors array to a flattened value' do
+        expect(result.errors).to eq %w[foo bar baz qux]
+      end
+    end
+
+    context 'when there is one error' do
+      let(:options) do
+        {
+          error: 'foobar'
+        }
+      end
+
+      it 'sets the errors to an array' do
+        expect(result.errors).to eq %w[foobar]
+      end
+    end
+
+    context 'when there are no errors' do
+      let(:options) { {} }
+
+      it 'sets the errors to an empty array' do
+        expect(result.errors).to eq []
+      end
+    end
+  end
+
+  describe 'instance methods' do
+    let(:options) { {} }
+
+    describe '#success?' do
+      it 'is false on the base class' do
+        expect(result.success?).to be false
+      end
+    end
+
+    describe '#failure?' do
+      it 'is false on the base class' do
+        expect(result.failure?).to be false
+      end
+    end
+
+    describe '#ok?' do
+      it 'is false on the base class' do
+        expect(result.ok?).to be false
+      end
+    end
+
+    describe '#created?' do
+      it 'is false on the base class' do
+        expect(result.created?).to be false
+      end
+    end
+
+    describe '#no_content?' do
+      it 'is false on the base class' do
+        expect(result.no_content?).to be false
+      end
+    end
+
+    describe '#unauthorized?' do
+      it 'is false on the base class' do
+        expect(result.unauthorized?).to be false
+      end
+    end
+
+    describe '#not_found?' do
+      it 'is false on the base class' do
+        expect(result.not_found?).to be false
+      end
+    end
+
+    describe '#method_not_allowed?' do
+      it 'is false on the base class' do
+        expect(result.method_not_allowed?).to be false
+      end
+    end
+
+    describe '#unprocessable_entity?' do
+      it 'is false on the base class' do
+        expect(result.unprocessable_entity?).to be false
+      end
+    end
+  end
+end

--- a/spec/lib/service/result_spec.rb
+++ b/spec/lib/service/result_spec.rb
@@ -8,8 +8,10 @@ RSpec.describe Service::Result do
   describe 'initialisation' do
     let(:options) { { status: :unprocessable_entity, errors: ['Title is already taken'] } }
 
-    it 'sets the status' do
-      expect(result.status).to eq :unprocessable_entity
+    describe 'status' do
+      it 'raises a NotImplementedError on the base class' do
+        expect { result.status }.to raise_error NotImplementedError
+      end
     end
 
     context 'when a resource is given' do

--- a/spec/lib/service/unauthorized_result_spec.rb
+++ b/spec/lib/service/unauthorized_result_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'service/unauthorized_result'
+
+RSpec.describe Service::UnauthorizedResult do
+  subject(:result) { described_class.new({}) }
+
+  describe '#status' do
+    it 'is :unauthorized' do
+      expect(result.status).to eq :unauthorized
+    end
+  end
+end

--- a/spec/lib/service/unprocessable_entity_result_spec.rb
+++ b/spec/lib/service/unprocessable_entity_result_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'service/unprocessable_entity_result'
+
+RSpec.describe Service::UnprocessableEntityResult do
+  subject(:result) { described_class.new(errors: ['Cannot manually update a master list']) }
+
+  describe '#status' do
+    it 'is :unprocessable_entity' do
+      expect(result.status).to eq :unprocessable_entity
+    end
+  end
+end

--- a/spec/models/shopping_list_item_spec.rb
+++ b/spec/models/shopping_list_item_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ShoppingListItem, type: :model do
     subject(:user) { create(:user) }
 
     let(:shopping_list) { create(:shopping_list, user: user) }
-    let(:list_item) { create(:shopping_list_item, shopping_list: shopping_list) }
+    let(:list_item) { create(:shopping_list_item, list: shopping_list) }
     
     before do
       create(:master_shopping_list, user: user)
@@ -24,9 +24,9 @@ RSpec.describe ShoppingListItem, type: :model do
     describe '::index_order' do
       let!(:master_list) { create(:master_shopping_list) }
 
-      let!(:list_item1) { create(:shopping_list_item, shopping_list: list) }
-      let!(:list_item2) { create(:shopping_list_item, shopping_list: list) }
-      let!(:list_item3) { create(:shopping_list_item, shopping_list: list) }
+      let!(:list_item1) { create(:shopping_list_item, list: list) }
+      let!(:list_item2) { create(:shopping_list_item, list: list) }
+      let!(:list_item3) { create(:shopping_list_item, list: list) }
 
       let(:list) { create(:shopping_list, user: master_list.user) }
 
@@ -35,21 +35,21 @@ RSpec.describe ShoppingListItem, type: :model do
       end
 
       it 'returns the list items in descending chronological order by updated_at' do
-        expect(list.shopping_list_items.index_order.to_a).to eq([list_item2, list_item3, list_item1])
+        expect(list.list_items.index_order.to_a).to eq([list_item2, list_item3, list_item1])
       end
     end
   end
 
   describe '::combine_or_create!' do
     context 'when there is an existing item on the same list with the same description' do
-      subject(:combine_or_create) { described_class.combine_or_create!(description: 'existing item', quantity: 1, shopping_list: shopping_list, notes: 'notes 2') }
+      subject(:combine_or_create) { described_class.combine_or_create!(description: 'existing item', quantity: 1, list: shopping_list, notes: 'notes 2') }
 
       let(:master_list) { create(:master_shopping_list) }
       let!(:shopping_list) { create(:shopping_list, user: master_list.user) }
-      let!(:existing_item) { create(:shopping_list_item, description: 'Existing item', quantity: 2, shopping_list: shopping_list, notes: 'notes 1') }
+      let!(:existing_item) { create(:shopping_list_item, description: 'Existing item', quantity: 2, list: shopping_list, notes: 'notes 1') }
 
       it "doesn't create a new list item" do
-        expect { combine_or_create }.not_to change(shopping_list.shopping_list_items, :count)
+        expect { combine_or_create }.not_to change(shopping_list.list_items, :count)
       end
 
       it 'adds the quantity to the existing item' do
@@ -66,11 +66,11 @@ RSpec.describe ShoppingListItem, type: :model do
 
   describe '::combine_or_new' do
     context 'when there is an existing item on the same list with the same description' do
-      subject(:combine_or_new) { described_class.combine_or_new(description: 'existing item', quantity: 1, shopping_list: shopping_list, notes: 'notes 2') }
+      subject(:combine_or_new) { described_class.combine_or_new(description: 'existing item', quantity: 1, list: shopping_list, notes: 'notes 2') }
 
       let(:master_list) { create(:master_shopping_list) }
       let!(:shopping_list) { create(:shopping_list, user: master_list.user) }
-      let!(:existing_item) { create(:shopping_list_item, description: 'Existing item', quantity: 2, shopping_list: shopping_list, notes: 'notes 1') }
+      let!(:existing_item) { create(:shopping_list_item, description: 'Existing item', quantity: 2, list: shopping_list, notes: 'notes 1') }
 
       before do
         allow(ShoppingListItem).to receive(:new)
@@ -93,17 +93,13 @@ RSpec.describe ShoppingListItem, type: :model do
     end
 
     context 'when there is not an existing item on the same list with that description' do
-      subject(:combine_or_create) { described_class.combine_or_create!(description: 'new item', quantity: 1, shopping_list: shopping_list) }
+      subject(:combine_or_create) { described_class.combine_or_create!(description: 'new item', quantity: 1, list: shopping_list) }
 
       let(:master_list) { create(:master_shopping_list) }
       let!(:shopping_list) { create(:shopping_list, user: master_list.user) }
 
       it 'creates a new item on the list' do
-        expect { combine_or_create }.to change(shopping_list.shopping_list_items, :count).by(1)
-      end
-
-      it 'creates a new item on the master list' do
-        expect { combine_or_create }.to change(shopping_list.user.master_shopping_list.shopping_list_items, :count).by(1)
+        expect { combine_or_create }.to change(shopping_list.list_items, :count).by(1)
       end
     end
   end
@@ -111,7 +107,7 @@ RSpec.describe ShoppingListItem, type: :model do
   describe '#update!' do
     let(:master_list) { create(:master_shopping_list) }
     let(:shopping_list) { create(:shopping_list, user: master_list.user) }
-    let!(:list_item) { create(:shopping_list_item, quantity: 1, shopping_list: shopping_list) }
+    let!(:list_item) { create(:shopping_list_item, quantity: 1, list: shopping_list) }
 
     context 'when updating quantity' do
       subject(:update_item) { list_item.update!(quantity: 4) }
@@ -126,173 +122,6 @@ RSpec.describe ShoppingListItem, type: :model do
 
       it 'raises an error' do
         expect { update_item }.to raise_error(ActiveRecord::RecordNotSaved)
-      end
-    end
-  end
-
-  describe 'updating the master list' do
-    let(:master_list) { create(:master_shopping_list) }
-    let(:shopping_list) { create(:shopping_list, user: master_list.user) }
-
-    context 'when creating a new list item' do
-      subject(:create_item) { create(:shopping_list_item, shopping_list: shopping_list) }
-
-      context 'when there is no matching item already on the master list' do
-        it 'adds the same item to the master list' do
-          expect { create_item }.to change(master_list.shopping_list_items, :count).from(0).to(1)
-        end
-      end
-
-      context 'when there is a matching item on the master list' do
-        subject(:create_item) { create(:shopping_list_item, description: 'Ebony sword', quantity: 2, notes: 'notes 2', shopping_list: shopping_list) }
-
-        let!(:item_on_master_list) { create(:shopping_list_item, description: 'Ebony sword', quantity: 1, notes: 'notes 1', shopping_list: master_list) }
-
-        it 'updates the quantity on the master list' do
-          create_item
-          expect(item_on_master_list.reload.quantity).to eq 3
-        end
-
-        it 'concatenates the notes fields' do
-          create_item
-          expect(item_on_master_list.reload.notes).to eq 'notes 1 -- notes 2'
-        end
-      end
-    end
-
-    context 'when updating an existing list item' do
-      let!(:list_item) { create(:shopping_list_item, description: 'Ebony sword', quantity: 2, notes: 'notes 1', shopping_list: shopping_list) }
-      
-      context 'when incrementing the quantity' do
-        subject(:update_item) { list_item.update!(quantity: 3) }
-
-        it 'increases the quantity on the master list' do
-          update_item
-          expect(master_list.shopping_list_items.find_by(description: 'Ebony sword').quantity).to eq 3
-        end
-      end
-
-      context 'when decrementing the quantity' do
-        subject(:update_item) { list_item.update!(quantity: 1) }
-
-        it 'decreases the quantity on the master list' do
-          update_item
-          expect(master_list.shopping_list_items.find_by(description: 'Ebony sword').quantity).to eq 1
-        end
-      end
-
-      context 'when changing the notes' do
-        subject(:update_item) { list_item.update!(notes: 'new notes') }
-
-        let(:master_list_item) { list_item.user.master_shopping_list.shopping_list_items.find_by_description('Ebony sword') }
-
-        context 'when the master list has a combined notes value from multiple items' do
-          before do
-            other_list = create(:shopping_list, user: list_item.user)
-            create(:shopping_list_item, description: 'Ebony sword', notes: 'notes 2', quantity: 1, shopping_list: other_list)
-          end
-
-          context 'when the new notes value is not empty' do
-            it 'changes the notes specified while leaving other notes intact' do
-              update_item
-              expect(master_list.shopping_list_items.find_by(description: 'Ebony sword').notes).to eq 'new notes -- notes 2'
-            end
-          end
-
-          context 'when the new notes value is empty' do
-            subject(:update_item) { list_item.update!(notes: nil) }
-
-            it 'removes the corresponding note from the master list' do
-              update_item
-              expect(master_list_item.reload.notes).to eq 'notes 2'
-            end 
-          end
-        end
-
-        context 'when the old notes value is nil' do
-          subject(:update_item) { list_item.update!(notes: 'new notes') }
-
-          let(:master_list) { create(:master_shopping_list) }
-          let(:shopping_list) { create(:shopping_list, user: master_list.user) }
-          let!(:list_item) { create(:shopping_list_item, description: 'Ebony sword', notes: nil, shopping_list: shopping_list) }
-
-          it 'updates the notes to the new notes value' do
-            update_item
-            expect(master_list_item.reload.notes).to eq 'new notes'
-          end
-        end
-
-        context 'when the master list matches the old notes value multiple times' do
-          before do
-            other_list = create(:shopping_list, user: list_item.user)
-            create(:shopping_list_item, shopping_list: other_list, description: 'Ebony sword', notes: list_item.notes)
-          end
-
-          it 'only changes one of the occurrences' do
-            update_item
-            expect(master_list_item.reload.notes).to eq 'new notes -- notes 1'
-          end
-        end
-      end
-    end
-
-    context 'when destroying a list item' do
-      subject(:destroy_item) { list_item.destroy! }
-
-      let!(:list_item) { create(:shopping_list_item, description: 'Ebony sword', quantity: 2, shopping_list: shopping_list) }
-      let(:master_list_item) { master_list.shopping_list_items.find_by_description('Ebony sword') }
-
-      context 'when the new quantity on the master list is greater than 0' do
-        before do
-          master_list_item.update!(quantity: 3)
-        end
-
-        it 'adjusts the quantity on the master list' do
-          destroy_item
-          expect(master_list_item.reload.quantity).to eq 1
-        end
-      end
-
-      context 'when the new quantity on the master list is 0' do
-        it 'removes the item from the master list' do
-          expect { destroy_item }.to change(master_list.shopping_list_items, :count).from(1).to(0)
-        end
-      end
-
-      context 'when neither list item has notes' do
-        before do
-          # so the master list item doesn't get deleted too
-          master_list_item.update!(quantity: 3)
-        end
-
-        it "doesn't change the notes field on the master list" do
-          destroy_item
-          expect(master_list_item.reload.notes).to be nil
-        end
-      end
-
-      context 'when the master list item has notes but the item being destroyed does not' do
-        before do
-          list_item.update!(notes: nil)
-          master_list_item.update!(notes: 'some notes', quantity: 3)
-        end
-
-        it "doesn't change the notes value on the master list" do
-          destroy_item
-          expect(master_list_item.reload.notes).to eq 'some notes'
-        end
-      end
-
-      context 'when the destroyed item has notes and the master list has combined notes with other items' do
-        before do
-          list_item.update!(notes: 'other notes')
-          master_list_item.update!(notes: 'some notes -- other notes', quantity: 3)
-        end
-
-        it 'removes the notes from the master list along with any leading/trailing whitespace or dashes' do
-          destroy_item
-          expect(master_list_item.reload.notes).to eq 'some notes'
-        end
       end
     end
   end

--- a/spec/models/shopping_list_spec.rb
+++ b/spec/models/shopping_list_spec.rb
@@ -485,7 +485,7 @@ RSpec.describe ShoppingList, type: :model do
           master_list.list_items.create!(description: description, quantity: 3, notes: existing_notes)
         end
   
-        context 'replacing the middle notes' do
+        context 'when replacing the middle notes' do
           let(:old_notes) { 'notes 2' }
           let(:new_notes) { 'something else' }
 
@@ -495,7 +495,7 @@ RSpec.describe ShoppingList, type: :model do
           end
         end
 
-        context 'replacing the first notes with nil' do
+        context 'when replacing the first notes with nil' do
           let(:old_notes) { 'notes 1' }
           let(:new_notes) { nil }
 
@@ -505,7 +505,7 @@ RSpec.describe ShoppingList, type: :model do
           end
         end
 
-        context 'replacing two of the notes values' do
+        context 'when replacing two of the notes values' do
           let(:old_notes) { 'notes 2 -- notes 3' }
           let(:new_notes) { 'something else' }
 
@@ -515,7 +515,7 @@ RSpec.describe ShoppingList, type: :model do
           end
         end
 
-        context 'replacing all of a combined note value' do
+        context 'when replacing all of a combined note value' do
           let(:old_notes) { 'notes 1 -- notes 2 -- notes 3' }
           let(:new_notes) { nil }
 
@@ -533,6 +533,26 @@ RSpec.describe ShoppingList, type: :model do
           it 'only replaces one instance' do
             update_item
             expect(master_list.list_items.first.notes).to eq 'something else -- notes 1 -- notes 2'
+          end
+        end
+
+        context 'when introducing new notes' do
+          let(:old_notes) { 'notes 2' }
+          let(:new_notes) { 'notes 2 -- notes 4' }
+
+          it 'adds the new notes' do
+            update_item
+            expect(master_list.list_items.last.notes).to eq 'notes 1 -- notes 2 -- notes 4 -- notes 3'
+          end
+        end
+
+        context 'when all the notes on the master list come from other items' do
+          let(:old_notes) { nil }
+          let(:new_notes) { 'notes 4' }
+
+          it 'adds the new notes' do
+            update_item
+            expect(master_list.list_items.last.notes).to eq 'notes 1 -- notes 2 -- notes 3 -- notes 4'
           end
         end
       end

--- a/spec/models/shopping_list_spec.rb
+++ b/spec/models/shopping_list_spec.rb
@@ -29,8 +29,20 @@ RSpec.describe ShoppingList, type: :model do
         shopping_list2.update!(title: 'Windstad Manor')
       end
 
-      it 'is in reverse chronological order with master before anything' do
+      it 'is in reverse chronological order by updated_at with master before anything' do
         expect(index_order).to eq([master_list, shopping_list2, shopping_list3, shopping_list1])
+      end
+    end
+
+    describe '::includes_items' do
+      subject(:includes_items) { user.shopping_lists.includes_items }
+
+      let!(:user) { create(:user) }
+      let!(:master_list) { create(:master_shopping_list, user: user) }
+      let!(:lists) { create_list(:shopping_list_with_list_items, 2, user: user) }
+
+      it 'includes the shopping list items' do
+        expect(includes_items).to eq user.shopping_lists.includes(:shopping_list_items)
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require 'rails_helper'

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,11 +1,53 @@
+
 # frozen_string_literal: true
 
 require 'rails_helper'
 
-RSpec.describe :user, type: :model do
-  subject(:user) { create(:user) }
+RSpec.describe User, type: :model do
+  describe '::create_or_update_for_google' do
+    subject(:create_or_update) { described_class.create_or_update_for_google(payload) }
+    let(:payload) do
+      {
+        'exp' => (Time.now + 2.days).to_i,
+        'email' => 'jane.doe@gmail.com',
+        'name' => 'Jane Doe',
+        'picture' => 'https://example.com/user_images/89'
+      }
+    end
+
+    context 'when a user with that email as uid does not exist' do
+      it 'creates a user' do
+        expect { create_or_update }.to change(User, :count).from(0).to(1)
+      end
+
+      it 'sets the attributes' do
+        create_or_update
+        expect(User.last.attributes).to include(
+          'uid' => 'jane.doe@gmail.com',
+          'email' => 'jane.doe@gmail.com',
+          'name' => 'Jane Doe',
+          'image_url' => 'https://example.com/user_images/89'
+        )
+      end
+    end
+
+    context 'when there is already a user with that email as uid' do
+      let!(:user) { create(:user, uid: 'jane.doe@gmail.com', email: 'jane.doe@gmail.com', name: 'Jane Doe', image_url: nil) }
+
+      it 'does not create a new user' do
+        expect { create_or_update }.not_to change(User, :count)
+      end
+
+      it 'updates the attributes' do
+        create_or_update
+        expect(user.reload.image_url).to eq 'https://example.com/user_images/89'
+      end
+    end
+  end
 
   describe '#master_shopping_list' do
+    subject(:user) { create(:user) }
+
     context 'when the user has a master shopping list' do
       let!(:master_list) { create(:master_shopping_list, user: user) }
 

--- a/spec/requests/shopping_list_items_spec.rb
+++ b/spec/requests/shopping_list_items_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
       it 'returns a helpful error' do
         create_item
-        expect(JSON.parse(response.body)).to eq({ 'error' => 'Google OAuth token validation failed' })
+        expect(JSON.parse(response.body)).to eq({ 'errors' => ['Google OAuth token validation failed'] })
       end
     end
   end

--- a/spec/requests/shopping_list_items_spec.rb
+++ b/spec/requests/shopping_list_items_spec.rb
@@ -17,10 +17,11 @@ RSpec.describe 'ShoppingListItems', type: :request do
            headers: headers
     end
 
-    let(:shopping_list) { create(:shopping_list) }
+    let(:master_list) { create(:master_shopping_list) }
+    let(:shopping_list) { create(:shopping_list, user: master_list.user) }
     
     context 'when authenticated' do
-      let!(:user) { shopping_list.user }
+      let!(:user) { master_list.user }
       
       let(:validation_data) do
         {
@@ -44,8 +45,6 @@ RSpec.describe 'ShoppingListItems', type: :request do
         end
 
         context 'when the master list has no items on it' do
-          let(:master_list) { user.master_shopping_list }
-
           it 'adds the item to the master list' do
             expect { create_item }.to change(ShoppingListItem, :count).from(0).to(2)
           end
@@ -72,8 +71,6 @@ RSpec.describe 'ShoppingListItems', type: :request do
         end
 
         context 'when the master list has a matching item' do
-          let!(:master_list) { user.master_shopping_list }
-
           before do
             second_list = user.shopping_lists.create!(title: 'Proudspire Manor')
             second_list.shopping_list_items.create!(
@@ -174,7 +171,8 @@ RSpec.describe 'ShoppingListItems', type: :request do
       end
 
       context 'when the shopping list is a master list' do
-        let(:shopping_list) { create(:master_shopping_list) }
+        let(:shopping_list) { master_list }
+
         let(:params) { "{\"shopping_list_item\":{\"description\":\"Corundum ingot\",\"quantity\":5,\"notes\":\"To make locks\",\"shopping_list_id\":#{shopping_list.id}}}" }
 
         it 'returns status 405' do

--- a/spec/requests/shopping_list_items_spec.rb
+++ b/spec/requests/shopping_list_items_spec.rb
@@ -10,15 +10,15 @@ RSpec.describe 'ShoppingListItems', type: :request do
     }
   end
 
-  describe 'POST /shopping_lists/:id/shopping_list_items' do
+  describe 'POST /shopping_lists/:shopping_list_id/shopping_list_items' do
     subject(:create_item) do
       post "/shopping_lists/#{shopping_list.id}/shopping_list_items",
            params: params,
            headers: headers
     end
 
-    let(:master_list) { create(:master_shopping_list) }
-    let(:shopping_list) { create(:shopping_list, user: master_list.user) }
+    let!(:master_list) { create(:master_shopping_list) }
+    let!(:shopping_list) { create(:shopping_list, user: master_list.user) }
     
     context 'when authenticated' do
       let!(:user) { master_list.user }
@@ -38,10 +38,10 @@ RSpec.describe 'ShoppingListItems', type: :request do
       end
       
       context 'when all goes well' do
-        let(:params) { "{\"shopping_list_item\":{\"description\":\"Corundum ingot\",\"quantity\":5,\"notes\":\"To make locks\",\"shopping_list_id\":#{shopping_list.id}}}" }
+        let(:params) { "{\"shopping_list_item\":{\"description\":\"Corundum ingot\",\"quantity\":5,\"notes\":\"To make locks\",\"list_id\":#{shopping_list.id}}}" }
 
         it 'creates a new shopping list item on the shopping list' do
-          expect { create_item }.to change(shopping_list.shopping_list_items, :count).from(0).to(1)
+          expect { create_item }.to change(shopping_list.list_items, :count).from(0).to(1)
         end
 
         context 'when the master list has no items on it' do
@@ -51,8 +51,8 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
           it 'assigns the right attributes' do
             create_item
-            item = shopping_list.shopping_list_items.last
-            expect(master_list.shopping_list_items.last.attributes).to include(
+            item = shopping_list.list_items.last
+            expect(master_list.list_items.last.attributes).to include(
               'description' => item.description,
               'quantity' => item.quantity,
               'notes' => item.notes
@@ -61,7 +61,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
           it 'returns the master list item and the regular list item' do
             create_item
-            expect(response.body).to eq([master_list.shopping_list_items.last, shopping_list.shopping_list_items.last].to_json)
+            expect(response.body).to eq([master_list.list_items.last, shopping_list.list_items.last].to_json)
           end
 
           it 'returns status 201' do
@@ -72,18 +72,19 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
         context 'when the master list has a matching item' do
           before do
-            second_list = user.shopping_lists.create!(title: 'Proudspire Manor')
-            second_list.shopping_list_items.create!(
+            second_list = user.shopping_lists.create!(title: 'Proudspire Manor', master_list: master_list)
+            second_list.list_items.create!(
               description: 'Corundum ingot',
               quantity: 1,
               notes: 'some other notes'
             )
+            master_list.add_item_from_child_list(second_list.list_items.last)
           end
 
           it 'updates the item on the master list', :aggregate_failures do
             create_item
-            expect(master_list.shopping_list_items.count).to eq 1
-            expect(master_list.shopping_list_items.last.attributes).to include(
+            expect(master_list.list_items.count).to eq 1
+            expect(master_list.list_items.last.attributes).to include(
               'description' => 'Corundum ingot',
               'quantity' => 6,
               'notes' => 'some other notes -- To make locks'
@@ -92,7 +93,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
           it 'returns the master list item and the regular list item' do
             create_item
-            expect(response.body).to eq([master_list.shopping_list_items.last, shopping_list.shopping_list_items.last].to_json)
+            expect(response.body).to eq([master_list.list_items.last, shopping_list.list_items.last].to_json)
           end
 
           it 'returns status 201' do
@@ -117,16 +118,16 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
         context 'when the new item matches an existing item on the list' do
           before do
-            shopping_list.shopping_list_items.create!(description: 'Corundum ingot', quantity: 2, notes: 'To make locks')
+            shopping_list.list_items.create!(description: 'Corundum ingot', quantity: 2, notes: 'To make locks')
           end
 
           it "doesn't create a new item" do
-            expect { create_item }.not_to change(shopping_list.shopping_list_items, :count)
+            expect { create_item }.not_to change(shopping_list.list_items, :count)
           end
 
           it 'updates the existing item' do
             create_item
-            expect(shopping_list.shopping_list_items.first.attributes).to include(
+            expect(shopping_list.list_items.first.attributes).to include(
               'description' => 'Corundum ingot',
               'quantity' => 7,
               'notes' => 'To make locks -- To make locks'
@@ -137,7 +138,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
       context 'when the shopping list belongs to a different user' do
         let(:user) { create(:user) }
-        let(:params) { "{\"shopping_list_item\":{\"description\":\"Corundum ingot\",\"quantity\":5,\"notes\":\"To make locks\",\"shopping_list_id\":#{shopping_list.id}}}" }
+        let(:params) { "{\"shopping_list_item\":{\"description\":\"Corundum ingot\",\"quantity\":5,\"notes\":\"To make locks\",\"list_id\":#{shopping_list.id}}}" }
 
         it 'returns 404' do
           create_item
@@ -157,7 +158,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
                headers: headers
         end
 
-        let(:params) { "{\"shopping_list_item\":{\"description\":\"Corundum ingot\",\"quantity\":5,\"notes\":\"To make locks\",\"shopping_list_id\":#{shopping_list.id}}}" }
+        let(:params) { "{\"shopping_list_item\":{\"description\":\"Corundum ingot\",\"quantity\":5,\"notes\":\"To make locks\",\"list_id\":#{shopping_list.id}}}" }
 
         it 'returns 404' do
           create_item
@@ -173,7 +174,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
       context 'when the shopping list is a master list' do
         let(:shopping_list) { master_list }
 
-        let(:params) { "{\"shopping_list_item\":{\"description\":\"Corundum ingot\",\"quantity\":5,\"notes\":\"To make locks\",\"shopping_list_id\":#{shopping_list.id}}}" }
+        let(:params) { "{\"shopping_list_item\":{\"description\":\"Corundum ingot\",\"quantity\":5,\"notes\":\"To make locks\",\"list_id\":#{shopping_list.id}}}" }
 
         it 'returns status 405' do
           create_item
@@ -182,7 +183,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
       end
 
       context 'when the params are invalid' do
-        let(:params) { "{\"shopping_list_item\":{\"description\":\"Corundum ingot\",\"quantity\":\"foooo\",\"notes\":\"To make locks\",\"shopping_list_id\":#{shopping_list.id}}}" }
+        let(:params) { "{\"shopping_list_item\":{\"description\":\"Corundum ingot\",\"quantity\":\"foooo\",\"notes\":\"To make locks\",\"list_id\":#{shopping_list.id}}}" }
 
         it 'returns 422' do
           create_item
@@ -201,7 +202,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
     end
 
     context 'when unauthenticated' do
-      let(:params) { "{\"shopping_list_item\":{\"description\":\"Corundum ingot\",\"quantity\":4,\"notes\":\"To make locks\",\"shopping_list_id\":#{shopping_list.id}}}" }
+      let(:params) { "{\"shopping_list_item\":{\"description\":\"Corundum ingot\",\"quantity\":4,\"notes\":\"To make locks\",\"list_id\":#{shopping_list.id}}}" }
 
       it 'returns 401' do
         create_item

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
           it 'returns the master list as well as the new list' do
             create_shopping_list
-            expect(response.body).to eq([user.master_shopping_list, user.shopping_lists.first].to_json)
+            expect(response.body).to eq([user.master_shopping_list, user.shopping_lists.last].to_json)
           end
 
           it 'returns status 201' do
@@ -103,7 +103,7 @@ RSpec.describe 'ShoppingLists', type: :request do
   end
 
   describe 'PUT /shopping_lists/:id' do
-    subject(:update_shopping_list) { put "/shopping_lists/#{shopping_list_id}", params: '{ "shopping_list": { "title": "Severin Manor" } }', headers: headers }
+    subject(:update_shopping_list) { put "/shopping_lists/#{list_id}", params: '{ "shopping_list": { "title": "Severin Manor" } }', headers: headers }
 
     context 'when authenticated' do
       let!(:user) { create(:user) }
@@ -123,7 +123,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       context 'when all goes well' do
         let!(:shopping_list) { create(:shopping_list, user: user) }
-        let(:shopping_list_id) { shopping_list.id }
+        let(:list_id) { shopping_list.id }
 
         it 'updates the title' do
           update_shopping_list
@@ -134,7 +134,7 @@ RSpec.describe 'ShoppingLists', type: :request do
           update_shopping_list
           # This ugly hack is needed because if we don't parse the JSON, it'll make an error
           # if everything isn't in the exact same order, but if we just use shopping_list.attributes
-          # it won't include the shopping_list_items. Ugly.
+          # it won't include the list_items. Ugly.
           expect(JSON.parse(response.body)).to eq(JSON.parse(shopping_list.reload.to_json))
         end
 
@@ -145,10 +145,10 @@ RSpec.describe 'ShoppingLists', type: :request do
       end
 
       context 'when something goes wrong' do
-        subject(:update_shopping_list) { put "/shopping_lists/#{shopping_list_id}", params: "{ \"shopping_list\": { \"title\": \"#{other_list.title}\" } }", headers: headers }
+        subject(:update_shopping_list) { put "/shopping_lists/#{list_id}", params: "{ \"shopping_list\": { \"title\": \"#{other_list.title}\" } }", headers: headers }
 
         let!(:shopping_list) { create(:shopping_list, user: user) }
-        let(:shopping_list_id) { shopping_list.id }
+        let(:list_id) { shopping_list.id }
         let(:other_list) { create(:shopping_list, user: user) }
 
         it 'returns status 422' do
@@ -164,7 +164,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       context 'when the list belongs to a different user' do
         let!(:shopping_list) { create(:shopping_list) }
-        let(:shopping_list_id) { shopping_list.id }
+        let(:list_id) { shopping_list.id }
 
         it 'returns status 404' do
           update_shopping_list
@@ -178,10 +178,10 @@ RSpec.describe 'ShoppingLists', type: :request do
       end
 
       context 'when the client attempts to update a master list' do
-        subject(:update_shopping_list) { put "/shopping_lists/#{shopping_list_id}", params: '{ "shopping_list": { "title": "Foo" } }', headers: headers }
+        subject(:update_shopping_list) { put "/shopping_lists/#{list_id}", params: '{ "shopping_list": { "title": "Foo" } }', headers: headers }
 
         let!(:shopping_list) { create(:master_shopping_list, user: user) }
-        let(:shopping_list_id) { shopping_list.id }
+        let(:list_id) { shopping_list.id }
 
         it "doesn't update the list" do
           update_shopping_list
@@ -200,10 +200,10 @@ RSpec.describe 'ShoppingLists', type: :request do
       end
 
       context 'when the client attempts to change a regular list to a master list' do
-        subject(:update_shopping_list) { put "/shopping_lists/#{shopping_list_id}", params: '{ "shopping_list": { "master": true } }', headers: headers }
+        subject(:update_shopping_list) { put "/shopping_lists/#{list_id}", params: '{ "shopping_list": { "master": true } }', headers: headers }
         
         let!(:shopping_list) { create(:shopping_list, user: user) }
-        let(:shopping_list_id) { shopping_list.id }
+        let(:list_id) { shopping_list.id }
 
         it "doesn't update the list" do
           update_shopping_list
@@ -223,7 +223,7 @@ RSpec.describe 'ShoppingLists', type: :request do
     end
 
     context 'when unauthenticated' do
-      let(:shopping_list_id) { 42 }
+      let(:list_id) { 42 }
 
       it 'returns 401' do
         update_shopping_list
@@ -233,7 +233,7 @@ RSpec.describe 'ShoppingLists', type: :request do
   end
 
   describe 'PATCH /shopping_lists/:id' do
-    subject(:update_shopping_list) { patch "/shopping_lists/#{shopping_list_id}", params: '{ "shopping_list": { "title": "Severin Manor" } }', headers: headers }
+    subject(:update_shopping_list) { patch "/shopping_lists/#{list_id}", params: '{ "shopping_list": { "title": "Severin Manor" } }', headers: headers }
 
     context 'when authenticated' do
       let!(:user) { create(:user) }
@@ -253,7 +253,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       context 'when all goes well' do
         let!(:shopping_list) { create(:shopping_list, user: user) }
-        let(:shopping_list_id) { shopping_list.id }
+        let(:list_id) { shopping_list.id }
 
         it 'updates the title' do
           update_shopping_list
@@ -264,7 +264,7 @@ RSpec.describe 'ShoppingLists', type: :request do
           update_shopping_list
           # This ugly hack is needed because if we don't parse the JSON, it'll make an error
           # if everything isn't in the exact same order, but if we just use shopping_list.attributes
-          # it won't include the shopping_list_items. Ugly.
+          # it won't include the list_items. Ugly.
           expect(JSON.parse(response.body)).to eq(JSON.parse(shopping_list.reload.to_json))
         end
 
@@ -275,10 +275,10 @@ RSpec.describe 'ShoppingLists', type: :request do
       end
 
       context 'when something goes wrong' do
-        subject(:update_shopping_list) { patch "/shopping_lists/#{shopping_list_id}", params: "{ \"shopping_list\": { \"title\": \"#{other_list.title}\" } }", headers: headers }
+        subject(:update_shopping_list) { patch "/shopping_lists/#{list_id}", params: "{ \"shopping_list\": { \"title\": \"#{other_list.title}\" } }", headers: headers }
 
         let!(:shopping_list) { create(:shopping_list, user: user) }
-        let(:shopping_list_id) { shopping_list.id }
+        let(:list_id) { shopping_list.id }
         let(:other_list) { create(:shopping_list, user: user) }
 
         it 'returns status 422' do
@@ -294,7 +294,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       context 'when the list belongs to a different user' do
         let!(:shopping_list) { create(:shopping_list) }
-        let(:shopping_list_id) { shopping_list.id }
+        let(:list_id) { shopping_list.id }
 
         it 'returns status 404' do
           update_shopping_list
@@ -308,10 +308,10 @@ RSpec.describe 'ShoppingLists', type: :request do
       end
 
       context 'when the client attempts to update a master list' do
-        subject(:update_shopping_list) { patch "/shopping_lists/#{shopping_list_id}", params: '{ "shopping_list": { "title": "Foo" } }', headers: headers }
+        subject(:update_shopping_list) { patch "/shopping_lists/#{list_id}", params: '{ "shopping_list": { "title": "Foo" } }', headers: headers }
 
         let!(:shopping_list) { create(:master_shopping_list, user: user) }
-        let(:shopping_list_id) { shopping_list.id }
+        let(:list_id) { shopping_list.id }
 
         it "doesn't update the list" do
           update_shopping_list
@@ -330,10 +330,10 @@ RSpec.describe 'ShoppingLists', type: :request do
       end
 
       context 'when the client attempts to change a regular list to a master list' do
-        subject(:update_shopping_list) { patch "/shopping_lists/#{shopping_list_id}", params: '{ "shopping_list": { "master": true } }', headers: headers }
+        subject(:update_shopping_list) { patch "/shopping_lists/#{list_id}", params: '{ "shopping_list": { "master": true } }', headers: headers }
         
         let!(:shopping_list) { create(:shopping_list, user: user) }
-        let(:shopping_list_id) { shopping_list.id }
+        let(:list_id) { shopping_list.id }
 
         it "doesn't update the list" do
           update_shopping_list
@@ -353,7 +353,7 @@ RSpec.describe 'ShoppingLists', type: :request do
     end
 
     context 'when unauthenticated' do
-      let(:shopping_list_id) { 42 }
+      let(:list_id) { 42 }
 
       it 'returns 401' do
         update_shopping_list
@@ -418,11 +418,11 @@ RSpec.describe 'ShoppingLists', type: :request do
   end
 
   describe 'DELETE /shopping_lists/:id' do
-    subject(:delete_shopping_list) { delete "/shopping_lists/#{shopping_list_id}", headers: headers }
+    subject(:delete_shopping_list) { delete "/shopping_lists/#{list_id}", headers: headers }
 
     context 'when unauthenticated' do
       let!(:shopping_list) { create(:shopping_list) }
-      let(:shopping_list_id) { shopping_list.id }
+      let(:list_id) { shopping_list.id }
 
       it 'returns 401' do
         delete_shopping_list
@@ -443,7 +443,7 @@ RSpec.describe 'ShoppingLists', type: :request do
       let(:user1) { create(:user) }
       let(:user2) { create(:user) }
       let!(:shopping_list) { create(:shopping_list, user: user2) }
-      let(:shopping_list_id) { shopping_list.id }
+      let(:list_id) { shopping_list.id }
       let(:validator) { instance_double(GoogleIDToken::Validator, check: validation_data) }
 
       let(:validation_data) do
@@ -463,9 +463,9 @@ RSpec.describe 'ShoppingLists', type: :request do
         expect(response.status).to eq 404
       end
 
-      it 'returns an error message indicating the list was not found' do
+      it "doesn't return data" do
         delete_shopping_list
-        expect(JSON.parse(response.body)).to eq({ 'error' => "Shopping list id=#{shopping_list_id} not found" })
+        expect(response.body).to be_empty
       end
 
       it 'does not delete any shopping lists' do
@@ -475,7 +475,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
     context 'when the shopping list does not exist' do
       let(:user) { create(:user) }
-      let(:shopping_list_id) { 24 } # could be anything
+      let(:list_id) { 24 } # could be anything
       let(:validator) { instance_double(GoogleIDToken::Validator, check: validation_data) }
 
       let(:validation_data) do
@@ -495,9 +495,9 @@ RSpec.describe 'ShoppingLists', type: :request do
         expect(response.status).to eq 404
       end
 
-      it 'returns an error message indicating the list was not found' do
+      it "doesn't return data" do
         delete_shopping_list
-        expect(JSON.parse(response.body)).to eq({ 'error' => "Shopping list id=#{shopping_list_id} not found" })
+        expect(response.body).to be_empty
       end
     end
 
@@ -505,7 +505,7 @@ RSpec.describe 'ShoppingLists', type: :request do
       let(:user) { create(:user) }
       let!(:master_list) { create(:master_shopping_list, user: user) }
       let!(:shopping_list) { create(:shopping_list, user: user) }
-      let(:shopping_list_id) { shopping_list.id }
+      let(:list_id) { shopping_list.id }
       let(:validator) { instance_double(GoogleIDToken::Validator, check: validation_data) }
 
       let(:validation_data) do
@@ -552,14 +552,14 @@ RSpec.describe 'ShoppingLists', type: :request do
 
         it 'returns the master list in the body' do
           delete_shopping_list
-          expect(response.body).to eq({ master_list: user.master_shopping_list }.to_json)
+          expect(response.body).to eq(user.master_shopping_list.to_json)
         end
       end
     end
 
     context 'when properly authenticated and attempting to delete the master list' do
       let(:user) { create(:user) }
-      let(:shopping_list_id) { shopping_list.id }
+      let(:list_id) { shopping_list.id }
       let(:validator) { instance_double(GoogleIDToken::Validator, check: validation_data) }
 
       let(:validation_data) do
@@ -576,7 +576,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       context 'when another list exists' do
         let!(:shopping_list) { create(:master_shopping_list, user: user) }
-        let(:shopping_list_id) { shopping_list.id }
+        let(:list_id) { shopping_list.id }
 
         it 'does not delete anything' do
           expect { delete_shopping_list }.not_to change(ShoppingList, :count)
@@ -589,7 +589,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
         it 'returns a helpful error body' do
           delete_shopping_list
-          expect(response.body).to eq({ error: 'Cannot manually destroy a master shopping list' }.to_json)
+          expect(response.body).to eq({ errors: ['Cannot manually delete a master shopping list'] }.to_json)
         end
       end
     end

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
           it 'returns only the newly created list' do
             create_shopping_list
-            expect(response.body).to eq([user.shopping_lists.last].to_json)
+            expect(response.body).to eq(user.shopping_lists.last.to_json)
           end
         end
       end
@@ -71,7 +71,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
         it "returns the errors" do
           create_shopping_list
-          expect(JSON.parse(response.body)).to eq({ 'errors' => { 'title' => ['has already been taken'] } })
+          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Title has already been taken'] })
         end
       end
 
@@ -89,7 +89,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
         it 'returns a helpful error body' do
           create_shopping_list
-          expect(JSON.parse(response.body)).to eq({ 'errors' => { 'master' => ['cannot manually create or update a master shopping list'] } })
+          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Cannot manually create a master shopping list'] })
         end
       end
     end
@@ -193,6 +193,7 @@ RSpec.describe 'ShoppingLists', type: :request do
       end
 
       before do
+        create(:master_shopping_list, user: user)
         allow(GoogleIDToken::Validator).to receive(:new).and_return(validator)
       end
 
@@ -498,6 +499,7 @@ RSpec.describe 'ShoppingLists', type: :request do
       before do
         allow(GoogleIDToken::Validator).to receive(:new).and_return(validator)
 
+        create(:master_shopping_list, user: authenticated_user)
         user_list = create_list(:shopping_list_with_list_items, 3, list_item_count: 2, user: authenticated_user)
         unauthenticated_user = create(:user)
         create_list(:shopping_list, 3, user: unauthenticated_user)
@@ -603,6 +605,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
     context 'when authenticated and the shopping list exists' do
       let(:user) { create(:user) }
+      let!(:master_list) { create(:master_shopping_list, user: user) }
       let!(:shopping_list) { create(:shopping_list, user: user) }
       let(:shopping_list_id) { shopping_list.id }
       let(:validator) { instance_double(GoogleIDToken::Validator, check: validation_data) }

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -507,7 +507,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       it 'returns all shopping lists belonging to the authenticated user' do
         get_index
-        expect(JSON.parse(response.body)).to eq JSON.parse(authenticated_user.shopping_lists.index_order.to_json(include: :shopping_list_items))
+        expect(response.body).to eq authenticated_user.shopping_lists.index_order.to_json
       end
 
       it 'returns status 200' do

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       it 'returns an error in the body' do
         get_shopping_list
-        expect(JSON.parse(response.body)).to eq({ 'error' => 'Google OAuth token validation failed' })
+        expect(JSON.parse(response.body)).to eq({ 'errors' => ['Google OAuth token validation failed'] })
       end
     end
 
@@ -479,7 +479,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       it 'returns an error body indicating authorisation failed' do
         get_index
-        expect(JSON.parse(response.body)).to eq({ 'error' => 'Google OAuth token validation failed' })
+        expect(JSON.parse(response.body)).to eq({ 'errors' => ['Google OAuth token validation failed'] })
       end
     end
 
@@ -535,7 +535,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       it 'returns an error in the body' do
         delete_shopping_list
-        expect(JSON.parse(response.body)).to eq({ 'error' => 'Google OAuth token validation failed' })
+        expect(JSON.parse(response.body)).to eq({ 'errors' => ['Google OAuth token validation failed'] })
       end
     end
 


### PR DESCRIPTION
## Context

[**Routes for managing shopping list items**](https://trello.com/c/K4501FRt/18-routes-for-managing-shopping-list-items)
[**Use controller services to handle complex shopping list logic**](https://trello.com/c/1gjVL1ix/62-use-controller-services-to-handle-complex-shopping-list-logic)
[**Consider shopping list updated when items added, removed, or edited**](https://trello.com/c/5DEczwm5/56-consider-shopping-list-updated-when-items-added-removed-or-edited)

It started that I was just going to add some routes to allow users to manage shopping list items from the UI. It ended in a sea of carnage enveloping three different cards. As I got started, I realised that the refactoring of shopping list logic could not wait and that the refactor would only get uglier if I waited until the routes were done. So I went ahead with a planned refactor to use controller services to handle requests and also added a `MasterListable` concern adding validations, scopes, hooks, and methods to the `ShoppingList` model.

As cool as it was, I decided that the self-updating logic of shopping list items was too magical. Now, to update a master list, call one of the methods provided by `MasterListable`.

## Changes

* Create `MasterListable` concern module (with docs) and add it to `ShoppingList`
* Implement controller service objects to handle requests
* Change `shopping_list.shopping_list_items` and `list_item.shopping_list` to `shopping_list.list_items` and `list_item.list`
* Standardise API responses to always either include a resource or a JSON object with `"errors"` array

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

Since there are going to be other list models with master list behaviour (such as an inventory list), I decided it would be good to separate some of the master list logic into its own module. An ActiveSupport concern was a good way to do this since it had built-in support for scopes, validations, and other ActiveRecord stuff.

Controller services are a pattern I've seen in the wild that can be very useful to abstract away overly complex controller logic.

I didn't like that lists are no longer self-managing, however, I was concerned that self-managing lists were going to be buggy and overly complex due to their magic. Now, instead of automagically updating the master list when a list item is changed/added/removed, you have to call one of the new `MasterListable` methods on the master list to update it:

```ruby
item = ShoppingListItem.combine_or_create!(params)
master_list.add_item_from_child_list(item)
```
The `MasterListable` methods handle logic for combining, creating, updating, and removing items from master lists.