### PR TITLE
Scope shopping list destroy route to games

### DIFF
--- a/app/controller_services/shopping_lists_controller/destroy_service.rb
+++ b/app/controller_services/shopping_lists_controller/destroy_service.rb
@@ -44,6 +44,7 @@ class ShoppingListsController < ApplicationController
         # If shopping_list is the user's last regular shopping list, this will also
         # destroy their aggregate list
         shopping_list.destroy!
+
         if aggregate_list&.persisted?
           list_items.each { |item_attributes| aggregate_list.remove_item_from_child_list(item_attributes) }
           aggregate_list

--- a/app/controller_services/shopping_lists_controller/destroy_service.rb
+++ b/app/controller_services/shopping_lists_controller/destroy_service.rb
@@ -44,7 +44,6 @@ class ShoppingListsController < ApplicationController
         # If shopping_list is the user's last regular shopping list, this will also
         # destroy their aggregate list
         shopping_list.destroy!
-        
         if aggregate_list&.persisted?
           list_items.each { |item_attributes| aggregate_list.remove_item_from_child_list(item_attributes) }
           aggregate_list

--- a/spec/controller_services/shopping_list_items_controller/destroy_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/destroy_service_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe ShoppingListItemsController::DestroyService do
           expect(perform.resource).to be nil
         end
 
-        it 'sets the updated_at timestamp on the shopping list', do
+        it 'sets the updated_at timestamp on the shopping list' do
           t = Time.now + 3.days
           Timecop.freeze(t) do
             perform

--- a/spec/controller_services/shopping_lists_controller/destroy_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/destroy_service_spec.rb
@@ -30,6 +30,14 @@ RSpec.describe ShoppingListsController::DestroyService do
           expect { perform }.to change(game.shopping_lists, :count).from(3).to(2)
         end
 
+        it 'updates the game' do
+          t = Time.now + 3.days
+          Timecop.freeze(t) do
+            perform
+            expect(game.reload.updated_at).to be_within(0.005.seconds).of(t)
+          end
+        end
+
         it 'returns a Service::OKResult' do
           expect(perform).to be_a(Service::OKResult)
         end
@@ -72,6 +80,14 @@ RSpec.describe ShoppingListsController::DestroyService do
 
         it 'destroys the aggregate list too' do
           expect { perform }.to change(game.shopping_lists, :count).from(2).to(0)
+        end
+
+        it 'updates the game' do
+          t = Time.now + 3.days
+          Timecop.freeze(t) do
+            perform
+            expect(game.reload.updated_at).to be_within(0.005.seconds).of(t)
+          end
         end
 
         it 'returns a Service::NoContentResult' do

--- a/spec/controller_services/shopping_lists_controller/destroy_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/destroy_service_spec.rb
@@ -13,11 +13,12 @@ RSpec.describe ShoppingListsController::DestroyService do
     let(:user) { create(:user) }
 
     context 'when all goes well' do
-      let!(:shopping_list) { create(:shopping_list_with_list_items, user: user) }
+      let!(:aggregate_list) { create(:aggregate_shopping_list, game: game) }
+      let!(:shopping_list) { create(:shopping_list_with_list_items, game: game) }
+      let(:game) { create(:game, user: user) }
 
-      context 'when the user has additional regular lists' do
-        let!(:aggregate_list) { user.aggregate_shopping_list }
-        let!(:third_list) { create(:shopping_list, user: user, aggregate_list: aggregate_list) }
+      context 'when the game has additional regular lists' do
+        let!(:third_list) { create(:shopping_list, game: game, aggregate_list: aggregate_list) }
 
         before do
           shopping_list.list_items.each do |list_item|
@@ -26,7 +27,7 @@ RSpec.describe ShoppingListsController::DestroyService do
         end
 
         it 'destroys the shopping list' do
-          expect { perform }.to change(user.shopping_lists, :count).from(3).to(2)
+          expect { perform }.to change(game.shopping_lists, :count).from(3).to(2)
         end
 
         it 'returns a Service::OKResult' do
@@ -45,7 +46,9 @@ RSpec.describe ShoppingListsController::DestroyService do
             # Because in the code it finds the shopping list by ID and then gets the aggregate list
             # off that instance, the tests don't have access to the instance of the aggregate list that
             # the method is actually being called on, so we have to resort to this hack.
-            allow(user.shopping_lists).to receive(:find).and_return(shopping_list)
+            user_lists = user.shopping_lists
+            allow(user).to receive(:shopping_lists).and_return(user_lists)
+            allow(user_lists).to receive(:find).and_return(shopping_list)
             allow(shopping_list).to receive(:aggregate_list).and_return(aggregate_list)
             allow(aggregate_list).to receive(:remove_item_from_child_list).twice
           end
@@ -54,14 +57,13 @@ RSpec.describe ShoppingListsController::DestroyService do
             perform
 
             shopping_list.list_items.each do |item|
-              puts aggregate_list.inspect
               expect(aggregate_list).to have_received(:remove_item_from_child_list).with(item.attributes)
             end
           end
         end
       end
 
-      context "when this is the user's last regular list" do
+      context "when this is the game's last regular list" do
         before do
           shopping_list.list_items.each do |item|
             shopping_list.aggregate_list.add_item_from_child_list(item)
@@ -69,7 +71,7 @@ RSpec.describe ShoppingListsController::DestroyService do
         end
 
         it 'destroys the aggregate list too' do
-          expect { perform }.to change(user.shopping_lists, :count).from(2).to(0)
+          expect { perform }.to change(game.shopping_lists, :count).from(2).to(0)
         end
 
         it 'returns a Service::NoContentResult' do
@@ -79,7 +81,8 @@ RSpec.describe ShoppingListsController::DestroyService do
     end
 
     context 'when the list is an aggregate list' do
-      let!(:shopping_list) { create(:aggregate_shopping_list, user: user) }
+      let!(:shopping_list) { create(:aggregate_shopping_list, game: game) }
+      let(:game) { create(:game, user: user) }
 
       it 'returns a Service::MethodNotAllowedResult' do
         expect(perform).to be_a(Service::MethodNotAllowedResult)
@@ -107,7 +110,8 @@ RSpec.describe ShoppingListsController::DestroyService do
     end
 
     context 'when something unexpected goes wrong' do
-      let!(:shopping_list) { create(:shopping_list, user: user) }
+      let!(:shopping_list) { create(:shopping_list, game: game) }
+      let(:game) { create(:game, user: user) }
 
       before do
         allow_any_instance_of(ShoppingList).to receive(:aggregate_list).and_raise(StandardError, 'Something went horribly wrong')


### PR DESCRIPTION
## Context

[**Scope shopping list routes to games**](https://trello.com/c/1Om5C5ek/95-scope-shopping-list-routes-to-games)

This is the last PR for making sure that shopping list routes/the shopping lists controller are accounting for the new relation from shopping lists to games, and the removal of a direct relation between shopping lists and users.

## Changes

* Update specs to make sure `DELETE /shopping_lists/:id` route works as expected

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

The actual logic of the `DestroyService` did not need to change, but test changes were needed to account for the changed relations.
