### PR TITLE
Compare list item descriptions case-insensitively throughout code base

### DIFF
--- a/app/controller_services/shopping_list_items_controller/destroy_service.rb
+++ b/app/controller_services/shopping_list_items_controller/destroy_service.rb
@@ -33,10 +33,6 @@ class ShoppingListItemsController < ApplicationController
       @master_list ||= shopping_list_item.list.master_list
     end
 
-    def master_list_item
-      @master_list_item ||= master_list.list_items.find_by(description: shopping_list_item.description)
-    end
-
     def shopping_list
       @shopping_list = shopping_list_item.list
     end

--- a/app/models/concerns/master_listable.rb
+++ b/app/models/concerns/master_listable.rb
@@ -66,7 +66,7 @@ module MasterListable
   def remove_item_from_child_list(attrs)
     raise MasterListError, 'remove_item_from_child_list method only available on master lists' unless is_master_list?
 
-    existing_item = list_items.find_by(description: attrs['description'])
+    existing_item = list_items.find_by('description ILIKE ?', attrs['description'])
 
     if existing_item.nil? || existing_item.quantity < attrs['quantity']
       raise MasterListError, 'item passed to remove_item_from_child_list method is not represented on the master list'
@@ -86,7 +86,7 @@ module MasterListable
   def update_item_from_child_list(description, delta_quantity, old_notes, new_notes)
     raise MasterListError, 'update_item_from_child_list method only available on master lists' unless is_master_list?
 
-    existing_item = list_items.find_by(description: description)
+    existing_item = list_items.find_by('description ILIKE ?', description)
 
     if existing_item.nil? || delta_quantity < (-existing_item.quantity)
       raise MasterListError, 'invalid data to update master list item'

--- a/spec/controller_services/shopping_list_items_controller/destroy_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/destroy_service_spec.rb
@@ -54,12 +54,12 @@ RSpec.describe ShoppingListItemsController::DestroyService do
         end
       end
 
-      context 'when the quantity on the master list exceed the quantity on the regular list' do
+      context 'when the quantity on the master list exceeds the quantity on the regular list' do
         let(:second_list) { create(:shopping_list, user: user, master_list: master_list) }
         let(:second_list_item) do
           create(:shopping_list_item,
                   list: second_list,
-                  description: list_item.description,
+                  description: list_item.description.upcase, # make sure comparison is case insensitive
                   quantity: 2,
                   notes: 'some other notes'
                 )

--- a/spec/models/shopping_list_spec.rb
+++ b/spec/models/shopping_list_spec.rb
@@ -428,7 +428,8 @@ RSpec.describe ShoppingList, type: :model do
         let(:new_notes) { 'another thing' }
 
         before do
-          master_list.list_items.create(description: description, quantity: 1, notes: "#{old_notes} -- something else")
+          # upcase the description to test that the comparison is case insensitive
+          master_list.list_items.create(description: description.upcase, quantity: 1, notes: "#{old_notes} -- something else")
         end
 
         it 'adds the quantity delta to the existing one' do


### PR DESCRIPTION
## Context

In #22, I made sure that the `ShoppingListItem#combine_or_new` method compared item descriptions case-insensitively when determining whether to create a new item or combine the attributes with those of an existing one. However, elsewhere in the codebase, description comparisons remain case-sensitive.

## Changes

* Change all description comparisons to be case-insensitive
* Update tests to ensure misbehaviour will be caught before it reaches prod

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [ ] ~~Added and updated API docs and developer docs as appropriate~~
