### PR TITLE
Scope shopping list index route to game

### DIFF
--- a/app/controller_services/shopping_lists_controller/index_service.rb
+++ b/app/controller_services/shopping_lists_controller/index_service.rb
@@ -1,16 +1,20 @@
 # frozen_string_literal: true
 
 require 'service/ok_result'
+require 'service/not_found_result'
 require 'service/internal_server_error_result'
 
 class ShoppingListsController < ApplicationController
   class IndexService
-    def initialize(game)
-      @game = game
+    def initialize(user, game_id)
+      @user = user
+      @game_id = game_id
     end
 
     def perform
       Service::OKResult.new(resource: game.shopping_lists.index_order)
+    rescue ActiveRecord::RecordNotFound
+      Service::NotFoundResult.new
     rescue => e
       Rails.logger.error "Internal Server Error: #{e.message}"
       Service::InternalServerErrorResult.new(errors: [e.message])
@@ -18,6 +22,10 @@ class ShoppingListsController < ApplicationController
 
     private
 
-    attr_reader :game
+    attr_reader :user, :game_id
+
+    def game
+      user.games.find(game_id)
+    end
   end
 end

--- a/app/controller_services/shopping_lists_controller/index_service.rb
+++ b/app/controller_services/shopping_lists_controller/index_service.rb
@@ -5,12 +5,12 @@ require 'service/internal_server_error_result'
 
 class ShoppingListsController < ApplicationController
   class IndexService
-    def initialize(user)
-      @user = user
+    def initialize(game)
+      @game = game
     end
 
     def perform
-      Service::OKResult.new(resource: user.shopping_lists.index_order)
+      Service::OKResult.new(resource: game.shopping_lists.index_order)
     rescue => e
       Rails.logger.error "Internal Server Error: #{e.message}"
       Service::InternalServerErrorResult.new(errors: [e.message])
@@ -18,6 +18,6 @@ class ShoppingListsController < ApplicationController
 
     private
 
-    attr_reader :user
+    attr_reader :game
   end
 end

--- a/app/controllers/shopping_lists_controller.rb
+++ b/app/controllers/shopping_lists_controller.rb
@@ -4,7 +4,7 @@ require 'controller/response'
 
 class ShoppingListsController < ApplicationController
   def index
-    result = IndexService.new(current_user).perform
+    result = IndexService.new(current_user, params[:game_id]).perform
 
     ::Controller::Response.new(self, result).execute
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,8 +6,10 @@ Rails.application.routes.draw do
   get '/auth/verify_token', to: 'verifications#verify_token', as: 'verify_token'
   get '/users/current', to: 'users#current', as: 'current_user'
 
-  resources :shopping_lists do
-    resources :shopping_list_items, shallow: true, except: %i[index show]
+  resources :games do
+    resources :shopping_lists, shallow: true, except: %i[show] do
+      resources :shopping_list_items, shallow: true, except: %i[index show]
+    end
   end
 
   get '/privacy', to: 'utilities#privacy'

--- a/docs/api/resources/shopping-lists.md
+++ b/docs/api/resources/shopping-lists.md
@@ -1,6 +1,6 @@
 # Shopping Lists
 
-Shopping lists represent lists of items a user needs in the game. Users can have different lists corresponding to different property locations. Users with shopping lists also have an aggregate list that includes the combined list items and quantities from all their other lists. Aggregate lists are created, updated, and destroyed automatically. They cannot be created, updated, or destroyed through the API (including to change attributes or to add, remove, or update list items).
+Shopping lists represent lists of items a user needs in a given game. Users can have different lists corresponding to different property locations within each game. Games with shopping lists also have an aggregate list that includes the combined list items and quantities from all the other lists for that game. Aggregate lists are created, updated, and destroyed automatically. They cannot be created, updated, or destroyed through the API (including to change attributes or to add, remove, or update list items).
 
 Each list contains list items, which are returned with each response that includes the list.
 
@@ -18,15 +18,15 @@ Like other resources in SIM, shopping lists are scoped to the authenticated user
 
 ## Endpoints
 
-* [`GET /shopping_lists`](#get-shopping_lists)
+* [`GET /games/:game_id/shopping_lists`](#get-gamesgame_idshopping_lists)
 * [`GET /shopping_lists/:id`](#get-shopping_listsid)
 * [`POST /shopping_lists`](#post-shopping_lists)
 * [`PUT|PATCH /shopping_lists/:id`](#patch-shopping_listsid)
 * [`DELETE /shopping_lists/:id`](#delete-shopping_listsid)
 
-## GET /shopping_lists
+## GET /games/:game_id/shopping_lists
 
-Returns all shopping lists owned by the authenticated user. The aggregate shopping list will be returned first, followed by the user's other shopping lists in reverse chronological order by `updated_at` (i.e., the lists that were edited most recently will be on top).
+Returns all shopping lists for the game indicated by the `:game_id` param, provided the game is owned by the authenticated user. The aggregate shopping list will be returned first, followed by the game's other shopping lists in reverse chronological order by `updated_at` (i.e., the lists that were edited most recently will be on top).
 
 ### Example Request
 
@@ -43,16 +43,16 @@ Authorization: Bearer xxxxxxxxxxxxx
 
 #### Example Bodies
 
-For a user with no lists:
+For a game with no lists:
 ```json
 []
 ```
-For a user with multiple lists:
+For a game with multiple lists:
 ```json
 [
   {
     "id": 43,
-    "user_id": 8234,
+    "game_id": 8234,
     "aggregate": true,
     "title": "All Items",
     "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
@@ -78,7 +78,7 @@ For a user with multiple lists:
   },
   {
     "id": 46,
-    "user_id": 8234,
+    "game_id": 8234,
     "aggregate": false,
     "aggregate_list_id": 43,
     "title": "Lakeview Manor",
@@ -105,7 +105,7 @@ For a user with multiple lists:
   },
   {
     "id": 52,
-    "user_id": 8234,
+    "game_id": 8234,
     "aggregate": false,
     "aggregate_list_id": 43,
     "title": "Severin Manor",
@@ -131,9 +131,12 @@ In general, no errors are expected to be returned from this endpoint. However, u
 
 #### Statuses
 
+* 404 Not Found
 * 500 Internal Server Error
 
 #### Example Bodies
+
+A 404 error is the result of the game not being found or not belonging to the authenticated user. It does not include a response body.
 
 A 500 error response, which is always a result of an unforeseen problem, includes the error message:
 ```json

--- a/spec/controller_services/shopping_lists_controller/index_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/index_service_spec.rb
@@ -5,11 +5,11 @@ require 'service/ok_result'
 
 RSpec.describe ShoppingListsController::IndexService do
   describe '#perform' do
-    subject(:perform) { described_class.new(user).perform }
+    subject(:perform) { described_class.new(game).perform }
 
-    let(:user) { create(:user) }
+    let(:game) { create(:game) }
 
-    context 'when the user has no shopping lists' do
+    context 'when there are no shopping lists for that game' do
       it 'returns a Service::OKResult' do
         expect(perform).to be_a(Service::OKResult)
       end
@@ -19,22 +19,22 @@ RSpec.describe ShoppingListsController::IndexService do
       end
     end
 
-    context 'when the user has shopping lists' do
-      let!(:aggregate_list) { create(:aggregate_shopping_list, user: user) }
-      let!(:lists) { create_list(:shopping_list_with_list_items, 2, user: user) }
+    context 'when there are shopping lists for that game' do
+      let!(:aggregate_list) { create(:aggregate_shopping_list, game: game) }
+      let!(:lists) { create_list(:shopping_list_with_list_items, 2, game: game) }
 
       it 'returns a Service::OKResult' do
         expect(perform).to be_a(Service::OKResult)
       end
 
-      it "sets the resource to the user's shopping lists" do
-        expect(perform.resource).to eq user.shopping_lists.index_order
+      it "sets the resource to the game's shopping lists" do
+        expect(perform.resource).to eq game.shopping_lists.index_order
       end
     end
 
     context 'when something unexpected goes wrong' do
       before do
-        allow_any_instance_of(User).to receive(:shopping_lists).and_raise(StandardError, 'Something went horribly wrong')
+        allow_any_instance_of(Game).to receive(:shopping_lists).and_raise(StandardError, 'Something went horribly wrong')
       end
 
       it 'returns a Service::InternalServerErrorResult' do

--- a/spec/factories/games.rb
+++ b/spec/factories/games.rb
@@ -5,5 +5,16 @@ FactoryBot.define do
     user
     
     sequence(:name) { |n| "My Game #{n}" }
+
+    factory :game_with_shopping_lists do
+      transient do
+        shopping_list_count { 2 }
+      end
+
+      after(:create) do |game, evaluator|
+        create(:aggregate_shopping_list, game: game)
+        create_list(:shopping_list, evaluator.shopping_list_count, game: game)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

[**Scope shopping list routes to games**](95-scope-shopping-list-routes-to-games)

Shopping lists are now owned by `Game` models. Each game `has_many :shopping_lists`. However, the resource routes for shopping lists do not reflect this. They are still as if users owned shopping lists directly.

## Changes

* Move from a `GET /shopping_lists` index route to a `GET /games/:game_id/shopping_lists` route

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

I didn't add any documentation explaining games as resources, because right now there aren't really any routes that deal with games as resources.
