### PR TITLE
Scope shopping lists to games in update route

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ To run the server, simply run `bundle exec rails s` and your server will start o
 
 Note that if you are also running the [SIM front end](https://github.com/danascheider/skyrim_inventory_management_frontend), it will require the backend to run on localhost:3000 in development. CORS settings on the API require the front end to run on `localhost:3001`.
 
-### Running Tests
+### Testing
 
 The SIM API is tested using [RSpec](https://github.com/rspec/rspec) with [FactoryBot](https://github.com/thoughtbot/factory_bot_rails) for factories. Run specs on the command line using:
 ```bash
@@ -108,6 +108,19 @@ bundle exec rspec spec/requests/shopping_lists_spec.rb
 
 # runs a specific spec on line 42 of the specified file
 bundle exec rspec spec/models/shopping_list_item_spec.rb:42
+```
+
+All pull requests should include whatever test updates are required to ensure the new code is thoroughly covered by quality, passing tests.
+
+#### Testing Timestamps
+
+One caveat in testing is that timestamps may be treated differently in [GitHub Actions](#ci) than they are in your development environment. Specifically, the last four digits of timestamps are truncated in the GitHub Actions environment. That means that you will not be able to use the `eq` matcher for timestamp tests, even with Timecop. Instead, you should use the `be_within` timestamp, using Timecop and keeping the tolerance as small as possible (0.005 seconds is usually plenty):
+```ruby
+t = Time.now + 3.days
+Timecop.freeze(t) do
+  perform
+  expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+end
 ```
 
 ### Workflows

--- a/app/controller_services/shopping_list_items_controller/create_service.rb
+++ b/app/controller_services/shopping_list_items_controller/create_service.rb
@@ -24,7 +24,6 @@ class ShoppingListItemsController < ApplicationController
 
       ActiveRecord::Base.transaction do
         item.save!
-        shopping_list.touch
 
         if preexisting_item.blank?
           aggregate_list_item = aggregate_list.add_item_from_child_list(item)

--- a/app/controller_services/shopping_list_items_controller/destroy_service.rb
+++ b/app/controller_services/shopping_list_items_controller/destroy_service.rb
@@ -22,7 +22,6 @@ class ShoppingListItemsController < ApplicationController
 
       ActiveRecord::Base.transaction do
         shopping_list_item.destroy!
-        shopping_list.touch
         aggregate_list_item = aggregate_list.remove_item_from_child_list(shopping_list_item.attributes)
       end
       

--- a/app/controller_services/shopping_list_items_controller/update_service.rb
+++ b/app/controller_services/shopping_list_items_controller/update_service.rb
@@ -25,7 +25,6 @@ class ShoppingListItemsController < ApplicationController
       aggregate_list_item = nil
       ActiveRecord::Base.transaction do
         list_item.update!(params)
-        shopping_list.touch
         
         aggregate_list_item = aggregate_list.update_item_from_child_list(list_item.description, delta_qty, old_notes, params[:notes])
       end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -4,7 +4,7 @@ require 'titlecase'
 
 class Game < ApplicationRecord
   belongs_to :user
-  has_many :shopping_lists, dependent: :destroy
+  has_many :shopping_lists, -> { index_order }, dependent: :destroy
 
   validates :name, uniqueness: { scope: :user_id },
                    format: {
@@ -13,6 +13,8 @@ class Game < ApplicationRecord
                    }
 
   before_save :format_name
+
+  scope :index_order, -> { order(updated_at: :desc) }
 
   def aggregate_shopping_list
     shopping_lists.find_by(aggregate: true)

--- a/app/models/shopping_list.rb
+++ b/app/models/shopping_list.rb
@@ -24,6 +24,7 @@ class ShoppingList < ApplicationRecord
   include Aggregatable
 
   scope :index_order, -> { includes_items.aggregate_first.order(updated_at: :desc) }
+  scope :belonging_to_user, ->(user) { joins(:game).where('games.user_id = ?', user.id).order('shopping_lists.updated_at DESC') }
 
   private
 

--- a/app/models/shopping_list_item.rb
+++ b/app/models/shopping_list_item.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ShoppingListItem < ApplicationRecord
-  belongs_to :list, class_name: 'ShoppingList'
+  belongs_to :list, class_name: 'ShoppingList', touch: true
 
   validates :description, presence: true, uniqueness: { scope: :list_id, case_sensitive: false }
   validates :quantity, presence: true, numericality: { only_integer: true, greater_than: 0 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,4 +15,8 @@ class User < ApplicationRecord
       user.save!
     end
   end
+
+  def shopping_lists
+    ShoppingList.belonging_to_user(self)
+  end
 end

--- a/docs/api/resources/shopping-lists.md
+++ b/docs/api/resources/shopping-lists.md
@@ -21,7 +21,7 @@ Like other resources in SIM, shopping lists are scoped to the authenticated user
 * [`GET /games/:game_id/shopping_lists`](#get-gamesgame_idshopping_lists)
 * [`GET /shopping_lists/:id`](#get-shopping_listsid)
 * [`POST /games/:game_id/shopping_lists`](#post-gamesgame_idshopping_lists)
-* [`PUT|PATCH /shopping_lists/:id`](#patch-shopping_listsid)
+* [`PATCH|PUT /shopping_lists/:id`](#patchput-shopping_listsid)
 * [`DELETE /shopping_lists/:id`](#delete-shopping_listsid)
 
 ## GET /games/:game_id/shopping_lists
@@ -265,7 +265,7 @@ A 500 error response, which is always a result of an unforeseen problem, include
 }
 ```
 
-## PATCH /shopping_lists/:id
+## PATCH|PUT /shopping_lists/:id
 
 If the specified shopping list exists, belongs to the authenticated user, and is not an aggregate list, updates the title and returns the shopping list. Title is the only shopping list attribute that can be modified using this endpoint. This endpoint also supports the `PUT` method.
 
@@ -332,9 +332,9 @@ Content-Type: application/json
 
 #### Statuses
 
-* 422 Unprocessable Entity
-* 405 Method Not Allowed
 * 404 Not Found
+* 405 Method Not Allowed
+* 422 Unprocessable Entity
 * 500 Internal Server Error
 
 #### Example Bodies

--- a/spec/controller_services/shopping_list_items_controller/create_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/create_service_spec.rb
@@ -46,6 +46,14 @@ RSpec.describe ShoppingListItemsController::CreateService do
           expect(aggregate_list).to have_received(:add_item_from_child_list).with(shopping_list.list_items.last)
         end
 
+        it 'updates the list model itself' do
+          t = Time.now + 3.days
+          Timecop.freeze(t) do
+            perform
+            expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+          end
+        end
+
         it 'returns a Service::CreatedResult' do
           expect(perform).to be_a(Service::CreatedResult)
         end
@@ -68,6 +76,14 @@ RSpec.describe ShoppingListItemsController::CreateService do
 
         it "doesn't create a new item on the aggregate list" do
           expect { perform }.not_to change(aggregate_list.list_items, :count)
+        end
+
+        it 'updates the list itself' do
+          t = Time.now + 3.days
+          Timecop.freeze(t) do
+            perform
+            expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+          end
         end
 
         it 'updates the aggregate list correctly' do
@@ -107,6 +123,14 @@ RSpec.describe ShoppingListItemsController::CreateService do
 
       it 'combines the item with an existing one' do
         expect { perform }.not_to change(shopping_list.list_items, :count)
+      end
+
+      it 'updates the shopping list' do
+        t = Time.now + 3.days
+        Timecop.freeze(t) do
+          perform
+          expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+        end
       end
 
       it 'returns a Service::OKResult' do

--- a/spec/controller_services/shopping_list_items_controller/destroy_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/destroy_service_spec.rb
@@ -40,17 +40,15 @@ RSpec.describe ShoppingListItemsController::DestroyService do
           expect(perform.resource).to be nil
         end
 
-        it 'sets the updated_at timestamp on the shopping list', :aggregate_failures do
+        it 'sets the updated_at timestamp on the shopping list', do
           t = Time.now + 3.days
-
           Timecop.freeze(t) do
             perform
             # use `be_within` even though the time will be set to the time Timecop
             # has frozen because Rails (Postgres?) sets the last three digits of
             # the timestamp to 0, which was breaking stuff in CI (but somehow not
             # in dev).
-            expect(shopping_list.reload.updated_at).to be_within(0.05.seconds).of(t)
-            expect(aggregate_list.reload.updated_at).not_to be_within(0.05.seconds).of(t)
+            expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
           end
         end
       end
@@ -86,9 +84,8 @@ RSpec.describe ShoppingListItemsController::DestroyService do
           expect(aggregate_list.list_items.first.notes).not_to match /some notes/
         end
 
-        it 'sets the updated_at timestamp on the shopping list', :aggregate_failures do
+        it 'sets the updated_at timestamp on the shopping list' do
           t = Time.now + 3.days
-
           Timecop.freeze(t) do
             perform
             # use `be_within` even though the time will be set to the time Timecop
@@ -96,7 +93,6 @@ RSpec.describe ShoppingListItemsController::DestroyService do
             # the timestamp to 0, which was breaking stuff in CI (but somehow not
             # in dev).
             expect(shopping_list.reload.updated_at).to be_within(0.05.seconds).of(t)
-            expect(aggregate_list.reload.updated_at).not_to be_within(0.05.seconds).of(t)
           end
         end
 

--- a/spec/controller_services/shopping_list_items_controller/destroy_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/destroy_service_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe ShoppingListItemsController::DestroyService do
             # has frozen because Rails (Postgres?) sets the last three digits of
             # the timestamp to 0, which was breaking stuff in CI (but somehow not
             # in dev).
-            expect(shopping_list.reload.updated_at).to be_within(0.05.seconds).of(t)
+            expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
           end
         end
 

--- a/spec/controller_services/shopping_lists_controller/create_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/create_service_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe ShoppingListsController::CreateService do
     end
 
     context 'when params are valid' do
-      let(:game) { create(:game, user: user) }
+      let!(:game) { create(:game, user: user) }
       let(:params) { { title: 'Proudspire Manor' } }
 
       context 'when the game has an aggregate shopping list' do
@@ -75,6 +75,14 @@ RSpec.describe ShoppingListsController::CreateService do
 
         it 'sets the resource to the created list' do
           expect(perform.resource).to eq game.shopping_lists.last
+        end
+
+        it 'updates the game' do
+          t = Time.now + 3.days
+          Timecop.freeze(t) do
+            perform
+            expect(game.reload.updated_at).to be_within(0.005.seconds).of(t)
+          end
         end
       end
 

--- a/spec/controller_services/shopping_lists_controller/create_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/create_service_spec.rb
@@ -101,6 +101,14 @@ RSpec.describe ShoppingListsController::CreateService do
           expect(game.shopping_lists.last.title).to eq 'Proudspire Manor'
         end
 
+        it 'updates the game' do
+          t = Time.now + 3.days
+          Timecop.freeze(t) do
+            perform
+            expect(game.reload.updated_at).to be_within(0.005.seconds).of(t)
+          end
+        end
+
         it 'returns a Service::CreatedResult' do
           expect(perform).to be_a(Service::CreatedResult)
         end

--- a/spec/controller_services/shopping_lists_controller/update_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/update_service_spec.rb
@@ -31,6 +31,14 @@ RSpec.describe ShoppingListsController::UpdateService do
       it 'sets the resource to the updated shopping list' do
         expect(perform.resource).to eq shopping_list
       end
+
+      it 'updates the game' do
+        t = Time.now + 3.days
+        Timecop.freeze(t) do
+          perform
+          expect(game.reload.updated_at).to be_within(0.005.seconds).of(t)
+        end
+      end
     end
 
     context 'when the params are invalid' do

--- a/spec/controller_services/shopping_lists_controller/update_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/update_service_spec.rb
@@ -11,11 +11,12 @@ RSpec.describe ShoppingListsController::UpdateService do
   describe '#perform' do
     subject(:perform) { described_class.new(user, shopping_list.id, params).perform }
     
-    let!(:aggregate_list) { create(:aggregate_shopping_list, user: user) }
+    let!(:aggregate_list) { create(:aggregate_shopping_list, game: game) }
     let(:user) { create(:user) }
     
     context 'when all goes well' do
-      let(:shopping_list) { create(:shopping_list, user: user, aggregate_list_id: aggregate_list.id) }
+      let(:shopping_list) { create(:shopping_list, game: game, aggregate_list_id: aggregate_list.id) }
+      let(:game) { create(:game, user: user) }
       let(:params) { { title: 'My New Title' } }
 
       it 'updates the shopping list' do
@@ -33,7 +34,8 @@ RSpec.describe ShoppingListsController::UpdateService do
     end
 
     context 'when the params are invalid' do
-      let(:shopping_list) { create(:shopping_list, user: user) }
+      let(:shopping_list) { create(:shopping_list, game: game) }
+      let(:game) { create(:game, user: user) }
       let(:params) { { title: '|nvalid Tit|e' } }
 
       it 'returns a Service::UnprocessableEntityResult' do
@@ -46,7 +48,8 @@ RSpec.describe ShoppingListsController::UpdateService do
     end
 
     context 'when the shopping list does not belong to the user' do
-      let(:shopping_list) { create(:shopping_list) }
+      let(:shopping_list) { create(:shopping_list, game: game) }
+      let(:game) { create(:game) }
       let(:params) { { title: 'Valid New Title' } }
       
       it 'returns a Service::NotFoundResult' do
@@ -56,6 +59,7 @@ RSpec.describe ShoppingListsController::UpdateService do
 
     context 'when the shopping list is an aggregate shopping list' do
       let(:shopping_list) { aggregate_list }
+      let(:game) { create(:game, user: user) }
       let(:params) { { title: 'New Title' } }
 
       it 'returns a Service::MethodNotAllowedResult' do
@@ -68,7 +72,8 @@ RSpec.describe ShoppingListsController::UpdateService do
     end
 
     context 'when the request tries to set aggregate to true' do
-      let(:shopping_list) { create(:shopping_list, user: user) }
+      let(:shopping_list) { create(:shopping_list, game: game) }
+      let(:game) { create(:game, user: user) }
       let(:params) { { aggregate: true } }
 
       it 'returns a Service::UnprocessableEntityResult' do
@@ -81,7 +86,8 @@ RSpec.describe ShoppingListsController::UpdateService do
     end
 
     context 'when something unexpected goes wrong' do
-      let!(:shopping_list) { create(:shopping_list, user: user) }
+      let!(:shopping_list) { create(:shopping_list, game: game) }
+      let(:game) { create(:game, user: user) }
       let(:params) { { title: 'New Title' } }
 
       before do

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -30,6 +30,25 @@ RSpec.describe Game, type: :model do
     end
   end
 
+  describe 'scopes' do
+    describe '::index_order' do
+      subject(:index_order) { described_class.index_order }
+
+      let!(:game1) { create(:game) }
+      let!(:game2) { create(:game) }
+      let!(:game3) { create(:game) }
+
+      before do
+        # make sure the last updated game is first, not the last created
+        game2.update!(name: 'New Name')
+      end
+
+      it 'returns the games in descending order of updated_at' do
+        expect(index_order.to_a).to eq([game2, game3, game1])
+      end
+    end
+  end
+
   describe 'name transformations' do
     context 'when the user has set a name' do
       subject(:name) { user.games.create!(name: 'Skyrim, Baby').name }

--- a/spec/models/shopping_list_spec.rb
+++ b/spec/models/shopping_list_spec.rb
@@ -47,6 +47,35 @@ RSpec.describe ShoppingList, type: :model do
         expect(aggregate_first).to eq([aggregate_list, shopping_list])
       end
     end
+
+    describe '::belongs_to_user' do
+      let(:user) { create(:user) }
+      let!(:game1) { create(:game_with_shopping_lists, user: user) }
+      let!(:game2) { create(:game_with_shopping_lists, user: user) }
+      let!(:game3) { create(:game_with_shopping_lists, user: user) }
+
+      it "returns all list items from all the user's lists" do
+        # These are going to be rearranged in the output since game.shopping_lists
+        # comes back aggregate list first and the scope will return them in descending
+        # updated_at order. There was no easy programmatic way to rearrange them so
+        # I just have to pull them all out and reorder them in the expectation.
+        agg_list1, game1_list1, game1_list2 = game1.shopping_lists.to_a
+        agg_list2, game2_list1, game2_list2 = game2.shopping_lists.to_a
+        agg_list3, game3_list1, game3_list2 = game3.shopping_lists.to_a
+
+        expect(ShoppingList.belonging_to_user(user).to_a).to eq([
+                                                                  game3_list1,
+                                                                  game3_list2,
+                                                                  agg_list3,
+                                                                  game2_list1,
+                                                                  game2_list2,
+                                                                  agg_list2,
+                                                                  game1_list1,
+                                                                  game1_list2,
+                                                                  agg_list1
+                                                                ])
+      end
+    end
   end
 
   describe 'validations' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -43,4 +43,27 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe '#shopping_lists' do
+    let(:user1) { create(:user) }
+    let(:user2) { create(:user) }
+
+    let(:game1) { create(:game, user: user1) }
+    let(:game2) { create(:game, user: user1) }
+    let(:game3) { create(:game_with_shopping_lists, user: user2) }
+
+    let!(:shopping_list1) { create(:aggregate_shopping_list, game: game1) }
+    let!(:shopping_list2) { create(:shopping_list, game: game1) }
+    let!(:shopping_list3) { create(:aggregate_shopping_list, game: game2) }
+    let!(:shopping_list4) { create(:shopping_list, game: game2) }
+
+    it "returns all the shopping lists for the user's games" do
+      expect(user1.shopping_lists).to eq([
+                                           shopping_list4,
+                                           shopping_list3,
+                                           shopping_list2,
+                                           shopping_list1
+                                         ])
+    end
+  end
 end

--- a/spec/requests/shopping_list_items_spec.rb
+++ b/spec/requests/shopping_list_items_spec.rb
@@ -114,17 +114,15 @@ RSpec.describe 'ShoppingListItems', type: :request do
             expect(response.status).to eq 201
           end
 
-          it 'updates the regular list', :aggregate_failures do
+          it 'updates the regular list' do
             t = Time.now + 3.days
-
             Timecop.freeze(t) do
               create_item
               # use `be_within` even though the time will be set to the time Timecop
               # has frozen because Rails (Postgres?) sets the last three digits of
               # the timestamp to 0, which was breaking stuff in CI (but somehow not
               # in dev).
-              expect(shopping_list.reload.updated_at).to be_within(0.05.seconds).of(t)
-              expect(aggregate_list.reload.updated_at).not_to be_within(0.05.seconds).of(t)
+              expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
             end
           end
         end
@@ -290,17 +288,15 @@ RSpec.describe 'ShoppingListItems', type: :request do
                                                                     )
         end
 
-        it 'updates the regular list', :aggregate_failures do
+        it 'updates the regular list' do
           t = Time.now + 3.days
-
           Timecop.freeze(t) do
             update_item
             # use `be_within` even though the time will be set to the time Timecop
             # has frozen because Rails (Postgres?) sets the last three digits of
             # the timestamp to 0, which was breaking stuff in CI (but somehow not
             # in dev).
-            expect(shopping_list.reload.updated_at).to be_within(0.05.seconds).of(t)
-            expect(aggregate_list.reload.updated_at).not_to be_within(0.05.seconds).of(t)
+            expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
           end
         end
 
@@ -486,17 +482,15 @@ RSpec.describe 'ShoppingListItems', type: :request do
                                                                     )
         end
 
-        it 'updates the regular list', :aggregate_failures do
+        it 'updates the regular list' do
           t = Time.now + 3.days
-
           Timecop.freeze(t) do
             update_item
             # use `be_within` even though the time will be set to the time Timecop
             # has frozen because Rails (Postgres?) sets the last three digits of
             # the timestamp to 0, which was breaking stuff in CI (but somehow not
             # in dev).
-            expect(shopping_list.reload.updated_at).to be_within(0.05.seconds).of(t)
-            expect(aggregate_list.reload.updated_at).not_to be_within(0.05.seconds).of(t)
+            expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
           end
         end
 


### PR DESCRIPTION
## Context

[**Scope shopping list routes to games**](https://trello.com/c/1Om5C5ek/95-scope-shopping-list-routes-to-games)

We've changed things so the `ShoppingList` model now belongs to the `Game` model and not the `User` model, but the routes and controller services have not been updated to reflect the change.

## Changes

* Fix `ShoppingListsController::UpdateService` to handle the fact that shopping lists now belong to games
* Add scope to `ShoppingList` model allowing shopping lists to be found by their user rather than just their game
* Add method to `User` model to retrieve all of a user's shopping lists
* Use `touch: true` on shopping list items/shopping lists relation to make sure shopping list updates when a list item is changed/added/removed without any action in the controller service (tests don't pass yet because we haven't made shopping list item stuff work with the `Game` model yet)

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

There were minimal changes required here since the shallowly nested routes don't really bring the game model into the equation. The biggest change was creating the `User#shopping_lists` method to retrieve all of the shopping lists belonging to an individual user, enabling the controller to find a shopping list belonging to the authenticated user without knowing what game that shopping list belongs to.
