### PR TITLE
Implement 500 errors

### DIFF
--- a/app/controller_services/application_controller/authorization_service.rb
+++ b/app/controller_services/application_controller/authorization_service.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'service/unauthorized_result'
+require 'service/internal_server_error_result'
 
 class ApplicationController < ActionController::API
   class AuthorizationService
@@ -25,6 +26,9 @@ class ApplicationController < ActionController::API
     rescue GoogleIDToken::CertificateError => e
       Rails.logger.error "Problem with OAuth certificate -- #{e.message}"
       Service::UnauthorizedResult.new(errors: ['Invalid OAuth certificate'])
+    rescue => e
+      Rails.logger.error "Internal Server Error: #{e.message}"
+      Service::InternalServerErrorResult.new(errors: [e.message])
     end
 
     private

--- a/app/controller_services/shopping_list_items_controller/create_service.rb
+++ b/app/controller_services/shopping_list_items_controller/create_service.rb
@@ -34,10 +34,12 @@ class ShoppingListItemsController < ApplicationController
           Service::OKResult.new(resource: [aggregate_list_item, item])
         end
       end
-    rescue ActiveRecord::RecordInvalid => e
+    rescue ActiveRecord::RecordInvalid
       Service::UnprocessableEntityResult.new(errors: item.error_array)
     rescue ActiveRecord::RecordNotFound
       Service::NotFoundResult.new
+    rescue => e
+      Service::InternalServerErrorResult.new(errors: [e.message])
     end
 
     private

--- a/app/controller_services/shopping_list_items_controller/create_service.rb
+++ b/app/controller_services/shopping_list_items_controller/create_service.rb
@@ -39,6 +39,7 @@ class ShoppingListItemsController < ApplicationController
     rescue ActiveRecord::RecordNotFound
       Service::NotFoundResult.new
     rescue => e
+      Rails.logger.error "Internal Server Error: #{e.message}"
       Service::InternalServerErrorResult.new(errors: [e.message])
     end
 

--- a/app/controller_services/shopping_list_items_controller/destroy_service.rb
+++ b/app/controller_services/shopping_list_items_controller/destroy_service.rb
@@ -4,6 +4,7 @@ require 'service/no_content_result'
 require 'service/ok_result'
 require 'service/not_found_result'
 require 'service/method_not_allowed_result'
+require 'service/internal_server_error_result'
 
 class ShoppingListItemsController < ApplicationController
   class DestroyService
@@ -28,6 +29,8 @@ class ShoppingListItemsController < ApplicationController
       aggregate_list_item.nil? ? Service::NoContentResult.new : Service::OKResult.new(resource: aggregate_list_item)
     rescue ActiveRecord::RecordNotFound
       Service::NotFoundResult.new
+    rescue => e
+      Service::InternalServerErrorResult.new(errors: [e.message])
     end
 
     private

--- a/app/controller_services/shopping_list_items_controller/destroy_service.rb
+++ b/app/controller_services/shopping_list_items_controller/destroy_service.rb
@@ -30,6 +30,7 @@ class ShoppingListItemsController < ApplicationController
     rescue ActiveRecord::RecordNotFound
       Service::NotFoundResult.new
     rescue => e
+      Rails.logger.error "Internal Server Error: #{e.message}"
       Service::InternalServerErrorResult.new(errors: [e.message])
     end
 

--- a/app/controller_services/shopping_list_items_controller/update_service.rb
+++ b/app/controller_services/shopping_list_items_controller/update_service.rb
@@ -36,6 +36,7 @@ class ShoppingListItemsController < ApplicationController
     rescue ActiveRecord::RecordNotFound
       Service::NotFoundResult.new
     rescue => e
+      Rails.logger.error "Internal Server Error: #{e.message}"
       Service::InternalServerErrorResult.new(errors: [e.message])
     end
     

--- a/app/controller_services/shopping_list_items_controller/update_service.rb
+++ b/app/controller_services/shopping_list_items_controller/update_service.rb
@@ -4,6 +4,7 @@ require 'service/ok_result'
 require 'service/not_found_result'
 require 'service/unprocessable_entity_result'
 require 'service/method_not_allowed_result'
+require 'service/internal_server_error_result'
 
 class ShoppingListItemsController < ApplicationController
   class UpdateService
@@ -34,6 +35,8 @@ class ShoppingListItemsController < ApplicationController
       Service::UnprocessableEntityResult.new(errors: list_item.error_array)
     rescue ActiveRecord::RecordNotFound
       Service::NotFoundResult.new
+    rescue => e
+      Service::InternalServerErrorResult.new(errors: [e.message])
     end
     
     private

--- a/app/controller_services/shopping_lists_controller/create_service.rb
+++ b/app/controller_services/shopping_lists_controller/create_service.rb
@@ -27,6 +27,8 @@ class ShoppingListsController < ApplicationController
       else
         Service::UnprocessableEntityResult.new(errors: shopping_list.error_array)
       end
+    rescue => e
+      Service::InternalServerErrorResult.new(errors: [e.message])
     end
 
     private

--- a/app/controller_services/shopping_lists_controller/create_service.rb
+++ b/app/controller_services/shopping_lists_controller/create_service.rb
@@ -29,6 +29,7 @@ class ShoppingListsController < ApplicationController
         Service::UnprocessableEntityResult.new(errors: shopping_list.error_array)
       end
     rescue => e
+      Rails.logger.error "Internal Server Error: #{e.message}"
       Service::InternalServerErrorResult.new(errors: [e.message])
     end
 

--- a/app/controller_services/shopping_lists_controller/create_service.rb
+++ b/app/controller_services/shopping_lists_controller/create_service.rb
@@ -3,6 +3,7 @@
 require 'service/created_result'
 require 'service/unprocessable_entity_result'
 require 'service/method_not_allowed_result'
+require 'service/internal_server_error_result'
 require 'service/ok_result'
 
 class ShoppingListsController < ApplicationController

--- a/app/controller_services/shopping_lists_controller/destroy_service.rb
+++ b/app/controller_services/shopping_lists_controller/destroy_service.rb
@@ -4,6 +4,7 @@ require 'service/no_content_result'
 require 'service/method_not_allowed_result'
 require 'service/not_found_result'
 require 'service/ok_result'
+require 'service/internal_server_error_result'
 
 class ShoppingListsController < ApplicationController
   class DestroyService
@@ -21,6 +22,9 @@ class ShoppingListsController < ApplicationController
       aggregate_list.nil? ? Service::NoContentResult.new : Service::OKResult.new(resource: aggregate_list)
     rescue ActiveRecord::RecordNotFound
       Service::NotFoundResult.new
+    rescue => e
+      Rails.logger.error "Internal Server Error: #{e.message}"
+      Service::InternalServerErrorResult.new(errors: [e.message])
     end
 
     private

--- a/app/controller_services/shopping_lists_controller/index_service.rb
+++ b/app/controller_services/shopping_lists_controller/index_service.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'service/ok_result'
+require 'service/internal_server_error_result'
 
 class ShoppingListsController < ApplicationController
   class IndexService
@@ -10,6 +11,9 @@ class ShoppingListsController < ApplicationController
 
     def perform
       Service::OKResult.new(resource: user.shopping_lists.index_order)
+    rescue => e
+      Rails.logger.error "Internal Server Error: #{e.message}"
+      Service::InternalServerErrorResult.new(errors: [e.message])
     end
 
     private

--- a/app/controller_services/shopping_lists_controller/update_service.rb
+++ b/app/controller_services/shopping_lists_controller/update_service.rb
@@ -4,6 +4,7 @@ require 'service/ok_result'
 require 'service/method_not_allowed_result'
 require 'service/not_found_result'
 require 'service/unprocessable_entity_result'
+require 'service/internal_server_error_result'
 
 class ShoppingListsController < ApplicationController
   class UpdateService
@@ -27,6 +28,9 @@ class ShoppingListsController < ApplicationController
       end
     rescue ActiveRecord::RecordNotFound
       Service::NotFoundResult.new
+    rescue => e
+      Rails.logger.error "Internal Server Error: #{e.message}"
+      Service::InternalServerErrorResult.new(errors: [e.message])
     end
 
     private

--- a/app/controllers/health_checks_controller.rb
+++ b/app/controllers/health_checks_controller.rb
@@ -1,9 +1,14 @@
 # frozen_string_literal: true
 
+require 'service/ok_result'
+require 'controller/response'
+
 class HealthChecksController < ApplicationController
   skip_before_action :validate_google_oauth_token
 
   def index
-    render json: {}, status: :ok
+    result = Service::OKResult.new(resource: {})
+
+    ::Controller::Response.new(self, result).execute
   end
 end

--- a/app/controllers/verifications_controller.rb
+++ b/app/controllers/verifications_controller.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'service/no_content_result'
+require 'controller/response'
+
 class VerificationsController < ApplicationController
   # The token will be verified in the before_action defined
   # in the ApplicationController class. If it gets to this
@@ -8,6 +11,8 @@ class VerificationsController < ApplicationController
   # token has been verified server-side and that there is
   # a corresponding user in the system.
   def verify_token
-    head :no_content
+    result = Service::NoContentResult.new
+
+    ::Controller::Response.new(self, result).execute
   end
 end

--- a/docs/api/resources/authorization.md
+++ b/docs/api/resources/authorization.md
@@ -28,6 +28,7 @@ Authorization: Bearer xxxxxxxxxxxxx
 #### Statuses
 
 * 401 Unauthorized
+* 500 Internal Server Error
 
 #### Example Bodies
 
@@ -45,3 +46,9 @@ Failed certificate validation:
 }
 ```
 
+Internal server error (this is an unexpected error but could occur if there is a bug):
+```json
+{
+  "errors": ["Something went horribly wrong"]
+}
+```

--- a/docs/api/resources/shopping-list-items.md
+++ b/docs/api/resources/shopping-list-items.md
@@ -110,13 +110,14 @@ Body contains the updated item from the aggregate list first and the item from t
 
 ### Error Responses
 
-Three error responses are possible.
+Four error responses are possible.
 
 #### Statuses
 
 * 404 Not Found
 * 405 Method Not Allowed
 * 422 Unprocessable Entity
+* 500 Internal Server Error
 
 #### Example Bodies
 
@@ -139,6 +140,13 @@ A 422 error, returned as a result of a validation error, includes whichever erro
     "Quantity must be greater than zero",
     "Description is required"
   ]
+}
+```
+
+A 500 error response, which is always a result of an unforeseen problem, includes the error message:
+```json
+{
+  "errors": ["Something went horribly wrong"]
 }
 ```
 
@@ -202,13 +210,14 @@ Body contains the item from the aggregate list first and the item from the regul
 
 ### Error Responses
 
-Three error responses are possible.
+Four error responses are possible.
 
 #### Statuses
 
 * 404 Not Found
 * 405 Method Not Allowed
 * 422 Unprocessable Entity
+* 500 Internal Server Error
 
 #### Example Bodies
 
@@ -233,69 +242,10 @@ A 422 error, returned as a result of a validation error, includes whichever erro
 }
 ```
 
-### Success Responses
-
-#### Statuses
-
-* 200 OK
-
-#### Example Body
-
-Body contains the item from the aggregate list first and the item from the regular list that you requested second.
-```json
-[
-  {
-    "id": 87,
-    "list_id": 238,
-    "description": "Ebony sword",
-    "quantity": 9,
-    "notes": "To sell -- To enchant with 'Absorb Health'",
-    "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "updated_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00"
-  },
-  {
-    "id": 126,
-    "list_id": 237,
-    "description": "Ebony sword",
-    "quantity": 7,
-    "notes": "To enchant with 'Absorb Health'",
-    "created_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00",
-    "updated_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00"
-  }
-]
-```
-
-### Error Responses
-
-Three error responses are possible.
-
-#### Statuses
-
-* 404 Not Found
-* 405 Method Not Allowed
-* 422 Unprocessable Entity
-
-#### Example Bodies
-
-No body will be returned with a 404 error, which is returned if the specified shopping list doesn't exist or doesn't belong to the authenticated user.
-
-A 405 error, which is returned if the specified shopping list item is on an aggregate shopping list, comes with the following body:
+A 500 error response, which is always a result of an unforeseen problem, includes the error message:
 ```json
 {
-  "errors": [
-    "Cannot manually manage items on an aggregate shopping list"
-  ]
-}
-```
-
-A 422 error, returned as a result of a validation error, includes whichever errors prevented the list item from being created:
-```json
-{
-  "errors": [
-    "Quantity must be a number",
-    "Quantity must be greater than zero",
-    "Description is required"
-  ]
+  "errors": ["Something went horribly wrong"]
 }
 ```
 
@@ -360,13 +310,14 @@ Body contains the item from the aggregate list first and the item from the regul
 
 ### Error Responses
 
-Three error responses are possible.
+Four error responses are possible.
 
 #### Statuses
 
 * 404 Not Found
 * 405 Method Not Allowed
 * 422 Unprocessable Entity
+* 500 Internal Server Error
 
 #### Example Bodies
 
@@ -388,6 +339,13 @@ A 422 error, returned as a result of a validation error, includes whichever erro
     "Quantity must be a number",
     "Quantity must be greater than zero"
   ]
+}
+```
+
+A 500 error response, which is always a result of an unforeseen problem, includes the error message:
+```json
+{
+  "errors": ["Something went horribly wrong"]
 }
 ```
 
@@ -433,12 +391,13 @@ Example 200 response body containing the updated aggregate list item:
 
 ### Error Responses
 
-Two error responses are possible.
+Three error responses are possible.
 
 #### Statuses
 
 * 404 Not Found
 * 405 Method Not Allowed
+* 500 Internal Server Error
 
 #### Example Bodies
 
@@ -460,5 +419,12 @@ A 422 error, returned as a result of a validation error, includes whichever erro
     "Quantity must be a number",
     "Quantity must be greater than zero"
   ]
+}
+```
+
+A 500 error response, which is always a result of an unforeseen problem, includes the error message:
+```json
+{
+  "errors": ["Something went horribly wrong"]
 }
 ```

--- a/docs/api/resources/shopping-lists.md
+++ b/docs/api/resources/shopping-lists.md
@@ -125,6 +125,23 @@ For a user with multiple lists:
 ]
 ```
 
+### Error Responses
+
+In general, no errors are expected to be returned from this endpoint. However, unanticipated problems can always come up.
+
+#### Statuses
+
+* 500 Internal Server Error
+
+#### Example Bodies
+
+A 500 error response, which is always a result of an unforeseen problem, includes the error message:
+```json
+{
+  "errors": ["Something went horribly wrong"]
+}
+```
+
 ## POST /shopping_lists
 
 Creates a new shopping list for the authenticated user. If the user does not already have an aggregate list, an aggregate list will also be created automatically. The response is an array that includes the newly created shopping list(s).
@@ -211,24 +228,28 @@ When the aggregate list has also been created:
 #### Statuses
 
 * 422 Unprocessable Entity
+* 500 Internal Server Error
 
 #### Example Bodies
 
 If duplicate title is given:
 ```json
 {
-  "errors": [
-    "Title has already been taken"
-  ]
+  "errors": ["Title has already been taken"]
 }
 ```
 
 If request attempts to create an aggregate list:
 ```json
 {
-  "errors": [
-    "Cannot manually create an aggregate shopping list"
-  ]
+  "errors": ["Cannot manually create an aggregate shopping list"]
+}
+```
+
+A 500 error response, which is always a result of an unforeseen problem, includes the error message:
+```json
+{
+  "errors": ["Something went horribly wrong"]
 }
 ```
 
@@ -302,28 +323,33 @@ Content-Type: application/json
 * 422 Unprocessable Entity
 * 405 Method Not Allowed
 * 404 Not Found
+* 500 Internal Server Error
 
 #### Example Bodies
+
+
+For a 404 response, no response body is returned.
 
 For a 422 response due to title uniqueness constraint:
 ```json
 {
-  "errors": [
-    "Title has already been taken"
-  ]
+  "errors": ["Title has already been taken"]
 }
 ```
 
 For a 405 response due to attempting to update an aggregate list or convert a regular list to an aggregate list:
 ```json
 {
-  "errors": [
-    "Cannot manually update an aggregate shopping list"
-  ]
+  "errors": ["Cannot manually update an aggregate shopping list"]
 }
 ```
 
-For a 404 response, no response body is returned.
+A 500 error response, which is always a result of an unforeseen problem, includes the error message:
+```json
+{
+  "errors": ["Something went horribly wrong"]
+}
+```
 
 ## DELETE /shopping_lists/:id
 
@@ -379,16 +405,22 @@ If the specified list does not exist or does not belong to the authenticated use
 
 * 404 Not Found
 * 405 Method Not Allowed
+* 500 Internal Server Error
 
 #### Example Bodies
 
-For a 404 response, no response body will be returned
+For a 404 response, no response body will be returned.
 
 For a 405 response:
 ```json
 {
-  "errors": [
-    "Cannot manually delete an aggregate shopping list"
-  ]
+  "errors": ["Cannot manually delete an aggregate shopping list"]
+}
+```
+
+A 500 error response, which is always a result of an unforeseen problem, includes the error message:
+```json
+{
+  "errors": ["Something went horribly wrong"]
 }
 ```

--- a/docs/api/resources/users.md
+++ b/docs/api/resources/users.md
@@ -19,9 +19,9 @@ Authorization: Bearer xxxxxxxxx
 
 ### Success Responses
 
-#### Status
+#### Statuses
 
-200 OK
+* 200 OK
 
 #### Example Body
 
@@ -34,3 +34,7 @@ Authorization: Bearer xxxxxxxxx
   "name": "Jane Doe"
 }
 ```
+
+### Error Responses
+
+No errors are expected from this endpoint, however, it can still result in errors during the authorisation phase, returning the same errors as the [authorisation endpoint](/docs/api/authorization.md).

--- a/lib/service/internal_server_error_result.rb
+++ b/lib/service/internal_server_error_result.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'service/result'
+
+module Service
+  class InternalServerErrorResult < Result
+    def status
+      :internal_server_error
+    end
+  end
+end

--- a/spec/controller_services/application_controller/authorization_service_spec.rb
+++ b/spec/controller_services/application_controller/authorization_service_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 require 'service/unauthorized_result'
+require 'service/internal_server_error_result'
 
 RSpec.describe ApplicationController::AuthorizationService do
   describe '#perform' do
@@ -114,6 +115,22 @@ RSpec.describe ApplicationController::AuthorizationService do
 
       it 'returns an UnauthorizedResult' do
         expect(perform).to be_a(Service::UnauthorizedResult)
+      end
+    end
+
+    context 'when something unexpected goes wrong' do
+      let(:payload) { {} }
+
+      before do
+        allow(GoogleIDToken::Validator).to receive(:new).and_raise(StandardError, 'Something went horribly wrong')
+      end
+
+      it 'returns a Service::InternalServerErrorResult' do
+        expect(perform).to be_a(Service::InternalServerErrorResult)
+      end
+
+      it 'sets the errors' do
+        expect(perform.errors).to eq(['Something went horribly wrong'])
       end
     end
   end

--- a/spec/controller_services/shopping_list_items_controller/destroy_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/destroy_service_spec.rb
@@ -5,6 +5,7 @@ require 'service/no_content_result'
 require 'service/ok_result'
 require 'service/not_found_result'
 require 'service/method_not_allowed_result'
+require 'service/internal_server_error_result'
 
 RSpec.describe ShoppingListItemsController::DestroyService do
   describe '#perform' do
@@ -147,6 +148,22 @@ RSpec.describe ShoppingListItemsController::DestroyService do
 
       it 'includes a helpful error message' do
         expect(perform.errors).to eq ['Cannot manually delete list item from aggregate shopping list']
+      end
+    end
+
+    context 'when something unexpected goes wrong' do
+      let(:list_item) { create(:shopping_list_item, list: shopping_list) }
+
+      before do
+        allow_any_instance_of(ShoppingListItem).to receive(:destroy!).and_raise(StandardError, 'Something went horribly wrong')
+      end
+
+      it 'returns a Service::InternalServerErrorResult' do
+        expect(perform).to be_a(Service::InternalServerErrorResult)
+      end
+
+      it 'sets the errors' do
+        expect(perform.errors).to eq(['Something went horribly wrong'])
       end
     end
   end

--- a/spec/controller_services/shopping_lists_controller/create_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/create_service_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 require 'service/created_result'
 require 'service/unprocessable_entity_result'
+require 'service/internal_server_error_result'
 
 RSpec.describe ShoppingListsController::CreateService do
   describe '#perform' do
@@ -86,6 +87,21 @@ RSpec.describe ShoppingListsController::CreateService do
 
       it 'sets the errors' do
         expect(perform.errors).to eq(['Title can only include alphanumeric characters and spaces'])
+      end
+    end
+
+    context 'when something unexpected goes wrong' do
+      let(:params) { { title: 'Foobar' } }
+      before do
+        allow_any_instance_of(ShoppingList).to receive(:save).and_raise(StandardError, 'Something went horribly wrong')
+      end
+
+      it 'returns a Service::InternalServerErrorResult' do
+        expect(perform).to be_a(Service::InternalServerErrorResult)
+      end
+
+      it 'sets the errors' do
+        expect(perform.errors).to eq ['Something went horribly wrong']
       end
     end
   end

--- a/spec/controller_services/shopping_lists_controller/destroy_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/destroy_service_spec.rb
@@ -105,5 +105,21 @@ RSpec.describe ShoppingListsController::DestroyService do
         expect(perform).to be_a(Service::NotFoundResult)
       end
     end
+
+    context 'when something unexpected goes wrong' do
+      let!(:shopping_list) { create(:shopping_list, user: user) }
+
+      before do
+        allow_any_instance_of(ShoppingList).to receive(:aggregate_list).and_raise(StandardError, 'Something went horribly wrong')
+      end
+
+      it 'returns a Service::InternalServerErrorResult' do
+        expect(perform).to be_a(Service::InternalServerErrorResult)
+      end
+
+      it 'sets the errors' do
+        expect(perform.errors).to eq(['Something went horribly wrong'])
+      end
+    end
   end
 end

--- a/spec/controller_services/shopping_lists_controller/index_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/index_service_spec.rb
@@ -31,5 +31,19 @@ RSpec.describe ShoppingListsController::IndexService do
         expect(perform.resource).to eq user.shopping_lists.index_order
       end
     end
+
+    context 'when something unexpected goes wrong' do
+      before do
+        allow_any_instance_of(User).to receive(:shopping_lists).and_raise(StandardError, 'Something went horribly wrong')
+      end
+
+      it 'returns a Service::InternalServerErrorResult' do
+        expect(perform).to be_a(Service::InternalServerErrorResult)
+      end
+
+      it 'sets the errors' do
+        expect(perform.errors).to eq(['Something went horribly wrong'])
+      end
+    end
   end
 end

--- a/spec/controller_services/shopping_lists_controller/update_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/update_service_spec.rb
@@ -5,6 +5,7 @@ require 'service/ok_result'
 require 'service/method_not_allowed_result'
 require 'service/not_found_result'
 require 'service/unprocessable_entity_result'
+require 'service/internal_server_error_result'
 
 RSpec.describe ShoppingListsController::UpdateService do
   describe '#perform' do
@@ -76,6 +77,23 @@ RSpec.describe ShoppingListsController::UpdateService do
 
       it 'sets the error message' do
         expect(perform.errors).to eq(['Cannot make a regular shopping list an aggregate list'])
+      end
+    end
+
+    context 'when something unexpected goes wrong' do
+      let!(:shopping_list) { create(:shopping_list, user: user) }
+      let(:params) { { title: 'New Title' } }
+
+      before do
+        allow_any_instance_of(ShoppingList).to receive(:update).and_raise(StandardError, 'Something went horribly wrong')
+      end
+
+      it 'returns a Service::InternalServerErrorResult' do
+        expect(perform).to be_a(Service::InternalServerErrorResult)
+      end
+
+      it 'sets the errors' do
+        expect(perform.errors).to eq(['Something went horribly wrong'])
       end
     end
   end

--- a/spec/lib/service/internal_server_error_result_spec.rb
+++ b/spec/lib/service/internal_server_error_result_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'service/internal_server_error_result'
+
+RSpec.describe Service::InternalServerErrorResult do
+  subject(:result) { described_class.new(errors: ['Something went horribly wrong']) }
+
+  describe '#status' do
+    it 'is :internal_server_error' do
+      expect(result.status).to eq :internal_server_error
+    end
+  end
+end


### PR DESCRIPTION
## Context

[**Implement 500 errors**](https://trello.com/c/8cbmEK0m/73-implement-500-errors)

There is currently no real error handling as far as unexpected errors are concerned. We needed to add handling for 500 responses.

## Changes

* Create `Service::InternalServerErrorResult` class
* Use the new result class in existing controller services
* Update specs

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

It's always possible that something goes really sideways and an error bypasses the error handling and gets sent to the client outside of the handling I've added. This is a risk but I still thought it was better to use a class similar to the others we're using where possible. 