### PR TITLE
Make regular list changes and master list changes inside transaction

### DIFF
--- a/app/controller_services/shopping_list_items_controller/destroy_service.rb
+++ b/app/controller_services/shopping_list_items_controller/destroy_service.rb
@@ -17,9 +17,14 @@ class ShoppingListItemsController < ApplicationController
     def perform
       return Service::MethodNotAllowedResult.new(errors: [MASTER_LIST_ERROR]) if shopping_list.master == true
 
-      shopping_list_item.destroy!
-      shopping_list.touch
-      master_list_item = master_list.remove_item_from_child_list(shopping_list_item.attributes)
+      master_list_item = nil
+
+      ActiveRecord::Base.transaction do
+        shopping_list_item.destroy!
+        shopping_list.touch
+        master_list_item = master_list.remove_item_from_child_list(shopping_list_item.attributes)
+      end
+      
       master_list_item.nil? ? Service::NoContentResult.new : Service::OKResult.new(resource: master_list_item)
     rescue ActiveRecord::RecordNotFound
       Service::NotFoundResult.new

--- a/app/controller_services/shopping_lists_controller/destroy_service.rb
+++ b/app/controller_services/shopping_lists_controller/destroy_service.rb
@@ -36,13 +36,15 @@ class ShoppingListsController < ApplicationController
 
       list_items = shopping_list.list_items.map(&:attributes)
 
-      # If shopping_list is the user's last regular shopping list, this will also
-      # destroy their master list
-      shopping_list.destroy!
-      
-      if master_list&.persisted?
-        list_items.each { |item_attributes| master_list.remove_item_from_child_list(item_attributes) }
-        master_list
+      ActiveRecord::Base.transaction do
+        # If shopping_list is the user's last regular shopping list, this will also
+        # destroy their master list
+        shopping_list.destroy!
+        
+        if master_list&.persisted?
+          list_items.each { |item_attributes| master_list.remove_item_from_child_list(item_attributes) }
+          master_list
+        end
       end
     end
   end


### PR DESCRIPTION
## Context

[**Make regular list changes and master list changes inside a transaction**](https://trello.com/c/fDIQMTLG/63-make-regular-list-changes-and-master-list-changes-inside-transaction)

Currently, when a shopping list or shopping list item updates, the master list is updated accordingly. However, these changes don't happen within a transaction, meaning that one could fail and the other succeed. This runs the risk of master lists going out of sync with the lists they track. Master lists should not be updated if the regular list changes do not work and vice versa.

## Changes

* Use ActiveRecord transactions to make changes to shopping lists and shopping list items

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~

## Considerations

These changes shouldn't affect outward behaviour much so I didn't feel the need to change the tests. It's enough that they pass.
