### PR TITLE
Add destroy route for shopping list items

### DIFF
--- a/app/controller_services/shopping_list_items_controller/destroy_service.rb
+++ b/app/controller_services/shopping_list_items_controller/destroy_service.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'service/no_content_result'
+require 'service/ok_result'
+require 'service/not_found_result'
+require 'service/method_not_allowed_result'
+
+class ShoppingListItemsController < ApplicationController
+  class DestroyService
+    MASTER_LIST_ERROR = 'Cannot manually delete list item from master shopping list'
+
+    def initialize(user, item_id)
+      @user = user
+      @item_id = item_id
+    end
+
+    def perform
+      return Service::MethodNotAllowedResult.new(errors: [MASTER_LIST_ERROR]) if shopping_list_item.list.master == true
+
+      shopping_list_item.destroy!
+      master_list_item = master_list.remove_item_from_child_list(shopping_list_item.attributes)
+      master_list_item.nil? ? Service::NoContentResult.new : Service::OKResult.new(resource: master_list_item)
+    rescue ActiveRecord::RecordNotFound
+      Service::NotFoundResult.new
+    end
+
+    private
+
+    attr_reader :user, :item_id
+
+    def master_list
+      @master_list ||= shopping_list_item.list.master_list
+    end
+
+    def master_list_item
+      @master_list_item ||= master_list.list_items.find_by(description: shopping_list_item.description)
+    end
+
+    def shopping_list_item
+      @shopping_list_item ||= user.shopping_list_items.find(item_id)
+    end
+  end
+end

--- a/app/controller_services/shopping_list_items_controller/destroy_service.rb
+++ b/app/controller_services/shopping_list_items_controller/destroy_service.rb
@@ -15,9 +15,10 @@ class ShoppingListItemsController < ApplicationController
     end
 
     def perform
-      return Service::MethodNotAllowedResult.new(errors: [MASTER_LIST_ERROR]) if shopping_list_item.list.master == true
+      return Service::MethodNotAllowedResult.new(errors: [MASTER_LIST_ERROR]) if shopping_list.master == true
 
       shopping_list_item.destroy!
+      shopping_list.touch
       master_list_item = master_list.remove_item_from_child_list(shopping_list_item.attributes)
       master_list_item.nil? ? Service::NoContentResult.new : Service::OKResult.new(resource: master_list_item)
     rescue ActiveRecord::RecordNotFound
@@ -34,6 +35,10 @@ class ShoppingListItemsController < ApplicationController
 
     def master_list_item
       @master_list_item ||= master_list.list_items.find_by(description: shopping_list_item.description)
+    end
+
+    def shopping_list
+      @shopping_list = shopping_list_item.list
     end
 
     def shopping_list_item

--- a/app/controllers/shopping_list_items_controller.rb
+++ b/app/controllers/shopping_list_items_controller.rb
@@ -3,8 +3,6 @@
 require 'controller/response'
 
 class ShoppingListItemsController < ApplicationController
-  before_action :set_shopping_list_item, only: %i[destroy]
-
   def create
     result = CreateService.new(current_user, params[:shopping_list_id], list_item_params).perform
 
@@ -17,6 +15,12 @@ class ShoppingListItemsController < ApplicationController
     ::Controller::Response.new(self, result).execute
   end
 
+  def destroy
+    result = DestroyService.new(current_user, params[:id]).perform
+
+    ::Controller::Response.new(self, result).execute
+  end
+
   private
 
   def list_item_params
@@ -25,9 +29,5 @@ class ShoppingListItemsController < ApplicationController
       :quantity,
       :notes
     )
-  end
-
-  def set_shopping_list_item
-    @shopping_list_item ||= ShoppingListItem.find(params[:id])
   end
 end

--- a/spec/controller_services/shopping_list_items_controller/destroy_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/destroy_service_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'service/no_content_result'
+require 'service/ok_result'
+require 'service/not_found_result'
+require 'service/method_not_allowed_result'
+
+RSpec.describe ShoppingListItemsController::DestroyService do
+  describe '#perform' do
+    subject(:perform) { described_class.new(user, list_item.id).perform }
+
+    let(:user) { create(:user) }
+    let!(:master_list) { create(:master_shopping_list, user: user) }
+    let!(:shopping_list) { create(:shopping_list, user: user, master_list: master_list) }
+
+    context 'when all goes well' do
+      let(:list_item) { create(:shopping_list_item, list: shopping_list, notes: 'some notes') }
+
+      before do
+        master_list.add_item_from_child_list(list_item)
+      end
+
+      context 'when the quantity on the master list equals the quantity on the regular list' do
+        it 'destroys the list item' do
+          perform
+          expect { ShoppingListItem.find(list_item.id) }.to raise_error ActiveRecord::RecordNotFound
+        end
+
+        it 'destroys the item on the master list' do
+          expect { perform }.to change(master_list.list_items, :count).from(1).to(0)
+        end
+
+        it 'returns a Service::NoContentResult' do
+          expect(perform).to be_a Service::NoContentResult
+        end
+
+        it 'does not return data' do
+          expect(perform.resource).to be nil
+        end
+      end
+
+      context 'when the quantity on the master list exceed the quantity on the regular list' do
+        let(:second_list) { create(:shopping_list, user: user, master_list: master_list) }
+        let(:second_list_item) do
+          create(:shopping_list_item,
+                  list: second_list,
+                  description: list_item.description,
+                  quantity: 2,
+                  notes: 'some other notes'
+                )
+        end
+
+        before do
+          master_list.add_item_from_child_list(second_list_item)
+        end
+
+        it 'destroys the list item' do
+          perform
+          expect { ShoppingListItem.find(list_item.id) }.to raise_error ActiveRecord::RecordNotFound
+        end
+        
+        it 'changes the quantity of the master list item' do
+          perform
+          expect(master_list.list_items.first.quantity).to eq 2
+        end
+
+        it 'changes the notes of the master list item', :aggregate_failures do
+          perform
+          expect(master_list.list_items.first.notes).to match /some other notes/
+          expect(master_list.list_items.first.notes).not_to match /some notes/
+        end
+
+        it 'returns a Service::OKResult' do
+          expect(perform).to be_a Service::OKResult
+        end
+
+        it 'returns the updated master list item' do
+          expect(perform.resource).to eq master_list.list_items.first
+        end
+      end
+    end
+
+    context "when the specified list item doesn't exist" do
+      let(:list_item) { double("this item doesn't exist", id: 389) }
+
+      it 'returns a Service::NotFoundResult' do
+        expect(perform).to be_a(Service::NotFoundResult)
+      end
+
+      it "doesn't return any error messages" do
+        expect(perform.errors).to eq []
+      end
+    end
+
+    context "when the specified list item doesn't belong to the authenticated user" do
+      let(:list_item) { create(:shopping_list_item) }
+
+      it 'returns a Service::NotFoundResult' do
+        expect(perform).to be_a Service::NotFoundResult
+      end
+
+      it "doesn't return any error messages" do
+        expect(perform.errors).to eq []
+      end
+    end
+
+    context 'when the specified list item is on a master list' do
+      let(:list_item) { create(:shopping_list_item, list: master_list) }
+
+      it "doesn't destroy the list item" do
+        perform
+        expect(ShoppingListItem.find(list_item.id)).to be_a ShoppingListItem
+      end
+
+      it 'returns a Service::MethodNotAllowedResult' do
+        expect(perform).to be_a Service::MethodNotAllowedResult
+      end
+
+      it 'includes a helpful error message' do
+        expect(perform.errors).to eq ['Cannot manually delete list item from master shopping list']
+      end
+    end
+  end
+end

--- a/spec/controller_services/shopping_list_items_controller/destroy_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/destroy_service_spec.rb
@@ -38,6 +38,20 @@ RSpec.describe ShoppingListItemsController::DestroyService do
         it 'does not return data' do
           expect(perform.resource).to be nil
         end
+
+        it 'sets the updated_at timestamp on the shopping list', :aggregate_failures do
+          t = Time.now + 3.days
+
+          Timecop.freeze(t) do
+            perform
+            # use `be_within` even though the time will be set to the time Timecop
+            # has frozen because Rails (Postgres?) sets the last three digits of
+            # the timestamp to 0, which was breaking stuff in CI (but somehow not
+            # in dev).
+            expect(shopping_list.reload.updated_at).to be_within(0.05.seconds).of(t)
+            expect(master_list.reload.updated_at).not_to be_within(0.05.seconds).of(t)
+          end
+        end
       end
 
       context 'when the quantity on the master list exceed the quantity on the regular list' do
@@ -69,6 +83,20 @@ RSpec.describe ShoppingListItemsController::DestroyService do
           perform
           expect(master_list.list_items.first.notes).to match /some other notes/
           expect(master_list.list_items.first.notes).not_to match /some notes/
+        end
+
+        it 'sets the updated_at timestamp on the shopping list', :aggregate_failures do
+          t = Time.now + 3.days
+
+          Timecop.freeze(t) do
+            perform
+            # use `be_within` even though the time will be set to the time Timecop
+            # has frozen because Rails (Postgres?) sets the last three digits of
+            # the timestamp to 0, which was breaking stuff in CI (but somehow not
+            # in dev).
+            expect(shopping_list.reload.updated_at).to be_within(0.05.seconds).of(t)
+            expect(master_list.reload.updated_at).not_to be_within(0.05.seconds).of(t)
+          end
         end
 
         it 'returns a Service::OKResult' do


### PR DESCRIPTION
## Context

[**Routes for managing shopping list items**](https://trello.com/c/K4501FRt/18-routes-for-managing-shopping-list-items)
[**Consider shopping list updated when items added, removed, or edited**](https://trello.com/c/5DEczwm5/56-consider-shopping-list-updated-when-items-added-removed-or-edited)

This is the final PR adding routes to manage shopping list items through the API. It also ensures that, when an item is removed from a shopping list, that shopping list's `:updated_at` timestamp is updated.

## Changes

* Create `ShoppingListItemsController::DestroyService` class to handle requests to destroy a shopping list item
* Incorporate the new service class into the `ShoppingListItemsController`
* Add request specs and unit tests for the new class
* Add section on the destroy endpoint to the API docs

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

I debated whether I should include some sort of 500 error in case of an unexpected failure to destroy a shopping list item, but I didn't ultimately end up doing that because I couldn't think of a situation where that would happen and I didn't want to write more code than I needed to to handle an error that's never expected to come up.
