### PR TITLE
Update shopping list item model

### DIFF
--- a/app/models/concerns/aggregatable.rb
+++ b/app/models/concerns/aggregatable.rb
@@ -42,9 +42,6 @@ module Aggregatable
 
     serialize :list_items, class_name: 'Array'
 
-    scope :aggregate_first, -> { order(aggregate: :desc) }
-    scope :includes_items, -> { includes(:list_items) }
-
     validate :one_aggregate_list_per_game,        if: :is_aggregate_list?
     validate :not_named_all_items,                unless: :is_aggregate_list?
     validate :ensure_aggregate_list_is_aggregate, unless: :is_aggregate_list?
@@ -56,6 +53,11 @@ module Aggregatable
     before_save :set_title_to_all_items,     if: :is_aggregate_list?
     before_destroy :abort_if_aggregate,      if: :has_child_lists?
     after_destroy :destroy_aggregate_list,   unless: -> { is_aggregate_list? || aggregate_has_other_children? }
+
+    scope :aggregate_first, -> { order(aggregate: :desc) }
+    scope :includes_items, -> { includes(:list_items) }
+
+    delegate :user, to: :game
   end
 
   def add_item_from_child_list(item)

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -20,6 +20,10 @@ class Game < ApplicationRecord
     shopping_lists.find_by(aggregate: true)
   end
 
+  def shopping_list_items
+    ShoppingListItem.belonging_to_game(self)
+  end
+
   private
 
   def format_name

--- a/app/models/shopping_list_item.rb
+++ b/app/models/shopping_list_item.rb
@@ -14,6 +14,11 @@ class ShoppingListItem < ApplicationRecord
   scope :index_order, -> { order(updated_at: :desc) }
   scope :belonging_to_game, ->(game) { joins(:list).where('shopping_lists.game_id = ?', game.id).order('shopping_lists.updated_at DESC') }
 
+  def self.belonging_to_user(user)
+    shopping_list_ids = ShoppingList.belonging_to_user(user).pluck(:id)
+    joins(:list).where('shopping_lists.id IN (?)', shopping_list_ids).order('shopping_lists.updated_at DESC')
+  end
+
   def self.combine_or_create!(attrs)
     obj = combine_or_new(attrs)
     obj.save!

--- a/app/models/shopping_list_item.rb
+++ b/app/models/shopping_list_item.rb
@@ -9,7 +9,7 @@ class ShoppingListItem < ApplicationRecord
 
   before_save :clean_up_notes
 
-  delegate :game, to: :list
+  delegate :game, :user, to: :list
 
   scope :index_order, -> { order(updated_at: :desc) }
   scope :belonging_to_game, ->(game) { joins(:list).where('shopping_lists.game_id = ?', game.id).order('shopping_lists.updated_at DESC') }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,4 +19,8 @@ class User < ApplicationRecord
   def shopping_lists
     ShoppingList.belonging_to_user(self)
   end
+
+  def shopping_list_items
+    ShoppingListItem.belonging_to_user(self)
+  end
 end

--- a/spec/factories/games.rb
+++ b/spec/factories/games.rb
@@ -16,5 +16,22 @@ FactoryBot.define do
         create_list(:shopping_list, evaluator.shopping_list_count, game: game)
       end
     end
+
+    factory :game_with_shopping_lists_and_items do
+      transient do
+        shopping_list_count { 2 }
+      end
+
+      after(:create) do |game, evaluator|
+        aggregate_list = create(:aggregate_shopping_list, game: game)
+        shopping_lists = create_list(:shopping_list_with_list_items, evaluator.shopping_list_count, game: game)
+
+        shopping_lists.each do |list|
+          list.list_items.each do |item|
+            aggregate_list.add_item_from_child_list(item)
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -100,4 +100,21 @@ RSpec.describe Game, type: :model do
       expect(aggregate_shopping_list).to eq aggregate_list
     end
   end
+
+  describe '#shopping_list_items' do
+    subject(:shopping_list_items) { game.shopping_list_items.to_a.sort }
+
+    let(:game) { create(:game, user: user) }
+
+    before do
+      create_list(:shopping_list_with_list_items, 2, game: game)
+      create(:game_with_shopping_lists_and_items, user: user) # one that shouldn't be included
+    end
+
+    it 'returns all list items belonging to the game' do
+      items = game.shopping_lists.map { |list| list.list_items.to_a }.flatten.sort
+
+      expect(shopping_list_items).to eq items
+    end
+  end
 end

--- a/spec/models/shopping_list_item_spec.rb
+++ b/spec/models/shopping_list_item_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe ShoppingListItem, type: :model do
-  let(:game) { create(:game) }
+  let!(:game) { create(:game) }
 
   describe 'delegation' do
     let(:shopping_list) { create(:shopping_list, game: game) }
@@ -58,6 +58,28 @@ RSpec.describe ShoppingListItem, type: :model do
                                                                       list2.list_items.to_a.reverse,
                                                                       list1.list_items.to_a.reverse
                                                                     ].flatten)
+      end
+    end
+
+    describe '::belonging_to_user' do
+      # We're going to sort these because we don't actually care what order they're in
+      subject(:belonging_to_user) { described_class.belonging_to_user(user).to_a.sort }
+
+      let(:user) { game.user }
+
+      before do
+        create(:shopping_list_with_list_items, game: game)
+        create(:game_with_shopping_lists_and_items, user: user)
+        create(:game_with_shopping_lists_and_items, user: user)
+        create(:shopping_list_with_list_items) # one from a different user
+      end
+
+      it 'returns all the list items belonging to the user', :aggregate_failures do
+        all_items = []
+        user.shopping_lists.each { |list| all_items << list.list_items }
+        all_items.flatten!.sort!
+
+        expect(belonging_to_user).to eq all_items
       end
     end
   end

--- a/spec/models/shopping_list_item_spec.rb
+++ b/spec/models/shopping_list_item_spec.rb
@@ -18,6 +18,12 @@ RSpec.describe ShoppingListItem, type: :model do
         expect(list_item.game).to eq(game)
       end
     end
+
+    describe '#user' do
+      it 'returns the user the game belongs to' do
+        expect(list_item.user).to eq game.user
+      end
+    end
   end
 
   describe 'scopes' do

--- a/spec/models/shopping_list_item_spec.rb
+++ b/spec/models/shopping_list_item_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ShoppingListItem, type: :model do
     end
 
     describe '#game' do
-      it 'returns the owner of its ShoppingList' do
+      it 'returns game its ShoppingList belongs to' do
         expect(list_item.game).to eq(game)
       end
     end
@@ -39,12 +39,12 @@ RSpec.describe ShoppingListItem, type: :model do
       end
     end
 
-    describe '::belongs_to_user' do
+    describe '::belonging_to_game' do
       let!(:list1) { create(:shopping_list_with_list_items, game: game) }
       let!(:list2) { create(:shopping_list_with_list_items, game: game) }
       let!(:list3) { create(:shopping_list_with_list_items, game: game) }
 
-      it "returns all list items from all the user's lists" do
+      it 'returns all list items from all the lists for the given game' do
         # Reverse the arrays of list items because the index_only scope used in the ShoppingList
         # class for :list_items will return them in descending order of `:updated_at`
         expect(ShoppingListItem.belonging_to_game(game).to_a).to eq([

--- a/spec/models/shopping_list_spec.rb
+++ b/spec/models/shopping_list_spec.rb
@@ -249,7 +249,7 @@ RSpec.describe ShoppingList, type: :model do
     end
   end
 
-  describe 'relations' do
+  describe 'associations' do
     subject(:items) { shopping_list.list_items }
 
     let!(:aggregate_list) { create(:aggregate_shopping_list) }
@@ -678,6 +678,14 @@ RSpec.describe ShoppingList, type: :model do
         it 'raises an error' do
           expect { update_item }.to raise_error(Aggregatable::AggregateListError)
         end
+      end
+    end
+
+    describe '#user' do
+      let(:shopping_list) { create(:shopping_list) }
+
+      it 'delegates to the game' do
+        expect(shopping_list.user).to eq (shopping_list.game.user)
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -66,4 +66,22 @@ RSpec.describe User, type: :model do
                                          ])
     end
   end
+
+  describe '#shopping_list_items' do
+    subject(:shopping_list_items) { user1.shopping_list_items.to_a.sort }
+
+    let(:user1) { create(:user) }
+    let(:user2) { create(:user) }
+
+    let(:game1) { create(:game_with_shopping_lists_and_items, user: user1) }
+    let(:game2) { create(:game_with_shopping_lists_and_items, user: user1) }
+    let(:game3) { create(:game_with_shopping_lists_and_items, user: user2) }
+
+    it 'includes the shopping list items belonging to that user' do
+      user1_list_items = game1.shopping_list_items.to_a + game2.shopping_list_items.to_a
+      user1_list_items.sort!
+
+      expect(shopping_list_items).to eq user1_list_items
+    end
+  end
 end


### PR DESCRIPTION
## Context

[**Update shopping list item model and routes to account for new relation between shopping lists and games**](https://trello.com/c/yhSEVWui/97-update-shopping-list-item-model-and-routes-to-account-for-new-relation-between-shopping-lists-and-games)

We haven't yet updated the shopping list item model and its associated functionality to account for the fact that shopping lists now belong to games and not users. It turned out that the model itself needed minimal changes, primarily to make sure it's easy to access the user to which the list item belongs without chaining models.

## Changes

* Ensure that `#user` methods are available on shopping lists and shopping list items to retrieve the user that owns the models
* Make sure that user and game models know which shopping list items belong to them
* Update specs to test new methods and change some wording to clarify associations

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

The `Game#shopping_list_items` method might not actually be needed for this card given that list items will be found by user in the controller services, but it'll probably be useful eventually so I added it anyway.
