### PR TITLE
Route for creating a new game

### DIFF
--- a/app/controller_services/games_controller/create_service.rb
+++ b/app/controller_services/games_controller/create_service.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'service/created_result'
+require 'service/unprocessable_entity_result'
+require 'service/internal_server_error_result'
+
+class GamesController < ApplicationController
+  class CreateService
+    def initialize(user, params)
+      @user = user
+      @params = params
+    end
+
+    def perform
+      game = user.games.new(params)
+      if game.save
+        Service::CreatedResult.new(resource: game)
+      else
+        Service::UnprocessableEntityResult.new(errors: game.error_array)
+      end
+    rescue => e
+      Service::InternalServerErrorResult.new(errors: [e.message])
+    end
+
+    private
+
+    attr_reader :user, :params
+  end
+end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'controller/response'
+
+class GamesController < ApplicationController
+  def create
+    result = CreateService.new(current_user, game_params).perform
+
+    ::Controller::Response.new(self, result).execute
+  end
+
+  private
+
+  def game_params
+    params.require(:game).permit(:name, :description)
+  end
+end

--- a/docs/api/resources/games.md
+++ b/docs/api/resources/games.md
@@ -1,0 +1,75 @@
+# Games
+
+Each user in Skyrim Inventory Management can have many games. The game is the base resource that owns other resources a user may create, such as shopping lists and shopping list items. All game routes are scoped to the currently authenticated user. There are no admin routes or any way to access, create, remove, or modify data from a user that is not currently authenticated.
+
+## Endpoints
+
+There is currently one endpoint available:
+
+* [`POST /games`](#post-games)
+
+## POST /games
+
+Creates a game for the authenticated user with the given attributes. Requests may or may not include JSON request bodies. If a body is included, it should have a `"game"` key whose value is an object. That object can contain the keys `"name"` and `"description"`, both of which are optional. If a `"name"` is not specified, the game will be created with a default name. Default names take the form "My Game N", where _N_ is an integer one higher than the highest existing number in a default name. So if a user has games named "My Game 1" and "My Game 3", their next default-titled game will be "My Game 4". If a user chooses to specify a name, the name must consist of alphanumeric characters, spaces, commas, hyphens, and/or apostrophes. Other values will result in a 422 response. Additionally, game names must be unique per user.
+
+### Example Requests
+
+Request with no request body (will result in a default name being given to the new game, and an empty description):
+```
+POST /games
+Authorization: Bearer xxxxxxxx
+```
+
+Request with a request body specifying a name and description:
+```
+POST /games
+Authorization: Bearer xxxxxxxx
+Content-Type: application/json
+{
+  "game": {
+    "name": "My Non Default Game Name"
+  }
+}
+```
+
+### Success Responses
+
+#### Statuses
+
+* 201 Created
+
+#### Example Bodies
+
+```json
+{
+  "id": 83226,
+  "user_id": 20082,
+  "name": "My Game 1",
+  "description": "This could also be null",
+  "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+  "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+}
+```
+
+### Error Responses
+
+#### Statuses
+
+* 422 Unprocessable Entity
+* 500 Internal Server Error
+
+#### Example Bodies
+
+A 422 response results from a validation error when the attributes provided in the request don't fit the requirements of the API. It includes an array of the errors that prevented the game from being created:
+```json
+{
+  "errors": ["Name is already taken"]
+}
+```
+
+A 500 error will be returned only when an unanticipated error is raised. The response body will include the error message.
+```json
+{
+  "errors": ["Something went horribly wrong"]
+}
+```

--- a/spec/controller_services/games_controller/create_service_spec.rb
+++ b/spec/controller_services/games_controller/create_service_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'service/created_result'
+require 'service/unprocessable_entity_result'
+require 'service/internal_server_error_result'
+
+RSpec.describe GamesController::CreateService do
+  subject(:perform) { described_class.new(user, params).perform }
+
+  let!(:user) { create(:user) }
+
+  context 'when the params are valid' do
+    let(:params) { { name: 'Skyrim, Baby' } }
+
+    it 'creates a new game' do
+      expect { perform }.to change(user.games, :count).from(0).to(1)
+    end
+
+    it 'returns a Service::CreatedResult' do
+      expect(perform).to be_a(Service::CreatedResult)
+    end
+
+    it 'sets the game as the resource' do
+      expect(perform.resource).to eq user.games.last
+    end
+  end
+
+  context 'when the params are invalid' do
+    let(:params) { { name: '$@#*$&' } }
+
+    it "doesn't create a new game" do
+      expect { perform }.not_to change(Game, :count)
+    end
+
+    it 'returns a Service::UnprocessableEntityResult' do
+      expect(perform).to be_a(Service::UnprocessableEntityResult)
+    end
+
+    it 'sets the errors' do
+      expect(perform.errors).to eq(["Name can only contain alphanumeric characters, spaces, commas (,), and apostrophes (')"])
+    end
+  end
+
+  context 'when something unexpected goes wrong' do
+    let(:params) { { name: 'My Game' } }
+
+    before do
+      allow_any_instance_of(Game).to receive(:save).and_raise(StandardError, 'Something has gone horribly wrong')
+    end
+
+    it 'returns a Service::InternalServerErrorResult' do
+      expect(perform).to be_a(Service::InternalServerErrorResult)
+    end
+
+    it 'sets the errors' do
+      expect(perform.errors).to eq(['Something has gone horribly wrong'])
+    end
+  end
+end

--- a/spec/requests/games_spec.rb
+++ b/spec/requests/games_spec.rb
@@ -84,6 +84,18 @@ RSpec.describe 'Games', type: :request do
       end
     end
 
-    context 'when unauthenticated'
+    context 'when unauthenticated' do
+      let(:params) { { game: { name: 'My Game' } } }
+
+      it 'returns status 401' do
+        create_game
+        expect(response.status).to eq 401
+      end
+
+      it 'returns an error message' do
+        create_game
+        expect(response.body).to eq({ errors: ['Google OAuth token validation failed'] }.to_json)
+      end
+    end
   end
 end

--- a/spec/requests/games_spec.rb
+++ b/spec/requests/games_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Games', type: :request do
+  let(:headers) do
+    {
+      'Content-Type' => 'application/json',
+      'Authorization' => 'Bearer xxxxxxx'
+    }
+  end
+
+  describe 'POST /games' do
+    subject(:create_game) { post '/games', headers: headers, params: params.to_json }
+
+    context 'when authenticated' do
+      let(:user) { create(:user) }
+      let(:validation_data) do
+        {
+          'exp' => (Time.now + 1.year).to_i,
+          'email' => user.email,
+          'name' => user.name
+        }
+      end
+
+      let(:validator) { instance_double(GoogleIDToken::Validator, check: validation_data) }
+
+      before do
+        allow(GoogleIDToken::Validator).to receive(:new).and_return(validator)
+      end
+
+      context 'when all goes well' do
+        let(:params) { { game: { name: 'My Game' } } }
+
+        it 'creates a game' do
+          expect { create_game }.to change(user.games, :count).by(1)
+        end
+
+        it 'returns status 201' do
+          create_game
+          expect(response.status).to eq 201
+        end
+
+        it 'returns the game' do
+          create_game
+          expect(response.body).to eq user.games.last.to_json
+        end
+      end
+
+      context 'when the params are invalid' do
+        let(:params) { { game: { name: '@#*!)&' } } }
+
+        it "doesn't create a game" do
+          expect { create_game }.not_to change(user.games, :count)
+        end
+
+        it 'returns status 422' do
+          create_game
+          expect(response.status).to eq 422
+        end
+
+        it 'returns the errors in the response body' do
+          create_game
+          expect(response.body).to eq({ errors: ["Name can only contain alphanumeric characters, spaces, commas (,), and apostrophes (')"] }.to_json)
+        end
+      end
+
+      context 'when something unexpected goes wrong' do
+        let(:params) { { name: 'My Game' } }
+
+        before do
+          allow_any_instance_of(Game).to receive(:save).and_raise(StandardError, 'Something has gone horribly wrong')
+        end
+
+        it 'returns a 500 status' do
+          create_game
+          expect(response.status).to eq 500
+        end
+
+        it 'returns the error message' do
+          create_game
+          expect(response.body).to eq({ errors: ['Something has gone horribly wrong'] }.to_json)
+        end
+      end
+    end
+
+    context 'when unauthenticated'
+  end
+end


### PR DESCRIPTION
## Context

[**Route for creating a new game**](https://trello.com/c/fGTt183b/91-route-for-creating-a-new-game)

We are in the process of implementing a feature whereby a user can have multiple concurrent games. These new `Game` models now need their own CRUD routes. This PR adds the first, the create route (`POST /games`).

## Changes

* `GamesController` with `create` method defined
* `GamesController::CreateService` to handle requests

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

Games are a relatively simple model since they don't have parent models or complex validations and logic. I've implemented the route using a controller service like we do for the other resource controllers.
