### PR TITLE
Change notes value of "--" to nil on shopping list items

### DIFF
--- a/app/models/shopping_list_item.rb
+++ b/app/models/shopping_list_item.rb
@@ -48,6 +48,6 @@ class ShoppingListItem < ApplicationRecord
 
   def clean_up_notes
     return true unless notes
-    self.notes = notes.strip.gsub(/^(\-\- )*/, '').gsub(/( \-\-)*$/, '').gsub(/( \-\- ){2,}/, ' -- ')
+    self.notes = notes.strip.gsub(/^(\-\- ?)*/, '').gsub(/( ?\-\-)*$/, '').gsub(/( \-\- ){2,}/, ' -- ').presence
   end
 end

--- a/spec/models/shopping_list_item_spec.rb
+++ b/spec/models/shopping_list_item_spec.rb
@@ -141,4 +141,16 @@ RSpec.describe ShoppingListItem, type: :model do
       end
     end
   end
+
+  describe 'notes field' do
+    it 'cleans up leading and trailing dashes or whitespace' do
+      shopping_list_item = build(:shopping_list_item, notes: ' -- some notes --')
+      expect { shopping_list_item.save }.to change(shopping_list_item, :notes).to('some notes')
+    end
+
+    it 'saves as nil if it consists only of dashes' do
+      shopping_list_item = build(:shopping_list_item, notes: '--')
+      expect { shopping_list_item.save }.to change(shopping_list_item, :notes).to(nil)
+    end
+  end
 end


### PR DESCRIPTION
## Context

[**Prevent shopping list item notes from being two dashes**](https://trello.com/c/HyjyRxil/70-prevent-shopping-list-item-notes-from-being-two-dashes)

The nature of shopping list items is that they are continually combined with other items (especially on master lists) and then un-combined when one of the combined items is deleted. In the `ShoppingListItem` model, when one instance is combined with another, the values of the `notes` for the two instances are concatenated, separated by ` -- `. When an item is deleted or its `notes` changed to `nil`, the notes for any items that it was combined with have that part of the `notes` value removed. This can lead to a lot of orphaned dashes and spaces, so the `ShoppingListItem` cleans up long strings of dashes and spaces or any leading and trailing dashes/whitespace.

Unfortunately, I wasn't quite thorough enough and `"--"` was still allowed as a `notes` value. This value should be saved as `nil` instead of being left as `"--"`.

## Changes

* Change the value of a shopping list item's `notes` to `nil` if it is `"--"`
* Test this change

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [ ] ~~Added and updated API docs and developer docs as appropriate~~
