### PR TITLE
Route for destroying a game

### DIFF
--- a/app/controller_services/games_controller/destroy_service.rb
+++ b/app/controller_services/games_controller/destroy_service.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'service/no_content_result'
+require 'service/not_found_result'
+require 'service/internal_server_error_result'
+
+class GamesController < ApplicationController
+  class DestroyService
+    def initialize(user, game_id)
+      @user = user
+      @game_id = game_id
+    end
+
+    def perform
+      game.destroy!
+      Service::NoContentResult.new
+    rescue ActiveRecord::RecordNotFound
+      Service::NotFoundResult.new
+    rescue => e
+      Service::InternalServerErrorResult.new(errors: [e.message])
+    end
+
+    private
+
+    attr_reader :user, :game_id
+
+    def game
+      @game ||= user.games.find(game_id)
+    end
+  end
+end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -21,6 +21,12 @@ class GamesController < ApplicationController
     ::Controller::Response.new(self, result).execute
   end
 
+  def destroy
+    result = DestroyService.new(current_user, params[:id]).perform
+
+    ::Controller::Response.new(self, result).execute
+  end
+
   private
 
   def game_params

--- a/docs/api/resources/games.md
+++ b/docs/api/resources/games.md
@@ -9,6 +9,7 @@ There is currently one endpoint available:
 * [`GET /games`](#get-games)
 * [`POST /games`](#post-games)
 * [`PATCH|PUT /games/:id`](#patchput-gamesid)
+* [`DELETE /games/:id`](#delete-gamesid)
 
 ## GET /games
 
@@ -211,6 +212,45 @@ A 422 response returns the validation errors that prevented the record from bein
 ```
 
 A 500 response, which is returned when an unexpected error is returned, returns an error message:
+```json
+{
+  "errors": ["Mistakes were made"]
+}
+```
+
+## DELETE /games/:id
+
+Deletes the given game if it exists and belongs to the authenticated user.
+
+### Example Request
+
+```
+DELETE /games/4754
+Authorization: Bearer xxxxxxxx
+```
+
+### Success Responses
+
+#### Statuses
+
+* 204 No Content
+
+#### Example Bodies
+
+A successful response will not include a body.
+
+### Error Responses
+
+#### Statuses
+
+* 404 Not Found
+* 500 Internal Server Error
+
+#### Example Bodies
+
+A 404 response, returned if the game is not found or does not belong to the authenticated user, does not include a response body.
+
+A 500 response, returned if an unexpected error occurs, includes the error message in the body:
 ```json
 {
   "errors": ["Mistakes were made"]

--- a/spec/controller_services/games_controller/destroy_service_spec.rb
+++ b/spec/controller_services/games_controller/destroy_service_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'service/no_content_result'
+require 'service/internal_server_error_result'
+
+RSpec.describe GamesController::DestroyService do
+  describe '#perform' do
+    subject(:perform) { described_class.new(user, game.id).perform }
+
+    context 'when all goes well' do
+      let!(:game) { create(:game) }
+      let!(:user) { game.user }
+
+      it 'destroys the game' do
+        expect { perform }.to change(user.games, :count).from(1).to(0)
+      end
+
+      it 'returns a Service::NoContentResult' do
+        expect(perform).to be_a(Service::NoContentResult)
+      end
+
+      it "doesn't return any data", :aggregate_failures do
+        result = perform
+        expect(result.resource).to be_blank
+        expect(result.errors).to be_blank
+      end
+    end
+
+    context 'when the game does not exist' do
+      let(:game) { double(id: 43598) }
+      let(:user) { create(:user) }
+
+      it 'returns a Service::NotFoundResult' do
+        expect(perform).to be_a(Service::NotFoundResult)
+      end
+
+      it "doesn't set data", :aggregate_failures do
+        result = perform
+        expect(perform.resource).to be_blank
+        expect(perform.errors).to be_blank
+      end
+    end
+
+    context 'when the game does not belong to the user' do
+      let(:game) { create(:game) }
+      let(:user) { create(:user) }
+
+      it 'returns a Service::NotFoundResult' do
+        expect(perform).to be_a(Service::NotFoundResult)
+      end
+
+      it "doesn't set data", :aggregate_failures do
+        result = perform
+        expect(perform.resource).to be_blank
+        expect(perform.errors).to be_blank
+      end
+    end
+
+    context 'when something unexpected goes wrong' do
+      let!(:game) { create(:game) }
+      let!(:user) { game.user }
+
+      before do
+        allow_any_instance_of(Game).to receive(:destroy!).and_raise(StandardError, 'Something went horribly wrong')
+      end
+
+      it 'returns a Service::InternalServerErrorResult' do
+        expect(perform).to be_a(Service::InternalServerErrorResult)
+      end
+
+      it 'sets the errors' do
+        expect(perform.errors).to eq(['Something went horribly wrong'])
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

[**Route for destroying a game**](https://trello.com/c/uMfTu1lX/99-route-for-destroying-a-game)

This is the last PR for CRUD routes for the new `game` resource. Others are linked on the [feature branch PR](https://github.com/danascheider/skyrim_inventory_management/pull/32).

## Changes

* Create `GamesController::DestroyService` that handles `DELETE /games/:id` requests
* Define `#destroy` method in `GamesController` using the new service class

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate
