### PR TITLE
Fix bug in default titles

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -28,8 +28,9 @@ class Game < ApplicationRecord
 
   def format_name
     if name.blank?
-      highest_number = user.games.where("name LIKE 'My Game %'").pluck(:name).map { |n| n.gsub('My Game ', '').to_i }.max || 0
-      self.name = "My Game #{highest_number + 1}"
+      max_existing_number = user.games.where("name LIKE 'My Game %'").pluck(:name).map { |t| t.gsub('My Game ', '').to_i }.max || 0
+      next_number = max_existing_number >= 0 ? max_existing_number + 1 : 1 
+      self.name = "My Game #{next_number}"
     else
       self.name = Titlecase.titleize(name.strip)
     end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -28,7 +28,7 @@ class Game < ApplicationRecord
 
   def format_name
     if name.blank?
-      highest_number = user.games.where("name like '%My Game%'").pluck(:name).map { |n| n.gsub('My Game ', '').to_i }.max || 0
+      highest_number = user.games.where("name LIKE 'My Game %'").pluck(:name).map { |n| n.gsub('My Game ', '').to_i }.max || 0
       self.name = "My Game #{highest_number + 1}"
     else
       self.name = Titlecase.titleize(name.strip)

--- a/app/models/shopping_list.rb
+++ b/app/models/shopping_list.rb
@@ -9,8 +9,8 @@ class ShoppingList < ApplicationRecord
   # ignores any leading or trailing whitespace characters.
   validates :title, uniqueness: { scope: :game_id },
                     format: {
-                      with: /\A\s*[a-z0-9 ]*\s*\z/i,
-                      message: 'can only include alphanumeric characters and spaces'
+                      with: /\A\s*[a-z0-9 \-'\,]*\s*\z/i,
+                      message: "can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')"
                     }
 
   before_save :format_title
@@ -32,8 +32,9 @@ class ShoppingList < ApplicationRecord
     return if aggregate
 
     if title.blank?
-      highest_number = game.shopping_lists.where("title LIKE 'My List %'").pluck(:title).map { |t| t.gsub('My List ', '').to_i }.max || 0
-      self.title = "My List #{highest_number + 1}"
+      max_existing_number = game.shopping_lists.where("title LIKE 'My List %'").pluck(:title).map { |t| t.gsub('My List ', '').to_i }.max || 0
+      next_number = max_existing_number >= 0 ? max_existing_number + 1 : 1 
+      self.title = "My List #{next_number}"
     else
       self.title = Titlecase.titleize(title.strip)
     end

--- a/app/models/shopping_list.rb
+++ b/app/models/shopping_list.rb
@@ -32,7 +32,7 @@ class ShoppingList < ApplicationRecord
     return if aggregate
 
     if title.blank?
-      highest_number = game.shopping_lists.where("title like '%My List%'").pluck(:title).map { |t| t.gsub('My List ', '').to_i }.max || 0
+      highest_number = game.shopping_lists.where("title LIKE 'My List %'").pluck(:title).map { |t| t.gsub('My List ', '').to_i }.max || 0
       self.title = "My List #{highest_number + 1}"
     else
       self.title = Titlecase.titleize(title.strip)

--- a/spec/controller_services/shopping_lists_controller/create_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/create_service_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe ShoppingListsController::CreateService do
       end
 
       it 'sets the errors' do
-        expect(perform.errors).to eq(['Title can only include alphanumeric characters and spaces'])
+        expect(perform.errors).to eq(["Title can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')"])
       end
     end
 

--- a/spec/controller_services/shopping_lists_controller/update_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/update_service_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe ShoppingListsController::UpdateService do
       end
 
       it 'sets the errors' do
-        expect(perform.errors).to eq(['Title can only include alphanumeric characters and spaces'])
+        expect(perform.errors).to eq(["Title can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')"])
       end
     end
 

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -111,6 +111,16 @@ RSpec.describe Game, type: :model do
           expect(name).to eq 'My Game 3'
         end
       end
+
+      context 'when there is a game called "My Game <negative integer>"' do
+        before do
+          create(:game, user: user, name: 'My Game -4')
+        end
+
+        it 'ignores the game name with the negative integer' do
+          expect(name).to eq 'My Game 1'
+        end
+      end
     end
 
     context 'when the request includes sloppy data' do

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -61,18 +61,55 @@ RSpec.describe Game, type: :model do
       end
     end
 
-    context 'wheen the name has a default value' do
+    context 'when the name has a default value' do
       subject(:name) { user.games.create!.name }
 
-      before do
-        # create games for a different user to makee sure the name of the
-        # game isn't affected by them
-        create_list(:game, 2, name: nil)
-        create_list(:game, 2, name: nil, user: user)
+      context 'when the user has all default-named games' do
+        before do
+          # Create games for a different user to make sure the name of this game's
+          # name isn't affected by them
+          create_list(:game, 2, name: nil)
+          create_list(:game, 2, name: nil, user: user)
+        end
+
+        it 'sets the title based on the highest numbered default title' do
+          expect(name).to eq 'My Game 3'
+        end
       end
 
-      it 'sets the name based on how many default-named games the user has' do
-        expect(name).to eq 'My Game 3'
+      context 'when the user has differently titled games' do
+        before do
+          create(:game, name: nil)
+          create(:game, user: user, name: nil)
+          create(:game, user: user, name: 'New Game')
+          create(:game, user: user, name: nil)
+        end
+
+        it 'uses the next highest number in default-named games' do
+          expect(name).to eq 'My Game 3'
+        end
+      end
+
+      context 'when the user has a game with a similar name' do
+        before do
+          create(:game, user: user, name: 'This Game is Called My Game 4')
+          create_list(:game, 2, user: user, name: nil)
+        end
+
+        it 'sets the name based on the highest numbered game called "My Game N"' do
+          expect(name).to eq 'My Game 3'
+        end
+      end
+
+      context 'when there is a game called "My Game <non-integer>"' do
+        before do
+          create(:game, user: user, name: "My Game Is the Best Game")
+          create_list(:game, 2, user: user, name: nil)
+        end
+
+        it 'sets the name based on the highest numbered game called "My Game N"' do
+          expect(name).to eq 'My Game 3'
+        end
       end
     end
 

--- a/spec/models/shopping_list_item_spec.rb
+++ b/spec/models/shopping_list_item_spec.rb
@@ -51,13 +51,13 @@ RSpec.describe ShoppingListItem, type: :model do
       let!(:list3) { create(:shopping_list_with_list_items, game: game) }
 
       it 'returns all list items from all the lists for the given game' do
-        # Reverse the arrays of list items because the index_only scope used in the ShoppingList
-        # class for :list_items will return them in descending order of `:updated_at`
-        expect(ShoppingListItem.belonging_to_game(game).to_a).to eq([
-                                                                      list3.list_items.to_a.reverse,
-                                                                      list2.list_items.to_a.reverse,
-                                                                      list1.list_items.to_a.reverse
-                                                                    ].flatten)
+        # We don't actually care what order these are in since we currently only use this
+        # scope to determine whether a given item belongs to a particular game
+        expect(ShoppingListItem.belonging_to_game(game).to_a.sort).to eq([
+                                                                           list1.list_items.to_a,
+                                                                           list2.list_items.to_a,
+                                                                           list3.list_items.to_a
+                                                                         ].flatten.sort)
       end
     end
 

--- a/spec/models/shopping_list_spec.rb
+++ b/spec/models/shopping_list_spec.rb
@@ -141,27 +141,27 @@ RSpec.describe ShoppingList, type: :model do
       end
 
       context 'allowed characters' do
-        it 'allows alphanumeric characters and spaces' do
-          list = build(:shopping_list, title: 'My List 1  ')
+        it 'allows alphanumeric characters, spaces, commas, apostrophes, and hyphens' do
+          list = build(:shopping_list, title: "aB 61 ,'-")
           expect(list).to be_valid
         end
 
         it "doesn't allow newlines", :aggregate_failures do
           list = build(:shopping_list, title: "My\nList 1  ")
           expect(list).not_to be_valid
-          expect(list.errors[:title]).to eq(['can only include alphanumeric characters and spaces'])
+          expect(list.errors[:title]).to eq(["can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')"])
         end
 
         it "doesn't allow other non-space whitespace", :aggregate_failures do
           list = build(:shopping_list, title: "My\tList 1")
           expect(list).not_to be_valid
-          expect(list.errors[:title]).to eq(['can only include alphanumeric characters and spaces'])
+          expect(list.errors[:title]).to eq(["can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')"])
         end
 
         it "doesn't allow special characters", :aggregate_failures do
           list = build(:shopping_list, title: 'My^List&1')
           expect(list).not_to be_valid
-          expect(list.errors[:title]).to eq(['can only include alphanumeric characters and spaces'])
+          expect(list.errors[:title]).to eq(["can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')"])
         end
 
         # Leading and trailing whitespace characters will be stripped anyway so no need to validate
@@ -248,6 +248,16 @@ RSpec.describe ShoppingList, type: :model do
 
             it 'sets the title based on the highest numbered list called "My List N"' do
               expect(title).to eq 'My List 3'
+            end
+          end
+
+          context 'when there is a shopping list called "My List <negative integer>"' do
+            before do
+              create(:shopping_list, game: game, title: 'My List -4')
+            end
+
+            it 'ignores the list title with the negative integer' do
+              expect(title).to eq 'My List 1'
             end
           end
         end

--- a/spec/models/shopping_list_spec.rb
+++ b/spec/models/shopping_list_spec.rb
@@ -203,15 +203,52 @@ RSpec.describe ShoppingList, type: :model do
         context 'when the user has not set a title' do
           subject(:title) { game.shopping_lists.create!.title }
   
-          before do
-            # Create lists for a different gamee to make sure the name of this game's
-            # list isn't affected by them
-            create_list(:shopping_list, 2, title: nil)
-            create_list(:shopping_list, 2, title: nil, game: game)
+          context 'when the game has all default-titled regular lists' do
+            before do
+              # Create lists for a different game to make sure the name of this game's
+              # list isn't affected by them
+              create_list(:shopping_list, 2, title: nil)
+              create_list(:shopping_list, 2, title: nil, game: game)
+            end
+    
+            it 'sets the title based on the highest numbered default title' do
+              expect(title).to eq 'My List 3'
+            end
           end
-  
-          it 'sets the title based on how many regular lists the user has' do
-            expect(title).to eq 'My List 3'
+
+          context 'when the game has differently titled regular lists' do
+            before do
+              create(:shopping_list, title: nil)
+              create(:shopping_list, game: game, title: nil)
+              create(:shopping_list, game: game, title: 'Windstad Manor')
+              create(:shopping_list, game: game, title: nil)
+            end
+
+            it 'uses the next highest number in default lists' do
+              expect(title).to eq 'My List 3'
+            end
+          end
+
+          context 'when the game has a shopping list with a similar title' do
+            before do
+              create(:shopping_list, game: game, title: 'This List is Called My List 4')
+              create_list(:shopping_list, 2, game: game, title: nil)
+            end
+
+            it 'sets the title based on the highest numbered list called "My List N"' do
+              expect(title).to eq 'My List 3'
+            end
+          end
+
+          context 'when there is a shopping list called "My List <non-integer>"' do
+            before do
+              create(:shopping_list, game: game, title: "My List Is the Best List")
+              create_list(:shopping_list, 2, game: game, title: nil)
+            end
+
+            it 'sets the title based on the highest numbered list called "My List N"' do
+              expect(title).to eq 'My List 3'
+            end
           end
         end
       end


### PR DESCRIPTION
## Context

[**Fix bug in default titles**](https://trello.com/c/RWYeeWGP/94-fix-bug-in-default-titles)

There was a (suspected) bug where default titles of shopping lists and names of games could be set to the wrong value. This bug didn't end up actually being a significant bug due to the fact that non-numeric strings will be cast to `0` and the minimum value is `1`.

The only case where this bug would be an issue is the case where there are no existing default names/titles but there is, for instance, a list titled "My List -3". This would lead the first default list to be named "My List -2" since the max exists but is not zero. It's hardly a likely bug, but would be a little weird if it were to come up, so I fixed it. There is a foreseeable issue where a similar problem could occur if there were no default games but one game was named "My Game 2.6", which would evaluate to `2`. However, `.` is not currently an allowed character in shopping list titles or game names, so for now this issue does not exist.

## Changes

* Add additional specs for game and shopping list models to check default titling/naming behaviour
* Tweak code so it works if a list is titled "My List <negative integer>" or a game is named "My Game <negative integer>"
* Allow additional characters (`","`, `"-"`, and `"'"`) in shopping list titles to bring them in line with allowed game names 

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [ ] ~~Added and updated API docs and developer docs as appropriate~~
