### PR TITLE
Scope shopping list create route to game

### DIFF
--- a/app/controller_services/shopping_lists_controller/create_service.rb
+++ b/app/controller_services/shopping_lists_controller/create_service.rb
@@ -2,6 +2,7 @@
 
 require 'service/created_result'
 require 'service/unprocessable_entity_result'
+require 'service/not_found_result'
 require 'service/method_not_allowed_result'
 require 'service/internal_server_error_result'
 require 'service/ok_result'
@@ -10,24 +11,27 @@ class ShoppingListsController < ApplicationController
   class CreateService
     AGGREGATE_LIST_ERROR = 'Cannot manually create an aggregate shopping list'
 
-    def initialize(user, params)
+    def initialize(user, game_id, params)
       @user = user
+      @game_id = game_id
       @params = params
     end
 
     def perform
       return Service::UnprocessableEntityResult.new(errors: [AGGREGATE_LIST_ERROR]) if params[:aggregate]
 
-      shopping_list = user.shopping_lists.new(params)
-      preexisting_aggregate_list = user.aggregate_shopping_list
+      shopping_list = game.shopping_lists.new(params)
+      preexisting_aggregate_list = game.aggregate_shopping_list
 
       if shopping_list.save
         # Check if the aggregate shopping list is newly created and return it too if so
-        resource = preexisting_aggregate_list ? shopping_list : [user.aggregate_shopping_list, shopping_list]
+        resource = preexisting_aggregate_list ? shopping_list : [game.aggregate_shopping_list, shopping_list]
         Service::CreatedResult.new(resource: resource)
       else
         Service::UnprocessableEntityResult.new(errors: shopping_list.error_array)
       end
+    rescue ActiveRecord::RecordNotFound
+      Service::NotFoundResult.new
     rescue => e
       Rails.logger.error "Internal Server Error: #{e.message}"
       Service::InternalServerErrorResult.new(errors: [e.message])
@@ -35,6 +39,10 @@ class ShoppingListsController < ApplicationController
 
     private
 
-    attr_reader :user, :params
+    attr_reader :user, :game_id, :params
+
+    def game
+      user.games.find(game_id)
+    end
   end
 end

--- a/app/controllers/shopping_lists_controller.rb
+++ b/app/controllers/shopping_lists_controller.rb
@@ -10,7 +10,7 @@ class ShoppingListsController < ApplicationController
   end
 
   def create
-    result = CreateService.new(current_user, shopping_list_params).perform
+    result = CreateService.new(current_user, params[:game_id], shopping_list_params).perform
 
     ::Controller::Response.new(self, result).execute
   end

--- a/spec/controller_services/shopping_lists_controller/create_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/create_service_spec.rb
@@ -8,12 +8,12 @@ require 'service/internal_server_error_result'
 
 RSpec.describe ShoppingListsController::CreateService do
   describe '#perform' do
-    subject(:perform) { described_class.new(user, game_id, params).perform }
+    subject(:perform) { described_class.new(user, game.id, params).perform }
     
     let(:user) { create(:user) }
 
     context 'when the game is not found' do
-      let(:game_id) { 898243 }
+      let(:game) { double(id: 898243) }
       let(:params) { { title: 'My Shopping List' } }
 
       it 'returns a Service::NotFoundResult' do
@@ -27,7 +27,6 @@ RSpec.describe ShoppingListsController::CreateService do
 
     context "when the game doesn't belong to the given user" do
       let(:game) { create(:game) }
-      let(:game_id) { game.id }
       let(:params) { { title: 'My Shopping List' } }
 
       it 'returns a Service::NotFoundResult' do
@@ -41,7 +40,6 @@ RSpec.describe ShoppingListsController::CreateService do
 
     context 'when the request tries to create an aggregate list' do
       let(:game) { create(:game, user: user) }
-      let(:game_id) { game.id }
       let(:params) do
         {
           title: 'All Items',
@@ -60,7 +58,6 @@ RSpec.describe ShoppingListsController::CreateService do
 
     context 'when params are valid' do
       let(:game) { create(:game, user: user) }
-      let(:game_id) { game.id }
       let(:params) { { title: 'Proudspire Manor' } }
 
       context 'when the game has an aggregate shopping list' do
@@ -126,7 +123,6 @@ RSpec.describe ShoppingListsController::CreateService do
 
     context 'when something unexpected goes wrong' do
       let(:game) { create(:game, user: user) }
-      let(:game_id) { game.id }
       let(:params) { { title: 'Foobar' } }
 
       before do

--- a/spec/controller_services/shopping_lists_controller/create_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/create_service_spec.rb
@@ -2,16 +2,46 @@
 
 require 'rails_helper'
 require 'service/created_result'
+require 'service/not_found_result'
 require 'service/unprocessable_entity_result'
 require 'service/internal_server_error_result'
 
 RSpec.describe ShoppingListsController::CreateService do
   describe '#perform' do
-    subject(:perform) { described_class.new(user, params).perform }
+    subject(:perform) { described_class.new(user, game_id, params).perform }
     
     let(:user) { create(:user) }
 
+    context 'when the game is not found' do
+      let(:game_id) { 898243 }
+      let(:params) { { title: 'My Shopping List' } }
+
+      it 'returns a Service::NotFoundResult' do
+        expect(perform).to be_a(Service::NotFoundResult)
+      end
+
+      it "doesn't return any data" do
+        expect(perform.errors).to be_empty
+      end
+    end
+
+    context "when the game doesn't belong to the given user" do
+      let(:game) { create(:game) }
+      let(:game_id) { game.id }
+      let(:params) { { title: 'My Shopping List' } }
+
+      it 'returns a Service::NotFoundResult' do
+        expect(perform).to be_a(Service::NotFoundResult)
+      end
+
+      it "doesn't return any data" do
+        expect(perform.errors).to be_empty
+      end
+    end
+
     context 'when the request tries to create an aggregate list' do
+      let(:game) { create(:game, user: user) }
+      let(:game_id) { game.id }
       let(:params) do
         {
           title: 'All Items',
@@ -29,15 +59,17 @@ RSpec.describe ShoppingListsController::CreateService do
     end
 
     context 'when params are valid' do
+      let(:game) { create(:game, user: user) }
+      let(:game_id) { game.id }
       let(:params) { { title: 'Proudspire Manor' } }
 
-      context 'when the user has an aggregate shopping list' do
+      context 'when the game has an aggregate shopping list' do
         before do
-          create(:aggregate_shopping_list, user: user)
+          create(:aggregate_shopping_list, game: game)
         end
 
-        it 'creates a shopping list for the given user' do
-          expect { perform }.to change(user.shopping_lists, :count).from(1).to(2)
+        it 'creates a shopping list for the given game' do
+          expect { perform }.to change(game.shopping_lists, :count).from(1).to(2)
         end
 
         it 'returns a Service::CreatedResult' do
@@ -45,23 +77,23 @@ RSpec.describe ShoppingListsController::CreateService do
         end
 
         it 'sets the resource to the created list' do
-          expect(perform.resource).to eq user.shopping_lists.last
+          expect(perform.resource).to eq game.shopping_lists.last
         end
       end
 
-      context "when the user doesn't have an aggregate shopping list" do
+      context "when the game doesn't have an aggregate shopping list" do
         it 'creates two lists' do
-          expect { perform }.to change(user.shopping_lists, :count).from(0).to(2)
+          expect { perform }.to change(game.shopping_lists, :count).from(0).to(2)
         end
 
-        it 'creates an aggregate shopping list for the given user' do
+        it 'creates an aggregate shopping list for the given game' do
           perform
-          expect(user.aggregate_shopping_list).to be_present
+          expect(game.aggregate_shopping_list).to be_present
         end
 
-        it 'creates a regular shopping list for the given user' do
+        it 'creates a regular shopping list for the given game' do
           perform
-          expect(user.shopping_lists.last.title).to eq 'Proudspire Manor'
+          expect(game.shopping_lists.last.title).to eq 'Proudspire Manor'
         end
 
         it 'returns a Service::CreatedResult' do
@@ -69,16 +101,18 @@ RSpec.describe ShoppingListsController::CreateService do
         end
 
         it 'sets the resource to include both lists' do
-          expect(perform.resource).to eq([user.aggregate_shopping_list, user.shopping_lists.last])
+          expect(perform.resource).to eq([game.aggregate_shopping_list, game.shopping_lists.last])
         end
       end
     end
 
     context 'when params are invalid' do
+      let(:game) { create(:game, user: user) }
+      let(:game_id) { game.id }
       let(:params) { { title: '|nvalid Tit|e' } }
 
       it 'does not create a shopping list' do
-        expect { perform }.not_to change(user.shopping_lists, :count)
+        expect { perform }.not_to change(game.shopping_lists, :count)
       end
 
       it 'returns a Service::UnprocessableEntityResult' do
@@ -91,7 +125,10 @@ RSpec.describe ShoppingListsController::CreateService do
     end
 
     context 'when something unexpected goes wrong' do
+      let(:game) { create(:game, user: user) }
+      let(:game_id) { game.id }
       let(:params) { { title: 'Foobar' } }
+
       before do
         allow_any_instance_of(ShoppingList).to receive(:save).and_raise(StandardError, 'Something went horribly wrong')
       end

--- a/spec/factories/games.rb
+++ b/spec/factories/games.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :game do
     user
     
-    sequence(:name) { |n| "My Game #{n}" }
+    sequence(:name) { |n| "Skyrim Game #{n}" }
 
     factory :game_with_shopping_lists do
       transient do

--- a/spec/factories/shopping_lists.rb
+++ b/spec/factories/shopping_lists.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :shopping_list do
     game
 
-    sequence(:title) { |n| "My List #{n}" }
+    sequence(:title) { |n| "Shopping List #{n}" }
 
     factory :aggregate_shopping_list do
       aggregate { true }

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'ShoppingLists', type: :request do
   end
 
   describe 'POST /shopping_lists' do
-    subject(:create_shopping_list) { post '/shopping_lists', params: '{ "shopping_list": {} }', headers: headers }
+    subject(:create_shopping_list) { post "/games/#{game.id}/shopping_lists", params: '{ "shopping_list": {} }', headers: headers }
 
     context 'when authenticated' do
       let!(:user) { create(:user) }
@@ -30,14 +30,16 @@ RSpec.describe 'ShoppingLists', type: :request do
       end
 
       context 'when all goes well' do
+        let(:game) { create(:game, user: user) }
+
         context 'when an aggregate list has also been created' do
           it 'creates a new shopping list' do
-            expect { create_shopping_list }.to change(user.shopping_lists, :count).from(0).to(2) # because of the aggregate list
+            expect { create_shopping_list }.to change(game.shopping_lists, :count).from(0).to(2) # because of the aggregate list
           end
 
           it 'returns the aggregate list as well as the new list' do
             create_shopping_list
-            expect(response.body).to eq([user.aggregate_shopping_list, user.shopping_lists.last].to_json)
+            expect(response.body).to eq([game.aggregate_shopping_list, game.shopping_lists.last].to_json)
           end
 
           it 'returns status 201' do
@@ -47,22 +49,51 @@ RSpec.describe 'ShoppingLists', type: :request do
         end
 
         context 'when only the new shopping list has been created' do
-          let!(:aggregate_list) { create(:aggregate_shopping_list, user: user, created_at: 2.seconds.ago, updated_at: 2.seconds.ago) }
+          let!(:aggregate_list) { create(:aggregate_shopping_list, game: game, created_at: 2.seconds.ago, updated_at: 2.seconds.ago) }
 
           it 'creates one list' do
-            expect{ create_shopping_list }.to change(user.shopping_lists, :count).from(1).to(2)
+            expect{ create_shopping_list }.to change(game.shopping_lists, :count).from(1).to(2)
           end
 
           it 'returns only the newly created list' do
             create_shopping_list
-            expect(response.body).to eq(user.shopping_lists.last.to_json)
+            expect(response.body).to eq(game.shopping_lists.last.to_json)
           end
         end
       end
 
-      context 'when something goes wrong' do
-        subject(:create_shopping_list) { post '/shopping_lists', params: "{ \"shopping_list\": { \"title\": \"#{existing_list.title}\" } }", headers: headers }
-        let(:existing_list) { create(:shopping_list, user: user) }
+      context 'when the game is not found' do
+        let(:game) { double(id: 84968294) }
+
+        it 'returns status 404' do
+          create_shopping_list
+          expect(response.status).to eq 404
+        end
+
+        it "doesn't return any data" do
+          create_shopping_list
+          expect(response.body).to be_empty
+        end
+      end
+
+      context "when the game doesn't belong to the authenticated user" do
+        let(:game) { create(:game) }
+
+        it 'returns status 404' do
+          create_shopping_list
+          expect(response.status).to eq 404
+        end
+
+        it "doesn't return any data" do
+          create_shopping_list
+          expect(response.body).to be_empty
+        end
+      end
+
+      context 'when the params are invalid' do
+        subject(:create_shopping_list) { post "/games/#{game.id}/shopping_lists", params: "{ \"shopping_list\": { \"title\": \"#{existing_list.title}\" } }", headers: headers }
+        let(:game) { create(:game, user: user) }
+        let(:existing_list) { create(:shopping_list, game: game) }
 
         it 'returns status 422' do
           create_shopping_list
@@ -76,10 +107,11 @@ RSpec.describe 'ShoppingLists', type: :request do
       end
 
       context 'when the client attempts to create an aggregate list' do
-        subject(:create_shopping_list) { post '/shopping_lists', params: '{ "shopping_list": { "aggregate": true } }', headers: headers }
+        subject(:create_shopping_list) { post "/games/#{game.id}/shopping_lists", params: '{ "shopping_list": { "aggregate": true } }', headers: headers }
+        let(:game) { create(:game, user: user) }
 
         it "doesn't create a list" do
-          expect { create_shopping_list }.not_to change(ShoppingList, :count)
+          expect { create_shopping_list }.not_to change(game.shopping_lists, :count)
         end
 
         it 'returns an error' do
@@ -95,6 +127,8 @@ RSpec.describe 'ShoppingLists', type: :request do
     end
 
     context 'when unauthenticated' do
+      let(:game) { create(:game) }
+
       it 'returns 401' do
         create_shopping_list
         expect(response.status).to eq 401

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'ShoppingLists', type: :request do
   end
 
   describe 'POST /shopping_lists' do
-    subject(:create_shopping_list) { post "/games/#{game.id}/shopping_lists", params: '{ "shopping_list": {} }', headers: headers }
+    subject(:create_shopping_list) { post "/games/#{game.id}/shopping_lists", params: { shopping_list: {} }.to_json, headers: headers }
 
     context 'when authenticated' do
       let!(:user) { create(:user) }
@@ -111,7 +111,7 @@ RSpec.describe 'ShoppingLists', type: :request do
       end
 
       context 'when the params are invalid' do
-        subject(:create_shopping_list) { post "/games/#{game.id}/shopping_lists", params: "{ \"shopping_list\": { \"title\": \"#{existing_list.title}\" } }", headers: headers }
+        subject(:create_shopping_list) { post "/games/#{game.id}/shopping_lists", params: { shopping_list: { title: existing_list.title } }.to_json, headers: headers }
         let(:game) { create(:game, user: user) }
         let(:existing_list) { create(:shopping_list, game: game) }
 
@@ -127,7 +127,7 @@ RSpec.describe 'ShoppingLists', type: :request do
       end
 
       context 'when the client attempts to create an aggregate list' do
-        subject(:create_shopping_list) { post "/games/#{game.id}/shopping_lists", params: '{ "shopping_list": { "aggregate": true } }', headers: headers }
+        subject(:create_shopping_list) { post "/games/#{game.id}/shopping_lists", params: { shopping_list: { aggregate: true } }.to_json, headers: headers }
         let(:game) { create(:game, user: user) }
 
         it "doesn't create a list" do

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -60,6 +60,26 @@ RSpec.describe 'ShoppingLists', type: :request do
             expect(response.body).to eq(game.shopping_lists.last.to_json)
           end
         end
+
+        context 'when the request does not include a body' do
+          subject(:create_shopping_list) { post "/games/#{game.id}/shopping_lists", headers: headers }
+
+          before do
+            # let's not have this request create an aggregate list too
+            create(:aggregate_shopping_list, game: game)
+          end
+          
+          it 'returns status 201' do
+            create_shopping_list
+            expect(response.status).to eq 201
+          end
+
+          it 'creates the shopping list with a default title' do
+            create_shopping_list
+            list_attributes = JSON.parse(response.body)
+            expect(list_attributes['title']).to eq 'My List 1'
+          end
+        end
       end
 
       context 'when the game is not found' do


### PR DESCRIPTION
## Context

[**Scope shopping list routes to games**](https://trello.com/c/1Om5C5ek/95-scope-shopping-list-routes-to-games)

We've changed the `ShoppingList` model so it now belongs to the `Game` model, but not all the shopping list routes have been updated to reflect this fact. This PR tackles the `create` route.

## Changes

* Scope shopping list creation route to game
* Add 404 error response in case the game is not found or doesn't belong to the authenticated user

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

The changes needed to scope the route to `games` was not that big. Mostly it was tests that needed updating. There were also some updates needed to the `ShoppingListsController::CreateService` class, which now takes a `game_id` param in addition to the user and the shopping list params and has additional error handling for the case where the game is not found or does not belong to the authenticated user.
