### PR TITLE
Fix bug where list items were not being included with their parent lists

### DIFF
--- a/app/models/concerns/master_listable.rb
+++ b/app/models/concerns/master_listable.rb
@@ -39,6 +39,8 @@ module MasterListable
     belongs_to :master_list, class_name: self.to_s, foreign_key: :master_list_id, optional: true
     has_many :child_lists, class_name: self.to_s, foreign_key: :master_list_id, inverse_of: :master_list
 
+    serialize :list_items, class_name: 'Array'
+
     scope :master_first, -> { order(master: :desc) }
     scope :includes_items, -> { includes(:list_items) }
 


### PR DESCRIPTION
## Context

After the big front end refactor (although maybe not because of it), I realised that lists were not being serialised with their list items - specifically when they were included in an array. Because the `Controller::Response` object handles controller responses, sticking a generic `include: :list_items` with `render json: lists` wouldn't work since that option would then be used with all models.

## Changes

* Add `serialize :list_items, class_name: 'Array'` to `MasterListable` module

## Considerations

I researched extensively to find a solution to this problem. It looked for a while like I was running up against one of Rails' opinions - perhaps it didn't like the un-REST-like API? Nevertheless, including `serialize` in the concern has made things work so all the lists are now returned and serialised with their list items.