### PR TITLE
Add update route for shopping list items

### DIFF
--- a/app/controller_services/shopping_list_items_controller/update_service.rb
+++ b/app/controller_services/shopping_list_items_controller/update_service.rb
@@ -18,7 +18,7 @@ class ShoppingListItemsController < ApplicationController
     def perform
       return Service::MethodNotAllowedResult.new(errors: [MASTER_LIST_ERROR]) if shopping_list.master == true
 
-      delta_qty = params[:quantity] ? params[:quantity] - list_item.quantity : 0
+      delta_qty = params[:quantity] ? params[:quantity].to_i - list_item.quantity : 0
       old_notes = list_item.notes
 
       if list_item.update(params)

--- a/app/controller_services/shopping_list_items_controller/update_service.rb
+++ b/app/controller_services/shopping_list_items_controller/update_service.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'service/ok_result'
+require 'service/not_found_result'
+require 'service/unprocessable_entity_result'
+require 'service/method_not_allowed_result'
+
+class ShoppingListItemsController < ApplicationController
+  class UpdateService
+    MASTER_LIST_ERROR = 'Cannot manually update list items on a master shopping list'
+
+    def initialize(user, item_id, params)
+      @user = user
+      @item_id = item_id
+      @params = params
+    end
+
+    def perform
+      return Service::MethodNotAllowedResult.new(errors: [MASTER_LIST_ERROR]) if shopping_list.master == true
+
+      delta_qty = params[:quantity] ? params[:quantity] - list_item.quantity : 0
+      old_notes = list_item.notes
+
+      if list_item.update(params)
+        shopping_list.touch
+        master_list_item = master_list.update_item_from_child_list(list_item.description, delta_qty, old_notes, params[:notes])
+        Service::OKResult.new(resource: [master_list_item, list_item])
+      else
+        Service::UnprocessableEntityResult.new(errors: list_item.error_array)
+      end
+    rescue ActiveRecord::RecordNotFound
+      Service::NotFoundResult.new
+    end
+    
+    private
+
+    attr_reader :user, :item_id, :params
+
+    def master_list
+      @master_list ||= list_item.list.master_list
+    end
+
+    def shopping_list
+      @shopping_list ||= list_item.list
+    end
+
+    def list_item
+      @list_item ||= ShoppingListItem.belonging_to_user(user).find(item_id)
+    end
+  end
+end

--- a/app/controller_services/shopping_lists_controller/create_service.rb
+++ b/app/controller_services/shopping_lists_controller/create_service.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'service/created_result'
-require 'service/not_found_result'
 require 'service/unprocessable_entity_result'
 require 'service/method_not_allowed_result'
 require 'service/ok_result'

--- a/app/controllers/shopping_list_items_controller.rb
+++ b/app/controllers/shopping_list_items_controller.rb
@@ -3,10 +3,16 @@
 require 'controller/response'
 
 class ShoppingListItemsController < ApplicationController
-  before_action :set_shopping_list_item, only: %i[update destroy]
+  before_action :set_shopping_list_item, only: %i[destroy]
 
   def create
     result = CreateService.new(current_user, params[:shopping_list_id], list_item_params).perform
+
+    ::Controller::Response.new(self, result).execute
+  end
+
+  def update
+    result = UpdateService.new(current_user, params[:id], list_item_params).perform
 
     ::Controller::Response.new(self, result).execute
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,4 +19,8 @@ class User < ApplicationRecord
   def master_shopping_list
     shopping_lists.find_by(master: true)
   end
+
+  def shopping_list_items
+    ShoppingListItem.belonging_to_user(self)
+  end
 end

--- a/docs/api/resources/shopping-list-items.md
+++ b/docs/api/resources/shopping-list-items.md
@@ -41,11 +41,13 @@ When a client destroys a list item on a user's regular shopping list, one of the
 
 The following endpoints are available to manage shopping list items:
 
-* [`POST /shopping_lists/:id/shopping_list_items`](#post-shoppinglistsidshoppinglistitems)
+* [`POST /shopping_lists/:shopping_list_id/shopping_list_items`](#post-shoppinglistsshoppinglistidshoppinglistitems)
+* [`PATCH /shopping_list_items/:id`](#patch-shoppinglistitemsid)
+* [`PUT /shopping_list_items/:id`](#put-shoppinglistitemsid)
 
 ## POST /shopping_lists/:shopping_list_id/shopping_list_items
 
-If the shopping list with the given ID exists, belongs to the authenticated user, is not a master shopping list, and does not have an existing shopping list item with the same (case-insensitive) description, Creates a shopping list item on the given list if the shopping list with the given ID:
+Creates a shopping list item on the given list if the shopping list with the given ID:
 
 1. Exists
 2. Belongs to the authenticated user
@@ -134,6 +136,251 @@ A 422 error, returned as a result of a validation error, includes whichever erro
     "Quantity must be a number",
     "Quantity must be greater than zero",
     "Description is required"
+  ]
+}
+```
+
+## PATCH /shopping_list_items/:id
+
+Updates a given shopping list item provided the list the item is on:
+
+1. Exists
+2. Belongs to the authenticated user AND
+3. Is not a master list
+
+When this happens, the corresponding list item on the master list is also automatically updated to stay synced with the other lists. When the master list is synced, the `notes` value may be shortened, changed, or concatenated with notes from matching items on other lists, depending on which changes were requested.
+
+Requests may specify two fields to update: `quantity` (integer, greater than 0) and `notes` (any string). Requests attempting to update `description` will result in a validation error.
+
+This route also supports `PUT` requests. Usage of the route with `PUT` is identical but has its own section below for the reader's convenience.
+
+### Example Request
+
+```
+PATCH /shopping_list_items/72
+Authorization: Bearer xxxxxxxxxxx
+Content-Type: application/json
+{
+  "quantity": 7,
+  "notes": "To enchant with 'Absorb Health'"
+}
+```
+
+### Success Responses
+
+#### Statuses
+
+* 200 OK
+
+#### Example Body
+
+```json
+[
+  {
+    "id": 87,
+    "list_id": 238,
+    "description": "Ebony sword",
+    "quantity": 9,
+    "notes": "To sell -- To enchant with 'Absorb Health'",
+    "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "updated_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00"
+  },
+  {
+    "id": 126,
+    "list_id": 237,
+    "description": "Ebony sword",
+    "quantity": 7,
+    "notes": "To enchant with 'Absorb Health'",
+    "created_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00",
+    "updated_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00"
+  }
+]
+```
+
+### Error Responses
+
+Three error responses are possible.
+
+#### Statuses
+
+* 404 Not Found
+* 405 Method Not Allowed
+* 422 Unprocessable Entity
+
+#### Example Bodies
+
+No body will be returned with a 404 error, which is returned if the specified shopping list item doesn't exist or doesn't belong to the authenticated user.
+
+A 405 error, which is returned if the specified shopping list is a master shopping list, comes with the following body:
+```json
+{
+  "errors": [
+    "Cannot manually update list items on a master shopping list"
+  ]
+}
+```
+
+A 422 error, returned as a result of a validation error, includes whichever errors prevented the list item from being created:
+```json
+{
+  "errors": [
+    "Quantity must be a number",
+    "Quantity must be greater than zero"
+  ]
+}
+```
+
+### Success Responses
+
+#### Statuses
+
+* 200 OK
+
+#### Example Body
+
+```json
+[
+  {
+    "id": 87,
+    "list_id": 238,
+    "description": "Ebony sword",
+    "quantity": 9,
+    "notes": "To sell -- To enchant with 'Absorb Health'",
+    "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "updated_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00"
+  },
+  {
+    "id": 126,
+    "list_id": 237,
+    "description": "Ebony sword",
+    "quantity": 7,
+    "notes": "To enchant with 'Absorb Health'",
+    "created_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00",
+    "updated_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00"
+  }
+]
+```
+
+### Error Responses
+
+Three error responses are possible.
+
+#### Statuses
+
+* 404 Not Found
+* 405 Method Not Allowed
+* 422 Unprocessable Entity
+
+#### Example Bodies
+
+No body will be returned with a 404 error, which is returned if the specified shopping list doesn't exist or doesn't belong to the authenticated user.
+
+A 405 error, which is returned if the specified shopping list is a master shopping list, comes with the following body:
+```json
+{
+  "errors": [
+    "Cannot manually manage items on a master shopping list"
+  ]
+}
+```
+
+A 422 error, returned as a result of a validation error, includes whichever errors prevented the list item from being created:
+```json
+{
+  "errors": [
+    "Quantity must be a number",
+    "Quantity must be greater than zero",
+    "Description is required"
+  ]
+}
+```
+
+## PUT /shopping_list_items/:id
+
+Updates a given shopping list item provided the list the item is on:
+
+1. Exists
+2. Belongs to the authenticated user AND
+3. Is not a master list
+
+When this happens, the corresponding list item on the master list is also automatically updated to stay synced with the other lists. When the master list is synced, the `notes` value may be shortened, changed, or concatenated with notes from matching items on other lists, depending on which changes were requested.
+
+Requests may specify two fields to update: `quantity` (integer, greater than 0) and `notes` (any string). Requests attempting to update `description` will result in a validation error.
+
+This route also supports `PATCH` requests. Usage of the route with `PATCH` is identical but has its own section above for the reader's convenience.
+
+### Example Request
+
+```
+PUT /shopping_list_items/72
+Authorization: Bearer xxxxxxxxxxx
+Content-Type: application/json
+{
+  "quantity": 7,
+  "notes": "To enchant with 'Absorb Health'"
+}
+```
+
+### Success Responses
+
+#### Statuses
+
+* 200 OK
+
+#### Example Body
+
+```json
+[
+  {
+    "id": 87,
+    "list_id": 238,
+    "description": "Ebony sword",
+    "quantity": 9,
+    "notes": "To sell -- To enchant with 'Absorb Health'",
+    "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "updated_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00"
+  },
+  {
+    "id": 126,
+    "list_id": 237,
+    "description": "Ebony sword",
+    "quantity": 7,
+    "notes": "To enchant with 'Absorb Health'",
+    "created_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00",
+    "updated_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00"
+  }
+]
+```
+
+### Error Responses
+
+Three error responses are possible.
+
+#### Statuses
+
+* 404 Not Found
+* 405 Method Not Allowed
+* 422 Unprocessable Entity
+
+#### Example Bodies
+
+No body will be returned with a 404 error, which is returned if the specified shopping list item doesn't exist or doesn't belong to the authenticated user.
+
+A 405 error, which is returned if the specified shopping list is a master shopping list, comes with the following body:
+```json
+{
+  "errors": [
+    "Cannot manually update list items on a master shopping list"
+  ]
+}
+```
+
+A 422 error, returned as a result of a validation error, includes whichever errors prevented the list item from being created:
+```json
+{
+  "errors": [
+    "Quantity must be a number",
+    "Quantity must be greater than zero"
   ]
 }
 ```

--- a/spec/controller_services/shopping_list_items_controller/update_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/update_service_spec.rb
@@ -52,6 +52,10 @@ RSpec.describe ShoppingListItemsController::UpdateService do
       it 'updates the updated_at timestamp on the list' do
         Timecop.freeze do
           perform
+          # This is another case of a rounding error in the CI environment. The server where
+          # GitHub Actions run seems to truncate the last few digits of the timestamp, resulting
+          # in things being not quite equal in that environment. Since it's not that important
+          # that it be that exact, I'm just using the `be_within` matcher.
           expect(shopping_list.reload.updated_at).to be_within(0.05.seconds).of(Time.now.utc)
         end
       end

--- a/spec/controller_services/shopping_list_items_controller/update_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/update_service_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'service/ok_result'
+require 'service/no_content_result'
+require 'service/not_found_result'
+require 'service/method_not_allowed_result'
+require 'service/unprocessable_entity_result'
+
+RSpec.describe ShoppingListItemsController::UpdateService do
+  describe '#perform' do
+    subject(:perform) { described_class.new(user, list_item.id, params).perform }
+
+    let(:user) { create(:user) }
+    let(:shopping_list) { user.shopping_lists.create! }
+    
+    context 'when all goes well' do
+      let!(:list_item) { create(:shopping_list_item, list: shopping_list, quantity: 2) }
+      let(:params) { { quantity: 3 } }
+      let(:master_list) { user.master_shopping_list }
+      let(:scope) { ShoppingListItem.belonging_to_user(user) }
+
+      before do
+        master_list.add_item_from_child_list(list_item)
+      end
+
+      it 'updates the shopping list item', :aggregate_failures do
+        perform
+        expect(list_item.reload.quantity).to eq 3
+        expect(list_item.reload.notes).to be nil
+      end
+
+      it 'updates the item on the master list' do
+        # Put the mocks in here because I don't want this much mocking in the other specs
+        allow(ShoppingListItem).to receive(:belonging_to_user).with(user).and_return(scope)
+        allow(scope).to receive(:find).and_return(list_item)
+        allow(list_item).to receive(:list).and_return(shopping_list)
+        allow(shopping_list).to receive(:master_list).and_return(master_list)
+        allow(master_list).to receive(:update_item_from_child_list)
+        perform
+        expect(master_list).to have_received(:update_item_from_child_list).with(list_item.description, 1, nil, nil)
+      end
+
+      it 'returns a Service::OKResult' do
+        expect(perform).to be_a(Service::OKResult)
+      end
+
+      it 'sets the resource to include both the regular and master list item' do
+        expect(perform.resource).to eq([master_list.list_items.first, list_item])
+      end
+
+      it 'updates the updated_at timestamp on the list' do
+        Timecop.freeze do
+          perform
+          expect(shopping_list.reload.updated_at).to eq Time.now.utc
+        end
+      end
+    end
+
+    context 'when the shopping list item is not found' do
+      let(:list_item) { double("the item that doesn't exist", id: 838) }
+      let(:params) { { quantity: 3 } }
+
+      it 'returns a Service::NotFoundResult' do
+        expect(perform).to be_a(Service::NotFoundResult)
+      end
+
+      it 'sets the errors to empty' do
+        expect(perform.errors).to eq []
+      end
+    end
+
+    context 'when the shopping list item does not belong to the user' do
+      let(:list_item) { create(:shopping_list_item) }
+      let(:params) { { quantity: 3 } }
+
+      it 'returns a Service::NotFoundResult' do
+        expect(perform).to be_a(Service::NotFoundResult)
+      end
+
+      it 'sets the errors to empty' do
+        expect(perform.errors).to eq []
+      end
+    end
+
+    context 'when the params are invalid' do
+      let(:list_item) { create(:shopping_list_item, list: shopping_list) }
+      let(:params) { { description: 'This is not allowed' } }
+      let(:master_list) { shopping_list.master_list }
+      let(:scope) { ShoppingListItem.belonging_to_user(user) }
+
+      it 'does not update the master list' do
+        # Put the mocks in here because I don't want this much mocking in the other specs
+        allow(ShoppingListItem).to receive(:belonging_to_user).with(user).and_return(scope)
+        allow(scope).to receive(:find).and_return(list_item)
+        allow(list_item).to receive(:list).and_return(shopping_list)
+        allow(shopping_list).to receive(:master_list).and_return(master_list)
+        allow(master_list).to receive(:update_item_from_child_list)
+        perform
+        expect(master_list).not_to have_received(:update_item_from_child_list).with(list_item.description, 1, nil, nil)
+      end
+
+      it 'returns a Service::UnprocessableEntityResult' do
+        expect(perform).to be_a Service::UnprocessableEntityResult
+      end
+
+      it 'returns the errors' do
+        expect(perform.errors).to eq ['Description cannot be updated on an existing list item']
+      end
+    end
+
+    context "when the shopping list item doesn't belong to the authenticated user" do
+      let(:shopping_list) { create(:shopping_list) }
+      let(:list_item) { create(:shopping_list_item, list: shopping_list) }
+      let(:params) { { quantity: 4 } }
+
+      it 'returns a Service::NotFoundResult' do
+        expect(perform).to be_a Service::NotFoundResult
+      end
+
+      it 'does not include any errors' do
+        expect(perform.errors).to eq []
+      end
+    end
+
+    context 'when the list item is on a master list' do
+      let(:shopping_list) { create(:master_shopping_list, user: user) }
+      let(:list_item) { create(:shopping_list_item, list: shopping_list) }
+      let(:params) { { quantity: 4 } }
+
+      it 'does not update the item' do
+        perform
+        expect(list_item.quantity).to eq 1
+      end
+
+      it 'returns a Service::MethodNotAllowedResult' do
+        expect(perform).to be_a(Service::MethodNotAllowedResult)
+      end
+
+      it 'sets the errors' do
+        expect(perform.errors).to eq ['Cannot manually update list items on a master shopping list']
+      end
+    end
+  end
+end

--- a/spec/controller_services/shopping_list_items_controller/update_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/update_service_spec.rb
@@ -2,7 +2,6 @@
 
 require 'rails_helper'
 require 'service/ok_result'
-require 'service/no_content_result'
 require 'service/not_found_result'
 require 'service/method_not_allowed_result'
 require 'service/unprocessable_entity_result'

--- a/spec/controller_services/shopping_list_items_controller/update_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/update_service_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe ShoppingListItemsController::UpdateService do
       it 'updates the updated_at timestamp on the list' do
         Timecop.freeze do
           perform
-          expect(shopping_list.reload.updated_at).to eq Time.now.utc
+          expect(shopping_list.reload.updated_at).to be_within(0.05.seconds).of(Time.now.utc)
         end
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -61,4 +61,17 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe '#shopping_list_items' do
+    subject(:shopping_list_items) { user.shopping_list_items }
+
+    let(:user) { create(:user) }
+    let!(:list1) { create(:shopping_list_with_list_items, user: user) }
+    let!(:list2) { create(:shopping_list_with_list_items, user: user) }
+    let!(:list3) { create(:shopping_list_with_list_items) } # belongs to another user
+
+    it 'calls the ::belonging_to_user scope on ShoppingListItem' do
+      expect(shopping_list_items).to eq([list2.list_items.to_a.reverse, list1.list_items.to_a.reverse].flatten)
+    end
+  end
 end

--- a/spec/requests/shopping_list_items_spec.rb
+++ b/spec/requests/shopping_list_items_spec.rb
@@ -320,7 +320,13 @@ RSpec.describe 'ShoppingListItems', type: :request do
       context 'when the shopping list belongs to a different user' do
         let(:user) { create(:user) }
         let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 5, notes: 'To make locks' } } }
-        let(:list_item) { create(:shopping_list_item) }
+        let(:list_item) { create(:shopping_list_item, description: 'Corundum ingot', notes: nil) }
+
+        it 'does not updatte the list item' do
+          update_item
+          expect(list_item.quantity).to eq 1
+          expect(list_item.notes).to be nil
+        end
 
         it 'returns 404' do
           update_item

--- a/spec/requests/shopping_list_items_spec.rb
+++ b/spec/requests/shopping_list_items_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
   describe 'POST /shopping_lists/:shopping_list_id/shopping_list_items' do
     subject(:create_item) do
       post "/shopping_lists/#{shopping_list.id}/shopping_list_items",
-           params: params,
+           params: params.to_json,
            headers: headers
     end
 
@@ -38,7 +38,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
       end
       
       context 'when all goes well' do
-        let(:params) { "{\"shopping_list_item\":{\"description\":\"Corundum ingot\",\"quantity\":5,\"notes\":\"To make locks\",\"list_id\":#{shopping_list.id}}}" }
+        let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 5, notes: 'To make locks' } } }
 
         it 'creates a new shopping list item on the shopping list' do
           expect { create_item }.to change(shopping_list.list_items, :count).from(0).to(1)
@@ -151,7 +151,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
       context 'when the shopping list belongs to a different user' do
         let(:user) { create(:user) }
-        let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 5, notes: 'To make locks' } }.to_json }
+        let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 5, notes: 'To make locks' } } }
 
         it 'returns 404' do
           create_item
@@ -167,11 +167,11 @@ RSpec.describe 'ShoppingListItems', type: :request do
       context 'when the shopping list does not exist' do
         subject(:create_item) do
           post '/shopping_lists/838934/shopping_list_items',
-               params: params,
+               params: params.to_json,
                headers: headers
         end
 
-        let(:params) { "{\"shopping_list_item\":{\"description\":\"Corundum ingot\",\"quantity\":5,\"notes\":\"To make locks\",\"list_id\":#{shopping_list.id}}}" }
+        let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 5, notes: 'To make locks' } } }
 
         it 'returns 404' do
           create_item
@@ -187,7 +187,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
       context 'when the shopping list is a master list' do
         let(:shopping_list) { master_list }
 
-        let(:params) { "{\"shopping_list_item\":{\"description\":\"Corundum ingot\",\"quantity\":5,\"notes\":\"To make locks\",\"list_id\":#{shopping_list.id}}}" }
+        let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 5, notes: 'To make locks' } } }
 
         it 'returns status 405' do
           create_item
@@ -196,7 +196,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
       end
 
       context 'when the params are invalid' do
-        let(:params) { "{\"shopping_list_item\":{\"description\":\"Corundum ingot\",\"quantity\":\"foooo\",\"notes\":\"To make locks\",\"list_id\":#{shopping_list.id}}}" }
+        let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 'fooooo', notes: 'To make locks' } } }
 
         it 'returns 422' do
           create_item
@@ -211,7 +211,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
     end
 
     context 'when unauthenticated' do
-      let(:params) { "{\"shopping_list_item\":{\"description\":\"Corundum ingot\",\"quantity\":4,\"notes\":\"To make locks\",\"list_id\":#{shopping_list.id}}}" }
+      let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 5, notes: 'To make locks' } } }
 
       it 'returns 401' do
         create_item

--- a/spec/requests/shopping_list_items_spec.rb
+++ b/spec/requests/shopping_list_items_spec.rb
@@ -123,8 +123,8 @@ RSpec.describe 'ShoppingListItems', type: :request do
               # has frozen because Rails (Postgres?) sets the last three digits of
               # the timestamp to 0, which was breaking stuff in CI (but somehow not
               # in dev).
-              expect(shopping_list.reload.updated_at).to be_within(0.25.seconds).of(t)
-              expect(master_list.reload.updated_at).not_to be_within(0.25.seconds).of(t)
+              expect(shopping_list.reload.updated_at).to be_within(0.05.seconds).of(t)
+              expect(master_list.reload.updated_at).not_to be_within(0.05.seconds).of(t)
             end
           end
         end
@@ -277,6 +277,20 @@ RSpec.describe 'ShoppingListItems', type: :request do
                                                                       'quantity' => 7,
                                                                       'notes' => 'To make locks'
                                                                     )
+        end
+
+        it 'updates the regular list', :aggregate_failures do
+          t = Time.now + 3.days
+
+          Timecop.freeze(t) do
+            update_item
+            # use `be_within` even though the time will be set to the time Timecop
+            # has frozen because Rails (Postgres?) sets the last three digits of
+            # the timestamp to 0, which was breaking stuff in CI (but somehow not
+            # in dev).
+            expect(shopping_list.reload.updated_at).to be_within(0.05.seconds).of(t)
+            expect(master_list.reload.updated_at).not_to be_within(0.05.seconds).of(t)
+          end
         end
 
         it 'returns the master list item and the regular list item', :aggregate_failures do

--- a/spec/requests/shopping_list_items_spec.rb
+++ b/spec/requests/shopping_list_items_spec.rb
@@ -420,4 +420,200 @@ RSpec.describe 'ShoppingListItems', type: :request do
       end
     end
   end
+
+  describe 'PUT /shopping_list_items/:id' do
+    subject(:update_item) do
+      put "/shopping_list_items/#{list_item.id}", params: params.to_json, headers: headers
+    end
+
+    let!(:master_list) { create(:master_shopping_list) }
+    let!(:shopping_list) { create(:shopping_list_with_list_items, user: master_list.user) }
+    
+    context 'when authenticated' do
+      let!(:user) { master_list.user }
+      
+      let(:validation_data) do
+        {
+          'exp' => (Time.now + 1.year).to_i,
+          'email' => user.email,
+          'name' => user.name
+        }
+      end
+      
+      let(:validator) { instance_double(GoogleIDToken::Validator, check: validation_data) }
+      
+      before do
+        allow(GoogleIDToken::Validator).to receive(:new).and_return(validator)
+      end
+      
+      context 'when all goes well' do
+        let(:params) { { shopping_list_item: { quantity: 5, notes: 'To make locks' } } }
+        let(:list_item) { shopping_list.list_items.first }
+
+        before do
+          second_list = create(:shopping_list, user: user, master_list: master_list)
+          second_list.list_items.create!(description: list_item.description, quantity: 2)
+          master_list.add_item_from_child_list(shopping_list.list_items.first)
+          master_list.add_item_from_child_list(shopping_list.list_items.last) # for the sake of realism
+          master_list.add_item_from_child_list(second_list.list_items.first) 
+        end
+
+        it 'updates the regular list item' do
+          update_item
+          expect(list_item.reload.attributes).to include(
+                                                          'quantity' => 5,
+                                                          'notes' => 'To make locks'
+                                                        )
+        end
+
+        it 'updates the item on the master list' do
+          update_item
+          expect(master_list.list_items.first.attributes).to include(
+                                                                      'description' => list_item.description,
+                                                                      'quantity' => 7,
+                                                                      'notes' => 'To make locks'
+                                                                    )
+        end
+
+        it 'updates the regular list', :aggregate_failures do
+          t = Time.now + 3.days
+
+          Timecop.freeze(t) do
+            update_item
+            # use `be_within` even though the time will be set to the time Timecop
+            # has frozen because Rails (Postgres?) sets the last three digits of
+            # the timestamp to 0, which was breaking stuff in CI (but somehow not
+            # in dev).
+            expect(shopping_list.reload.updated_at).to be_within(0.05.seconds).of(t)
+            expect(master_list.reload.updated_at).not_to be_within(0.05.seconds).of(t)
+          end
+        end
+
+        it 'returns the master list item and the regular list item', :aggregate_failures do
+          update_item
+
+          # The serialization isn't as simple as .to_json and it makes it hard to determine if the JSON
+          # string is correct as some attributes are out of order and the timestamps are serialized
+          # differently. Here we grab the individual items and then we'll filter out the timestamps to
+          # verify them.
+          master_list_item_actual, regular_list_item_actual = JSON.parse(response.body).map do |item_attrs|
+            item_attrs.reject { |key, value| %w[created_at updated_at].include?(key) }
+          end
+
+          master_list_item_expected = master_list.list_items.first.attributes.reject { |k, v| %w[created_at updated_at].include?(k) }
+          regular_list_item_expected = shopping_list.list_items.first.attributes.reject { |k, v| %w[created_at updated_at].include?(k) }
+
+          expect(master_list_item_actual).to eq(master_list_item_expected)
+          expect(regular_list_item_actual).to eq(regular_list_item_expected)
+        end
+
+        it 'returns status 200' do
+          update_item
+          expect(response.status).to eq 200
+        end
+      end
+
+      context 'when the shopping list belongs to a different user' do
+        let(:user) { create(:user) }
+        let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 5, notes: 'To make locks' } } }
+        let(:list_item) { create(:shopping_list_item, description: 'Corundum ingot', notes: nil) }
+
+        it 'does not updatte the list item' do
+          update_item
+          expect(list_item.quantity).to eq 1
+          expect(list_item.notes).to be nil
+        end
+
+        it 'returns 404' do
+          update_item
+          expect(response.status).to eq 404
+        end
+
+        it 'does not return content' do
+          update_item
+          expect(response.body).to be_empty
+        end
+      end
+
+      context 'when the shopping list does not exist' do
+        let(:user) { create(:user) }
+        let(:list_item) { double("this item doesn't exist", id: 8942) }
+        let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 5, notes: 'To make locks' } } }
+
+        it 'returns 404' do
+          update_item
+          expect(response.status).to eq 404
+        end
+
+        it 'returns no body' do
+          update_item
+          expect(response.body).to be_empty
+        end
+      end
+
+      context 'when the shopping list is a master list' do
+        let(:shopping_list) { user.master_shopping_list }
+        let(:list_item) { shopping_list.list_items.create!(description: 'Corundum Ingot', list: shopping_list) }
+
+        let(:params) {  { shopping_list_item: { 'quantity': 5, notes: 'To make locks' } } }
+
+        it 'does not update the list', :aggregate_failures do
+          update_item
+          expect(list_item.quantity).to eq 1
+          expect(list_item.notes).to be nil
+        end
+
+        it 'returns status 405' do
+          update_item
+          expect(response.status).to eq 405
+        end
+
+        it 'returns a helpful error' do
+          update_item
+          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Cannot manually update list items on a master shopping list'] })
+        end
+      end
+
+      context 'when the params are invalid' do
+        let(:list_item) { shopping_list.list_items.create!(description: 'Corundum ingot') }
+        let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 'foooo', notes:'To make locks' } } }
+
+        before do
+          master_list.add_item_from_child_list(list_item)
+        end
+
+        it 'does not update the master list', :aggregate_failures do
+          update_item
+          expect(master_list.list_items.first.quantity).to eq 1
+          expect(master_list.list_items.first.notes).to be nil
+        end
+
+        it 'returns 422' do
+          update_item
+          expect(response.status).to eq 422
+        end
+
+        it 'returns the validation errors' do
+          update_item
+          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Quantity is not a number'] })
+        end
+      end
+    end
+
+    context 'when unauthenticated' do
+      let(:user) { create(:user) }
+      let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 4, notes: 'To make locks' } } }
+      let(:list_item) { create(:shopping_list_item, list: shopping_list) }
+
+      it 'returns 401' do
+        update_item
+        expect(response.status).to eq 401
+      end
+
+      it 'returns a helpful error' do
+        update_item
+        expect(JSON.parse(response.body)).to eq({ 'errors' => ['Google OAuth token validation failed'] })
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

[**Routes for managing shopping list items**](https://trello.com/c/K4501FRt/18-routes-for-managing-shopping-list-items)
[**Consider shopping list updated when items added, removed, or edited**](https://trello.com/c/5DEczwm5/56-consider-shopping-list-updated-when-items-added-removed-or-edited)

This is the second PR introducing routes for managing shopping list items. (The first one is [here](https://github.com/danascheider/skyrim_inventory_management/pull/16).) The first one introduced a `create` route, and this one adds an `update` route.

## Changes

* Create new `ShoppingListItemsController::UpdateService` class to handle the update action in the controller
* Add `:update` method to the `ShoppingListItemsController` that uses the new service class
* Add specs for update route (unit specs for the new service class as well as request specs)
* Bug fixes uncovered by the specs
* Update docs

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

I continued the pattern introduced in #17 to move to controller services to handle controller logic.
