### PR TITLE
Compare list item descriptions case-insensitively in combine_or_new

### DIFF
--- a/spec/models/shopping_list_item_spec.rb
+++ b/spec/models/shopping_list_item_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe ShoppingListItem, type: :model do
   end
 
   describe '::combine_or_create!' do
-    context 'when there is an existing item on the same list with the same description' do
+    context 'when there is an existing item on the same list with the same (case-insensitive) description' do
       subject(:combine_or_create) { described_class.combine_or_create!(description: 'existing item', quantity: 1, list: shopping_list, notes: 'notes 2') }
 
       let(:master_list) { create(:master_shopping_list) }
@@ -81,7 +81,7 @@ RSpec.describe ShoppingListItem, type: :model do
   end
 
   describe '::combine_or_new' do
-    context 'when there is an existing item on the same list with the same description' do
+    context 'when there is an existing item on the same list with the same (case-insensitive) description' do
       subject(:combine_or_new) { described_class.combine_or_new(description: 'existing item', quantity: 1, list: shopping_list, notes: 'notes 2') }
 
       let(:master_list) { create(:master_shopping_list) }

--- a/spec/models/shopping_list_item_spec.rb
+++ b/spec/models/shopping_list_item_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe ShoppingListItem, type: :model do
 
       let(:master_list) { create(:master_shopping_list) }
       let!(:shopping_list) { create(:shopping_list, user: master_list.user) }
-      let!(:existing_item) { create(:shopping_list_item, description: 'Existing item', quantity: 2, list: shopping_list, notes: 'notes 1') }
+      let!(:existing_item) { create(:shopping_list_item, description: 'ExIsTiNg ItEm', quantity: 2, list: shopping_list, notes: 'notes 1') }
 
       it "doesn't create a new list item" do
         expect { combine_or_create }.not_to change(shopping_list.list_items, :count)
@@ -86,7 +86,7 @@ RSpec.describe ShoppingListItem, type: :model do
 
       let(:master_list) { create(:master_shopping_list) }
       let!(:shopping_list) { create(:shopping_list, user: master_list.user) }
-      let!(:existing_item) { create(:shopping_list_item, description: 'Existing item', quantity: 2, list: shopping_list, notes: 'notes 1') }
+      let!(:existing_item) { create(:shopping_list_item, description: 'ExIsTiNg ItEm', quantity: 2, list: shopping_list, notes: 'notes 1') }
 
       before do
         allow(ShoppingListItem).to receive(:new)


### PR DESCRIPTION
## Context

After changing list items so that the `description` attribute is not "humanized" before save, the `ShoppingListItem#combine_or_new` method was failing to match list items by description if the descriptions differed by case.

## Changes

* Make list item descriptions be compared case-insensitively in `#combine_or_new`
* Make sure that uniqueness validation for ShoppingListItems is case-insensitive
* Ensure tests fail if this is not the case

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

The tests previously relied on the fact that the `ShoppingListItem` descriptions were `humanize`d before save. When I changed the validation to be `case_sensitive: false`, the tests initially failed to pick up on the error because the `#combine_or_new` method checked the humanised description from the attributes given to the description of the existing item. If there was an item with the description `humanize`d in the database, there would be a match, but if the item in the database did not have its description `humanized`, it would not be identified as the same item.

Initially, the tests passed because of the fact that the existing item in the database had an already-`humanize`d description assigned in the `let` block. When I changed the description to use different casing for different letters, the tests failed again. I then changed the `#combine_or_new` method to compare case-insensitively and now the specs work again.