### PR TITLE
Fix Rubocop Gemfile and layout violations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,6 +40,7 @@ require:
   - rubocop-performance
 AllCops:
   Exclude:
+    - 'bin/**/*'
     - 'db/schema.rb'
     - 'vendor/bundle/**/*'
   DisabledByDefault: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -322,1346 +322,1346 @@ Layout/TrailingWhitespace:
   Enabled: true
   AllowInHeredoc: false
 
-###############
-### Linting ###
-###############
+# ###############
+# ### Linting ###
+# ###############
 
-Lint/AmbiguousAssignment:
-  Enabled: true
-Lint/AmbiguousBlockAssociation:
-  Enabled: true
-Lint/AmbiguousOperator:
-  Enabled: true
-Lint/AmbiguousRegexpLiteral:
-  Enabled: true
-Lint/AssignmentInCondition:
-  Enabled: true
-Lint/BigDecimalNew:
-  Enabled: true
-Lint/CircularArgumentReference:
-  Enabled: true
-Lint/ConstantDefinitionInBlock:
-  Enabled: true
-Lint/Debugger:
-  Enabled: true
-Lint/DeprecatedClassMethods:
-  Enabled: true
-Lint/DeprecatedConstants:
-  Enabled: true
-Lint/DeprecatedOpenSSLConstant:
-  Enabled: true
-Lint/DisjunctiveAssignmentInConstructor:
-  Enabled: true
-Lint/DuplicateBranch:
-  Enabled: true
-Lint/DuplicateCaseCondition:
-  Enabled: true
-Lint/DuplicateElsifCondition:
-  Enabled: true
-Lint/DuplicateHashKey:
-  Enabled: true
-Lint/DuplicateMethods:
-  Enabled: true
-Lint/DuplicateRegexpCharacterClassElement:
-  Enabled: true
-Lint/DuplicateRequire:
-  Enabled: true
-Lint/DuplicateRescueException:
-  Enabled: true
-Lint/EachWithObjectArgument:
-  Enabled: true
-Lint/ElseLayout:
-  Enabled: true
-Lint/EmptyBlock:
-  Enabled: true
-  AllowEmptyLambdas: true
-Lint/EmptyConditionalBody:
-  Enabled: true
-Lint/EmptyEnsure:
-  Enabled: true
-Lint/EmptyExpression:
-  Enabled: true
-Lint/EmptyFile:
-  Enabled: true
-Lint/EmptyInPattern:
-  Enabled: true
-Lint/EmptyInterpolation:
-  Enabled: true
-Lint/EmptyWhen:
-  Enabled: true
-Lint/EnsureReturn:
-  Enabled: true
-Lint/ErbNewArguments:
-  Enabled: true
-Lint/FlipFlop:
-  Enabled: true
-Lint/FloatComparison:
-  Enabled: true
-Lint/FloatOutOfRange:
-  Enabled: true
-Lint/FormatParameterMismatch:
-  Enabled: true
-Lint/HeredocMethodCallPosition:
-  Enabled: true
-Lint/ImplicitStringConcatenation:
-  Enabled: true
-Lint/IneffectiveAccessModifier:
-  Enabled: true
-Lint/InheritException:
-  Enabled: true
-  EnforcedStyle: standard_error
-Lint/InterpolationCheck:
-  Enabled: true
-Lint/LiteralAsCondition:
-  Enabled: true
-Lint/LiteralInInterpolation:
-  Enabled: true
-Lint/Loop:
-  Enabled: true
-Lint/MissingCopEnableDirective:
-  Enabled: true
-Lint/MissingSuper:
-  Enabled: true
-Lint/MixedRegexpCaptureTypes:
-  Enabled: true
-Lint/MultipleComparison:
-  Enabled: true
-Lint/NestedMethodDefinition:
-  Enabled: true
-Lint/NestedPercentLiteral:
-  Enabled: true
-Lint/NextWithoutAccumulator:
-  Enabled: true
-Lint/NoReturnInBeginEndBlocks:
-  Enabled: true
-Lint/NonDeterministicRequireOrder:
-  Enabled: true
-Lint/OrAssignmentToConstant:
-  Enabled: true
-Lint/OrderedMagicComments:
-  Enabled: true
-Lint/ParenthesesAsGroupedExpression:
-  Enabled: true
-Lint/PercentStringArray:
-  Enabled: true
-Lint/PercentSymbolArray:
-  Enabled: true
-Lint/RaiseException:
-  Enabled: true
-Lint/RandOne:
-  Enabled: true
-Lint/RedundantCopDisableDirective:
-  Enabled: true
-Lint/RedundantCopEnableDirective:
-  Enabled: true
-Lint/RedundantDirGlobSort:
-  Enabled: true
-Lint/RedundantRequireStatement:
-  Enabled: true
-Lint/RedundantSafeNavigation:
-  Enabled: true
-Lint/RedundantSplatExpansion:
-  Enabled: true
-  AllowPercentLiteralArrayArgument: true
-Lint/RedundantStringCoercion:
-  Enabled: true
-Lint/RedundantWithIndex:
-  Enabled: true
-Lint/RedundantWithObject:
-  Enabled: true
-Lint/RegexpAsCondition:
-  Enabled: true
-Lint/RequireParentheses:
-  Enabled: true
-Lint/RescueException:
-  Enabled: true
-Lint/RescueType:
-  Enabled: true
-Lint/ReturnInVoidContext:
-  Enabled: true
-Lint/SafeNavigationChain:
-  Enabled: true
-Lint/SafeNavigationConsistency:
-  Enabled: true
-Lint/SafeNavigationWithEmpty:
-  Enabled: true
-Lint/ScriptPermission:
-  Enabled: true
-Lint/SelfAssignment:
-  Enabled: true
-Lint/SendWithMixinArgument:
-  Enabled: true
-Lint/ShadowedArgument:
-  Enabled: true
-Lint/ShadowedException:
-  Enabled: true
-Lint/ShadowingOuterLocalVariable:
-  Enabled: true
-Lint/StructNewOverride:
-  Enabled: true
-Lint/SuppressedException:
-  Enabled: true
-Lint/Syntax:
-  Enabled: true
-Lint/ToEnumArguments:
-  Enabled: true
-Lint/ToJSON:
-  Enabled: true
-Lint/TopLevelReturnWithArgument:
-  Enabled: true
-Lint/TrailingCommaInAttributeDeclaration:
-  Enabled: true
-Lint/TripleQuotes:
-  Enabled: true
-Lint/UnderscorePrefixedVariableName:
-  Enabled: true
-Lint/UnifiedInteger:
-  Enabled: true
-Lint/UnmodifiedReduceAccumulator:
-  Enabled: true
-Lint/UnreachableCode:
-  Enabled: true
-Lint/UnreachableLoop:
-  Enabled: true
-Lint/UnusedBlockArgument:
-  Enabled: true
-Lint/UnusedMethodArgument:
-  Enabled: true
-  AllowUnusedKeywordArguments: false
-  IgnoreEmptyMethods: true
-  IgnoreNotImplementedMethods: true
-Lint/UriEscapeUnescape:
-  Enabled: true
-Lint/UriRegexp:
-  Enabled: true
-Lint/UselessAccessModifier:
-  Enabled: true
-Lint/UselessAssignment:
-  Enabled: true
-Lint/UselessElseWithoutRescue:
-  Enabled: true
-Lint/UselessMethodDefinition:
-  Enabled: true
+# Lint/AmbiguousAssignment:
+#   Enabled: true
+# Lint/AmbiguousBlockAssociation:
+#   Enabled: true
+# Lint/AmbiguousOperator:
+#   Enabled: true
+# Lint/AmbiguousRegexpLiteral:
+#   Enabled: true
+# Lint/AssignmentInCondition:
+#   Enabled: true
+# Lint/BigDecimalNew:
+#   Enabled: true
+# Lint/CircularArgumentReference:
+#   Enabled: true
+# Lint/ConstantDefinitionInBlock:
+#   Enabled: true
+# Lint/Debugger:
+#   Enabled: true
+# Lint/DeprecatedClassMethods:
+#   Enabled: true
+# Lint/DeprecatedConstants:
+#   Enabled: true
+# Lint/DeprecatedOpenSSLConstant:
+#   Enabled: true
+# Lint/DisjunctiveAssignmentInConstructor:
+#   Enabled: true
+# Lint/DuplicateBranch:
+#   Enabled: true
+# Lint/DuplicateCaseCondition:
+#   Enabled: true
+# Lint/DuplicateElsifCondition:
+#   Enabled: true
+# Lint/DuplicateHashKey:
+#   Enabled: true
+# Lint/DuplicateMethods:
+#   Enabled: true
+# Lint/DuplicateRegexpCharacterClassElement:
+#   Enabled: true
+# Lint/DuplicateRequire:
+#   Enabled: true
+# Lint/DuplicateRescueException:
+#   Enabled: true
+# Lint/EachWithObjectArgument:
+#   Enabled: true
+# Lint/ElseLayout:
+#   Enabled: true
+# Lint/EmptyBlock:
+#   Enabled: true
+#   AllowEmptyLambdas: true
+# Lint/EmptyConditionalBody:
+#   Enabled: true
+# Lint/EmptyEnsure:
+#   Enabled: true
+# Lint/EmptyExpression:
+#   Enabled: true
+# Lint/EmptyFile:
+#   Enabled: true
+# Lint/EmptyInPattern:
+#   Enabled: true
+# Lint/EmptyInterpolation:
+#   Enabled: true
+# Lint/EmptyWhen:
+#   Enabled: true
+# Lint/EnsureReturn:
+#   Enabled: true
+# Lint/ErbNewArguments:
+#   Enabled: true
+# Lint/FlipFlop:
+#   Enabled: true
+# Lint/FloatComparison:
+#   Enabled: true
+# Lint/FloatOutOfRange:
+#   Enabled: true
+# Lint/FormatParameterMismatch:
+#   Enabled: true
+# Lint/HeredocMethodCallPosition:
+#   Enabled: true
+# Lint/ImplicitStringConcatenation:
+#   Enabled: true
+# Lint/IneffectiveAccessModifier:
+#   Enabled: true
+# Lint/InheritException:
+#   Enabled: true
+#   EnforcedStyle: standard_error
+# Lint/InterpolationCheck:
+#   Enabled: true
+# Lint/LiteralAsCondition:
+#   Enabled: true
+# Lint/LiteralInInterpolation:
+#   Enabled: true
+# Lint/Loop:
+#   Enabled: true
+# Lint/MissingCopEnableDirective:
+#   Enabled: true
+# Lint/MissingSuper:
+#   Enabled: true
+# Lint/MixedRegexpCaptureTypes:
+#   Enabled: true
+# Lint/MultipleComparison:
+#   Enabled: true
+# Lint/NestedMethodDefinition:
+#   Enabled: true
+# Lint/NestedPercentLiteral:
+#   Enabled: true
+# Lint/NextWithoutAccumulator:
+#   Enabled: true
+# Lint/NoReturnInBeginEndBlocks:
+#   Enabled: true
+# Lint/NonDeterministicRequireOrder:
+#   Enabled: true
+# Lint/OrAssignmentToConstant:
+#   Enabled: true
+# Lint/OrderedMagicComments:
+#   Enabled: true
+# Lint/ParenthesesAsGroupedExpression:
+#   Enabled: true
+# Lint/PercentStringArray:
+#   Enabled: true
+# Lint/PercentSymbolArray:
+#   Enabled: true
+# Lint/RaiseException:
+#   Enabled: true
+# Lint/RandOne:
+#   Enabled: true
+# Lint/RedundantCopDisableDirective:
+#   Enabled: true
+# Lint/RedundantCopEnableDirective:
+#   Enabled: true
+# Lint/RedundantDirGlobSort:
+#   Enabled: true
+# Lint/RedundantRequireStatement:
+#   Enabled: true
+# Lint/RedundantSafeNavigation:
+#   Enabled: true
+# Lint/RedundantSplatExpansion:
+#   Enabled: true
+#   AllowPercentLiteralArrayArgument: true
+# Lint/RedundantStringCoercion:
+#   Enabled: true
+# Lint/RedundantWithIndex:
+#   Enabled: true
+# Lint/RedundantWithObject:
+#   Enabled: true
+# Lint/RegexpAsCondition:
+#   Enabled: true
+# Lint/RequireParentheses:
+#   Enabled: true
+# Lint/RescueException:
+#   Enabled: true
+# Lint/RescueType:
+#   Enabled: true
+# Lint/ReturnInVoidContext:
+#   Enabled: true
+# Lint/SafeNavigationChain:
+#   Enabled: true
+# Lint/SafeNavigationConsistency:
+#   Enabled: true
+# Lint/SafeNavigationWithEmpty:
+#   Enabled: true
+# Lint/ScriptPermission:
+#   Enabled: true
+# Lint/SelfAssignment:
+#   Enabled: true
+# Lint/SendWithMixinArgument:
+#   Enabled: true
+# Lint/ShadowedArgument:
+#   Enabled: true
+# Lint/ShadowedException:
+#   Enabled: true
+# Lint/ShadowingOuterLocalVariable:
+#   Enabled: true
+# Lint/StructNewOverride:
+#   Enabled: true
+# Lint/SuppressedException:
+#   Enabled: true
+# Lint/Syntax:
+#   Enabled: true
+# Lint/ToEnumArguments:
+#   Enabled: true
+# Lint/ToJSON:
+#   Enabled: true
+# Lint/TopLevelReturnWithArgument:
+#   Enabled: true
+# Lint/TrailingCommaInAttributeDeclaration:
+#   Enabled: true
+# Lint/TripleQuotes:
+#   Enabled: true
+# Lint/UnderscorePrefixedVariableName:
+#   Enabled: true
+# Lint/UnifiedInteger:
+#   Enabled: true
+# Lint/UnmodifiedReduceAccumulator:
+#   Enabled: true
+# Lint/UnreachableCode:
+#   Enabled: true
+# Lint/UnreachableLoop:
+#   Enabled: true
+# Lint/UnusedBlockArgument:
+#   Enabled: true
+# Lint/UnusedMethodArgument:
+#   Enabled: true
+#   AllowUnusedKeywordArguments: false
+#   IgnoreEmptyMethods: true
+#   IgnoreNotImplementedMethods: true
+# Lint/UriEscapeUnescape:
+#   Enabled: true
+# Lint/UriRegexp:
+#   Enabled: true
+# Lint/UselessAccessModifier:
+#   Enabled: true
+# Lint/UselessAssignment:
+#   Enabled: true
+# Lint/UselessElseWithoutRescue:
+#   Enabled: true
+# Lint/UselessMethodDefinition:
+#   Enabled: true
 
-###########################
-### Naming Requirements ###
-###########################
+# ###########################
+# ### Naming Requirements ###
+# ###########################
 
-Naming/AccessorMethodName:
-  Enabled: true
-Naming/AsciiIdentifiers:
-  Enabled: true
-Naming/BinaryOperatorParameterName:
-  Enabled: true
-Naming/BlockParameterName:
-  Enabled: true
-  MinNameLength: 1
-  AllowNamesEndingInNumbers: true
-Naming/ClassAndModuleCamelCase:
-  Enabled: true
-Naming/ConstantName:
-  Enabled: true
-Naming/FileName:
-  Enabled: true
-  ExpectMatchingDefinition: true # might be redundant w/Zeitwerk
-  CheckDefinitionPathHierarchy: true
-  IgnoreExecutableScripts: true
-  AllowedAcronyms:
-    - CLI
-    - DSL
-    - ACL
-    - API
-    - ASCII
-    - CPU
-    - CSS
-    - CSV
-    - DNS
-    - EOF
-    - GUID
-    - HTML
-    - HTTP
-    - HTTPS
-    - ID
-    - IP
-    - JSON
-    - LHS
-    - QPS
-    - RAM
-    - RHS
-    - RPC
-    - SLA
-    - SMTP
-    - SQL
-    - SSH
-    - TCP
-    - TLS
-    - TTL
-    - UDP
-    - UI
-    - UID
-    - UUID
-    - URI
-    - URL
-    - UTF8
-    - VM
-    - XML
-    - XMPP
-    - XSRF
-    - XSS
-Naming/HeredocDelimiterCase:
-  Enabled: true
-  EnforcedStyle: uppercase
-Naming/InclusiveLanguage:
-  Enabled: true
-  CheckIdentifiers: true
-  CheckConstants: true
-  CheckVariables: true
-  CheckStrings: false
-  CheckSymbols: true
-  CheckComments: true
-  CheckFilepaths: true
-  FlaggedTerms:
-    whitelist:
-      Regex: !ruby/regexp '/white[-_\s]?list/'
-      Suggestions:
-        - allowlist
-        - permit
-    blacklist:
-      Regex: !ruby/regexp '/black[-_\s]?list/'
-      Suggestions:
-        - denylist
-        - block
-    slave:
-      Suggestions:
-        - replica
-        - secondary
-        - follower
-    master:
-      Suggestions:
-        - primary
-        - main
-Naming/MemoizedInstanceVariableName:
-  Enabled: true
-  EnforcedStyleForLeadingUnderscores: disallowed
-Naming/MethodName:
-  Enabled: true
-  EnforcedStyle: snake_case
-Naming/MethodParameterName:
-  Enabled: true
-  MinNameLength: 3
-  AllowNamesEndingInNumbers: true
-  AllowedNames:
-    - at
-    - by
-    - db
-    - id
-    - in
-    - io
-    - ip
-    - of
-    - 'on'
-    - os
-    - pp
-    - to
-Naming/PredicateName:
-  Enabled: true
-Naming/PredicateName:
-  Enabled: true
-  NamePrefix:
-    - is_
-    - has_
-    - have_
-  ForbiddenPrefixes:
-    - is_
-  AllowedMethods:
-    - is_a?
-  MethodDefinitionMacros:
-    - define_method
-    - define_singleton_method
-Naming/RescuedExceptionsVariableName:
-  Enabled: true
-  PreferredName: e
-Naming/VariableName:
-  Enabled: true
-  EnforcedStyle: snake_case
-Naming/VariableNumber:
-  Enabled: true
-  EnforcedStyle: normalcase
-  CheckMethodNames: true
-  CheckSymbols: true
+# Naming/AccessorMethodName:
+#   Enabled: true
+# Naming/AsciiIdentifiers:
+#   Enabled: true
+# Naming/BinaryOperatorParameterName:
+#   Enabled: true
+# Naming/BlockParameterName:
+#   Enabled: true
+#   MinNameLength: 1
+#   AllowNamesEndingInNumbers: true
+# Naming/ClassAndModuleCamelCase:
+#   Enabled: true
+# Naming/ConstantName:
+#   Enabled: true
+# Naming/FileName:
+#   Enabled: true
+#   ExpectMatchingDefinition: true # might be redundant w/Zeitwerk
+#   CheckDefinitionPathHierarchy: true
+#   IgnoreExecutableScripts: true
+#   AllowedAcronyms:
+#     - CLI
+#     - DSL
+#     - ACL
+#     - API
+#     - ASCII
+#     - CPU
+#     - CSS
+#     - CSV
+#     - DNS
+#     - EOF
+#     - GUID
+#     - HTML
+#     - HTTP
+#     - HTTPS
+#     - ID
+#     - IP
+#     - JSON
+#     - LHS
+#     - QPS
+#     - RAM
+#     - RHS
+#     - RPC
+#     - SLA
+#     - SMTP
+#     - SQL
+#     - SSH
+#     - TCP
+#     - TLS
+#     - TTL
+#     - UDP
+#     - UI
+#     - UID
+#     - UUID
+#     - URI
+#     - URL
+#     - UTF8
+#     - VM
+#     - XML
+#     - XMPP
+#     - XSRF
+#     - XSS
+# Naming/HeredocDelimiterCase:
+#   Enabled: true
+#   EnforcedStyle: uppercase
+# Naming/InclusiveLanguage:
+#   Enabled: true
+#   CheckIdentifiers: true
+#   CheckConstants: true
+#   CheckVariables: true
+#   CheckStrings: false
+#   CheckSymbols: true
+#   CheckComments: true
+#   CheckFilepaths: true
+#   FlaggedTerms:
+#     whitelist:
+#       Regex: !ruby/regexp '/white[-_\s]?list/'
+#       Suggestions:
+#         - allowlist
+#         - permit
+#     blacklist:
+#       Regex: !ruby/regexp '/black[-_\s]?list/'
+#       Suggestions:
+#         - denylist
+#         - block
+#     slave:
+#       Suggestions:
+#         - replica
+#         - secondary
+#         - follower
+#     master:
+#       Suggestions:
+#         - primary
+#         - main
+# Naming/MemoizedInstanceVariableName:
+#   Enabled: true
+#   EnforcedStyleForLeadingUnderscores: disallowed
+# Naming/MethodName:
+#   Enabled: true
+#   EnforcedStyle: snake_case
+# Naming/MethodParameterName:
+#   Enabled: true
+#   MinNameLength: 3
+#   AllowNamesEndingInNumbers: true
+#   AllowedNames:
+#     - at
+#     - by
+#     - db
+#     - id
+#     - in
+#     - io
+#     - ip
+#     - of
+#     - 'on'
+#     - os
+#     - pp
+#     - to
+# Naming/PredicateName:
+#   Enabled: true
+# Naming/PredicateName:
+#   Enabled: true
+#   NamePrefix:
+#     - is_
+#     - has_
+#     - have_
+#   ForbiddenPrefixes:
+#     - is_
+#   AllowedMethods:
+#     - is_a?
+#   MethodDefinitionMacros:
+#     - define_method
+#     - define_singleton_method
+# Naming/RescuedExceptionsVariableName:
+#   Enabled: true
+#   PreferredName: e
+# Naming/VariableName:
+#   Enabled: true
+#   EnforcedStyle: snake_case
+# Naming/VariableNumber:
+#   Enabled: true
+#   EnforcedStyle: normalcase
+#   CheckMethodNames: true
+#   CheckSymbols: true
 
-#############################
-### Security Requirements ###
-#############################
+# #############################
+# ### Security Requirements ###
+# #############################
 
-Security/Eval:
-  Enabled: true
-Security/JSONLoad:
-  Enabled: true
-Security/MarshalLoad:
-  Enabled: true
-Security/Open:
-  Enabled: true
-Security/YAMLLoad:
-  Enabled: true
+# Security/Eval:
+#   Enabled: true
+# Security/JSONLoad:
+#   Enabled: true
+# Security/MarshalLoad:
+#   Enabled: true
+# Security/Open:
+#   Enabled: true
+# Security/YAMLLoad:
+#   Enabled: true
 
-##########################
-### Style Requirements ###
-##########################
+# ##########################
+# ### Style Requirements ###
+# ##########################
 
-Style/AccessModifierDeclarations:
-  Enabled: true
-  EnforcedStyle: group
-Style/AccessorGrouping:
-  Enabled: true
-  EnforcedStyle: grouped
-Style/Alias:
-  Enabled: true
-  EnforcedStyle: prefer_alias_method
-Style/AndOr:
-  Enabled: true
-  EnforcedStyle: always
-Style/ArgumentsForwarding:
-  Enabled: true
-  AllowOnlyRestArgument: true
-Style/ArrayJoin:
-  Enabled: true
-Style/Attr:
-  Enabled: true
-Style/AutoResourceCleanup:
-  Enabled: true
-Style/BarePercentLiterals:
-  Enabled: true
-  EnforcedStyle: bare_percent
-Style/BeginBlock:
-  Enabled: true
-Style/BisectedAttrAccessor:
-  Enabled: true
-Style/BlockComments:
-  Enabled: true
-Style/BlockDelimiters:
-  Enabled: true
-  EnforcedStyle: line_count_based
-  ProceduralMethods:
-    # Methods that are known to be procedural in nature but look functional from
-    # their usage, e.g.
-    #
-    #   time = Benchmark.realtime do
-    #     foo.bar
-    #   end
-    #
-    # Here, the return value of the block is discarded but the return value of
-    # `Benchmark.realtime` is used.
-    - benchmark
-    - bm
-    - bmbm
-    - create
-    - each_with_object
-    - measure
-    - new
-    - realtime
-    - tap
-    - with_object
-  FunctionalMethods:
-    # Methods that are known to be functional in nature but look procedural from
-    # their usage, e.g.
-    #
-    #   let(:foo) { Foo.new }
-    #
-    # Here, the return value of `Foo.new` is used to define a `foo` helper but
-    # doesn't appear to be used from the return value of `let`.
-    - let
-    - let!
-    - subject
-    - watch
-  IgnoredMethods:
-    # Methods that can be either procedural or functional and cannot be
-    # categorised from their usage alone, e.g.
-    #
-    #   foo = lambda do |x|
-    #     puts "Hello, #{x}"
-    #   end
-    #
-    #   foo = lambda do |x|
-    #     x * 100
-    #   end
-    #
-    # Here, it is impossible to tell from the return value of `lambda` whether
-    # the inner block's return value is significant.
-    - lambda
-    - proc
-    - it
-Style/CaseEquality:
-  Enabled: true
-  AllowOnConstant: false
-Style/CharacterLiteral:
-  Enabled: true
-Style/ClassCheck:
-  Enabled: true
-  EnforcedStyle: is_a?
-Style/ClassEqualityComparison:
-  Enabled: true
-  IgnoredMethods:
-    - ==
-    - equal?
-    - eql?
-Style/ClassMethods:
-  Enabled: true
-Style/ClassMethodsDefinitions:
-  Enabled: true
-  EnforcedStyle: def_self
-Style/CollectionCompact:
-  Enabled: true
-Style/CollectionMethods:
-  Enabled: true
-  PreferredMethods:
-    collect: 'map'
-    collect!: 'map!'
-    inject: 'reduce'
-    detect: 'find'
-    find_all: 'select'
-    member?: 'include?'
-  MethodsAcceptingSymbol:
-    - inject
-    - reduce
-    - map
-    - map!
-Style/ColonMethodCall:
-  Enabled: true
-Style/ColonMethodDefinition:
-  Enabled: true
-Style/CombinableLoops:
-  Enabled: true
-Style/CommandLiteral:
-  Enabled: true
-  EnforcedStyle: percent_x
-Style/CommentAnnotation:
-  Enabled: true
-  Keywords:
-    - TODO
-    - FIXME
-  RequireColon: true
-Style/CommentedKeyword:
-  Enabled: true
-Style/ConditionalAssignment:
-  Enabled: true
-  EnforcedStyle: assign_to_condition
-  IncludeTernaryExpressions: true
-  SingleLineConditionsOnly: true
-Style/DefWithParentheses:
-  Enabled: true
-Style/Dir:
-  Enabled: true
-Style/DocumentDynamicEvalDefinition:
-  Enabled: true
-Style/DoubleCopDisableDirective:
-  Enabled: true
-Style/DoubleNegation:
-  Enabled: true
-  EnforcedStyle: allowed_in_returns
-Style/EachForSimpleLoop:
-  Enabled: true
-Style/EmptyBlockParameter:
-  Enabled: true
-Style/EmptyCaseCondition:
-  Enabled: true
-Style/EmptyElse:
-  Enabled: true
-  EnforcedStyle: both
-Style/EmptyLambdaParameter:
-  Enabled: true
-Style/EmptyLiteral:
-  Enabled: true
-Style/EmptyMethod:
-  Enabled: true
-  EnforcedStyle: compact
-Style/Encoding:
-  Enabled: true
-Style/EndBlock:
-  Enabled: true
-Style/EvalWithLocation:
-  Enabled: true
-Style/EvenOdd:
-  Enabled: true
-Style/ExpandPathArguments:
-  Enabled: true
-Style/ExplicitBlockArgument:
-  Enabled: true
-Style/ExponentialNotation:
-  Enabled: true
-  EnforcedStyle: scientific
-Style/FloatDivision:
-  Enabled: true
-  EnforcedStyle: single_coerce
-Style/For:
-  Enabled: true
-  EnforcedStyle: each
-Style/FrozenStringLiteralComment:
-  Enabled: true
-  EnforcedStyle: always
-Style/GlobalStdStream:
-  Enabled: true
-Style/GlobalVars:
-  Enabled: true
-Style/GuardClause:
-  Enabled: true
-Style/HashAsLastArrayItem:
-  Enabled: true
-  EnforcedStyle: braces
-Style/HashEachMethods:
-  Enabled: true
-Style/HashExcept:
-  Enabled: true
-Style/HashLikeCase:
-  Enabled: true
-Style/HashSyntax:
-  Enabled: true
-  EnforcedStyle: ruby19
-  UseHashRocketsWithSymbolValues: false
-  PreferHashRocketsForNonAlnumEndingSymbols: false
-Style/HashTransformKeys:
-  Enabled: true
-Style/HashTransformValues:
-  Enabled: true
-Style/IdenticalConditionalBranches:
-  Enabled: true
-Style/IfInsideElse:
-  Enabled: true
-Style/IfUnlessModifier:
-  Enabled: true
-Style/IfUnlessModifierOfIfUnless:
-  Enabled: true
-Style/IfWithBooleanLiteralBranches:
-  Enabled: true
-Style/IfWithSemicolon:
-  Enabled: true
-Style/ImplicitRuntimeError:
-  Enabled: true
-Style/InverseMethods:
-  Enabled: true
-  InverseMethods:
-    :any?: :none?
-    :even?: :odd?
-    :==: :!=
-    :=~: :!~
-    :<: :>=
-    :>: :<=
-  InverseBlocks:
-    :select: :reject
-    :select!: :reject!
-Style/IpAddresses:
-  Enabled: true
-  AllowedAddresses:
-    - '::'
-  Exclude:
-    - '**/Gemfile'
-Style/KeywordParametersOrder:
-  Enabled: true
-Style/Lambda:
-  Enabled: true
-  EnforcedStyle: line_count_dependent
-Style/LambdaCall:
-  Enabled: true
-  EnforcedStyle: call
-Style/LineEndConcatenation:
-  Enabled: true
-Style/MethodCallWithoutArgsParentheses:
-  Enabled: true
-Style/MethodDefParentheses:
-  Enabled: true
-  EnforcedStyle: require_parentheses
-Style/MinMax:
-  Enabled: true
-Style/MissingRespondToMissing:
-  Enabled: true
-Style/MixinGrouping:
-  Enabled: true
-  EnforcedStyle: separated
-Style/MixinUsage:
-  Enabled: true
-Style/ModuleFunction:
-  Enabled: true
-  EnforcedStyle: module_function
-Style/MultilineIfModifier:
-  Enabled: true
-Style/MultilineIfThen:
-  Enabled: true
-Style/MultilineInPatternThen:
-  Enabled: true
-Style/MultilineMemoization:
-  Enabled: true
-  EnforcedStyle: keyword
-Style/MultilineMethodSignature:
-  Enabled: true
-Style/MultilineTernaryOperator:
-  Enabled: true
-Style/MultilineWhenThen:
-  Enabled: true
-Style/MultipleComparison:
-  Enabled: true
-Style/MutableConstant:
-  Enabled: true
-  EnforcedStyle: literals
-Style/NegatedIf:
-  Enabled: true
-  EnforcedStyle: postfix
-Style/NegatedIfElseCondition:
-  Enabled: true
-Style/NegatedUnless:
-  Enabled: true
-  EnforcedStyle: both
-Style/NegatedWhile:
-  Enabled: true
-Style/NestedModifier:
-  Enabled: true
-Style/NestedParenthesizedCalls:
-  Enabled: true
-  AllowedMethods:
-    - be
-    - be_a
-    - be_an
-    - be_between
-    - be_falsey
-    - be_kind_of
-    - be_instance_of
-    - be_truthy
-    - be_within
-    - eq
-    - eql
-    - end_with
-    - include
-    - match
-    - raise_error
-    - respond_to
-    - start_with
-Style/NestedTernaryOperator:
-  Enabled: true
-Style/Next:
-  Enabled: true
-  EnforcedStyle: skip_modifier_ifs
-Style/NilComparison:
-  Enabled: true
-  EnforcedStyle: predicate
-Style/NilLambda:
-  Enabled: true
-Style/NonNilCheck:
-  Enabled: true
-  IncludeSemanticChanges: false
-Style/Not:
-  Enabled: true
-Style/NumericLiteralPrefix:
-  Enabled: true
-  EnforcedStyle: zero_with_o
-Style/NumericLiterals:
-  Enabled: true
-  MinDigits: 5
-Style/OneLineConditional:
-  Enabled: true
-Style/OptionalArguments:
-  Enabled: true
-Style/OrAssignment:
-  Enabled: true
-Style/ParallelAssignment:
-  Enabled: true
-Style/ParenthesesAroundCondition:
-  Enabled: true
-  AllowSafeAssignment: false
-  AllowInMultilineConditionals: false
-Style/PercentLiteralDelimiters:
-  Enabled: true
-  PreferredDelimiters:
-    default: ()
-    '%i': '[]'
-    '%I': '[]'
-    '%r': '{}'
-    '%w': '[]'
-    '%W': '[]'
-Style/PercentQLiterals:
-  Enabled: true
-  EnforcedStyle: lower_case_q
-Style/PerlBackrefs:
-  Enabled: true
-Style/PreferredHashMethods:
-  Enabled: true
-  EnforcedStyle: verbose
-Style/Proc:
-  Enabled: true
-Style/QuotedSymbols:
-  Enabled: true
-  EnforcedStyle: same_as_string_literals
-Style/RaiseArgs:
-  Enabled: true
-  EnforcedStyle: compact
-Style/RandomWithOffset:
-  Enabled: true
-Style/RedundantAssignment:
-  Enabled: true
-Style/RedundantBegin:
-  Enabled: true
-Style/RedundantCapitalW:
-  Enabled: true
-Style/RedundantCondition:
-  Enabled: true
-Style/RedundantConditional:
-  Enabled: true
-Style/RedundantFileExtensionInRequire:
-  Enabled: true
-Style/RedundantFreeze:
-  Enabled: true
-Style/RedundantInterpolation:
-  Enabled: true
-Style/RedundantParentheses:
-  Enabled: true
-Style/RedundantPercentQ:
-  Enabled: true
-Style/RedundantRegexpCharacterClass:
-  Enabled: true
-Style/RedundantRegexpEscape:
-  Enabled: true
-Style/RedundantReturn:
-  Enabled: true
-Style/RedundantSelf:
-  Enabled: true
-Style/RedundantSort:
-  Enabled: true
-Style/RedundantSortBy:
-  Enabled: true
-Style/RegexpLiteral:
-  Enabled: true
-  EnforcedStyle: mixed
-  AllowInnerSlashes: true
-Style/RescueModifier:
-  Enabled: true
-Style/RescueStandardError:
-  Enabled: true
-  EnforcedStyle: explicit
-Style/ReturnNil:
-  Enabled: true
-  EnforcedStyle: return
-Style/Sample:
-  Enabled: true
-Style/SelfAssignment:
-  Enabled: true
-Style/Semicolon:
-  Enabled: true
-Style/SignalException:
-  Enabled: true
-  EnforcedStyle: only_raise
-Style/SingleArgumentDig:
-  Enabled: true
-Style/SingleLineMethods:
-  Enabled: true
-  AllowIfMethodIsEmpty: true
-Style/SpecialGlobalVars:
-  Enabled: true
-  EnforcedStyle: use_english_names
-Style/StabbyLambdaParentheses:
-  Enabled: true
-  EnforcedStyle: require_parentheses
-Style/StaticClass:
-  Enabled: true
-Style/StderrPuts:
-  Enabled: true
-Style/StringConcatenation:
-  Enabled: true
-Style/StringLiterals:
-  Enabled: true
-  EnforcedStyle: single_quotes
-  ConsistentQuotesInMultiline: false # good if only one line has interpolation
-Style/StringLiteralsInInterpolation:
-  Enabled: true
-  EnforcedStyle: single_quotes
-Style/Strip:
-  Enabled: true
-Style/StructInheritance:
-  Enabled: true
-Style/SymbolArray:
-  Enabled: true
-  EnforcedStyle: percent
-Style/SymbolLiteral:
-  Enabled: true
-Style/SymbolProc:
-  Enabled: true
-  AllowMethodsWithArguments: false
-  IgnoredMethods:
-    - respond_to
-    - define_method
-Style/TernaryParentheses:
-  Enabled: true
-  EnforcedStyle: require_no_parentheses
-  AllowSafeAssignment: false
-Style/TrailingBodyOnClass:
-  Enabled: true
-Style/TrailingBodyOnMethodDefinition:
-  Enabled: true
-Style/TrailingBodyOnModule:
-  Enabled: true
-Style/TrailingCommaInArguments:
-  Enabled: true
-  EnforcedStyleForMultiline: consistent_comma
-Style/TrailingCommaInArrayLiteral:
-  Enabled: true
-  EnforcedStyleForMultiline: consistent_comma
-Style/TrailingCommaInHashLiteral:
-  Enabled: true
-  EnforcedStyleForMultiline: consistent_comma
-Style/TrailingMethodEndStatement:
-  Enabled: true
-Style/TrailingUnderscoreVariable:
-  Enabled: true
-  AllowNamedUnderscoreVariables: false
-Style/TrivialAccessors:
-  Enabled: true
-  ExactNameMatch: true
-  AllowPredicates: true
-  AllowDSLWriters: true
-  IgnoreClassMethods: false
-  AllowedMethods:
-    - to_ary
-    - to_a
-    - to_c
-    - to_enum
-    - to_h
-    - to_hash
-    - to_i
-    - to_int
-    - to_io
-    - to_open
-    - to_path
-    - to_proc
-    - to_r
-    - to_regexp
-    - to_str
-    - to_s
-    - to_sym
-Style/UnlessElse:
-  Enabled: true
-Style/UnlessLogicalOperators:
-  Enabled: true
-  EnforcedStyle: forbid_mixed_logical_operators
-Style/UnpackFirst:
-  Enabled: true
-Style/VariableInterpolation:
-  Enabled: true
-Style/WhenThen:
-  Enabled: true
-Style/WhileUntilDo:
-  Enabled: true
-Style/WhileUntilModifier:
-  Enabled: true
-Style/WordArray:
-  Enabled: true
-  EnforcedStyle: percent
-  MinSize: 1
-Style/YodaCondition:
-  Enabled: true
-  EnforcedStyle: forbid_for_all_comparison_operators
-Style/ZeroLengthPredicate:
-  Enabled: true
+# Style/AccessModifierDeclarations:
+#   Enabled: true
+#   EnforcedStyle: group
+# Style/AccessorGrouping:
+#   Enabled: true
+#   EnforcedStyle: grouped
+# Style/Alias:
+#   Enabled: true
+#   EnforcedStyle: prefer_alias_method
+# Style/AndOr:
+#   Enabled: true
+#   EnforcedStyle: always
+# Style/ArgumentsForwarding:
+#   Enabled: true
+#   AllowOnlyRestArgument: true
+# Style/ArrayJoin:
+#   Enabled: true
+# Style/Attr:
+#   Enabled: true
+# Style/AutoResourceCleanup:
+#   Enabled: true
+# Style/BarePercentLiterals:
+#   Enabled: true
+#   EnforcedStyle: bare_percent
+# Style/BeginBlock:
+#   Enabled: true
+# Style/BisectedAttrAccessor:
+#   Enabled: true
+# Style/BlockComments:
+#   Enabled: true
+# Style/BlockDelimiters:
+#   Enabled: true
+#   EnforcedStyle: line_count_based
+#   ProceduralMethods:
+#     # Methods that are known to be procedural in nature but look functional from
+#     # their usage, e.g.
+#     #
+#     #   time = Benchmark.realtime do
+#     #     foo.bar
+#     #   end
+#     #
+#     # Here, the return value of the block is discarded but the return value of
+#     # `Benchmark.realtime` is used.
+#     - benchmark
+#     - bm
+#     - bmbm
+#     - create
+#     - each_with_object
+#     - measure
+#     - new
+#     - realtime
+#     - tap
+#     - with_object
+#   FunctionalMethods:
+#     # Methods that are known to be functional in nature but look procedural from
+#     # their usage, e.g.
+#     #
+#     #   let(:foo) { Foo.new }
+#     #
+#     # Here, the return value of `Foo.new` is used to define a `foo` helper but
+#     # doesn't appear to be used from the return value of `let`.
+#     - let
+#     - let!
+#     - subject
+#     - watch
+#   IgnoredMethods:
+#     # Methods that can be either procedural or functional and cannot be
+#     # categorised from their usage alone, e.g.
+#     #
+#     #   foo = lambda do |x|
+#     #     puts "Hello, #{x}"
+#     #   end
+#     #
+#     #   foo = lambda do |x|
+#     #     x * 100
+#     #   end
+#     #
+#     # Here, it is impossible to tell from the return value of `lambda` whether
+#     # the inner block's return value is significant.
+#     - lambda
+#     - proc
+#     - it
+# Style/CaseEquality:
+#   Enabled: true
+#   AllowOnConstant: false
+# Style/CharacterLiteral:
+#   Enabled: true
+# Style/ClassCheck:
+#   Enabled: true
+#   EnforcedStyle: is_a?
+# Style/ClassEqualityComparison:
+#   Enabled: true
+#   IgnoredMethods:
+#     - ==
+#     - equal?
+#     - eql?
+# Style/ClassMethods:
+#   Enabled: true
+# Style/ClassMethodsDefinitions:
+#   Enabled: true
+#   EnforcedStyle: def_self
+# Style/CollectionCompact:
+#   Enabled: true
+# Style/CollectionMethods:
+#   Enabled: true
+#   PreferredMethods:
+#     collect: 'map'
+#     collect!: 'map!'
+#     inject: 'reduce'
+#     detect: 'find'
+#     find_all: 'select'
+#     member?: 'include?'
+#   MethodsAcceptingSymbol:
+#     - inject
+#     - reduce
+#     - map
+#     - map!
+# Style/ColonMethodCall:
+#   Enabled: true
+# Style/ColonMethodDefinition:
+#   Enabled: true
+# Style/CombinableLoops:
+#   Enabled: true
+# Style/CommandLiteral:
+#   Enabled: true
+#   EnforcedStyle: percent_x
+# Style/CommentAnnotation:
+#   Enabled: true
+#   Keywords:
+#     - TODO
+#     - FIXME
+#   RequireColon: true
+# Style/CommentedKeyword:
+#   Enabled: true
+# Style/ConditionalAssignment:
+#   Enabled: true
+#   EnforcedStyle: assign_to_condition
+#   IncludeTernaryExpressions: true
+#   SingleLineConditionsOnly: true
+# Style/DefWithParentheses:
+#   Enabled: true
+# Style/Dir:
+#   Enabled: true
+# Style/DocumentDynamicEvalDefinition:
+#   Enabled: true
+# Style/DoubleCopDisableDirective:
+#   Enabled: true
+# Style/DoubleNegation:
+#   Enabled: true
+#   EnforcedStyle: allowed_in_returns
+# Style/EachForSimpleLoop:
+#   Enabled: true
+# Style/EmptyBlockParameter:
+#   Enabled: true
+# Style/EmptyCaseCondition:
+#   Enabled: true
+# Style/EmptyElse:
+#   Enabled: true
+#   EnforcedStyle: both
+# Style/EmptyLambdaParameter:
+#   Enabled: true
+# Style/EmptyLiteral:
+#   Enabled: true
+# Style/EmptyMethod:
+#   Enabled: true
+#   EnforcedStyle: compact
+# Style/Encoding:
+#   Enabled: true
+# Style/EndBlock:
+#   Enabled: true
+# Style/EvalWithLocation:
+#   Enabled: true
+# Style/EvenOdd:
+#   Enabled: true
+# Style/ExpandPathArguments:
+#   Enabled: true
+# Style/ExplicitBlockArgument:
+#   Enabled: true
+# Style/ExponentialNotation:
+#   Enabled: true
+#   EnforcedStyle: scientific
+# Style/FloatDivision:
+#   Enabled: true
+#   EnforcedStyle: single_coerce
+# Style/For:
+#   Enabled: true
+#   EnforcedStyle: each
+# Style/FrozenStringLiteralComment:
+#   Enabled: true
+#   EnforcedStyle: always
+# Style/GlobalStdStream:
+#   Enabled: true
+# Style/GlobalVars:
+#   Enabled: true
+# Style/GuardClause:
+#   Enabled: true
+# Style/HashAsLastArrayItem:
+#   Enabled: true
+#   EnforcedStyle: braces
+# Style/HashEachMethods:
+#   Enabled: true
+# Style/HashExcept:
+#   Enabled: true
+# Style/HashLikeCase:
+#   Enabled: true
+# Style/HashSyntax:
+#   Enabled: true
+#   EnforcedStyle: ruby19
+#   UseHashRocketsWithSymbolValues: false
+#   PreferHashRocketsForNonAlnumEndingSymbols: false
+# Style/HashTransformKeys:
+#   Enabled: true
+# Style/HashTransformValues:
+#   Enabled: true
+# Style/IdenticalConditionalBranches:
+#   Enabled: true
+# Style/IfInsideElse:
+#   Enabled: true
+# Style/IfUnlessModifier:
+#   Enabled: true
+# Style/IfUnlessModifierOfIfUnless:
+#   Enabled: true
+# Style/IfWithBooleanLiteralBranches:
+#   Enabled: true
+# Style/IfWithSemicolon:
+#   Enabled: true
+# Style/ImplicitRuntimeError:
+#   Enabled: true
+# Style/InverseMethods:
+#   Enabled: true
+#   InverseMethods:
+#     :any?: :none?
+#     :even?: :odd?
+#     :==: :!=
+#     :=~: :!~
+#     :<: :>=
+#     :>: :<=
+#   InverseBlocks:
+#     :select: :reject
+#     :select!: :reject!
+# Style/IpAddresses:
+#   Enabled: true
+#   AllowedAddresses:
+#     - '::'
+#   Exclude:
+#     - '**/Gemfile'
+# Style/KeywordParametersOrder:
+#   Enabled: true
+# Style/Lambda:
+#   Enabled: true
+#   EnforcedStyle: line_count_dependent
+# Style/LambdaCall:
+#   Enabled: true
+#   EnforcedStyle: call
+# Style/LineEndConcatenation:
+#   Enabled: true
+# Style/MethodCallWithoutArgsParentheses:
+#   Enabled: true
+# Style/MethodDefParentheses:
+#   Enabled: true
+#   EnforcedStyle: require_parentheses
+# Style/MinMax:
+#   Enabled: true
+# Style/MissingRespondToMissing:
+#   Enabled: true
+# Style/MixinGrouping:
+#   Enabled: true
+#   EnforcedStyle: separated
+# Style/MixinUsage:
+#   Enabled: true
+# Style/ModuleFunction:
+#   Enabled: true
+#   EnforcedStyle: module_function
+# Style/MultilineIfModifier:
+#   Enabled: true
+# Style/MultilineIfThen:
+#   Enabled: true
+# Style/MultilineInPatternThen:
+#   Enabled: true
+# Style/MultilineMemoization:
+#   Enabled: true
+#   EnforcedStyle: keyword
+# Style/MultilineMethodSignature:
+#   Enabled: true
+# Style/MultilineTernaryOperator:
+#   Enabled: true
+# Style/MultilineWhenThen:
+#   Enabled: true
+# Style/MultipleComparison:
+#   Enabled: true
+# Style/MutableConstant:
+#   Enabled: true
+#   EnforcedStyle: literals
+# Style/NegatedIf:
+#   Enabled: true
+#   EnforcedStyle: postfix
+# Style/NegatedIfElseCondition:
+#   Enabled: true
+# Style/NegatedUnless:
+#   Enabled: true
+#   EnforcedStyle: both
+# Style/NegatedWhile:
+#   Enabled: true
+# Style/NestedModifier:
+#   Enabled: true
+# Style/NestedParenthesizedCalls:
+#   Enabled: true
+#   AllowedMethods:
+#     - be
+#     - be_a
+#     - be_an
+#     - be_between
+#     - be_falsey
+#     - be_kind_of
+#     - be_instance_of
+#     - be_truthy
+#     - be_within
+#     - eq
+#     - eql
+#     - end_with
+#     - include
+#     - match
+#     - raise_error
+#     - respond_to
+#     - start_with
+# Style/NestedTernaryOperator:
+#   Enabled: true
+# Style/Next:
+#   Enabled: true
+#   EnforcedStyle: skip_modifier_ifs
+# Style/NilComparison:
+#   Enabled: true
+#   EnforcedStyle: predicate
+# Style/NilLambda:
+#   Enabled: true
+# Style/NonNilCheck:
+#   Enabled: true
+#   IncludeSemanticChanges: false
+# Style/Not:
+#   Enabled: true
+# Style/NumericLiteralPrefix:
+#   Enabled: true
+#   EnforcedStyle: zero_with_o
+# Style/NumericLiterals:
+#   Enabled: true
+#   MinDigits: 5
+# Style/OneLineConditional:
+#   Enabled: true
+# Style/OptionalArguments:
+#   Enabled: true
+# Style/OrAssignment:
+#   Enabled: true
+# Style/ParallelAssignment:
+#   Enabled: true
+# Style/ParenthesesAroundCondition:
+#   Enabled: true
+#   AllowSafeAssignment: false
+#   AllowInMultilineConditionals: false
+# Style/PercentLiteralDelimiters:
+#   Enabled: true
+#   PreferredDelimiters:
+#     default: ()
+#     '%i': '[]'
+#     '%I': '[]'
+#     '%r': '{}'
+#     '%w': '[]'
+#     '%W': '[]'
+# Style/PercentQLiterals:
+#   Enabled: true
+#   EnforcedStyle: lower_case_q
+# Style/PerlBackrefs:
+#   Enabled: true
+# Style/PreferredHashMethods:
+#   Enabled: true
+#   EnforcedStyle: verbose
+# Style/Proc:
+#   Enabled: true
+# Style/QuotedSymbols:
+#   Enabled: true
+#   EnforcedStyle: same_as_string_literals
+# Style/RaiseArgs:
+#   Enabled: true
+#   EnforcedStyle: compact
+# Style/RandomWithOffset:
+#   Enabled: true
+# Style/RedundantAssignment:
+#   Enabled: true
+# Style/RedundantBegin:
+#   Enabled: true
+# Style/RedundantCapitalW:
+#   Enabled: true
+# Style/RedundantCondition:
+#   Enabled: true
+# Style/RedundantConditional:
+#   Enabled: true
+# Style/RedundantFileExtensionInRequire:
+#   Enabled: true
+# Style/RedundantFreeze:
+#   Enabled: true
+# Style/RedundantInterpolation:
+#   Enabled: true
+# Style/RedundantParentheses:
+#   Enabled: true
+# Style/RedundantPercentQ:
+#   Enabled: true
+# Style/RedundantRegexpCharacterClass:
+#   Enabled: true
+# Style/RedundantRegexpEscape:
+#   Enabled: true
+# Style/RedundantReturn:
+#   Enabled: true
+# Style/RedundantSelf:
+#   Enabled: true
+# Style/RedundantSort:
+#   Enabled: true
+# Style/RedundantSortBy:
+#   Enabled: true
+# Style/RegexpLiteral:
+#   Enabled: true
+#   EnforcedStyle: mixed
+#   AllowInnerSlashes: true
+# Style/RescueModifier:
+#   Enabled: true
+# Style/RescueStandardError:
+#   Enabled: true
+#   EnforcedStyle: explicit
+# Style/ReturnNil:
+#   Enabled: true
+#   EnforcedStyle: return
+# Style/Sample:
+#   Enabled: true
+# Style/SelfAssignment:
+#   Enabled: true
+# Style/Semicolon:
+#   Enabled: true
+# Style/SignalException:
+#   Enabled: true
+#   EnforcedStyle: only_raise
+# Style/SingleArgumentDig:
+#   Enabled: true
+# Style/SingleLineMethods:
+#   Enabled: true
+#   AllowIfMethodIsEmpty: true
+# Style/SpecialGlobalVars:
+#   Enabled: true
+#   EnforcedStyle: use_english_names
+# Style/StabbyLambdaParentheses:
+#   Enabled: true
+#   EnforcedStyle: require_parentheses
+# Style/StaticClass:
+#   Enabled: true
+# Style/StderrPuts:
+#   Enabled: true
+# Style/StringConcatenation:
+#   Enabled: true
+# Style/StringLiterals:
+#   Enabled: true
+#   EnforcedStyle: single_quotes
+#   ConsistentQuotesInMultiline: false # good if only one line has interpolation
+# Style/StringLiteralsInInterpolation:
+#   Enabled: true
+#   EnforcedStyle: single_quotes
+# Style/Strip:
+#   Enabled: true
+# Style/StructInheritance:
+#   Enabled: true
+# Style/SymbolArray:
+#   Enabled: true
+#   EnforcedStyle: percent
+# Style/SymbolLiteral:
+#   Enabled: true
+# Style/SymbolProc:
+#   Enabled: true
+#   AllowMethodsWithArguments: false
+#   IgnoredMethods:
+#     - respond_to
+#     - define_method
+# Style/TernaryParentheses:
+#   Enabled: true
+#   EnforcedStyle: require_no_parentheses
+#   AllowSafeAssignment: false
+# Style/TrailingBodyOnClass:
+#   Enabled: true
+# Style/TrailingBodyOnMethodDefinition:
+#   Enabled: true
+# Style/TrailingBodyOnModule:
+#   Enabled: true
+# Style/TrailingCommaInArguments:
+#   Enabled: true
+#   EnforcedStyleForMultiline: consistent_comma
+# Style/TrailingCommaInArrayLiteral:
+#   Enabled: true
+#   EnforcedStyleForMultiline: consistent_comma
+# Style/TrailingCommaInHashLiteral:
+#   Enabled: true
+#   EnforcedStyleForMultiline: consistent_comma
+# Style/TrailingMethodEndStatement:
+#   Enabled: true
+# Style/TrailingUnderscoreVariable:
+#   Enabled: true
+#   AllowNamedUnderscoreVariables: false
+# Style/TrivialAccessors:
+#   Enabled: true
+#   ExactNameMatch: true
+#   AllowPredicates: true
+#   AllowDSLWriters: true
+#   IgnoreClassMethods: false
+#   AllowedMethods:
+#     - to_ary
+#     - to_a
+#     - to_c
+#     - to_enum
+#     - to_h
+#     - to_hash
+#     - to_i
+#     - to_int
+#     - to_io
+#     - to_open
+#     - to_path
+#     - to_proc
+#     - to_r
+#     - to_regexp
+#     - to_str
+#     - to_s
+#     - to_sym
+# Style/UnlessElse:
+#   Enabled: true
+# Style/UnlessLogicalOperators:
+#   Enabled: true
+#   EnforcedStyle: forbid_mixed_logical_operators
+# Style/UnpackFirst:
+#   Enabled: true
+# Style/VariableInterpolation:
+#   Enabled: true
+# Style/WhenThen:
+#   Enabled: true
+# Style/WhileUntilDo:
+#   Enabled: true
+# Style/WhileUntilModifier:
+#   Enabled: true
+# Style/WordArray:
+#   Enabled: true
+#   EnforcedStyle: percent
+#   MinSize: 1
+# Style/YodaCondition:
+#   Enabled: true
+#   EnforcedStyle: forbid_for_all_comparison_operators
+# Style/ZeroLengthPredicate:
+#   Enabled: true
 
-##########################
-### Rails Requirements ###
-##########################
+# ##########################
+# ### Rails Requirements ###
+# ##########################
 
-Rails/ActionFilter:
-  Enabled: true
-  EnforcedStyle: action
-Rails/ActiveRecordCallbacksOrder:
-  Enabled: true
-Rails/ActiveSupportAliases:
-  Enabled: true
-Rails/AddColumnIndex:
-  Enabled: true
-Rails/AfterCommitOverride:
-  Enabled: true
-Rails/ApplicationController:
-  Enabled: true
-Rails/ApplicationRecord:
-  Enabled: true
-Rails/ArelStar:
-  Enabled: true
-Rails/AttributeDefaultBlockValue:
-  Enabled: true
-Rails/BelongsTo:
-  Enabled: true
-Rails/Blank:
-  Enabled: true
-  NilOrEmpty: true
-  NotPresent: true
-  UnlessPresent: true
-Rails/BulkChangeTable:
-  Enabled: true
-Rails/CreateTableWithTimestamps:
-  Enabled: true
-Rails/Date:
-  Enabled: true
-Rails/DefaultScope:
-  Enabled: true
-Rails/Delegate:
-  Enabled: true
-Rails/DelegateAllowBlank:
-  Enabled: true
-Rails/DynamicFindBy:
-  Enabled: true
-Rails/EagerEvaluationLogMessage:
-  Enabled: true
-Rails/EnumHash:
-  Enabled: true
-Rails/EnumUniqueness:
-  Enabled: true
-Rails/EnvironmentComparison:
-  Enabled: true
-Rails/EnvironmentVariableAccess:
-  Enabled: true
-Rails/Exit:
-  Enabled: true
-Rails/ExpandedDateRange:
-  Enabled: true
-Rails/FilePath:
-  Enabled: true
-  EnforcedStyle: arguments
-Rails/FindBy:
-  Enabled: true
-  IgnoreWhereFirst: false
-Rails/FindById:
-  Enabled: true
-Rails/FindEach:
-  Enabled: true
-Rails/HasManyOrHasOneDependent:
-  Enabled: true
-Rails/HttpPositionalArguments:
-  Enabled: true
-Rails/HttpStatus:
-  Enabled: true
-  EnforcedStyle: symbolic
-Rails/IgnoredSkipActionFilterOption:
-  Enabled: true
-Rails/IndexBy:
-  Enabled: true
-Rails/IndexWith:
-  Enabled: true
-Rails/Inquiry:
-  Enabled: true
-Rails/InverseOf:
-  Enabled: true
-Rails/LexicallyScopedActionFilter:
-  Enabled: true
-Rails/MatchRoute:
-  Enabled: true
-Rails/NegateInclude:
-  Enabled: true
-Rails/OrderById:
-  Enabled: true
-Rails/Output:
-  Enabled: true
-Rails/Pick:
-  Enabled: true
-Rails/Pluck:
-  Enabled: true
-Rails/PluckId:
-  Enabled: true
-Rails/PluckInWhere:
-  Enabled: true
-  EnforcedStyle: conservative
-Rails/PluralizationGrammar:
-  Enabled: true
-Rails/Presence:
-  Enabled: true
-Rails/Present:
-  Enabled: true
-  NotNilAndNotEmpty: true
-  NotBlank: true
-  UnlessBlank: true
-Rails/ReadWriteAttribute:
-  Enabled: true
-Rails/RedundantAllowNil:
-  Enabled: true
-Rails/RedundantForeignKey:
-  Enabled: true
-Rails/RedundantReceiverInWithOptions:
-  Enabled: true
-Rails/ReflectionClassName:
-  Enabled: true
-Rails/RelativeDateConstant:
-  Enabled: true
-Rails/RenderPlainText:
-  Enabled: true
-Rails/RequestReferer:
-  Enabled: true
-  EnforcedStyle: referrer
-Rails/SafeNavigation:
-  Enabled: true
-  ConvertTry: true
-Rails/SafeNavigationWithBlank:
-  Enabled: true
-Rails/SaveBang:
-  Enabled: true
-  AllowImplicitReturn: true
-Rails/ScopeArgs:
-  Enabled: true
-Rails/SkipsModelValidations:
-  Enabled: true
-  AllowedMethods:
-    - touch
-Rails/TimeZone:
-  Enabled: true
-Rails/UniqBeforePluck:
-  Enabled: true
-  EnforcedStyle: conservative
-Rails/UniqueValidationWithoutIndex:
-  Enabled: true
-Rails/UnknownEnv:
-  Enabled: true
-  Environments:
-    - development
-    - test
-    - staging
-    - production
-Rails/Validation:
-  Enabled: true
-Rails/WhereEquals:
-  Enabled: true
-Rails/WhereNot:
-  Enabled: true
+# Rails/ActionFilter:
+#   Enabled: true
+#   EnforcedStyle: action
+# Rails/ActiveRecordCallbacksOrder:
+#   Enabled: true
+# Rails/ActiveSupportAliases:
+#   Enabled: true
+# Rails/AddColumnIndex:
+#   Enabled: true
+# Rails/AfterCommitOverride:
+#   Enabled: true
+# Rails/ApplicationController:
+#   Enabled: true
+# Rails/ApplicationRecord:
+#   Enabled: true
+# Rails/ArelStar:
+#   Enabled: true
+# Rails/AttributeDefaultBlockValue:
+#   Enabled: true
+# Rails/BelongsTo:
+#   Enabled: true
+# Rails/Blank:
+#   Enabled: true
+#   NilOrEmpty: true
+#   NotPresent: true
+#   UnlessPresent: true
+# Rails/BulkChangeTable:
+#   Enabled: true
+# Rails/CreateTableWithTimestamps:
+#   Enabled: true
+# Rails/Date:
+#   Enabled: true
+# Rails/DefaultScope:
+#   Enabled: true
+# Rails/Delegate:
+#   Enabled: true
+# Rails/DelegateAllowBlank:
+#   Enabled: true
+# Rails/DynamicFindBy:
+#   Enabled: true
+# Rails/EagerEvaluationLogMessage:
+#   Enabled: true
+# Rails/EnumHash:
+#   Enabled: true
+# Rails/EnumUniqueness:
+#   Enabled: true
+# Rails/EnvironmentComparison:
+#   Enabled: true
+# Rails/EnvironmentVariableAccess:
+#   Enabled: true
+# Rails/Exit:
+#   Enabled: true
+# Rails/ExpandedDateRange:
+#   Enabled: true
+# Rails/FilePath:
+#   Enabled: true
+#   EnforcedStyle: arguments
+# Rails/FindBy:
+#   Enabled: true
+#   IgnoreWhereFirst: false
+# Rails/FindById:
+#   Enabled: true
+# Rails/FindEach:
+#   Enabled: true
+# Rails/HasManyOrHasOneDependent:
+#   Enabled: true
+# Rails/HttpPositionalArguments:
+#   Enabled: true
+# Rails/HttpStatus:
+#   Enabled: true
+#   EnforcedStyle: symbolic
+# Rails/IgnoredSkipActionFilterOption:
+#   Enabled: true
+# Rails/IndexBy:
+#   Enabled: true
+# Rails/IndexWith:
+#   Enabled: true
+# Rails/Inquiry:
+#   Enabled: true
+# Rails/InverseOf:
+#   Enabled: true
+# Rails/LexicallyScopedActionFilter:
+#   Enabled: true
+# Rails/MatchRoute:
+#   Enabled: true
+# Rails/NegateInclude:
+#   Enabled: true
+# Rails/OrderById:
+#   Enabled: true
+# Rails/Output:
+#   Enabled: true
+# Rails/Pick:
+#   Enabled: true
+# Rails/Pluck:
+#   Enabled: true
+# Rails/PluckId:
+#   Enabled: true
+# Rails/PluckInWhere:
+#   Enabled: true
+#   EnforcedStyle: conservative
+# Rails/PluralizationGrammar:
+#   Enabled: true
+# Rails/Presence:
+#   Enabled: true
+# Rails/Present:
+#   Enabled: true
+#   NotNilAndNotEmpty: true
+#   NotBlank: true
+#   UnlessBlank: true
+# Rails/ReadWriteAttribute:
+#   Enabled: true
+# Rails/RedundantAllowNil:
+#   Enabled: true
+# Rails/RedundantForeignKey:
+#   Enabled: true
+# Rails/RedundantReceiverInWithOptions:
+#   Enabled: true
+# Rails/ReflectionClassName:
+#   Enabled: true
+# Rails/RelativeDateConstant:
+#   Enabled: true
+# Rails/RenderPlainText:
+#   Enabled: true
+# Rails/RequestReferer:
+#   Enabled: true
+#   EnforcedStyle: referrer
+# Rails/SafeNavigation:
+#   Enabled: true
+#   ConvertTry: true
+# Rails/SafeNavigationWithBlank:
+#   Enabled: true
+# Rails/SaveBang:
+#   Enabled: true
+#   AllowImplicitReturn: true
+# Rails/ScopeArgs:
+#   Enabled: true
+# Rails/SkipsModelValidations:
+#   Enabled: true
+#   AllowedMethods:
+#     - touch
+# Rails/TimeZone:
+#   Enabled: true
+# Rails/UniqBeforePluck:
+#   Enabled: true
+#   EnforcedStyle: conservative
+# Rails/UniqueValidationWithoutIndex:
+#   Enabled: true
+# Rails/UnknownEnv:
+#   Enabled: true
+#   Environments:
+#     - development
+#     - test
+#     - staging
+#     - production
+# Rails/Validation:
+#   Enabled: true
+# Rails/WhereEquals:
+#   Enabled: true
+# Rails/WhereNot:
+#   Enabled: true
 
-##########################
-### RSpec Requirements ###
-##########################
+# ##########################
+# ### RSpec Requirements ###
+# ##########################
 
-RSpec/AlignLetLeftBrace:
-  Enabled: true
-RSpec/AroundBlock:
-  Enabled: true
-RSpec/Be:
-  Enabled: true
-RSpec/BeEql:
-  Enabled: true
-RSpec/BeforeAfterAll:
-  Enabled: true
-RSpec/ContextMethod:
-  Enabled: true
-RSpec/ContextWording:
-  Enabled: true
-  Prefixes:
-    - when
-    - with
-    - without
-RSpec/DescribeClass:
-  Enabled: true
-  IgnoredMetadata:
-    type:
-      - request
-RSpec/DescribedClass:
-  Enabled: true
-  EnforcedStyle: described_class
-RSpec/DescribedClassModuleWrapping:
-  Enabled: true
-RSpec/EmptyExampleGroup:
-  Enabled: true
-RSpec/EmptyHook:
-  Enabled: true
-RSpec/EmptyLineAfterExample:
-  Enabled: true
-  AllowConsecutiveOneLiners: true
-RSpec/EmptyLineAfterExampleGroup:
-  Enabled: true
-RSpec/EmptyLineAfterFinalLet:
-  Enabled: true
-RSpec/EmptyLineAfterHook:
-  Enabled: true
-RSpec/EmptyLineAfterSubject:
-  Enabled: true
-RSpec/ExampleWithoutDescription:
-  Enabled: true
-  EnforcedStyle: single_line_only
-RSpec/ExampleWording:
-  Enabled: true
-RSpec/ExpectActual:
-  Enabled: true
-RSpec/ExpectChange:
-  Enabled: true
-  EnforcedStyle: method_call
-RSpec/ExpectInHook:
-  Enabled: true
-RSpec/FilePath:
-  Enabled: true
-  IgnoreMethods: true
-RSpec/Focus:
-  Enabled: true
-RSpec/HookArgument:
-  Enabled: true
-  EnforcedStyle: implicit
-RSpec/HooksBeforeExamples:
-  Enabled: true
-RSpec/IdenticalEqualityAssertion:
-  Enabled: true
-RSpec/ImplicitBlockExpectation:
-  Enabled: true
-RSpec/ImplicitExpect:
-  Enabled: true
-  EnforcedStyle: is_expected
-RSpec/ImplicitSubject:
-  Enabled: true
-  EnforcedStyle: single_line_only
-RSpec/InstanceSpy:
-  Enabled: true
-RSpec/InstanceVariable:
-  Enabled: true
-RSpec/IteratedExpectation:
-  Enabled: true
-RSpec/LeadingSubject:
-  Enabled: true
-RSpec/LeakyConstantDeclaration:
-  Enabled: true
-RSpec/LetBeforeExamples:
-  Enabled: true
-RSpec/MessageSpies:
-  Enabled: true
-  EnforcedStyle: have_received
-RSpec/MissingExampleGroupArgument:
-  Enabled: true
-RSpec/MultipleDescribes:
-  Enabled: true
-RSpec/MultipleExpectations:
-  Enabled: true
-  Max: 3
-RSpec/MultipleSubjects:
-  Enabled: true
-RSpec/NamedSubject:
-  Enabled: true
-  IgnoreSharedExamples: true
-RSpec/NotToNot:
-  Enabled: true
-  EnforcedStyle: not_to
-RSpec/PredicateMatcher:
-  Enabled: true
-  Strict: false
-  EnforcedStyle: inflected
-RSpec/ReceiveCounts:
-  Enabled: true
-RSpec/ReceiveNever:
-  Enabled: true
-RSpec/RepeatedDescription:
-  Enabled: true
-RSpec/RepeatedExample:
-  Enabled: true
-RSpec/RepeatedExampleGroupDescription:
-  Enabled: true
-RSpec/RepeatedIncludeExample:
-  Enabled: true
-RSpec/ReturnFromStub:
-  Enabled: true
-  EnforcedStyle: and_return
-RSpec/ScatteredLet:
-  Enabled: true
-RSpec/ScatteredSetup:
-  Enabled: true
-RSpec/SharedContext:
-  Enabled: true
-RSpec/SharedExamples:
-  Enabled: true
-RSpec/SingleArgumentMessageChain:
-  Enabled: true
-RSpec/StubbedMock:
-  Enabled: true
-RSpec/SubjectStub:
-  Enabled: true
-RSpec/UnspecifiedException:
-  Enabled: true
-RSpec/VariableDefinition:
-  Enabled: true
-  EnforcedStyle: symbols
-RSpec/VariableName:
-  Enabled: true
-  EnforcedStyle: snake_case
-RSpec/VoidExpect:
-  Enabled: true
-RSpec/Yield:
-  Enabled: true
+# RSpec/AlignLetLeftBrace:
+#   Enabled: true
+# RSpec/AroundBlock:
+#   Enabled: true
+# RSpec/Be:
+#   Enabled: true
+# RSpec/BeEql:
+#   Enabled: true
+# RSpec/BeforeAfterAll:
+#   Enabled: true
+# RSpec/ContextMethod:
+#   Enabled: true
+# RSpec/ContextWording:
+#   Enabled: true
+#   Prefixes:
+#     - when
+#     - with
+#     - without
+# RSpec/DescribeClass:
+#   Enabled: true
+#   IgnoredMetadata:
+#     type:
+#       - request
+# RSpec/DescribedClass:
+#   Enabled: true
+#   EnforcedStyle: described_class
+# RSpec/DescribedClassModuleWrapping:
+#   Enabled: true
+# RSpec/EmptyExampleGroup:
+#   Enabled: true
+# RSpec/EmptyHook:
+#   Enabled: true
+# RSpec/EmptyLineAfterExample:
+#   Enabled: true
+#   AllowConsecutiveOneLiners: true
+# RSpec/EmptyLineAfterExampleGroup:
+#   Enabled: true
+# RSpec/EmptyLineAfterFinalLet:
+#   Enabled: true
+# RSpec/EmptyLineAfterHook:
+#   Enabled: true
+# RSpec/EmptyLineAfterSubject:
+#   Enabled: true
+# RSpec/ExampleWithoutDescription:
+#   Enabled: true
+#   EnforcedStyle: single_line_only
+# RSpec/ExampleWording:
+#   Enabled: true
+# RSpec/ExpectActual:
+#   Enabled: true
+# RSpec/ExpectChange:
+#   Enabled: true
+#   EnforcedStyle: method_call
+# RSpec/ExpectInHook:
+#   Enabled: true
+# RSpec/FilePath:
+#   Enabled: true
+#   IgnoreMethods: true
+# RSpec/Focus:
+#   Enabled: true
+# RSpec/HookArgument:
+#   Enabled: true
+#   EnforcedStyle: implicit
+# RSpec/HooksBeforeExamples:
+#   Enabled: true
+# RSpec/IdenticalEqualityAssertion:
+#   Enabled: true
+# RSpec/ImplicitBlockExpectation:
+#   Enabled: true
+# RSpec/ImplicitExpect:
+#   Enabled: true
+#   EnforcedStyle: is_expected
+# RSpec/ImplicitSubject:
+#   Enabled: true
+#   EnforcedStyle: single_line_only
+# RSpec/InstanceSpy:
+#   Enabled: true
+# RSpec/InstanceVariable:
+#   Enabled: true
+# RSpec/IteratedExpectation:
+#   Enabled: true
+# RSpec/LeadingSubject:
+#   Enabled: true
+# RSpec/LeakyConstantDeclaration:
+#   Enabled: true
+# RSpec/LetBeforeExamples:
+#   Enabled: true
+# RSpec/MessageSpies:
+#   Enabled: true
+#   EnforcedStyle: have_received
+# RSpec/MissingExampleGroupArgument:
+#   Enabled: true
+# RSpec/MultipleDescribes:
+#   Enabled: true
+# RSpec/MultipleExpectations:
+#   Enabled: true
+#   Max: 3
+# RSpec/MultipleSubjects:
+#   Enabled: true
+# RSpec/NamedSubject:
+#   Enabled: true
+#   IgnoreSharedExamples: true
+# RSpec/NotToNot:
+#   Enabled: true
+#   EnforcedStyle: not_to
+# RSpec/PredicateMatcher:
+#   Enabled: true
+#   Strict: false
+#   EnforcedStyle: inflected
+# RSpec/ReceiveCounts:
+#   Enabled: true
+# RSpec/ReceiveNever:
+#   Enabled: true
+# RSpec/RepeatedDescription:
+#   Enabled: true
+# RSpec/RepeatedExample:
+#   Enabled: true
+# RSpec/RepeatedExampleGroupDescription:
+#   Enabled: true
+# RSpec/RepeatedIncludeExample:
+#   Enabled: true
+# RSpec/ReturnFromStub:
+#   Enabled: true
+#   EnforcedStyle: and_return
+# RSpec/ScatteredLet:
+#   Enabled: true
+# RSpec/ScatteredSetup:
+#   Enabled: true
+# RSpec/SharedContext:
+#   Enabled: true
+# RSpec/SharedExamples:
+#   Enabled: true
+# RSpec/SingleArgumentMessageChain:
+#   Enabled: true
+# RSpec/StubbedMock:
+#   Enabled: true
+# RSpec/SubjectStub:
+#   Enabled: true
+# RSpec/UnspecifiedException:
+#   Enabled: true
+# RSpec/VariableDefinition:
+#   Enabled: true
+#   EnforcedStyle: symbols
+# RSpec/VariableName:
+#   Enabled: true
+#   EnforcedStyle: snake_case
+# RSpec/VoidExpect:
+#   Enabled: true
+# RSpec/Yield:
+#   Enabled: true
 
-################################
-### Performance Requirements ###
-################################
+# ################################
+# ### Performance Requirements ###
+# ################################
 
 
-Performance/BindCall:
-  Enabled: true
-Performance/BlockGivenWithExplicitBlock:
-  Enabled: true
-Performance/Caller:
-  Enabled: true
-Performance/CaseWhenSplat:
-  Enabled: true
-Performance/Casecmp:
-  Enabled: true
-Performance/ChainArrayAllocation:
-  Enabled: true
-Performance/CollectionLiteralInLoop:
-  Enabled: true
-Performance/CompareWithBlock:
-  Enabled: true
-Performance/Count:
-  Enabled: true
-Performance/DeletePrefix:
-  Enabled: true
-  SafeMultiline: true
-Performance/DeleteSuffix:
-  Enabled: true
-  SafeMultiline: true
-Performance/Detect:
-  Enabled: true
-Performance/DoubleStartEndWith:
-  Enabled: true
-Performance/EndWith:
-  Enabled: true
-Performance/FixedSize:
-  Enabled: true
-Performance/FlatMap:
-  Enabled: true
-Performance/InefficientHashSearch:
-  Enabled: true
-Performance/IoReadlines:
-  Enabled: true
-Performance/RangeInclude:
-  Enabled: true
-Performance/RedundantBlockCall:
-  Enabled: true
-Performance/RedundantMatch:
-  Enabled: true
-Performance/RedundantMerge:
-  Enabled: true
-Performance/RedundantSortBlock:
-  Enabled: true
-Performance/RedundantSplitRegexpArgument:
-  Enabled: true
-Performance/RedundantStringChars:
-  Enabled: true
-Performance/RegexpMatch:
-  Enabled: true
-Performance/ReverseEach:
-  Enabled: true
-Performance/ReverseFirst:
-  Enabled: true
-Performance/SelectMap:
-  Enabled: true
-Performance/Size:
-  Enabled: true
-Performance/SortReverse:
-  Enabled: true
-Performance/Squeeze:
-  Enabled: true
-Performance/StartWith:
-  Enabled: true
-  SafeMultiline: true
-Performance/StringInclude:
-  Enabled: true
-Performance/StringReplacement:
-  Enabled: true
-Performance/Sum:
-  Enabled: true
-Performance/TimesMap:
-  Enabled: true
-Performance/UnfreezeString:
-  Enabled: true
-Performance/UriDefaultParser:
-  Enabled: true
+# Performance/BindCall:
+#   Enabled: true
+# Performance/BlockGivenWithExplicitBlock:
+#   Enabled: true
+# Performance/Caller:
+#   Enabled: true
+# Performance/CaseWhenSplat:
+#   Enabled: true
+# Performance/Casecmp:
+#   Enabled: true
+# Performance/ChainArrayAllocation:
+#   Enabled: true
+# Performance/CollectionLiteralInLoop:
+#   Enabled: true
+# Performance/CompareWithBlock:
+#   Enabled: true
+# Performance/Count:
+#   Enabled: true
+# Performance/DeletePrefix:
+#   Enabled: true
+#   SafeMultiline: true
+# Performance/DeleteSuffix:
+#   Enabled: true
+#   SafeMultiline: true
+# Performance/Detect:
+#   Enabled: true
+# Performance/DoubleStartEndWith:
+#   Enabled: true
+# Performance/EndWith:
+#   Enabled: true
+# Performance/FixedSize:
+#   Enabled: true
+# Performance/FlatMap:
+#   Enabled: true
+# Performance/InefficientHashSearch:
+#   Enabled: true
+# Performance/IoReadlines:
+#   Enabled: true
+# Performance/RangeInclude:
+#   Enabled: true
+# Performance/RedundantBlockCall:
+#   Enabled: true
+# Performance/RedundantMatch:
+#   Enabled: true
+# Performance/RedundantMerge:
+#   Enabled: true
+# Performance/RedundantSortBlock:
+#   Enabled: true
+# Performance/RedundantSplitRegexpArgument:
+#   Enabled: true
+# Performance/RedundantStringChars:
+#   Enabled: true
+# Performance/RegexpMatch:
+#   Enabled: true
+# Performance/ReverseEach:
+#   Enabled: true
+# Performance/ReverseFirst:
+#   Enabled: true
+# Performance/SelectMap:
+#   Enabled: true
+# Performance/Size:
+#   Enabled: true
+# Performance/SortReverse:
+#   Enabled: true
+# Performance/Squeeze:
+#   Enabled: true
+# Performance/StartWith:
+#   Enabled: true
+#   SafeMultiline: true
+# Performance/StringInclude:
+#   Enabled: true
+# Performance/StringReplacement:
+#   Enabled: true
+# Performance/Sum:
+#   Enabled: true
+# Performance/TimesMap:
+#   Enabled: true
+# Performance/UnfreezeString:
+#   Enabled: true
+# Performance/UriDefaultParser:
+#   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -141,8 +141,6 @@ Layout/EmptyLinesAroundAccessModifier:
   Enabled: true
 Layout/EmptyLinesAroundArguments:
   Enabled: true
-Layout/EmptyLinesAroundArguments:
-  Enabled: true
 Layout/EmptyLinesAroundBeginBody:
   Enabled: true
 Layout/EmptyLinesAroundBlockBody:
@@ -257,7 +255,7 @@ Layout/SpaceAfterSemicolon:
   Enabled: true
 Layout/SpaceAroundBlockParameters:
   Enabled: true
-  EnforcedStyle: no_space
+  EnforcedStyleInsidePipes: no_space
 Layout/SpaceAroundEqualsInParameterDefault:
   Enabled: true
   EnforcedStyle: space
@@ -312,9 +310,6 @@ Layout/SpaceInsideReferenceBrackets:
   Enabled: true
   EnforcedStyle: no_space
   EnforcedStyleForEmptyBrackets: no_space
-Layout/SpaceInsideReferenceBrackets:
-  Enabled: true
-  EnforcedStyle: no_space
 Layout/TrailingEmptyLines:
   Enabled: true
   EnforcedStyle: final_newline
@@ -322,1346 +317,1346 @@ Layout/TrailingWhitespace:
   Enabled: true
   AllowInHeredoc: false
 
-# ###############
-# ### Linting ###
-# ###############
+###############
+### Linting ###
+###############
 
-# Lint/AmbiguousAssignment:
-#   Enabled: true
-# Lint/AmbiguousBlockAssociation:
-#   Enabled: true
-# Lint/AmbiguousOperator:
-#   Enabled: true
-# Lint/AmbiguousRegexpLiteral:
-#   Enabled: true
-# Lint/AssignmentInCondition:
-#   Enabled: true
-# Lint/BigDecimalNew:
-#   Enabled: true
-# Lint/CircularArgumentReference:
-#   Enabled: true
-# Lint/ConstantDefinitionInBlock:
-#   Enabled: true
-# Lint/Debugger:
-#   Enabled: true
-# Lint/DeprecatedClassMethods:
-#   Enabled: true
-# Lint/DeprecatedConstants:
-#   Enabled: true
-# Lint/DeprecatedOpenSSLConstant:
-#   Enabled: true
-# Lint/DisjunctiveAssignmentInConstructor:
-#   Enabled: true
-# Lint/DuplicateBranch:
-#   Enabled: true
-# Lint/DuplicateCaseCondition:
-#   Enabled: true
-# Lint/DuplicateElsifCondition:
-#   Enabled: true
-# Lint/DuplicateHashKey:
-#   Enabled: true
-# Lint/DuplicateMethods:
-#   Enabled: true
-# Lint/DuplicateRegexpCharacterClassElement:
-#   Enabled: true
-# Lint/DuplicateRequire:
-#   Enabled: true
-# Lint/DuplicateRescueException:
-#   Enabled: true
-# Lint/EachWithObjectArgument:
-#   Enabled: true
-# Lint/ElseLayout:
-#   Enabled: true
-# Lint/EmptyBlock:
-#   Enabled: true
-#   AllowEmptyLambdas: true
-# Lint/EmptyConditionalBody:
-#   Enabled: true
-# Lint/EmptyEnsure:
-#   Enabled: true
-# Lint/EmptyExpression:
-#   Enabled: true
-# Lint/EmptyFile:
-#   Enabled: true
-# Lint/EmptyInPattern:
-#   Enabled: true
-# Lint/EmptyInterpolation:
-#   Enabled: true
-# Lint/EmptyWhen:
-#   Enabled: true
-# Lint/EnsureReturn:
-#   Enabled: true
-# Lint/ErbNewArguments:
-#   Enabled: true
-# Lint/FlipFlop:
-#   Enabled: true
-# Lint/FloatComparison:
-#   Enabled: true
-# Lint/FloatOutOfRange:
-#   Enabled: true
-# Lint/FormatParameterMismatch:
-#   Enabled: true
-# Lint/HeredocMethodCallPosition:
-#   Enabled: true
-# Lint/ImplicitStringConcatenation:
-#   Enabled: true
-# Lint/IneffectiveAccessModifier:
-#   Enabled: true
-# Lint/InheritException:
-#   Enabled: true
-#   EnforcedStyle: standard_error
-# Lint/InterpolationCheck:
-#   Enabled: true
-# Lint/LiteralAsCondition:
-#   Enabled: true
-# Lint/LiteralInInterpolation:
-#   Enabled: true
-# Lint/Loop:
-#   Enabled: true
-# Lint/MissingCopEnableDirective:
-#   Enabled: true
-# Lint/MissingSuper:
-#   Enabled: true
-# Lint/MixedRegexpCaptureTypes:
-#   Enabled: true
-# Lint/MultipleComparison:
-#   Enabled: true
-# Lint/NestedMethodDefinition:
-#   Enabled: true
-# Lint/NestedPercentLiteral:
-#   Enabled: true
-# Lint/NextWithoutAccumulator:
-#   Enabled: true
-# Lint/NoReturnInBeginEndBlocks:
-#   Enabled: true
-# Lint/NonDeterministicRequireOrder:
-#   Enabled: true
-# Lint/OrAssignmentToConstant:
-#   Enabled: true
-# Lint/OrderedMagicComments:
-#   Enabled: true
-# Lint/ParenthesesAsGroupedExpression:
-#   Enabled: true
-# Lint/PercentStringArray:
-#   Enabled: true
-# Lint/PercentSymbolArray:
-#   Enabled: true
-# Lint/RaiseException:
-#   Enabled: true
-# Lint/RandOne:
-#   Enabled: true
-# Lint/RedundantCopDisableDirective:
-#   Enabled: true
-# Lint/RedundantCopEnableDirective:
-#   Enabled: true
-# Lint/RedundantDirGlobSort:
-#   Enabled: true
-# Lint/RedundantRequireStatement:
-#   Enabled: true
-# Lint/RedundantSafeNavigation:
-#   Enabled: true
-# Lint/RedundantSplatExpansion:
-#   Enabled: true
-#   AllowPercentLiteralArrayArgument: true
-# Lint/RedundantStringCoercion:
-#   Enabled: true
-# Lint/RedundantWithIndex:
-#   Enabled: true
-# Lint/RedundantWithObject:
-#   Enabled: true
-# Lint/RegexpAsCondition:
-#   Enabled: true
-# Lint/RequireParentheses:
-#   Enabled: true
-# Lint/RescueException:
-#   Enabled: true
-# Lint/RescueType:
-#   Enabled: true
-# Lint/ReturnInVoidContext:
-#   Enabled: true
-# Lint/SafeNavigationChain:
-#   Enabled: true
-# Lint/SafeNavigationConsistency:
-#   Enabled: true
-# Lint/SafeNavigationWithEmpty:
-#   Enabled: true
-# Lint/ScriptPermission:
-#   Enabled: true
-# Lint/SelfAssignment:
-#   Enabled: true
-# Lint/SendWithMixinArgument:
-#   Enabled: true
-# Lint/ShadowedArgument:
-#   Enabled: true
-# Lint/ShadowedException:
-#   Enabled: true
-# Lint/ShadowingOuterLocalVariable:
-#   Enabled: true
-# Lint/StructNewOverride:
-#   Enabled: true
-# Lint/SuppressedException:
-#   Enabled: true
-# Lint/Syntax:
-#   Enabled: true
-# Lint/ToEnumArguments:
-#   Enabled: true
-# Lint/ToJSON:
-#   Enabled: true
-# Lint/TopLevelReturnWithArgument:
-#   Enabled: true
-# Lint/TrailingCommaInAttributeDeclaration:
-#   Enabled: true
-# Lint/TripleQuotes:
-#   Enabled: true
-# Lint/UnderscorePrefixedVariableName:
-#   Enabled: true
-# Lint/UnifiedInteger:
-#   Enabled: true
-# Lint/UnmodifiedReduceAccumulator:
-#   Enabled: true
-# Lint/UnreachableCode:
-#   Enabled: true
-# Lint/UnreachableLoop:
-#   Enabled: true
-# Lint/UnusedBlockArgument:
-#   Enabled: true
-# Lint/UnusedMethodArgument:
-#   Enabled: true
-#   AllowUnusedKeywordArguments: false
-#   IgnoreEmptyMethods: true
-#   IgnoreNotImplementedMethods: true
-# Lint/UriEscapeUnescape:
-#   Enabled: true
-# Lint/UriRegexp:
-#   Enabled: true
-# Lint/UselessAccessModifier:
-#   Enabled: true
-# Lint/UselessAssignment:
-#   Enabled: true
-# Lint/UselessElseWithoutRescue:
-#   Enabled: true
-# Lint/UselessMethodDefinition:
-#   Enabled: true
+Lint/AmbiguousAssignment:
+  Enabled: true
+Lint/AmbiguousBlockAssociation:
+  Enabled: true
+Lint/AmbiguousOperator:
+  Enabled: true
+Lint/AmbiguousRegexpLiteral:
+  Enabled: true
+Lint/AssignmentInCondition:
+  Enabled: true
+Lint/BigDecimalNew:
+  Enabled: true
+Lint/CircularArgumentReference:
+  Enabled: true
+Lint/ConstantDefinitionInBlock:
+  Enabled: true
+Lint/Debugger:
+  Enabled: true
+Lint/DeprecatedClassMethods:
+  Enabled: true
+Lint/DeprecatedConstants:
+  Enabled: true
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: true
+Lint/DisjunctiveAssignmentInConstructor:
+  Enabled: true
+Lint/DuplicateBranch:
+  Enabled: true
+Lint/DuplicateCaseCondition:
+  Enabled: true
+Lint/DuplicateElsifCondition:
+  Enabled: true
+Lint/DuplicateHashKey:
+  Enabled: true
+Lint/DuplicateMethods:
+  Enabled: true
+Lint/DuplicateRegexpCharacterClassElement:
+  Enabled: true
+Lint/DuplicateRequire:
+  Enabled: true
+Lint/DuplicateRescueException:
+  Enabled: true
+Lint/EachWithObjectArgument:
+  Enabled: true
+Lint/ElseLayout:
+  Enabled: true
+Lint/EmptyBlock:
+  Enabled: true
+  AllowEmptyLambdas: true
+Lint/EmptyConditionalBody:
+  Enabled: true
+Lint/EmptyEnsure:
+  Enabled: true
+Lint/EmptyExpression:
+  Enabled: true
+Lint/EmptyFile:
+  Enabled: true
+Lint/EmptyInPattern:
+  Enabled: true
+Lint/EmptyInterpolation:
+  Enabled: true
+Lint/EmptyWhen:
+  Enabled: true
+Lint/EnsureReturn:
+  Enabled: true
+Lint/ErbNewArguments:
+  Enabled: true
+Lint/FlipFlop:
+  Enabled: true
+Lint/FloatComparison:
+  Enabled: true
+Lint/FloatOutOfRange:
+  Enabled: true
+Lint/FormatParameterMismatch:
+  Enabled: true
+Lint/HeredocMethodCallPosition:
+  Enabled: true
+Lint/ImplicitStringConcatenation:
+  Enabled: true
+Lint/IneffectiveAccessModifier:
+  Enabled: true
+Lint/InheritException:
+  Enabled: true
+  EnforcedStyle: standard_error
+Lint/InterpolationCheck:
+  Enabled: true
+Lint/LiteralAsCondition:
+  Enabled: true
+Lint/LiteralInInterpolation:
+  Enabled: true
+Lint/Loop:
+  Enabled: true
+Lint/MissingCopEnableDirective:
+  Enabled: true
+Lint/MissingSuper:
+  Enabled: true
+Lint/MixedRegexpCaptureTypes:
+  Enabled: true
+Lint/MultipleComparison:
+  Enabled: true
+Lint/NestedMethodDefinition:
+  Enabled: true
+Lint/NestedPercentLiteral:
+  Enabled: true
+Lint/NextWithoutAccumulator:
+  Enabled: true
+Lint/NoReturnInBeginEndBlocks:
+  Enabled: true
+Lint/NonDeterministicRequireOrder:
+  Enabled: true
+Lint/OrAssignmentToConstant:
+  Enabled: true
+Lint/OrderedMagicComments:
+  Enabled: true
+Lint/ParenthesesAsGroupedExpression:
+  Enabled: true
+Lint/PercentStringArray:
+  Enabled: true
+Lint/PercentSymbolArray:
+  Enabled: true
+Lint/RaiseException:
+  Enabled: true
+Lint/RandOne:
+  Enabled: true
+Lint/RedundantCopDisableDirective:
+  Enabled: true
+Lint/RedundantCopEnableDirective:
+  Enabled: true
+Lint/RedundantDirGlobSort:
+  Enabled: true
+Lint/RedundantRequireStatement:
+  Enabled: true
+Lint/RedundantSafeNavigation:
+  Enabled: true
+Lint/RedundantSplatExpansion:
+  Enabled: true
+  AllowPercentLiteralArrayArgument: true
+Lint/RedundantStringCoercion:
+  Enabled: true
+Lint/RedundantWithIndex:
+  Enabled: true
+Lint/RedundantWithObject:
+  Enabled: true
+Lint/RegexpAsCondition:
+  Enabled: true
+Lint/RequireParentheses:
+  Enabled: true
+Lint/RescueException:
+  Enabled: true
+Lint/RescueType:
+  Enabled: true
+Lint/ReturnInVoidContext:
+  Enabled: true
+Lint/SafeNavigationChain:
+  Enabled: true
+Lint/SafeNavigationConsistency:
+  Enabled: true
+Lint/SafeNavigationWithEmpty:
+  Enabled: true
+Lint/ScriptPermission:
+  Enabled: true
+Lint/SelfAssignment:
+  Enabled: true
+Lint/SendWithMixinArgument:
+  Enabled: true
+Lint/ShadowedArgument:
+  Enabled: true
+Lint/ShadowedException:
+  Enabled: true
+Lint/ShadowingOuterLocalVariable:
+  Enabled: true
+Lint/StructNewOverride:
+  Enabled: true
+Lint/SuppressedException:
+  Enabled: true
+Lint/Syntax:
+  Enabled: true
+Lint/ToEnumArguments:
+  Enabled: true
+Lint/ToJSON:
+  Enabled: true
+Lint/TopLevelReturnWithArgument:
+  Enabled: true
+Lint/TrailingCommaInAttributeDeclaration:
+  Enabled: true
+Lint/TripleQuotes:
+  Enabled: true
+Lint/UnderscorePrefixedVariableName:
+  Enabled: true
+Lint/UnifiedInteger:
+  Enabled: true
+Lint/UnmodifiedReduceAccumulator:
+  Enabled: true
+Lint/UnreachableCode:
+  Enabled: true
+Lint/UnreachableLoop:
+  Enabled: true
+Lint/UnusedBlockArgument:
+  Enabled: true
+Lint/UnusedMethodArgument:
+  Enabled: true
+  AllowUnusedKeywordArguments: false
+  IgnoreEmptyMethods: true
+  IgnoreNotImplementedMethods: true
+Lint/UriEscapeUnescape:
+  Enabled: true
+Lint/UriRegexp:
+  Enabled: true
+Lint/UselessAccessModifier:
+  Enabled: true
+Lint/UselessAssignment:
+  Enabled: true
+Lint/UselessElseWithoutRescue:
+  Enabled: true
+Lint/UselessMethodDefinition:
+  Enabled: true
 
-# ###########################
-# ### Naming Requirements ###
-# ###########################
+###########################
+### Naming Requirements ###
+###########################
 
-# Naming/AccessorMethodName:
-#   Enabled: true
-# Naming/AsciiIdentifiers:
-#   Enabled: true
-# Naming/BinaryOperatorParameterName:
-#   Enabled: true
-# Naming/BlockParameterName:
-#   Enabled: true
-#   MinNameLength: 1
-#   AllowNamesEndingInNumbers: true
-# Naming/ClassAndModuleCamelCase:
-#   Enabled: true
-# Naming/ConstantName:
-#   Enabled: true
-# Naming/FileName:
-#   Enabled: true
-#   ExpectMatchingDefinition: true # might be redundant w/Zeitwerk
-#   CheckDefinitionPathHierarchy: true
-#   IgnoreExecutableScripts: true
-#   AllowedAcronyms:
-#     - CLI
-#     - DSL
-#     - ACL
-#     - API
-#     - ASCII
-#     - CPU
-#     - CSS
-#     - CSV
-#     - DNS
-#     - EOF
-#     - GUID
-#     - HTML
-#     - HTTP
-#     - HTTPS
-#     - ID
-#     - IP
-#     - JSON
-#     - LHS
-#     - QPS
-#     - RAM
-#     - RHS
-#     - RPC
-#     - SLA
-#     - SMTP
-#     - SQL
-#     - SSH
-#     - TCP
-#     - TLS
-#     - TTL
-#     - UDP
-#     - UI
-#     - UID
-#     - UUID
-#     - URI
-#     - URL
-#     - UTF8
-#     - VM
-#     - XML
-#     - XMPP
-#     - XSRF
-#     - XSS
-# Naming/HeredocDelimiterCase:
-#   Enabled: true
-#   EnforcedStyle: uppercase
-# Naming/InclusiveLanguage:
-#   Enabled: true
-#   CheckIdentifiers: true
-#   CheckConstants: true
-#   CheckVariables: true
-#   CheckStrings: false
-#   CheckSymbols: true
-#   CheckComments: true
-#   CheckFilepaths: true
-#   FlaggedTerms:
-#     whitelist:
-#       Regex: !ruby/regexp '/white[-_\s]?list/'
-#       Suggestions:
-#         - allowlist
-#         - permit
-#     blacklist:
-#       Regex: !ruby/regexp '/black[-_\s]?list/'
-#       Suggestions:
-#         - denylist
-#         - block
-#     slave:
-#       Suggestions:
-#         - replica
-#         - secondary
-#         - follower
-#     master:
-#       Suggestions:
-#         - primary
-#         - main
-# Naming/MemoizedInstanceVariableName:
-#   Enabled: true
-#   EnforcedStyleForLeadingUnderscores: disallowed
-# Naming/MethodName:
-#   Enabled: true
-#   EnforcedStyle: snake_case
-# Naming/MethodParameterName:
-#   Enabled: true
-#   MinNameLength: 3
-#   AllowNamesEndingInNumbers: true
-#   AllowedNames:
-#     - at
-#     - by
-#     - db
-#     - id
-#     - in
-#     - io
-#     - ip
-#     - of
-#     - 'on'
-#     - os
-#     - pp
-#     - to
-# Naming/PredicateName:
-#   Enabled: true
-# Naming/PredicateName:
-#   Enabled: true
-#   NamePrefix:
-#     - is_
-#     - has_
-#     - have_
-#   ForbiddenPrefixes:
-#     - is_
-#   AllowedMethods:
-#     - is_a?
-#   MethodDefinitionMacros:
-#     - define_method
-#     - define_singleton_method
-# Naming/RescuedExceptionsVariableName:
-#   Enabled: true
-#   PreferredName: e
-# Naming/VariableName:
-#   Enabled: true
-#   EnforcedStyle: snake_case
-# Naming/VariableNumber:
-#   Enabled: true
-#   EnforcedStyle: normalcase
-#   CheckMethodNames: true
-#   CheckSymbols: true
+Naming/AccessorMethodName:
+  Enabled: true
+Naming/AsciiIdentifiers:
+  Enabled: true
+Naming/BinaryOperatorParameterName:
+  Enabled: true
+Naming/BlockParameterName:
+  Enabled: true
+  MinNameLength: 1
+  AllowNamesEndingInNumbers: true
+Naming/ClassAndModuleCamelCase:
+  Enabled: true
+Naming/ConstantName:
+  Enabled: true
+Naming/FileName:
+  Enabled: true
+  ExpectMatchingDefinition: true # might be redundant w/Zeitwerk
+  CheckDefinitionPathHierarchy: true
+  IgnoreExecutableScripts: true
+  AllowedAcronyms:
+    - CLI
+    - DSL
+    - ACL
+    - API
+    - ASCII
+    - CPU
+    - CSS
+    - CSV
+    - DNS
+    - EOF
+    - GUID
+    - HTML
+    - HTTP
+    - HTTPS
+    - ID
+    - IP
+    - JSON
+    - LHS
+    - QPS
+    - RAM
+    - RHS
+    - RPC
+    - SLA
+    - SMTP
+    - SQL
+    - SSH
+    - TCP
+    - TLS
+    - TTL
+    - UDP
+    - UI
+    - UID
+    - UUID
+    - URI
+    - URL
+    - UTF8
+    - VM
+    - XML
+    - XMPP
+    - XSRF
+    - XSS
+Naming/HeredocDelimiterCase:
+  Enabled: true
+  EnforcedStyle: uppercase
+Naming/InclusiveLanguage:
+  Enabled: true
+  CheckIdentifiers: true
+  CheckConstants: true
+  CheckVariables: true
+  CheckStrings: false
+  CheckSymbols: true
+  CheckComments: true
+  CheckFilepaths: true
+  FlaggedTerms:
+    whitelist:
+      Regex: !ruby/regexp '/white[-_\s]?list/'
+      Suggestions:
+        - allowlist
+        - permit
+    blacklist:
+      Regex: !ruby/regexp '/black[-_\s]?list/'
+      Suggestions:
+        - denylist
+        - block
+    slave:
+      Suggestions:
+        - replica
+        - secondary
+        - follower
+    master:
+      Suggestions:
+        - primary
+        - main
+Naming/MemoizedInstanceVariableName:
+  Enabled: true
+  EnforcedStyleForLeadingUnderscores: disallowed
+Naming/MethodName:
+  Enabled: true
+  EnforcedStyle: snake_case
+Naming/MethodParameterName:
+  Enabled: true
+  MinNameLength: 3
+  AllowNamesEndingInNumbers: true
+  AllowedNames:
+    - at
+    - by
+    - db
+    - id
+    - in
+    - io
+    - ip
+    - of
+    - 'on'
+    - os
+    - pp
+    - to
+Naming/PredicateName:
+  Enabled: true
+Naming/PredicateName:
+  Enabled: true
+  NamePrefix:
+    - is_
+    - has_
+    - have_
+  ForbiddenPrefixes:
+    - is_
+  AllowedMethods:
+    - is_a?
+  MethodDefinitionMacros:
+    - define_method
+    - define_singleton_method
+Naming/RescuedExceptionsVariableName:
+  Enabled: true
+  PreferredName: e
+Naming/VariableName:
+  Enabled: true
+  EnforcedStyle: snake_case
+Naming/VariableNumber:
+  Enabled: true
+  EnforcedStyle: normalcase
+  CheckMethodNames: true
+  CheckSymbols: true
 
-# #############################
-# ### Security Requirements ###
-# #############################
+#############################
+### Security Requirements ###
+#############################
 
-# Security/Eval:
-#   Enabled: true
-# Security/JSONLoad:
-#   Enabled: true
-# Security/MarshalLoad:
-#   Enabled: true
-# Security/Open:
-#   Enabled: true
-# Security/YAMLLoad:
-#   Enabled: true
+Security/Eval:
+  Enabled: true
+Security/JSONLoad:
+  Enabled: true
+Security/MarshalLoad:
+  Enabled: true
+Security/Open:
+  Enabled: true
+Security/YAMLLoad:
+  Enabled: true
 
-# ##########################
-# ### Style Requirements ###
-# ##########################
+##########################
+### Style Requirements ###
+##########################
 
-# Style/AccessModifierDeclarations:
-#   Enabled: true
-#   EnforcedStyle: group
-# Style/AccessorGrouping:
-#   Enabled: true
-#   EnforcedStyle: grouped
-# Style/Alias:
-#   Enabled: true
-#   EnforcedStyle: prefer_alias_method
-# Style/AndOr:
-#   Enabled: true
-#   EnforcedStyle: always
-# Style/ArgumentsForwarding:
-#   Enabled: true
-#   AllowOnlyRestArgument: true
-# Style/ArrayJoin:
-#   Enabled: true
-# Style/Attr:
-#   Enabled: true
-# Style/AutoResourceCleanup:
-#   Enabled: true
-# Style/BarePercentLiterals:
-#   Enabled: true
-#   EnforcedStyle: bare_percent
-# Style/BeginBlock:
-#   Enabled: true
-# Style/BisectedAttrAccessor:
-#   Enabled: true
-# Style/BlockComments:
-#   Enabled: true
-# Style/BlockDelimiters:
-#   Enabled: true
-#   EnforcedStyle: line_count_based
-#   ProceduralMethods:
-#     # Methods that are known to be procedural in nature but look functional from
-#     # their usage, e.g.
-#     #
-#     #   time = Benchmark.realtime do
-#     #     foo.bar
-#     #   end
-#     #
-#     # Here, the return value of the block is discarded but the return value of
-#     # `Benchmark.realtime` is used.
-#     - benchmark
-#     - bm
-#     - bmbm
-#     - create
-#     - each_with_object
-#     - measure
-#     - new
-#     - realtime
-#     - tap
-#     - with_object
-#   FunctionalMethods:
-#     # Methods that are known to be functional in nature but look procedural from
-#     # their usage, e.g.
-#     #
-#     #   let(:foo) { Foo.new }
-#     #
-#     # Here, the return value of `Foo.new` is used to define a `foo` helper but
-#     # doesn't appear to be used from the return value of `let`.
-#     - let
-#     - let!
-#     - subject
-#     - watch
-#   IgnoredMethods:
-#     # Methods that can be either procedural or functional and cannot be
-#     # categorised from their usage alone, e.g.
-#     #
-#     #   foo = lambda do |x|
-#     #     puts "Hello, #{x}"
-#     #   end
-#     #
-#     #   foo = lambda do |x|
-#     #     x * 100
-#     #   end
-#     #
-#     # Here, it is impossible to tell from the return value of `lambda` whether
-#     # the inner block's return value is significant.
-#     - lambda
-#     - proc
-#     - it
-# Style/CaseEquality:
-#   Enabled: true
-#   AllowOnConstant: false
-# Style/CharacterLiteral:
-#   Enabled: true
-# Style/ClassCheck:
-#   Enabled: true
-#   EnforcedStyle: is_a?
-# Style/ClassEqualityComparison:
-#   Enabled: true
-#   IgnoredMethods:
-#     - ==
-#     - equal?
-#     - eql?
-# Style/ClassMethods:
-#   Enabled: true
-# Style/ClassMethodsDefinitions:
-#   Enabled: true
-#   EnforcedStyle: def_self
-# Style/CollectionCompact:
-#   Enabled: true
-# Style/CollectionMethods:
-#   Enabled: true
-#   PreferredMethods:
-#     collect: 'map'
-#     collect!: 'map!'
-#     inject: 'reduce'
-#     detect: 'find'
-#     find_all: 'select'
-#     member?: 'include?'
-#   MethodsAcceptingSymbol:
-#     - inject
-#     - reduce
-#     - map
-#     - map!
-# Style/ColonMethodCall:
-#   Enabled: true
-# Style/ColonMethodDefinition:
-#   Enabled: true
-# Style/CombinableLoops:
-#   Enabled: true
-# Style/CommandLiteral:
-#   Enabled: true
-#   EnforcedStyle: percent_x
-# Style/CommentAnnotation:
-#   Enabled: true
-#   Keywords:
-#     - TODO
-#     - FIXME
-#   RequireColon: true
-# Style/CommentedKeyword:
-#   Enabled: true
-# Style/ConditionalAssignment:
-#   Enabled: true
-#   EnforcedStyle: assign_to_condition
-#   IncludeTernaryExpressions: true
-#   SingleLineConditionsOnly: true
-# Style/DefWithParentheses:
-#   Enabled: true
-# Style/Dir:
-#   Enabled: true
-# Style/DocumentDynamicEvalDefinition:
-#   Enabled: true
-# Style/DoubleCopDisableDirective:
-#   Enabled: true
-# Style/DoubleNegation:
-#   Enabled: true
-#   EnforcedStyle: allowed_in_returns
-# Style/EachForSimpleLoop:
-#   Enabled: true
-# Style/EmptyBlockParameter:
-#   Enabled: true
-# Style/EmptyCaseCondition:
-#   Enabled: true
-# Style/EmptyElse:
-#   Enabled: true
-#   EnforcedStyle: both
-# Style/EmptyLambdaParameter:
-#   Enabled: true
-# Style/EmptyLiteral:
-#   Enabled: true
-# Style/EmptyMethod:
-#   Enabled: true
-#   EnforcedStyle: compact
-# Style/Encoding:
-#   Enabled: true
-# Style/EndBlock:
-#   Enabled: true
-# Style/EvalWithLocation:
-#   Enabled: true
-# Style/EvenOdd:
-#   Enabled: true
-# Style/ExpandPathArguments:
-#   Enabled: true
-# Style/ExplicitBlockArgument:
-#   Enabled: true
-# Style/ExponentialNotation:
-#   Enabled: true
-#   EnforcedStyle: scientific
-# Style/FloatDivision:
-#   Enabled: true
-#   EnforcedStyle: single_coerce
-# Style/For:
-#   Enabled: true
-#   EnforcedStyle: each
-# Style/FrozenStringLiteralComment:
-#   Enabled: true
-#   EnforcedStyle: always
-# Style/GlobalStdStream:
-#   Enabled: true
-# Style/GlobalVars:
-#   Enabled: true
-# Style/GuardClause:
-#   Enabled: true
-# Style/HashAsLastArrayItem:
-#   Enabled: true
-#   EnforcedStyle: braces
-# Style/HashEachMethods:
-#   Enabled: true
-# Style/HashExcept:
-#   Enabled: true
-# Style/HashLikeCase:
-#   Enabled: true
-# Style/HashSyntax:
-#   Enabled: true
-#   EnforcedStyle: ruby19
-#   UseHashRocketsWithSymbolValues: false
-#   PreferHashRocketsForNonAlnumEndingSymbols: false
-# Style/HashTransformKeys:
-#   Enabled: true
-# Style/HashTransformValues:
-#   Enabled: true
-# Style/IdenticalConditionalBranches:
-#   Enabled: true
-# Style/IfInsideElse:
-#   Enabled: true
-# Style/IfUnlessModifier:
-#   Enabled: true
-# Style/IfUnlessModifierOfIfUnless:
-#   Enabled: true
-# Style/IfWithBooleanLiteralBranches:
-#   Enabled: true
-# Style/IfWithSemicolon:
-#   Enabled: true
-# Style/ImplicitRuntimeError:
-#   Enabled: true
-# Style/InverseMethods:
-#   Enabled: true
-#   InverseMethods:
-#     :any?: :none?
-#     :even?: :odd?
-#     :==: :!=
-#     :=~: :!~
-#     :<: :>=
-#     :>: :<=
-#   InverseBlocks:
-#     :select: :reject
-#     :select!: :reject!
-# Style/IpAddresses:
-#   Enabled: true
-#   AllowedAddresses:
-#     - '::'
-#   Exclude:
-#     - '**/Gemfile'
-# Style/KeywordParametersOrder:
-#   Enabled: true
-# Style/Lambda:
-#   Enabled: true
-#   EnforcedStyle: line_count_dependent
-# Style/LambdaCall:
-#   Enabled: true
-#   EnforcedStyle: call
-# Style/LineEndConcatenation:
-#   Enabled: true
-# Style/MethodCallWithoutArgsParentheses:
-#   Enabled: true
-# Style/MethodDefParentheses:
-#   Enabled: true
-#   EnforcedStyle: require_parentheses
-# Style/MinMax:
-#   Enabled: true
-# Style/MissingRespondToMissing:
-#   Enabled: true
-# Style/MixinGrouping:
-#   Enabled: true
-#   EnforcedStyle: separated
-# Style/MixinUsage:
-#   Enabled: true
-# Style/ModuleFunction:
-#   Enabled: true
-#   EnforcedStyle: module_function
-# Style/MultilineIfModifier:
-#   Enabled: true
-# Style/MultilineIfThen:
-#   Enabled: true
-# Style/MultilineInPatternThen:
-#   Enabled: true
-# Style/MultilineMemoization:
-#   Enabled: true
-#   EnforcedStyle: keyword
-# Style/MultilineMethodSignature:
-#   Enabled: true
-# Style/MultilineTernaryOperator:
-#   Enabled: true
-# Style/MultilineWhenThen:
-#   Enabled: true
-# Style/MultipleComparison:
-#   Enabled: true
-# Style/MutableConstant:
-#   Enabled: true
-#   EnforcedStyle: literals
-# Style/NegatedIf:
-#   Enabled: true
-#   EnforcedStyle: postfix
-# Style/NegatedIfElseCondition:
-#   Enabled: true
-# Style/NegatedUnless:
-#   Enabled: true
-#   EnforcedStyle: both
-# Style/NegatedWhile:
-#   Enabled: true
-# Style/NestedModifier:
-#   Enabled: true
-# Style/NestedParenthesizedCalls:
-#   Enabled: true
-#   AllowedMethods:
-#     - be
-#     - be_a
-#     - be_an
-#     - be_between
-#     - be_falsey
-#     - be_kind_of
-#     - be_instance_of
-#     - be_truthy
-#     - be_within
-#     - eq
-#     - eql
-#     - end_with
-#     - include
-#     - match
-#     - raise_error
-#     - respond_to
-#     - start_with
-# Style/NestedTernaryOperator:
-#   Enabled: true
-# Style/Next:
-#   Enabled: true
-#   EnforcedStyle: skip_modifier_ifs
-# Style/NilComparison:
-#   Enabled: true
-#   EnforcedStyle: predicate
-# Style/NilLambda:
-#   Enabled: true
-# Style/NonNilCheck:
-#   Enabled: true
-#   IncludeSemanticChanges: false
-# Style/Not:
-#   Enabled: true
-# Style/NumericLiteralPrefix:
-#   Enabled: true
-#   EnforcedStyle: zero_with_o
-# Style/NumericLiterals:
-#   Enabled: true
-#   MinDigits: 5
-# Style/OneLineConditional:
-#   Enabled: true
-# Style/OptionalArguments:
-#   Enabled: true
-# Style/OrAssignment:
-#   Enabled: true
-# Style/ParallelAssignment:
-#   Enabled: true
-# Style/ParenthesesAroundCondition:
-#   Enabled: true
-#   AllowSafeAssignment: false
-#   AllowInMultilineConditionals: false
-# Style/PercentLiteralDelimiters:
-#   Enabled: true
-#   PreferredDelimiters:
-#     default: ()
-#     '%i': '[]'
-#     '%I': '[]'
-#     '%r': '{}'
-#     '%w': '[]'
-#     '%W': '[]'
-# Style/PercentQLiterals:
-#   Enabled: true
-#   EnforcedStyle: lower_case_q
-# Style/PerlBackrefs:
-#   Enabled: true
-# Style/PreferredHashMethods:
-#   Enabled: true
-#   EnforcedStyle: verbose
-# Style/Proc:
-#   Enabled: true
-# Style/QuotedSymbols:
-#   Enabled: true
-#   EnforcedStyle: same_as_string_literals
-# Style/RaiseArgs:
-#   Enabled: true
-#   EnforcedStyle: compact
-# Style/RandomWithOffset:
-#   Enabled: true
-# Style/RedundantAssignment:
-#   Enabled: true
-# Style/RedundantBegin:
-#   Enabled: true
-# Style/RedundantCapitalW:
-#   Enabled: true
-# Style/RedundantCondition:
-#   Enabled: true
-# Style/RedundantConditional:
-#   Enabled: true
-# Style/RedundantFileExtensionInRequire:
-#   Enabled: true
-# Style/RedundantFreeze:
-#   Enabled: true
-# Style/RedundantInterpolation:
-#   Enabled: true
-# Style/RedundantParentheses:
-#   Enabled: true
-# Style/RedundantPercentQ:
-#   Enabled: true
-# Style/RedundantRegexpCharacterClass:
-#   Enabled: true
-# Style/RedundantRegexpEscape:
-#   Enabled: true
-# Style/RedundantReturn:
-#   Enabled: true
-# Style/RedundantSelf:
-#   Enabled: true
-# Style/RedundantSort:
-#   Enabled: true
-# Style/RedundantSortBy:
-#   Enabled: true
-# Style/RegexpLiteral:
-#   Enabled: true
-#   EnforcedStyle: mixed
-#   AllowInnerSlashes: true
-# Style/RescueModifier:
-#   Enabled: true
-# Style/RescueStandardError:
-#   Enabled: true
-#   EnforcedStyle: explicit
-# Style/ReturnNil:
-#   Enabled: true
-#   EnforcedStyle: return
-# Style/Sample:
-#   Enabled: true
-# Style/SelfAssignment:
-#   Enabled: true
-# Style/Semicolon:
-#   Enabled: true
-# Style/SignalException:
-#   Enabled: true
-#   EnforcedStyle: only_raise
-# Style/SingleArgumentDig:
-#   Enabled: true
-# Style/SingleLineMethods:
-#   Enabled: true
-#   AllowIfMethodIsEmpty: true
-# Style/SpecialGlobalVars:
-#   Enabled: true
-#   EnforcedStyle: use_english_names
-# Style/StabbyLambdaParentheses:
-#   Enabled: true
-#   EnforcedStyle: require_parentheses
-# Style/StaticClass:
-#   Enabled: true
-# Style/StderrPuts:
-#   Enabled: true
-# Style/StringConcatenation:
-#   Enabled: true
-# Style/StringLiterals:
-#   Enabled: true
-#   EnforcedStyle: single_quotes
-#   ConsistentQuotesInMultiline: false # good if only one line has interpolation
-# Style/StringLiteralsInInterpolation:
-#   Enabled: true
-#   EnforcedStyle: single_quotes
-# Style/Strip:
-#   Enabled: true
-# Style/StructInheritance:
-#   Enabled: true
-# Style/SymbolArray:
-#   Enabled: true
-#   EnforcedStyle: percent
-# Style/SymbolLiteral:
-#   Enabled: true
-# Style/SymbolProc:
-#   Enabled: true
-#   AllowMethodsWithArguments: false
-#   IgnoredMethods:
-#     - respond_to
-#     - define_method
-# Style/TernaryParentheses:
-#   Enabled: true
-#   EnforcedStyle: require_no_parentheses
-#   AllowSafeAssignment: false
-# Style/TrailingBodyOnClass:
-#   Enabled: true
-# Style/TrailingBodyOnMethodDefinition:
-#   Enabled: true
-# Style/TrailingBodyOnModule:
-#   Enabled: true
-# Style/TrailingCommaInArguments:
-#   Enabled: true
-#   EnforcedStyleForMultiline: consistent_comma
-# Style/TrailingCommaInArrayLiteral:
-#   Enabled: true
-#   EnforcedStyleForMultiline: consistent_comma
-# Style/TrailingCommaInHashLiteral:
-#   Enabled: true
-#   EnforcedStyleForMultiline: consistent_comma
-# Style/TrailingMethodEndStatement:
-#   Enabled: true
-# Style/TrailingUnderscoreVariable:
-#   Enabled: true
-#   AllowNamedUnderscoreVariables: false
-# Style/TrivialAccessors:
-#   Enabled: true
-#   ExactNameMatch: true
-#   AllowPredicates: true
-#   AllowDSLWriters: true
-#   IgnoreClassMethods: false
-#   AllowedMethods:
-#     - to_ary
-#     - to_a
-#     - to_c
-#     - to_enum
-#     - to_h
-#     - to_hash
-#     - to_i
-#     - to_int
-#     - to_io
-#     - to_open
-#     - to_path
-#     - to_proc
-#     - to_r
-#     - to_regexp
-#     - to_str
-#     - to_s
-#     - to_sym
-# Style/UnlessElse:
-#   Enabled: true
-# Style/UnlessLogicalOperators:
-#   Enabled: true
-#   EnforcedStyle: forbid_mixed_logical_operators
-# Style/UnpackFirst:
-#   Enabled: true
-# Style/VariableInterpolation:
-#   Enabled: true
-# Style/WhenThen:
-#   Enabled: true
-# Style/WhileUntilDo:
-#   Enabled: true
-# Style/WhileUntilModifier:
-#   Enabled: true
-# Style/WordArray:
-#   Enabled: true
-#   EnforcedStyle: percent
-#   MinSize: 1
-# Style/YodaCondition:
-#   Enabled: true
-#   EnforcedStyle: forbid_for_all_comparison_operators
-# Style/ZeroLengthPredicate:
-#   Enabled: true
+Style/AccessModifierDeclarations:
+  Enabled: true
+  EnforcedStyle: group
+Style/AccessorGrouping:
+  Enabled: true
+  EnforcedStyle: grouped
+Style/Alias:
+  Enabled: true
+  EnforcedStyle: prefer_alias_method
+Style/AndOr:
+  Enabled: true
+  EnforcedStyle: always
+Style/ArgumentsForwarding:
+  Enabled: true
+  AllowOnlyRestArgument: true
+Style/ArrayJoin:
+  Enabled: true
+Style/Attr:
+  Enabled: true
+Style/AutoResourceCleanup:
+  Enabled: true
+Style/BarePercentLiterals:
+  Enabled: true
+  EnforcedStyle: bare_percent
+Style/BeginBlock:
+  Enabled: true
+Style/BisectedAttrAccessor:
+  Enabled: true
+Style/BlockComments:
+  Enabled: true
+Style/BlockDelimiters:
+  Enabled: true
+  EnforcedStyle: line_count_based
+  ProceduralMethods:
+    # Methods that are known to be procedural in nature but look functional from
+    # their usage, e.g.
+    #
+    #   time = Benchmark.realtime do
+    #     foo.bar
+    #   end
+    #
+    # Here, the return value of the block is discarded but the return value of
+    # `Benchmark.realtime` is used.
+    - benchmark
+    - bm
+    - bmbm
+    - create
+    - each_with_object
+    - measure
+    - new
+    - realtime
+    - tap
+    - with_object
+  FunctionalMethods:
+    # Methods that are known to be functional in nature but look procedural from
+    # their usage, e.g.
+    #
+    #   let(:foo) { Foo.new }
+    #
+    # Here, the return value of `Foo.new` is used to define a `foo` helper but
+    # doesn't appear to be used from the return value of `let`.
+    - let
+    - let!
+    - subject
+    - watch
+  IgnoredMethods:
+    # Methods that can be either procedural or functional and cannot be
+    # categorised from their usage alone, e.g.
+    #
+    #   foo = lambda do |x|
+    #     puts "Hello, #{x}"
+    #   end
+    #
+    #   foo = lambda do |x|
+    #     x * 100
+    #   end
+    #
+    # Here, it is impossible to tell from the return value of `lambda` whether
+    # the inner block's return value is significant.
+    - lambda
+    - proc
+    - it
+Style/CaseEquality:
+  Enabled: true
+  AllowOnConstant: false
+Style/CharacterLiteral:
+  Enabled: true
+Style/ClassCheck:
+  Enabled: true
+  EnforcedStyle: is_a?
+Style/ClassEqualityComparison:
+  Enabled: true
+  IgnoredMethods:
+    - ==
+    - equal?
+    - eql?
+Style/ClassMethods:
+  Enabled: true
+Style/ClassMethodsDefinitions:
+  Enabled: true
+  EnforcedStyle: def_self
+Style/CollectionCompact:
+  Enabled: true
+Style/CollectionMethods:
+  Enabled: true
+  PreferredMethods:
+    collect: 'map'
+    collect!: 'map!'
+    inject: 'reduce'
+    detect: 'find'
+    find_all: 'select'
+    member?: 'include?'
+  MethodsAcceptingSymbol:
+    - inject
+    - reduce
+    - map
+    - map!
+Style/ColonMethodCall:
+  Enabled: true
+Style/ColonMethodDefinition:
+  Enabled: true
+Style/CombinableLoops:
+  Enabled: true
+Style/CommandLiteral:
+  Enabled: true
+  EnforcedStyle: percent_x
+Style/CommentAnnotation:
+  Enabled: true
+  Keywords:
+    - TODO
+    - FIXME
+  RequireColon: true
+Style/CommentedKeyword:
+  Enabled: true
+Style/ConditionalAssignment:
+  Enabled: true
+  EnforcedStyle: assign_to_condition
+  IncludeTernaryExpressions: true
+  SingleLineConditionsOnly: true
+Style/DefWithParentheses:
+  Enabled: true
+Style/Dir:
+  Enabled: true
+Style/DocumentDynamicEvalDefinition:
+  Enabled: true
+Style/DoubleCopDisableDirective:
+  Enabled: true
+Style/DoubleNegation:
+  Enabled: true
+  EnforcedStyle: allowed_in_returns
+Style/EachForSimpleLoop:
+  Enabled: true
+Style/EmptyBlockParameter:
+  Enabled: true
+Style/EmptyCaseCondition:
+  Enabled: true
+Style/EmptyElse:
+  Enabled: true
+  EnforcedStyle: both
+Style/EmptyLambdaParameter:
+  Enabled: true
+Style/EmptyLiteral:
+  Enabled: true
+Style/EmptyMethod:
+  Enabled: true
+  EnforcedStyle: compact
+Style/Encoding:
+  Enabled: true
+Style/EndBlock:
+  Enabled: true
+Style/EvalWithLocation:
+  Enabled: true
+Style/EvenOdd:
+  Enabled: true
+Style/ExpandPathArguments:
+  Enabled: true
+Style/ExplicitBlockArgument:
+  Enabled: true
+Style/ExponentialNotation:
+  Enabled: true
+  EnforcedStyle: scientific
+Style/FloatDivision:
+  Enabled: true
+  EnforcedStyle: single_coerce
+Style/For:
+  Enabled: true
+  EnforcedStyle: each
+Style/FrozenStringLiteralComment:
+  Enabled: true
+  EnforcedStyle: always
+Style/GlobalStdStream:
+  Enabled: true
+Style/GlobalVars:
+  Enabled: true
+Style/GuardClause:
+  Enabled: true
+Style/HashAsLastArrayItem:
+  Enabled: true
+  EnforcedStyle: braces
+Style/HashEachMethods:
+  Enabled: true
+Style/HashExcept:
+  Enabled: true
+Style/HashLikeCase:
+  Enabled: true
+Style/HashSyntax:
+  Enabled: true
+  EnforcedStyle: ruby19
+  UseHashRocketsWithSymbolValues: false
+  PreferHashRocketsForNonAlnumEndingSymbols: false
+Style/HashTransformKeys:
+  Enabled: true
+Style/HashTransformValues:
+  Enabled: true
+Style/IdenticalConditionalBranches:
+  Enabled: true
+Style/IfInsideElse:
+  Enabled: true
+Style/IfUnlessModifier:
+  Enabled: true
+Style/IfUnlessModifierOfIfUnless:
+  Enabled: true
+Style/IfWithBooleanLiteralBranches:
+  Enabled: true
+Style/IfWithSemicolon:
+  Enabled: true
+Style/ImplicitRuntimeError:
+  Enabled: true
+Style/InverseMethods:
+  Enabled: true
+  InverseMethods:
+    :any?: :none?
+    :even?: :odd?
+    :==: :!=
+    :=~: :!~
+    :<: :>=
+    :>: :<=
+  InverseBlocks:
+    :select: :reject
+    :select!: :reject!
+Style/IpAddresses:
+  Enabled: true
+  AllowedAddresses:
+    - '::'
+  Exclude:
+    - '**/Gemfile'
+Style/KeywordParametersOrder:
+  Enabled: true
+Style/Lambda:
+  Enabled: true
+  EnforcedStyle: line_count_dependent
+Style/LambdaCall:
+  Enabled: true
+  EnforcedStyle: call
+Style/LineEndConcatenation:
+  Enabled: true
+Style/MethodCallWithoutArgsParentheses:
+  Enabled: true
+Style/MethodDefParentheses:
+  Enabled: true
+  EnforcedStyle: require_parentheses
+Style/MinMax:
+  Enabled: true
+Style/MissingRespondToMissing:
+  Enabled: true
+Style/MixinGrouping:
+  Enabled: true
+  EnforcedStyle: separated
+Style/MixinUsage:
+  Enabled: true
+Style/ModuleFunction:
+  Enabled: true
+  EnforcedStyle: module_function
+Style/MultilineIfModifier:
+  Enabled: true
+Style/MultilineIfThen:
+  Enabled: true
+Style/MultilineInPatternThen:
+  Enabled: true
+Style/MultilineMemoization:
+  Enabled: true
+  EnforcedStyle: keyword
+Style/MultilineMethodSignature:
+  Enabled: true
+Style/MultilineTernaryOperator:
+  Enabled: true
+Style/MultilineWhenThen:
+  Enabled: true
+Style/MultipleComparison:
+  Enabled: true
+Style/MutableConstant:
+  Enabled: true
+  EnforcedStyle: literals
+Style/NegatedIf:
+  Enabled: true
+  EnforcedStyle: postfix
+Style/NegatedIfElseCondition:
+  Enabled: true
+Style/NegatedUnless:
+  Enabled: true
+  EnforcedStyle: both
+Style/NegatedWhile:
+  Enabled: true
+Style/NestedModifier:
+  Enabled: true
+Style/NestedParenthesizedCalls:
+  Enabled: true
+  AllowedMethods:
+    - be
+    - be_a
+    - be_an
+    - be_between
+    - be_falsey
+    - be_kind_of
+    - be_instance_of
+    - be_truthy
+    - be_within
+    - eq
+    - eql
+    - end_with
+    - include
+    - match
+    - raise_error
+    - respond_to
+    - start_with
+Style/NestedTernaryOperator:
+  Enabled: true
+Style/Next:
+  Enabled: true
+  EnforcedStyle: skip_modifier_ifs
+Style/NilComparison:
+  Enabled: true
+  EnforcedStyle: predicate
+Style/NilLambda:
+  Enabled: true
+Style/NonNilCheck:
+  Enabled: true
+  IncludeSemanticChanges: false
+Style/Not:
+  Enabled: true
+Style/NumericLiteralPrefix:
+  Enabled: true
+  EnforcedStyle: zero_with_o
+Style/NumericLiterals:
+  Enabled: true
+  MinDigits: 5
+Style/OneLineConditional:
+  Enabled: true
+Style/OptionalArguments:
+  Enabled: true
+Style/OrAssignment:
+  Enabled: true
+Style/ParallelAssignment:
+  Enabled: true
+Style/ParenthesesAroundCondition:
+  Enabled: true
+  AllowSafeAssignment: false
+  AllowInMultilineConditionals: false
+Style/PercentLiteralDelimiters:
+  Enabled: true
+  PreferredDelimiters:
+    default: ()
+    '%i': '[]'
+    '%I': '[]'
+    '%r': '{}'
+    '%w': '[]'
+    '%W': '[]'
+Style/PercentQLiterals:
+  Enabled: true
+  EnforcedStyle: lower_case_q
+Style/PerlBackrefs:
+  Enabled: true
+Style/PreferredHashMethods:
+  Enabled: true
+  EnforcedStyle: verbose
+Style/Proc:
+  Enabled: true
+Style/QuotedSymbols:
+  Enabled: true
+  EnforcedStyle: same_as_string_literals
+Style/RaiseArgs:
+  Enabled: true
+  EnforcedStyle: compact
+Style/RandomWithOffset:
+  Enabled: true
+Style/RedundantAssignment:
+  Enabled: true
+Style/RedundantBegin:
+  Enabled: true
+Style/RedundantCapitalW:
+  Enabled: true
+Style/RedundantCondition:
+  Enabled: true
+Style/RedundantConditional:
+  Enabled: true
+Style/RedundantFileExtensionInRequire:
+  Enabled: true
+Style/RedundantFreeze:
+  Enabled: true
+Style/RedundantInterpolation:
+  Enabled: true
+Style/RedundantParentheses:
+  Enabled: true
+Style/RedundantPercentQ:
+  Enabled: true
+Style/RedundantRegexpCharacterClass:
+  Enabled: true
+Style/RedundantRegexpEscape:
+  Enabled: true
+Style/RedundantReturn:
+  Enabled: true
+Style/RedundantSelf:
+  Enabled: true
+Style/RedundantSort:
+  Enabled: true
+Style/RedundantSortBy:
+  Enabled: true
+Style/RegexpLiteral:
+  Enabled: true
+  EnforcedStyle: mixed
+  AllowInnerSlashes: true
+Style/RescueModifier:
+  Enabled: true
+Style/RescueStandardError:
+  Enabled: true
+  EnforcedStyle: explicit
+Style/ReturnNil:
+  Enabled: true
+  EnforcedStyle: return
+Style/Sample:
+  Enabled: true
+Style/SelfAssignment:
+  Enabled: true
+Style/Semicolon:
+  Enabled: true
+Style/SignalException:
+  Enabled: true
+  EnforcedStyle: only_raise
+Style/SingleArgumentDig:
+  Enabled: true
+Style/SingleLineMethods:
+  Enabled: true
+  AllowIfMethodIsEmpty: true
+Style/SpecialGlobalVars:
+  Enabled: true
+  EnforcedStyle: use_english_names
+Style/StabbyLambdaParentheses:
+  Enabled: true
+  EnforcedStyle: require_parentheses
+Style/StaticClass:
+  Enabled: true
+Style/StderrPuts:
+  Enabled: true
+Style/StringConcatenation:
+  Enabled: true
+Style/StringLiterals:
+  Enabled: true
+  EnforcedStyle: single_quotes
+  ConsistentQuotesInMultiline: false # good if only one line has interpolation
+Style/StringLiteralsInInterpolation:
+  Enabled: true
+  EnforcedStyle: single_quotes
+Style/Strip:
+  Enabled: true
+Style/StructInheritance:
+  Enabled: true
+Style/SymbolArray:
+  Enabled: true
+  EnforcedStyle: percent
+Style/SymbolLiteral:
+  Enabled: true
+Style/SymbolProc:
+  Enabled: true
+  AllowMethodsWithArguments: false
+  IgnoredMethods:
+    - respond_to
+    - define_method
+Style/TernaryParentheses:
+  Enabled: true
+  EnforcedStyle: require_no_parentheses
+  AllowSafeAssignment: false
+Style/TrailingBodyOnClass:
+  Enabled: true
+Style/TrailingBodyOnMethodDefinition:
+  Enabled: true
+Style/TrailingBodyOnModule:
+  Enabled: true
+Style/TrailingCommaInArguments:
+  Enabled: true
+  EnforcedStyleForMultiline: consistent_comma
+Style/TrailingCommaInArrayLiteral:
+  Enabled: true
+  EnforcedStyleForMultiline: consistent_comma
+Style/TrailingCommaInHashLiteral:
+  Enabled: true
+  EnforcedStyleForMultiline: consistent_comma
+Style/TrailingMethodEndStatement:
+  Enabled: true
+Style/TrailingUnderscoreVariable:
+  Enabled: true
+  AllowNamedUnderscoreVariables: false
+Style/TrivialAccessors:
+  Enabled: true
+  ExactNameMatch: true
+  AllowPredicates: true
+  AllowDSLWriters: true
+  IgnoreClassMethods: false
+  AllowedMethods:
+    - to_ary
+    - to_a
+    - to_c
+    - to_enum
+    - to_h
+    - to_hash
+    - to_i
+    - to_int
+    - to_io
+    - to_open
+    - to_path
+    - to_proc
+    - to_r
+    - to_regexp
+    - to_str
+    - to_s
+    - to_sym
+Style/UnlessElse:
+  Enabled: true
+Style/UnlessLogicalOperators:
+  Enabled: true
+  EnforcedStyle: forbid_mixed_logical_operators
+Style/UnpackFirst:
+  Enabled: true
+Style/VariableInterpolation:
+  Enabled: true
+Style/WhenThen:
+  Enabled: true
+Style/WhileUntilDo:
+  Enabled: true
+Style/WhileUntilModifier:
+  Enabled: true
+Style/WordArray:
+  Enabled: true
+  EnforcedStyle: percent
+  MinSize: 1
+Style/YodaCondition:
+  Enabled: true
+  EnforcedStyle: forbid_for_all_comparison_operators
+Style/ZeroLengthPredicate:
+  Enabled: true
 
-# ##########################
-# ### Rails Requirements ###
-# ##########################
+##########################
+### Rails Requirements ###
+##########################
 
-# Rails/ActionFilter:
-#   Enabled: true
-#   EnforcedStyle: action
-# Rails/ActiveRecordCallbacksOrder:
-#   Enabled: true
-# Rails/ActiveSupportAliases:
-#   Enabled: true
-# Rails/AddColumnIndex:
-#   Enabled: true
-# Rails/AfterCommitOverride:
-#   Enabled: true
-# Rails/ApplicationController:
-#   Enabled: true
-# Rails/ApplicationRecord:
-#   Enabled: true
-# Rails/ArelStar:
-#   Enabled: true
-# Rails/AttributeDefaultBlockValue:
-#   Enabled: true
-# Rails/BelongsTo:
-#   Enabled: true
-# Rails/Blank:
-#   Enabled: true
-#   NilOrEmpty: true
-#   NotPresent: true
-#   UnlessPresent: true
-# Rails/BulkChangeTable:
-#   Enabled: true
-# Rails/CreateTableWithTimestamps:
-#   Enabled: true
-# Rails/Date:
-#   Enabled: true
-# Rails/DefaultScope:
-#   Enabled: true
-# Rails/Delegate:
-#   Enabled: true
-# Rails/DelegateAllowBlank:
-#   Enabled: true
-# Rails/DynamicFindBy:
-#   Enabled: true
-# Rails/EagerEvaluationLogMessage:
-#   Enabled: true
-# Rails/EnumHash:
-#   Enabled: true
-# Rails/EnumUniqueness:
-#   Enabled: true
-# Rails/EnvironmentComparison:
-#   Enabled: true
-# Rails/EnvironmentVariableAccess:
-#   Enabled: true
-# Rails/Exit:
-#   Enabled: true
-# Rails/ExpandedDateRange:
-#   Enabled: true
-# Rails/FilePath:
-#   Enabled: true
-#   EnforcedStyle: arguments
-# Rails/FindBy:
-#   Enabled: true
-#   IgnoreWhereFirst: false
-# Rails/FindById:
-#   Enabled: true
-# Rails/FindEach:
-#   Enabled: true
-# Rails/HasManyOrHasOneDependent:
-#   Enabled: true
-# Rails/HttpPositionalArguments:
-#   Enabled: true
-# Rails/HttpStatus:
-#   Enabled: true
-#   EnforcedStyle: symbolic
-# Rails/IgnoredSkipActionFilterOption:
-#   Enabled: true
-# Rails/IndexBy:
-#   Enabled: true
-# Rails/IndexWith:
-#   Enabled: true
-# Rails/Inquiry:
-#   Enabled: true
-# Rails/InverseOf:
-#   Enabled: true
-# Rails/LexicallyScopedActionFilter:
-#   Enabled: true
-# Rails/MatchRoute:
-#   Enabled: true
-# Rails/NegateInclude:
-#   Enabled: true
-# Rails/OrderById:
-#   Enabled: true
-# Rails/Output:
-#   Enabled: true
-# Rails/Pick:
-#   Enabled: true
-# Rails/Pluck:
-#   Enabled: true
-# Rails/PluckId:
-#   Enabled: true
-# Rails/PluckInWhere:
-#   Enabled: true
-#   EnforcedStyle: conservative
-# Rails/PluralizationGrammar:
-#   Enabled: true
-# Rails/Presence:
-#   Enabled: true
-# Rails/Present:
-#   Enabled: true
-#   NotNilAndNotEmpty: true
-#   NotBlank: true
-#   UnlessBlank: true
-# Rails/ReadWriteAttribute:
-#   Enabled: true
-# Rails/RedundantAllowNil:
-#   Enabled: true
-# Rails/RedundantForeignKey:
-#   Enabled: true
-# Rails/RedundantReceiverInWithOptions:
-#   Enabled: true
-# Rails/ReflectionClassName:
-#   Enabled: true
-# Rails/RelativeDateConstant:
-#   Enabled: true
-# Rails/RenderPlainText:
-#   Enabled: true
-# Rails/RequestReferer:
-#   Enabled: true
-#   EnforcedStyle: referrer
-# Rails/SafeNavigation:
-#   Enabled: true
-#   ConvertTry: true
-# Rails/SafeNavigationWithBlank:
-#   Enabled: true
-# Rails/SaveBang:
-#   Enabled: true
-#   AllowImplicitReturn: true
-# Rails/ScopeArgs:
-#   Enabled: true
-# Rails/SkipsModelValidations:
-#   Enabled: true
-#   AllowedMethods:
-#     - touch
-# Rails/TimeZone:
-#   Enabled: true
-# Rails/UniqBeforePluck:
-#   Enabled: true
-#   EnforcedStyle: conservative
-# Rails/UniqueValidationWithoutIndex:
-#   Enabled: true
-# Rails/UnknownEnv:
-#   Enabled: true
-#   Environments:
-#     - development
-#     - test
-#     - staging
-#     - production
-# Rails/Validation:
-#   Enabled: true
-# Rails/WhereEquals:
-#   Enabled: true
-# Rails/WhereNot:
-#   Enabled: true
+Rails/ActionFilter:
+  Enabled: true
+  EnforcedStyle: action
+Rails/ActiveRecordCallbacksOrder:
+  Enabled: true
+Rails/ActiveSupportAliases:
+  Enabled: true
+Rails/AddColumnIndex:
+  Enabled: true
+Rails/AfterCommitOverride:
+  Enabled: true
+Rails/ApplicationController:
+  Enabled: true
+Rails/ApplicationRecord:
+  Enabled: true
+Rails/ArelStar:
+  Enabled: true
+Rails/AttributeDefaultBlockValue:
+  Enabled: true
+Rails/BelongsTo:
+  Enabled: true
+Rails/Blank:
+  Enabled: true
+  NilOrEmpty: true
+  NotPresent: true
+  UnlessPresent: true
+Rails/BulkChangeTable:
+  Enabled: true
+Rails/CreateTableWithTimestamps:
+  Enabled: true
+Rails/Date:
+  Enabled: true
+Rails/DefaultScope:
+  Enabled: true
+Rails/Delegate:
+  Enabled: true
+Rails/DelegateAllowBlank:
+  Enabled: true
+Rails/DynamicFindBy:
+  Enabled: true
+Rails/EagerEvaluationLogMessage:
+  Enabled: true
+Rails/EnumHash:
+  Enabled: true
+Rails/EnumUniqueness:
+  Enabled: true
+Rails/EnvironmentComparison:
+  Enabled: true
+Rails/EnvironmentVariableAccess:
+  Enabled: true
+Rails/Exit:
+  Enabled: true
+Rails/ExpandedDateRange:
+  Enabled: true
+Rails/FilePath:
+  Enabled: true
+  EnforcedStyle: arguments
+Rails/FindBy:
+  Enabled: true
+  IgnoreWhereFirst: false
+Rails/FindById:
+  Enabled: true
+Rails/FindEach:
+  Enabled: true
+Rails/HasManyOrHasOneDependent:
+  Enabled: true
+Rails/HttpPositionalArguments:
+  Enabled: true
+Rails/HttpStatus:
+  Enabled: true
+  EnforcedStyle: symbolic
+Rails/IgnoredSkipActionFilterOption:
+  Enabled: true
+Rails/IndexBy:
+  Enabled: true
+Rails/IndexWith:
+  Enabled: true
+Rails/Inquiry:
+  Enabled: true
+Rails/InverseOf:
+  Enabled: true
+Rails/LexicallyScopedActionFilter:
+  Enabled: true
+Rails/MatchRoute:
+  Enabled: true
+Rails/NegateInclude:
+  Enabled: true
+Rails/OrderById:
+  Enabled: true
+Rails/Output:
+  Enabled: true
+Rails/Pick:
+  Enabled: true
+Rails/Pluck:
+  Enabled: true
+Rails/PluckId:
+  Enabled: true
+Rails/PluckInWhere:
+  Enabled: true
+  EnforcedStyle: conservative
+Rails/PluralizationGrammar:
+  Enabled: true
+Rails/Presence:
+  Enabled: true
+Rails/Present:
+  Enabled: true
+  NotNilAndNotEmpty: true
+  NotBlank: true
+  UnlessBlank: true
+Rails/ReadWriteAttribute:
+  Enabled: true
+Rails/RedundantAllowNil:
+  Enabled: true
+Rails/RedundantForeignKey:
+  Enabled: true
+Rails/RedundantReceiverInWithOptions:
+  Enabled: true
+Rails/ReflectionClassName:
+  Enabled: true
+Rails/RelativeDateConstant:
+  Enabled: true
+Rails/RenderPlainText:
+  Enabled: true
+Rails/RequestReferer:
+  Enabled: true
+  EnforcedStyle: referrer
+Rails/SafeNavigation:
+  Enabled: true
+  ConvertTry: true
+Rails/SafeNavigationWithBlank:
+  Enabled: true
+Rails/SaveBang:
+  Enabled: true
+  AllowImplicitReturn: true
+Rails/ScopeArgs:
+  Enabled: true
+Rails/SkipsModelValidations:
+  Enabled: true
+  AllowedMethods:
+    - touch
+Rails/TimeZone:
+  Enabled: true
+Rails/UniqBeforePluck:
+  Enabled: true
+  EnforcedStyle: conservative
+Rails/UniqueValidationWithoutIndex:
+  Enabled: true
+Rails/UnknownEnv:
+  Enabled: true
+  Environments:
+    - development
+    - test
+    - staging
+    - production
+Rails/Validation:
+  Enabled: true
+Rails/WhereEquals:
+  Enabled: true
+Rails/WhereNot:
+  Enabled: true
 
-# ##########################
-# ### RSpec Requirements ###
-# ##########################
+##########################
+### RSpec Requirements ###
+##########################
 
-# RSpec/AlignLetLeftBrace:
-#   Enabled: true
-# RSpec/AroundBlock:
-#   Enabled: true
-# RSpec/Be:
-#   Enabled: true
-# RSpec/BeEql:
-#   Enabled: true
-# RSpec/BeforeAfterAll:
-#   Enabled: true
-# RSpec/ContextMethod:
-#   Enabled: true
-# RSpec/ContextWording:
-#   Enabled: true
-#   Prefixes:
-#     - when
-#     - with
-#     - without
-# RSpec/DescribeClass:
-#   Enabled: true
-#   IgnoredMetadata:
-#     type:
-#       - request
-# RSpec/DescribedClass:
-#   Enabled: true
-#   EnforcedStyle: described_class
-# RSpec/DescribedClassModuleWrapping:
-#   Enabled: true
-# RSpec/EmptyExampleGroup:
-#   Enabled: true
-# RSpec/EmptyHook:
-#   Enabled: true
-# RSpec/EmptyLineAfterExample:
-#   Enabled: true
-#   AllowConsecutiveOneLiners: true
-# RSpec/EmptyLineAfterExampleGroup:
-#   Enabled: true
-# RSpec/EmptyLineAfterFinalLet:
-#   Enabled: true
-# RSpec/EmptyLineAfterHook:
-#   Enabled: true
-# RSpec/EmptyLineAfterSubject:
-#   Enabled: true
-# RSpec/ExampleWithoutDescription:
-#   Enabled: true
-#   EnforcedStyle: single_line_only
-# RSpec/ExampleWording:
-#   Enabled: true
-# RSpec/ExpectActual:
-#   Enabled: true
-# RSpec/ExpectChange:
-#   Enabled: true
-#   EnforcedStyle: method_call
-# RSpec/ExpectInHook:
-#   Enabled: true
-# RSpec/FilePath:
-#   Enabled: true
-#   IgnoreMethods: true
-# RSpec/Focus:
-#   Enabled: true
-# RSpec/HookArgument:
-#   Enabled: true
-#   EnforcedStyle: implicit
-# RSpec/HooksBeforeExamples:
-#   Enabled: true
-# RSpec/IdenticalEqualityAssertion:
-#   Enabled: true
-# RSpec/ImplicitBlockExpectation:
-#   Enabled: true
-# RSpec/ImplicitExpect:
-#   Enabled: true
-#   EnforcedStyle: is_expected
-# RSpec/ImplicitSubject:
-#   Enabled: true
-#   EnforcedStyle: single_line_only
-# RSpec/InstanceSpy:
-#   Enabled: true
-# RSpec/InstanceVariable:
-#   Enabled: true
-# RSpec/IteratedExpectation:
-#   Enabled: true
-# RSpec/LeadingSubject:
-#   Enabled: true
-# RSpec/LeakyConstantDeclaration:
-#   Enabled: true
-# RSpec/LetBeforeExamples:
-#   Enabled: true
-# RSpec/MessageSpies:
-#   Enabled: true
-#   EnforcedStyle: have_received
-# RSpec/MissingExampleGroupArgument:
-#   Enabled: true
-# RSpec/MultipleDescribes:
-#   Enabled: true
-# RSpec/MultipleExpectations:
-#   Enabled: true
-#   Max: 3
-# RSpec/MultipleSubjects:
-#   Enabled: true
-# RSpec/NamedSubject:
-#   Enabled: true
-#   IgnoreSharedExamples: true
-# RSpec/NotToNot:
-#   Enabled: true
-#   EnforcedStyle: not_to
-# RSpec/PredicateMatcher:
-#   Enabled: true
-#   Strict: false
-#   EnforcedStyle: inflected
-# RSpec/ReceiveCounts:
-#   Enabled: true
-# RSpec/ReceiveNever:
-#   Enabled: true
-# RSpec/RepeatedDescription:
-#   Enabled: true
-# RSpec/RepeatedExample:
-#   Enabled: true
-# RSpec/RepeatedExampleGroupDescription:
-#   Enabled: true
-# RSpec/RepeatedIncludeExample:
-#   Enabled: true
-# RSpec/ReturnFromStub:
-#   Enabled: true
-#   EnforcedStyle: and_return
-# RSpec/ScatteredLet:
-#   Enabled: true
-# RSpec/ScatteredSetup:
-#   Enabled: true
-# RSpec/SharedContext:
-#   Enabled: true
-# RSpec/SharedExamples:
-#   Enabled: true
-# RSpec/SingleArgumentMessageChain:
-#   Enabled: true
-# RSpec/StubbedMock:
-#   Enabled: true
-# RSpec/SubjectStub:
-#   Enabled: true
-# RSpec/UnspecifiedException:
-#   Enabled: true
-# RSpec/VariableDefinition:
-#   Enabled: true
-#   EnforcedStyle: symbols
-# RSpec/VariableName:
-#   Enabled: true
-#   EnforcedStyle: snake_case
-# RSpec/VoidExpect:
-#   Enabled: true
-# RSpec/Yield:
-#   Enabled: true
+RSpec/AlignLetLeftBrace:
+  Enabled: true
+RSpec/AroundBlock:
+  Enabled: true
+RSpec/Be:
+  Enabled: true
+RSpec/BeEql:
+  Enabled: true
+RSpec/BeforeAfterAll:
+  Enabled: true
+RSpec/ContextMethod:
+  Enabled: true
+RSpec/ContextWording:
+  Enabled: true
+  Prefixes:
+    - when
+    - with
+    - without
+RSpec/DescribeClass:
+  Enabled: true
+  IgnoredMetadata:
+    type:
+      - request
+RSpec/DescribedClass:
+  Enabled: true
+  EnforcedStyle: described_class
+RSpec/DescribedClassModuleWrapping:
+  Enabled: true
+RSpec/EmptyExampleGroup:
+  Enabled: true
+RSpec/EmptyHook:
+  Enabled: true
+RSpec/EmptyLineAfterExample:
+  Enabled: true
+  AllowConsecutiveOneLiners: true
+RSpec/EmptyLineAfterExampleGroup:
+  Enabled: true
+RSpec/EmptyLineAfterFinalLet:
+  Enabled: true
+RSpec/EmptyLineAfterHook:
+  Enabled: true
+RSpec/EmptyLineAfterSubject:
+  Enabled: true
+RSpec/ExampleWithoutDescription:
+  Enabled: true
+  EnforcedStyle: single_line_only
+RSpec/ExampleWording:
+  Enabled: true
+RSpec/ExpectActual:
+  Enabled: true
+RSpec/ExpectChange:
+  Enabled: true
+  EnforcedStyle: method_call
+RSpec/ExpectInHook:
+  Enabled: true
+RSpec/FilePath:
+  Enabled: true
+  IgnoreMethods: true
+RSpec/Focus:
+  Enabled: true
+RSpec/HookArgument:
+  Enabled: true
+  EnforcedStyle: implicit
+RSpec/HooksBeforeExamples:
+  Enabled: true
+RSpec/IdenticalEqualityAssertion:
+  Enabled: true
+RSpec/ImplicitBlockExpectation:
+  Enabled: true
+RSpec/ImplicitExpect:
+  Enabled: true
+  EnforcedStyle: is_expected
+RSpec/ImplicitSubject:
+  Enabled: true
+  EnforcedStyle: single_line_only
+RSpec/InstanceSpy:
+  Enabled: true
+RSpec/InstanceVariable:
+  Enabled: true
+RSpec/IteratedExpectation:
+  Enabled: true
+RSpec/LeadingSubject:
+  Enabled: true
+RSpec/LeakyConstantDeclaration:
+  Enabled: true
+RSpec/LetBeforeExamples:
+  Enabled: true
+RSpec/MessageSpies:
+  Enabled: true
+  EnforcedStyle: have_received
+RSpec/MissingExampleGroupArgument:
+  Enabled: true
+RSpec/MultipleDescribes:
+  Enabled: true
+RSpec/MultipleExpectations:
+  Enabled: true
+  Max: 3
+RSpec/MultipleSubjects:
+  Enabled: true
+RSpec/NamedSubject:
+  Enabled: true
+  IgnoreSharedExamples: true
+RSpec/NotToNot:
+  Enabled: true
+  EnforcedStyle: not_to
+RSpec/PredicateMatcher:
+  Enabled: true
+  Strict: false
+  EnforcedStyle: inflected
+RSpec/ReceiveCounts:
+  Enabled: true
+RSpec/ReceiveNever:
+  Enabled: true
+RSpec/RepeatedDescription:
+  Enabled: true
+RSpec/RepeatedExample:
+  Enabled: true
+RSpec/RepeatedExampleGroupDescription:
+  Enabled: true
+RSpec/RepeatedIncludeExample:
+  Enabled: true
+RSpec/ReturnFromStub:
+  Enabled: true
+  EnforcedStyle: and_return
+RSpec/ScatteredLet:
+  Enabled: true
+RSpec/ScatteredSetup:
+  Enabled: true
+RSpec/SharedContext:
+  Enabled: true
+RSpec/SharedExamples:
+  Enabled: true
+RSpec/SingleArgumentMessageChain:
+  Enabled: true
+RSpec/StubbedMock:
+  Enabled: true
+RSpec/SubjectStub:
+  Enabled: true
+RSpec/UnspecifiedException:
+  Enabled: true
+RSpec/VariableDefinition:
+  Enabled: true
+  EnforcedStyle: symbols
+RSpec/VariableName:
+  Enabled: true
+  EnforcedStyle: snake_case
+RSpec/VoidExpect:
+  Enabled: true
+RSpec/Yield:
+  Enabled: true
 
-# ################################
-# ### Performance Requirements ###
-# ################################
+################################
+### Performance Requirements ###
+################################
 
 
-# Performance/BindCall:
-#   Enabled: true
-# Performance/BlockGivenWithExplicitBlock:
-#   Enabled: true
-# Performance/Caller:
-#   Enabled: true
-# Performance/CaseWhenSplat:
-#   Enabled: true
-# Performance/Casecmp:
-#   Enabled: true
-# Performance/ChainArrayAllocation:
-#   Enabled: true
-# Performance/CollectionLiteralInLoop:
-#   Enabled: true
-# Performance/CompareWithBlock:
-#   Enabled: true
-# Performance/Count:
-#   Enabled: true
-# Performance/DeletePrefix:
-#   Enabled: true
-#   SafeMultiline: true
-# Performance/DeleteSuffix:
-#   Enabled: true
-#   SafeMultiline: true
-# Performance/Detect:
-#   Enabled: true
-# Performance/DoubleStartEndWith:
-#   Enabled: true
-# Performance/EndWith:
-#   Enabled: true
-# Performance/FixedSize:
-#   Enabled: true
-# Performance/FlatMap:
-#   Enabled: true
-# Performance/InefficientHashSearch:
-#   Enabled: true
-# Performance/IoReadlines:
-#   Enabled: true
-# Performance/RangeInclude:
-#   Enabled: true
-# Performance/RedundantBlockCall:
-#   Enabled: true
-# Performance/RedundantMatch:
-#   Enabled: true
-# Performance/RedundantMerge:
-#   Enabled: true
-# Performance/RedundantSortBlock:
-#   Enabled: true
-# Performance/RedundantSplitRegexpArgument:
-#   Enabled: true
-# Performance/RedundantStringChars:
-#   Enabled: true
-# Performance/RegexpMatch:
-#   Enabled: true
-# Performance/ReverseEach:
-#   Enabled: true
-# Performance/ReverseFirst:
-#   Enabled: true
-# Performance/SelectMap:
-#   Enabled: true
-# Performance/Size:
-#   Enabled: true
-# Performance/SortReverse:
-#   Enabled: true
-# Performance/Squeeze:
-#   Enabled: true
-# Performance/StartWith:
-#   Enabled: true
-#   SafeMultiline: true
-# Performance/StringInclude:
-#   Enabled: true
-# Performance/StringReplacement:
-#   Enabled: true
-# Performance/Sum:
-#   Enabled: true
-# Performance/TimesMap:
-#   Enabled: true
-# Performance/UnfreezeString:
-#   Enabled: true
-# Performance/UriDefaultParser:
-#   Enabled: true
+Performance/BindCall:
+  Enabled: true
+Performance/BlockGivenWithExplicitBlock:
+  Enabled: true
+Performance/Caller:
+  Enabled: true
+Performance/CaseWhenSplat:
+  Enabled: true
+Performance/Casecmp:
+  Enabled: true
+Performance/ChainArrayAllocation:
+  Enabled: true
+Performance/CollectionLiteralInLoop:
+  Enabled: true
+Performance/CompareWithBlock:
+  Enabled: true
+Performance/Count:
+  Enabled: true
+Performance/DeletePrefix:
+  Enabled: true
+  SafeMultiline: true
+Performance/DeleteSuffix:
+  Enabled: true
+  SafeMultiline: true
+Performance/Detect:
+  Enabled: true
+Performance/DoubleStartEndWith:
+  Enabled: true
+Performance/EndWith:
+  Enabled: true
+Performance/FixedSize:
+  Enabled: true
+Performance/FlatMap:
+  Enabled: true
+Performance/InefficientHashSearch:
+  Enabled: true
+Performance/IoReadlines:
+  Enabled: true
+Performance/RangeInclude:
+  Enabled: true
+Performance/RedundantBlockCall:
+  Enabled: true
+Performance/RedundantMatch:
+  Enabled: true
+Performance/RedundantMerge:
+  Enabled: true
+Performance/RedundantSortBlock:
+  Enabled: true
+Performance/RedundantSplitRegexpArgument:
+  Enabled: true
+Performance/RedundantStringChars:
+  Enabled: true
+Performance/RegexpMatch:
+  Enabled: true
+Performance/ReverseEach:
+  Enabled: true
+Performance/ReverseFirst:
+  Enabled: true
+Performance/SelectMap:
+  Enabled: true
+Performance/Size:
+  Enabled: true
+Performance/SortReverse:
+  Enabled: true
+Performance/Squeeze:
+  Enabled: true
+Performance/StartWith:
+  Enabled: true
+  SafeMultiline: true
+Performance/StringInclude:
+  Enabled: true
+Performance/StringReplacement:
+  Enabled: true
+Performance/Sum:
+  Enabled: true
+Performance/TimesMap:
+  Enabled: true
+Performance/UnfreezeString:
+  Enabled: true
+Performance/UriDefaultParser:
+  Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+git_source(:github) {|repo| "https://github.com/#{repo}.git" }
 
 ruby '3.0.2'
 
@@ -30,7 +30,7 @@ gem 'configatron', '~> 4.5.1'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', '~> 11.1', platforms: [:mri, :mingw, :x64_mingw]
-  
+
   # Use RSpec for unit and integration testing
   gem 'rspec-rails', '~> 5.0.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -232,7 +232,7 @@ DEPENDENCIES
   rack-cors (~> 1.1.1)
   rails (~> 6.1.3, >= 6.1.3.2)
   rspec-rails (~> 5.0.1)
-  rubocop-performance
+  rubocop-performance (~> 1.11.4)
   rubocop-rails (~> 2.11.3)
   rubocop-rspec (~> 2.4.0)
   spring (~> 2.1)

--- a/app/controller_services/application_controller/authorization_service.rb
+++ b/app/controller_services/application_controller/authorization_service.rb
@@ -7,12 +7,12 @@ class ApplicationController < ActionController::API
   class AuthorizationService
     def initialize(controller, token)
       @controller = controller
-      @token = token
+      @token      = token
     end
 
     def perform
       validator = GoogleIDToken::Validator.new
-      payload = validator.check(token, configatron.google_oauth_client_id)
+      payload   = validator.check(token, configatron.google_oauth_client_id)
 
       if current?(payload['exp'])
         controller.current_user = User.create_or_update_for_google(payload)

--- a/app/controller_services/games_controller/create_service.rb
+++ b/app/controller_services/games_controller/create_service.rb
@@ -7,7 +7,7 @@ require 'service/internal_server_error_result'
 class GamesController < ApplicationController
   class CreateService
     def initialize(user, params)
-      @user = user
+      @user   = user
       @params = params
     end
 

--- a/app/controller_services/games_controller/destroy_service.rb
+++ b/app/controller_services/games_controller/destroy_service.rb
@@ -7,7 +7,7 @@ require 'service/internal_server_error_result'
 class GamesController < ApplicationController
   class DestroyService
     def initialize(user, game_id)
-      @user = user
+      @user    = user
       @game_id = game_id
     end
 

--- a/app/controller_services/games_controller/update_service.rb
+++ b/app/controller_services/games_controller/update_service.rb
@@ -7,9 +7,9 @@ require 'service/not_found_result'
 class GamesController < ApplicationController
   class UpdateService
     def initialize(user, game_id, params)
-      @user = user
+      @user    = user
       @game_id = game_id
-      @params = params
+      @params  = params
     end
 
     def perform

--- a/app/controller_services/shopping_list_items_controller/create_service.rb
+++ b/app/controller_services/shopping_list_items_controller/create_service.rb
@@ -11,16 +11,16 @@ class ShoppingListItemsController < ApplicationController
     AGGREGATE_LIST_ERROR = 'Cannot manually manage items on an aggregate shopping list'
 
     def initialize(user, list_id, params)
-      @user = user
+      @user    = user
       @list_id = list_id
-      @params = params
+      @params  = params
     end
 
     def perform
       return Service::MethodNotAllowedResult.new(errors: [AGGREGATE_LIST_ERROR]) if shopping_list.aggregate == true
 
       preexisting_item = shopping_list.list_items.find_by('description ILIKE ?', params[:description])
-      item = ShoppingListItem.combine_or_new(params.merge(list_id: list_id))
+      item             = ShoppingListItem.combine_or_new(params.merge(list_id: list_id))
 
       ActiveRecord::Base.transaction do
         item.save!

--- a/app/controller_services/shopping_list_items_controller/destroy_service.rb
+++ b/app/controller_services/shopping_list_items_controller/destroy_service.rb
@@ -11,7 +11,7 @@ class ShoppingListItemsController < ApplicationController
     AGGREGATE_LIST_ERROR = 'Cannot manually delete list item from aggregate shopping list'
 
     def initialize(user, item_id)
-      @user = user
+      @user    = user
       @item_id = item_id
     end
 
@@ -24,7 +24,7 @@ class ShoppingListItemsController < ApplicationController
         shopping_list_item.destroy!
         aggregate_list_item = aggregate_list.remove_item_from_child_list(shopping_list_item.attributes)
       end
-      
+
       aggregate_list_item.nil? ? Service::NoContentResult.new : Service::OKResult.new(resource: aggregate_list_item)
     rescue ActiveRecord::RecordNotFound
       Service::NotFoundResult.new

--- a/app/controller_services/shopping_list_items_controller/update_service.rb
+++ b/app/controller_services/shopping_list_items_controller/update_service.rb
@@ -11,9 +11,9 @@ class ShoppingListItemsController < ApplicationController
     AGGREGATE_LIST_ERROR = 'Cannot manually update list items on an aggregate shopping list'
 
     def initialize(user, item_id, params)
-      @user = user
+      @user    = user
       @item_id = item_id
-      @params = params
+      @params  = params
     end
 
     def perform
@@ -25,7 +25,7 @@ class ShoppingListItemsController < ApplicationController
       aggregate_list_item = nil
       ActiveRecord::Base.transaction do
         list_item.update!(params)
-        
+
         aggregate_list_item = aggregate_list.update_item_from_child_list(list_item.description, delta_qty, old_notes, params[:notes])
       end
 
@@ -38,7 +38,7 @@ class ShoppingListItemsController < ApplicationController
       Rails.logger.error "Internal Server Error: #{e.message}"
       Service::InternalServerErrorResult.new(errors: [e.message])
     end
-    
+
     private
 
     attr_reader :user, :item_id, :params

--- a/app/controller_services/shopping_lists_controller/create_service.rb
+++ b/app/controller_services/shopping_lists_controller/create_service.rb
@@ -12,15 +12,15 @@ class ShoppingListsController < ApplicationController
     AGGREGATE_LIST_ERROR = 'Cannot manually create an aggregate shopping list'
 
     def initialize(user, game_id, params)
-      @user = user
+      @user    = user
       @game_id = game_id
-      @params = params
+      @params  = params
     end
 
     def perform
       return Service::UnprocessableEntityResult.new(errors: [AGGREGATE_LIST_ERROR]) if params[:aggregate]
 
-      shopping_list = game.shopping_lists.new(params)
+      shopping_list              = game.shopping_lists.new(params)
       preexisting_aggregate_list = game.aggregate_shopping_list
 
       if shopping_list.save

--- a/app/controller_services/shopping_lists_controller/destroy_service.rb
+++ b/app/controller_services/shopping_lists_controller/destroy_service.rb
@@ -11,7 +11,7 @@ class ShoppingListsController < ApplicationController
     AGGREGATE_LIST_ERROR = 'Cannot manually delete an aggregate shopping list'
 
     def initialize(user, list_id)
-      @user = user
+      @user    = user
       @list_id = list_id
     end
 
@@ -46,7 +46,7 @@ class ShoppingListsController < ApplicationController
         shopping_list.destroy!
 
         if aggregate_list&.persisted?
-          list_items.each { |item_attributes| aggregate_list.remove_item_from_child_list(item_attributes) }
+          list_items.each {|item_attributes| aggregate_list.remove_item_from_child_list(item_attributes) }
           aggregate_list
         end
       end

--- a/app/controller_services/shopping_lists_controller/index_service.rb
+++ b/app/controller_services/shopping_lists_controller/index_service.rb
@@ -7,7 +7,7 @@ require 'service/internal_server_error_result'
 class ShoppingListsController < ApplicationController
   class IndexService
     def initialize(user, game_id)
-      @user = user
+      @user    = user
       @game_id = game_id
     end
 

--- a/app/controller_services/shopping_lists_controller/update_service.rb
+++ b/app/controller_services/shopping_lists_controller/update_service.rb
@@ -8,13 +8,13 @@ require 'service/internal_server_error_result'
 
 class ShoppingListsController < ApplicationController
   class UpdateService
-    AGGREGATE_LIST_ERROR = 'Cannot manually update an aggregate shopping list'
+    AGGREGATE_LIST_ERROR    = 'Cannot manually update an aggregate shopping list'
     DISALLOWED_UPDATE_ERROR = 'Cannot make a regular shopping list an aggregate list'
 
     def initialize(user, list_id, params)
-      @user = user
+      @user    = user
       @list_id = list_id
-      @params = params
+      @params  = params
     end
 
     def perform

--- a/app/controllers/shopping_lists_controller.rb
+++ b/app/controllers/shopping_lists_controller.rb
@@ -17,7 +17,7 @@ class ShoppingListsController < ApplicationController
 
   def update
     result = UpdateService.new(current_user, params[:id], shopping_list_params).perform
-    
+
     ::Controller::Response.new(self, result).execute
   end
 

--- a/app/controllers/utilities_controller.rb
+++ b/app/controllers/utilities_controller.rb
@@ -22,7 +22,7 @@ class UtilitiesController < ApplicationController
     about you is your name, your email, and your Google profile image, all
     of which we get from Google when you log in. That means the name, email,
     and profile image we have on file for you will be the ones associated
-    with the Google account you use to log in. 
+    with the Google account you use to log in.#{' '}
   HEREDOC
 
   TOS = <<~HEREDOC

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -2,6 +2,6 @@ class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
   def error_array
-    errors.map { |error| "#{error.attribute.capitalize} #{error.message}"}
+    errors.map {|error| "#{error.attribute.capitalize} #{error.message}" }
   end
 end

--- a/app/models/concerns/aggregatable.rb
+++ b/app/models/concerns/aggregatable.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 # There is always a risk with concerns that they will not ultimately provide
@@ -14,7 +13,7 @@
 #
 # The database schema for a Aggregatable model has a few requirements. It must
 # contain the following columns:
-# 
+#
 #    | Column            | Type    | Constraints                 |
 #    | ----------------- | ------- | --------------------------- |
 #    | title             | string  | null: false                 |
@@ -33,7 +32,7 @@ module Aggregatable
   extend ActiveSupport::Concern
 
   class AggregateListError < StandardError; end
-  
+
   included do
     belongs_to :game, touch: true
     has_many :list_items, -> { index_order }, class_name: self.list_item_class_name, dependent: :destroy, foreign_key: :list_id
@@ -79,7 +78,7 @@ module Aggregatable
       existing_item.destroy!
     else
       existing_item.quantity -= attrs['quantity']
-      existing_item.notes = extract_notes(attrs['notes'], existing_item.notes)
+      existing_item.notes     = extract_notes(attrs['notes'], existing_item.notes)
       existing_item.save!
     end
 
@@ -96,11 +95,11 @@ module Aggregatable
     end
 
     existing_item.quantity += delta_quantity
-    existing_item.notes = if old_notes.nil? && new_notes.present?
-                            [existing_item.notes.to_s, new_notes.to_s].join(' -- ')
-                          else
-                            existing_item.notes&.sub(/#{old_notes}/, new_notes.to_s).presence || new_notes
-                          end
+    existing_item.notes     = if old_notes.nil? && new_notes.present?
+                                [existing_item.notes.to_s, new_notes.to_s].join(' -- ')
+                              else
+                                existing_item.notes&.sub(/#{old_notes}/, new_notes.to_s).presence || new_notes
+                              end
 
     existing_item.save!
     existing_item
@@ -138,7 +137,7 @@ module Aggregatable
   def public_list_item_attrs(item)
     private_attrs = [:id, 'id', :created_at, 'created_at', :updated_at, 'updated_at']
 
-    item.attributes.reject { |key, value| private_attrs.include?(key) }
+    item.attributes.reject {|key, value| private_attrs.include?(key) }
   end
 
   def abort_if_aggregate

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -6,11 +6,12 @@ class Game < ApplicationRecord
   belongs_to :user
   has_many :shopping_lists, -> { index_order }, dependent: :destroy
 
-  validates :name, uniqueness: { scope: :user_id, message: 'must be unique' },
-                   format: {
-                     with: /\A\s*[a-z0-9 \-'\,]*\s*\z/i,
-                     message: "can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')"
-                   }
+  validates :name,
+            uniqueness: { scope: :user_id, message: 'must be unique' },
+            format:     {
+                          with:    /\A\s*[a-z0-9 \-'\,]*\s*\z/i,
+                          message: "can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')"
+                        }
 
   before_save :format_name
 
@@ -28,9 +29,10 @@ class Game < ApplicationRecord
 
   def format_name
     if name.blank?
-      max_existing_number = user.games.where("name LIKE 'My Game %'").pluck(:name).map { |t| t.gsub('My Game ', '').to_i }.max || 0
-      next_number = max_existing_number >= 0 ? max_existing_number + 1 : 1 
-      self.name = "My Game #{next_number}"
+      max_existing_number = user.games.where("name LIKE 'My Game %'").pluck(:name).map {|t| t.gsub('My Game ', '').to_i }
+                              .max || 0
+      next_number         = max_existing_number >= 0 ? max_existing_number + 1 : 1
+      self.name           = "My Game #{next_number}"
     else
       self.name = Titlecase.titleize(name.strip)
     end

--- a/app/models/shopping_list.rb
+++ b/app/models/shopping_list.rb
@@ -7,11 +7,12 @@ class ShoppingList < ApplicationRecord
   # contain alphanumeric characters and spaces with no special characters or whitespace
   # other than spaces. Leading or trailing whitespace is stripped anyway so the validation
   # ignores any leading or trailing whitespace characters.
-  validates :title, uniqueness: { scope: :game_id },
-                    format: {
-                      with: /\A\s*[a-z0-9 \-'\,]*\s*\z/i,
-                      message: "can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')"
-                    }
+  validates :title,
+            uniqueness: { scope: :game_id },
+            format:     {
+                          with:    /\A\s*[a-z0-9 \-'\,]*\s*\z/i,
+                          message: "can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')"
+                        }
 
   before_save :format_title
 
@@ -32,9 +33,10 @@ class ShoppingList < ApplicationRecord
     return if aggregate
 
     if title.blank?
-      max_existing_number = game.shopping_lists.where("title LIKE 'My List %'").pluck(:title).map { |t| t.gsub('My List ', '').to_i }.max || 0
-      next_number = max_existing_number >= 0 ? max_existing_number + 1 : 1 
-      self.title = "My List #{next_number}"
+      max_existing_number = game.shopping_lists.where("title LIKE 'My List %'").pluck(:title).map {|t| t.gsub('My List ', '').to_i }
+                              .max || 0
+      next_number         = max_existing_number >= 0 ? max_existing_number + 1 : 1
+      self.title          = "My List #{next_number}"
     else
       self.title = Titlecase.titleize(title.strip)
     end

--- a/app/models/shopping_list_item.rb
+++ b/app/models/shopping_list_item.rb
@@ -27,18 +27,18 @@ class ShoppingListItem < ApplicationRecord
 
   def self.combine_or_new(attrs)
     shopping_list = attrs[:list] || attrs['list'] || ShoppingList.find(attrs[:list_id] || attrs['list_id'])
-    desc = (attrs[:description] || attrs['description'])
+    desc          = (attrs[:description] || attrs['description'])
     existing_item = shopping_list.list_items.find_by('description ILIKE ?', desc)
 
     if existing_item.nil?
       new attrs
     else
-      qty = attrs[:quantity] || attrs['quantity'] || 1
+      qty       = attrs[:quantity] || attrs['quantity'] || 1
       new_notes = attrs[:notes] || attrs['notes']
       old_notes = existing_item.notes
 
       new_quantity = existing_item.quantity + qty
-      new_notes = [old_notes, new_notes].compact.join(' -- ').presence
+      new_notes    = [old_notes, new_notes].compact.join(' -- ').presence
 
       existing_item.assign_attributes(quantity: new_quantity, notes: new_notes)
       existing_item
@@ -53,6 +53,7 @@ class ShoppingListItem < ApplicationRecord
 
   def clean_up_notes
     return true unless notes
+
     self.notes = notes.strip.gsub(/^(\-\- ?)*/, '').gsub(/( ?\-\-)*$/, '').gsub(/( \-\- ){2,}/, ' -- ').presence
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,9 +8,9 @@ class User < ApplicationRecord
 
   def self.create_or_update_for_google(data)
     where(uid: data['email']).first_or_initialize.tap do |user|
-      user.uid = data['email']
-      user.email = data['email']
-      user.name = data['name']
+      user.uid       = data['email']
+      user.email     = data['email']
+      user.name      = data['name']
       user.image_url = data['picture']
       user.save!
     end

--- a/bin/bundle
+++ b/bin/bundle
@@ -24,15 +24,17 @@ m = Module.new do
   def cli_arg_version
     return unless invoked_as_script? # don't want to hijack other binstubs
     return unless "update".start_with?(ARGV.first || " ") # must be running `bundle update`
+
     bundler_version = nil
-    update_index = nil
+    update_index    = nil
     ARGV.each_with_index do |a, i|
       if update_index && update_index.succ == i && a =~ Gem::Version::ANCHORED_VERSION_PATTERN
         bundler_version = a
       end
       next unless a =~ /\A--bundler(?:[= ](#{Gem::Version::VERSION_PATTERN}))?\z/
+
       bundler_version = $1
-      update_index = i
+      update_index    = i
     end
     bundler_version
   end
@@ -45,25 +47,26 @@ m = Module.new do
   end
 
   def lockfile
-    lockfile =
-      case File.basename(gemfile)
-      when "gems.rb" then gemfile.sub(/\.rb$/, gemfile)
-      else "#{gemfile}.lock"
-      end
+    lockfile = case File.basename(gemfile)
+               when "gems.rb" then gemfile.sub(/\.rb$/, gemfile)
+               else "#{gemfile}.lock"
+               end
     File.expand_path(lockfile)
   end
 
   def lockfile_version
     return unless File.file?(lockfile)
+
     lockfile_contents = File.read(lockfile)
     return unless lockfile_contents =~ /\n\nBUNDLED WITH\n\s{2,}(#{Gem::Version::VERSION_PATTERN})\n/
+
     Regexp.last_match(1)
   end
 
   def bundler_version
     @bundler_version ||=
       env_var_version || cli_arg_version ||
-        lockfile_version
+      lockfile_version
   end
 
   def bundler_requirement
@@ -87,14 +90,16 @@ m = Module.new do
   end
 
   def activate_bundler
-    gem_error = activation_error_handling do
+    gem_error     = activation_error_handling do
       gem "bundler", bundler_requirement
     end
     return if gem_error.nil?
+
     require_error = activation_error_handling do
       require "bundler/version"
     end
     return if require_error.nil? && Gem::Requirement.new(bundler_requirement).satisfied_by?(Gem::Version.new(Bundler::VERSION))
+
     warn "Activating bundler (#{bundler_requirement}) failed:\n#{gem_error.message}\n\nTo install the version of bundler this project requires, run `gem install bundler -v '#{bundler_requirement}'`"
     exit 42
   end

--- a/bin/spring
+++ b/bin/spring
@@ -4,7 +4,7 @@ if !defined?(Spring) && [nil, "development", "test"].include?(ENV["RAILS_ENV"])
   require "bundler"
 
   # Load Spring without loading other gems in the Gemfile, for speed.
-  Bundler.locked_gems&.specs&.find { |spec| spec.name == "spring" }&.tap do |spring|
+  Bundler.locked_gems&.specs&.find {|spec| spec.name == "spring" }&.tap do |spring|
     Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
     gem "spring", spring.version
     require "spring/binstub"

--- a/config/configatron/defaults.rb
+++ b/config/configatron/defaults.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-configatron.client_origin = ENV['CLIENT_ORIGIN'] || 'http://localhost:3001'
+configatron.client_origin          = ENV['CLIENT_ORIGIN'] || 'http://localhost:3001'
 configatron.google_oauth_client_id = ENV['GOOGLE_OAUTH_CLIENT_ID']

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -17,10 +17,10 @@ Rails.application.configure do
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
   if Rails.root.join('tmp', 'caching-dev.txt').exist?
-    config.cache_store = :memory_store
+    config.cache_store                = :memory_store
     config.public_file_server.headers = {
-      'Cache-Control' => "public, max-age=#{2.days.to_i}"
-    }
+                                          'Cache-Control' => "public, max-age=#{2.days.to_i}"
+                                        }
   else
     config.action_controller.perform_caching = false
 
@@ -46,7 +46,6 @@ Rails.application.configure do
 
   # Highlight code that triggered database queries in logs.
   config.active_record.verbose_query_logs = true
-
 
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = false
+  config.consider_all_requests_local = false
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
@@ -38,11 +38,10 @@ Rails.application.configure do
   config.log_level = :info
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
-
 
   config.action_mailer.perform_caching = false
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -8,7 +8,7 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  config.cache_classes = false
+  config.cache_classes                      = false
   config.action_view.cache_template_loading = true
 
   # Do not eager load code on boot. This avoids loading your whole application
@@ -19,13 +19,13 @@ Rails.application.configure do
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-    'Cache-Control' => "public, max-age=#{1.hour.to_i}"
-  }
+                                        'Cache-Control' => "public, max-age=#{1.hour.to_i}"
+                                      }
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
-  config.cache_store = :null_store
+  config.cache_store                       = :null_store
 
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -12,7 +12,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
     origins configatron.client_origin
 
     resource '*',
-      headers: :any,
-      methods: %i[get post put patch delete options head]
+             headers: :any,
+             methods: %i[get post put patch delete options head]
   end
 end

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -2,5 +2,5 @@
 
 # Configure sensitive parameters which will be filtered from the log file.
 Rails.application.config.filter_parameters += [
-  :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn
-]
+                                                :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn
+                                              ]

--- a/db/migrate/20210619225944_add_title_to_shopping_lists.rb
+++ b/db/migrate/20210619225944_add_title_to_shopping_lists.rb
@@ -5,5 +5,4 @@ class AddTitleToShoppingLists < ActiveRecord::Migration[6.1]
     add_column :shopping_lists, :title, :string, null: false
     add_index :shopping_lists, %i[user_id title], unique: true
   end
-
 end

--- a/lib/controller/response.rb
+++ b/lib/controller/response.rb
@@ -4,8 +4,8 @@ module Controller
   class Response
     def initialize(controller, result, options = {})
       @controller = controller
-      @result = result
-      @options = options
+      @result     = result
+      @options    = options
     end
 
     def execute

--- a/lib/titlecase.rb
+++ b/lib/titlecase.rb
@@ -53,25 +53,25 @@
 
 module Titlecase
   LOWERCASE_WORDS = %w[
-    a
-    an
-    the
-    and
-    but
-    for
-    at
-    by
-    from
-    with
-    to
-    in
-    of
-    into
-    onto
-    on
-    without
-    within
-  ]
+                      a
+                      an
+                      the
+                      and
+                      but
+                      for
+                      at
+                      by
+                      from
+                      with
+                      to
+                      in
+                      of
+                      into
+                      onto
+                      on
+                      without
+                      within
+                    ]
 
   module_function
 

--- a/spec/controller_services/application_controller/authorization_service_spec.rb
+++ b/spec/controller_services/application_controller/authorization_service_spec.rb
@@ -19,9 +19,9 @@ RSpec.describe ApplicationController::AuthorizationService do
       let(:user) { create(:user, name: 'Jane Doe', email: 'jane.doe@gmail.com', uid: 'jane.doe@gmail.com') }
       let(:payload) do
         {
-          'exp' => (Time.now + 1.day).to_i,
-          'email' => 'jane.doe@gmail.com',
-          'name' => 'Jane Doe',
+          'exp'     => (Time.now + 1.day).to_i,
+          'email'   => 'jane.doe@gmail.com',
+          'name'    => 'Jane Doe',
           'picture' => nil
         }
       end
@@ -49,9 +49,9 @@ RSpec.describe ApplicationController::AuthorizationService do
     context 'when the token is invalid' do
       let(:payload) do
         {
-          'exp' => (Time.now - 1.day).to_i,
-          'email' => 'jane.doe@gmail.com',
-          'name' => 'Jane Doe',
+          'exp'     => (Time.now - 1.day).to_i,
+          'email'   => 'jane.doe@gmail.com',
+          'name'    => 'Jane Doe',
           'picture' => nil
         }
       end

--- a/spec/controller_services/games_controller/create_service_spec.rb
+++ b/spec/controller_services/games_controller/create_service_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe GamesController::CreateService do
     let(:params) { { name: 'Skyrim, Baby' } }
 
     it 'creates a new game' do
-      expect { perform }.to change(user.games, :count).from(0).to(1)
+      expect { perform }
+        .to change(user.games, :count).from(0).to(1)
     end
 
     it 'returns a Service::CreatedResult' do
@@ -30,7 +31,8 @@ RSpec.describe GamesController::CreateService do
     let(:params) { { name: '$@#*$&' } }
 
     it "doesn't create a new game" do
-      expect { perform }.not_to change(Game, :count)
+      expect { perform }
+        .not_to change(Game, :count)
     end
 
     it 'returns a Service::UnprocessableEntityResult' do

--- a/spec/controller_services/games_controller/destroy_service_spec.rb
+++ b/spec/controller_services/games_controller/destroy_service_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe GamesController::DestroyService do
       let!(:user) { game.user }
 
       it 'destroys the game' do
-        expect { perform }.to change(user.games, :count).from(1).to(0)
+        expect { perform }
+          .to change(user.games, :count).from(1).to(0)
       end
 
       it 'returns a Service::NoContentResult' do

--- a/spec/controller_services/shopping_list_items_controller/create_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/create_service_spec.rb
@@ -33,12 +33,13 @@ RSpec.describe ShoppingListItemsController::CreateService do
         end
 
         it 'adds a list item to the given list' do
-          expect { perform }.to change(shopping_list.list_items, :count).from(0).to(1)
+          expect { perform }
+            .to change(shopping_list.list_items, :count).from(0).to(1)
         end
 
         it 'assigns the correct values' do
-          params_with_string_keys = {}
-          params.each { |key, value| params_with_string_keys[key.to_s] = value }
+          params_with_string_keys                                     = {}
+          params.each {|key, value| params_with_string_keys[key.to_s] = value }
 
           perform
           expect(shopping_list.list_items.last.attributes).to include(**params_with_string_keys)
@@ -82,11 +83,13 @@ RSpec.describe ShoppingListItemsController::CreateService do
         end
 
         it "doesn't create a new item on the regular list" do
-          expect { perform }.not_to change(shopping_list.list_items, :count)
+          expect { perform }
+            .not_to change(shopping_list.list_items, :count)
         end
 
         it "doesn't create a new item on the aggregate list" do
-          expect { perform }.not_to change(aggregate_list.list_items, :count)
+          expect { perform }
+            .not_to change(aggregate_list.list_items, :count)
         end
 
         it 'updates the list itself' do
@@ -151,7 +154,8 @@ RSpec.describe ShoppingListItemsController::CreateService do
       end
 
       it 'combines the item with an existing one' do
-        expect { perform }.not_to change(shopping_list.list_items, :count)
+        expect { perform }
+          .not_to change(shopping_list.list_items, :count)
       end
 
       it 'updates the shopping list' do

--- a/spec/controller_services/shopping_list_items_controller/destroy_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/destroy_service_spec.rb
@@ -26,11 +26,13 @@ RSpec.describe ShoppingListItemsController::DestroyService do
       context 'when the quantity on the aggregate list equals the quantity on the regular list' do
         it 'destroys the list item' do
           perform
-          expect { ShoppingListItem.find(list_item.id) }.to raise_error ActiveRecord::RecordNotFound
+          expect { ShoppingListItem.find(list_item.id) }
+            .to raise_error ActiveRecord::RecordNotFound
         end
 
         it 'destroys the item on the aggregate list' do
-          expect { perform }.to change(aggregate_list.list_items, :count).from(1).to(0)
+          expect { perform }
+            .to change(aggregate_list.list_items, :count).from(1).to(0)
         end
 
         it 'returns a Service::NoContentResult' do
@@ -59,11 +61,10 @@ RSpec.describe ShoppingListItemsController::DestroyService do
         let(:second_list) { create(:shopping_list, game: game, aggregate_list: aggregate_list) }
         let(:second_list_item) do
           create(:shopping_list_item,
-                  list: second_list,
-                  description: list_item.description.upcase, # make sure comparison is case insensitive
-                  quantity: 2,
-                  notes: 'some other notes'
-                )
+                 list:        second_list,
+                 description: list_item.description.upcase, # make sure comparison is case insensitive
+                 quantity:    2,
+                 notes:       'some other notes')
         end
 
         before do
@@ -72,9 +73,10 @@ RSpec.describe ShoppingListItemsController::DestroyService do
 
         it 'destroys the list item' do
           perform
-          expect { ShoppingListItem.find(list_item.id) }.to raise_error ActiveRecord::RecordNotFound
+          expect { ShoppingListItem.find(list_item.id) }
+            .to raise_error ActiveRecord::RecordNotFound
         end
-        
+
         it 'changes the quantity of the aggregate list item' do
           perform
           expect(aggregate_list.list_items.first.quantity).to eq 2

--- a/spec/controller_services/shopping_lists_controller/create_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/create_service_spec.rb
@@ -9,7 +9,7 @@ require 'service/internal_server_error_result'
 RSpec.describe ShoppingListsController::CreateService do
   describe '#perform' do
     subject(:perform) { described_class.new(user, game.id, params).perform }
-    
+
     let(:user) { create(:user) }
 
     context 'when the game is not found' do
@@ -42,7 +42,7 @@ RSpec.describe ShoppingListsController::CreateService do
       let(:game) { create(:game, user: user) }
       let(:params) do
         {
-          title: 'All Items',
+          title:     'All Items',
           aggregate: true
         }
       end
@@ -66,7 +66,8 @@ RSpec.describe ShoppingListsController::CreateService do
         end
 
         it 'creates a shopping list for the given game' do
-          expect { perform }.to change(game.shopping_lists, :count).from(1).to(2)
+          expect { perform }
+            .to change(game.shopping_lists, :count).from(1).to(2)
         end
 
         it 'returns a Service::CreatedResult' do
@@ -88,7 +89,8 @@ RSpec.describe ShoppingListsController::CreateService do
 
       context "when the game doesn't have an aggregate shopping list" do
         it 'creates two lists' do
-          expect { perform }.to change(game.shopping_lists, :count).from(0).to(2)
+          expect { perform }
+            .to change(game.shopping_lists, :count).from(0).to(2)
         end
 
         it 'creates an aggregate shopping list for the given game' do
@@ -125,7 +127,8 @@ RSpec.describe ShoppingListsController::CreateService do
       let(:params) { { title: '|nvalid Tit|e' } }
 
       it 'does not create a shopping list' do
-        expect { perform }.not_to change(game.shopping_lists, :count)
+        expect { perform }
+          .not_to change(game.shopping_lists, :count)
       end
 
       it 'returns a Service::UnprocessableEntityResult' do

--- a/spec/controller_services/shopping_lists_controller/destroy_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/destroy_service_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe ShoppingListsController::DestroyService do
         end
 
         it 'destroys the shopping list' do
-          expect { perform }.to change(game.shopping_lists, :count).from(3).to(2)
+          expect { perform }
+            .to change(game.shopping_lists, :count).from(3).to(2)
         end
 
         it 'updates the game' do
@@ -49,7 +50,7 @@ RSpec.describe ShoppingListsController::DestroyService do
         describe 'updating the aggregate list' do
           before do
             items = create_list(:shopping_list_item, 2, list: third_list)
-            items.each { |item| aggregate_list.add_item_from_child_list(item) }
+            items.each {|item| aggregate_list.add_item_from_child_list(item) }
 
             # Because in the code it finds the shopping list by ID and then gets the aggregate list
             # off that instance, the tests don't have access to the instance of the aggregate list that
@@ -79,7 +80,8 @@ RSpec.describe ShoppingListsController::DestroyService do
         end
 
         it 'destroys the aggregate list too' do
-          expect { perform }.to change(game.shopping_lists, :count).from(2).to(0)
+          expect { perform }
+            .to change(game.shopping_lists, :count).from(2).to(0)
         end
 
         it 'updates the game' do

--- a/spec/controller_services/shopping_lists_controller/update_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/update_service_spec.rb
@@ -10,10 +10,10 @@ require 'service/internal_server_error_result'
 RSpec.describe ShoppingListsController::UpdateService do
   describe '#perform' do
     subject(:perform) { described_class.new(user, shopping_list.id, params).perform }
-    
+
     let!(:aggregate_list) { create(:aggregate_shopping_list, game: game) }
     let(:user) { create(:user) }
-    
+
     context 'when all goes well' do
       let(:shopping_list) { create(:shopping_list, game: game, aggregate_list_id: aggregate_list.id) }
       let(:game) { create(:game, user: user) }
@@ -59,7 +59,7 @@ RSpec.describe ShoppingListsController::UpdateService do
       let(:shopping_list) { create(:shopping_list, game: game) }
       let(:game) { create(:game) }
       let(:params) { { title: 'Valid New Title' } }
-      
+
       it 'returns a Service::NotFoundResult' do
         expect(perform).to be_a(Service::NotFoundResult)
       end

--- a/spec/factories/games.rb
+++ b/spec/factories/games.rb
@@ -3,8 +3,8 @@
 FactoryBot.define do
   factory :game do
     user
-    
-    sequence(:name) { |n| "Skyrim Game #{n}" }
+
+    sequence(:name) {|n| "Skyrim Game #{n}" }
 
     factory :game_with_shopping_lists do
       transient do

--- a/spec/factories/shopping_list_items.rb
+++ b/spec/factories/shopping_list_items.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :shopping_list_item do
     association :list, factory: :shopping_list
 
-    sequence(:description) { |n| "Item #{n}" }
+    sequence(:description) {|n| "Item #{n}" }
     quantity { 1 }
   end
 end

--- a/spec/factories/shopping_lists.rb
+++ b/spec/factories/shopping_lists.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :shopping_list do
     game
 
-    sequence(:title) { |n| "Shopping List #{n}" }
+    sequence(:title) {|n| "Shopping List #{n}" }
 
     factory :aggregate_shopping_list do
       aggregate { true }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,8 +2,8 @@
 
 FactoryBot.define do
   factory(:user) do
-    sequence(:uid) { |n| "foo#{n}@example.com" }
-    sequence(:email) { |n| "foo#{n}@example.com" }
+    sequence(:uid) {|n| "foo#{n}@example.com" }
+    sequence(:email) {|n| "foo#{n}@example.com" }
     name { 'Jane Doe' }
 
     factory :user_with_games do

--- a/spec/lib/controller/response_spec.rb
+++ b/spec/lib/controller/response_spec.rb
@@ -40,9 +40,9 @@ RSpec.describe Controller::Response do
 
       let(:resource) do
         {
-          id: 927,
-          user_id: 72,
-          title: 'My List 2',
+          id:         927,
+          user_id:    72,
+          title:      'My List 2',
           created_at: Time.now - 2.days,
           updated_at: Time.now
         }

--- a/spec/lib/service/result_spec.rb
+++ b/spec/lib/service/result_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe Service::Result do
 
     describe 'status' do
       it 'raises a NotImplementedError on the base class' do
-        expect { result.status }.to raise_error NotImplementedError
+        expect { result.status }
+          .to raise_error NotImplementedError
       end
     end
 
@@ -18,21 +19,21 @@ RSpec.describe Service::Result do
       let(:options) do
         {
           resource: {
-            id: 32,
-            uid: 'jane.doe@gmail.com',
-            email: 'jane.doe@gmail.com',
-            name: 'Jane Doe',
-            image_url: nil
-          }
+                      id:        32,
+                      uid:       'jane.doe@gmail.com',
+                      email:     'jane.doe@gmail.com',
+                      name:      'Jane Doe',
+                      image_url: nil
+                    }
         }
       end
 
       it 'sets the resource if one is given' do
         expect(result.resource).to eq({
-                                        id: 32,
-                                        uid: 'jane.doe@gmail.com',
-                                        email: 'jane.doe@gmail.com',
-                                        name: 'Jane Doe',
+                                        id:        32,
+                                        uid:       'jane.doe@gmail.com',
+                                        email:     'jane.doe@gmail.com',
+                                        name:      'Jane Doe',
                                         image_url: nil
                                       })
       end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -162,7 +162,8 @@ RSpec.describe Game, type: :model do
     end
 
     it 'returns all list items belonging to the game' do
-      items = game.shopping_lists.map { |list| list.list_items.to_a }.flatten.sort
+      items = game.shopping_lists.map {|list| list.list_items.to_a }
+                .flatten.sort
 
       expect(shopping_list_items).to eq items
     end

--- a/spec/models/shopping_list_item_spec.rb
+++ b/spec/models/shopping_list_item_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ShoppingListItem, type: :model do
   describe 'delegation' do
     let(:shopping_list) { create(:shopping_list, game: game) }
     let(:list_item) { create(:shopping_list_item, list: shopping_list) }
-    
+
     before do
       create(:aggregate_shopping_list, game: game)
     end
@@ -76,7 +76,7 @@ RSpec.describe ShoppingListItem, type: :model do
 
       it 'returns all the list items belonging to the user', :aggregate_failures do
         all_items = []
-        user.shopping_lists.each { |list| all_items << list.list_items }
+        user.shopping_lists.each {|list| all_items << list.list_items }
         all_items.flatten!.sort!
 
         expect(belonging_to_user).to eq all_items
@@ -93,7 +93,8 @@ RSpec.describe ShoppingListItem, type: :model do
       let!(:existing_item) { create(:shopping_list_item, description: 'ExIsTiNg ItEm', quantity: 2, list: shopping_list, notes: 'notes 1') }
 
       it "doesn't create a new list item" do
-        expect { combine_or_create }.not_to change(shopping_list.list_items, :count)
+        expect { combine_or_create }
+          .not_to change(shopping_list.list_items, :count)
       end
 
       it 'adds the quantity to the existing item' do
@@ -143,7 +144,8 @@ RSpec.describe ShoppingListItem, type: :model do
       let!(:shopping_list) { create(:shopping_list, game: aggregate_list.game) }
 
       it 'creates a new item on the list' do
-        expect { combine_or_create }.to change(shopping_list.list_items, :count).by(1)
+        expect { combine_or_create }
+          .to change(shopping_list.list_items, :count).by(1)
       end
     end
   end
@@ -157,7 +159,8 @@ RSpec.describe ShoppingListItem, type: :model do
       subject(:update_item) { list_item.update!(quantity: 4) }
 
       it 'updates as normal' do
-        expect { update_item }.to change(list_item, :quantity).from(1).to(4)
+        expect { update_item }
+          .to change(list_item, :quantity).from(1).to(4)
       end
     end
 
@@ -165,7 +168,8 @@ RSpec.describe ShoppingListItem, type: :model do
       subject(:update_item) { list_item.update!(description: 'Something else') }
 
       it 'raises an error' do
-        expect { update_item }.to raise_error(ActiveRecord::RecordInvalid)
+        expect { update_item }
+          .to raise_error(ActiveRecord::RecordInvalid)
       end
     end
   end
@@ -173,12 +177,14 @@ RSpec.describe ShoppingListItem, type: :model do
   describe 'notes field' do
     it 'cleans up leading and trailing dashes or whitespace' do
       shopping_list_item = build(:shopping_list_item, notes: ' -- some notes --')
-      expect { shopping_list_item.save }.to change(shopping_list_item, :notes).to('some notes')
+      expect { shopping_list_item.save }
+        .to change(shopping_list_item, :notes).to('some notes')
     end
 
     it 'saves as nil if it consists only of dashes' do
       shopping_list_item = build(:shopping_list_item, notes: '--')
-      expect { shopping_list_item.save }.to change(shopping_list_item, :notes).to(nil)
+      expect { shopping_list_item.save }
+        .to change(shopping_list_item, :notes).to(nil)
     end
   end
 end

--- a/spec/models/shopping_list_spec.rb
+++ b/spec/models/shopping_list_spec.rb
@@ -186,23 +186,23 @@ RSpec.describe ShoppingList, type: :model do
   describe 'title transformations' do
     describe 'setting a default title' do
       let(:game) { create(:game) }
-  
+
       # I don't use FactoryBot to create the models in the subject blocks because
       # it sets values for certain attributes and I don't want those to get in the way.
       context 'when the list is not an aggregate list' do
         context 'when the user has set a title' do
           subject(:title) { game.shopping_lists.create!(title: 'Heljarchen Hall').title }
-  
+
           let(:game) { create(:game) }
-  
+
           it 'keeps the title the user has set' do
             expect(title).to eq 'Heljarchen Hall'
           end
         end
-  
+
         context 'when the user has not set a title' do
           subject(:title) { game.shopping_lists.create!.title }
-  
+
           context 'when the game has all default-titled regular lists' do
             before do
               # Create lists for a different game to make sure the name of this game's
@@ -210,7 +210,7 @@ RSpec.describe ShoppingList, type: :model do
               create_list(:shopping_list, 2, title: nil)
               create_list(:shopping_list, 2, title: nil, game: game)
             end
-    
+
             it 'sets the title based on the highest numbered default title' do
               expect(title).to eq 'My List 3'
             end
@@ -262,20 +262,20 @@ RSpec.describe ShoppingList, type: :model do
           end
         end
       end
-  
+
       # Aggregatable
       context 'when the list is an aggregate list' do
         context 'when the user has set a title' do
           subject(:title) { game.shopping_lists.create!(aggregate: true, title: 'Something other than all items').title }
-          
+
           it 'overrides the title the user has set' do
             expect(title).to eq 'All Items'
           end
         end
-  
+
         context 'when the user has not set a title' do
           subject(:title) { game.shopping_lists.create!(aggregate: true).title }
-  
+
           it 'sets the title to "All Items"' do
             expect(title).to eq 'All Items'
           end
@@ -326,13 +326,15 @@ RSpec.describe ShoppingList, type: :model do
         end
 
         it 'raises an error and does not destroy the list' do
-          expect { destroy_list }.to raise_error(ActiveRecord::RecordNotDestroyed)
+          expect { destroy_list }
+            .to raise_error(ActiveRecord::RecordNotDestroyed)
         end
       end
 
       context 'when the game has no regular lists' do
         it 'destroys the aggregate list' do
-          expect { destroy_list }.to change(shopping_list.game.shopping_lists, :count).from(1).to(0)
+          expect { destroy_list }
+            .to change(shopping_list.game.shopping_lists, :count).from(1).to(0)
         end
       end
     end
@@ -352,13 +354,15 @@ RSpec.describe ShoppingList, type: :model do
       end
 
       it "doesn't destroy the aggregate list" do
-        expect { destroy_list }.not_to change(game, :aggregate_shopping_list)
+        expect { destroy_list }
+          .not_to change(game, :aggregate_shopping_list)
       end
     end
 
     context 'when the user has no additional regular lists' do
       it 'destroys the aggregate list' do
-        expect { destroy_list }.to change(game.shopping_lists, :count).from(2).to(0)
+        expect { destroy_list }
+          .to change(game.shopping_lists, :count).from(2).to(0)
       end
     end
   end
@@ -373,16 +377,17 @@ RSpec.describe ShoppingList, type: :model do
         let(:list_item) { create(:shopping_list_item) }
 
         it 'creates a corresponding item on the aggregate list' do
-          expect { add_item }.to change(aggregate_list.list_items, :count).from(0).to(1)
+          expect { add_item }
+            .to change(aggregate_list.list_items, :count).from(0).to(1)
         end
 
         it 'sets the correct attributes' do
           add_item
           expect(aggregate_list.list_items.last.attributes).to include(
-                                                                     'description' => list_item.description,
-                                                                     'quantity' => list_item.quantity,
-                                                                     'notes' => list_item.notes
-                                                                    )
+                                                                 'description' => list_item.description,
+                                                                 'quantity'    => list_item.quantity,
+                                                                 'notes'       => list_item.notes
+                                                               )
         end
       end
 
@@ -398,7 +403,7 @@ RSpec.describe ShoppingList, type: :model do
             expect(existing_list_item.reload.quantity).to eq 5
           end
         end
-        
+
         context 'when neither have notes' do
           let!(:existing_list_item) { create(:shopping_list_item, list: aggregate_list, quantity: 3, notes: nil) }
           let(:list_item) { create(:shopping_list_item, description: existing_list_item.description, quantity: 2, notes: nil) }
@@ -406,7 +411,7 @@ RSpec.describe ShoppingList, type: :model do
           it 'combines the quantities and leaves the notes nil' do
             add_item
             expect(existing_list_item.reload.quantity).to eq 5
-            expect(existing_list_item.reload.notes). to be nil
+            expect(existing_list_item.reload.notes).to be nil
           end
         end
 
@@ -426,7 +431,8 @@ RSpec.describe ShoppingList, type: :model do
         let(:list_item) { create(:shopping_list_item) }
 
         it 'raises an AggregateListError' do
-          expect { add_item }.to raise_error(Aggregatable::AggregateListError)
+          expect { add_item }
+            .to raise_error(Aggregatable::AggregateListError)
         end
       end
     end
@@ -439,7 +445,8 @@ RSpec.describe ShoppingList, type: :model do
         let(:item_attrs) { { description: 'Necklace', quantity: 3, notes: 'some notes' } }
 
         it 'raises an error' do
-          expect { remove_item }.to raise_error(Aggregatable::AggregateListError)
+          expect { remove_item }
+            .to raise_error(Aggregatable::AggregateListError)
         end
       end
 
@@ -452,7 +459,8 @@ RSpec.describe ShoppingList, type: :model do
         end
 
         it 'raises an error' do
-          expect { remove_item }.to raise_error(Aggregatable::AggregateListError)
+          expect { remove_item }
+            .to raise_error(Aggregatable::AggregateListError)
         end
       end
 
@@ -465,7 +473,8 @@ RSpec.describe ShoppingList, type: :model do
         end
 
         it 'removes the item from the aggregate list' do
-          expect { remove_item }.to change(aggregate_list.list_items, :count).from(1).to(0)
+          expect { remove_item }
+            .to change(aggregate_list.list_items, :count).from(1).to(0)
         end
       end
 
@@ -547,7 +556,8 @@ RSpec.describe ShoppingList, type: :model do
         let(:item_attrs) { { description: 'Necklace', quantity: 3, notes: 'some notes' } }
 
         it 'raises an error' do
-          expect { remove_item }.to raise_error(Aggregatable::AggregateListError)
+          expect { remove_item }
+            .to raise_error(Aggregatable::AggregateListError)
         end
       end
     end
@@ -610,7 +620,7 @@ RSpec.describe ShoppingList, type: :model do
 
         it "doesn't mess with the notes" do
           update_item
-          expect(aggregate_list.list_items.first.notes).to eq 'something -- something else'  
+          expect(aggregate_list.list_items.first.notes).to eq 'something -- something else'
         end
       end
 
@@ -621,7 +631,7 @@ RSpec.describe ShoppingList, type: :model do
         before do
           aggregate_list.list_items.create!(description: description, quantity: 3, notes: existing_notes)
         end
-  
+
         context 'when replacing the middle notes' do
           let(:old_notes) { 'notes 2' }
           let(:new_notes) { 'something else' }
@@ -700,7 +710,8 @@ RSpec.describe ShoppingList, type: :model do
         let(:new_notes) { 'something else' }
 
         it 'raises an error' do
-          expect { update_item }.to raise_error(Aggregatable::AggregateListError)
+          expect { update_item }
+            .to raise_error(Aggregatable::AggregateListError)
         end
       end
 
@@ -711,7 +722,8 @@ RSpec.describe ShoppingList, type: :model do
         let(:new_notes) { 'something else' }
 
         it 'raises an error' do
-          expect { update_item }.to raise_error(Aggregatable::AggregateListError)
+          expect { update_item }
+            .to raise_error(Aggregatable::AggregateListError)
         end
       end
 
@@ -723,7 +735,8 @@ RSpec.describe ShoppingList, type: :model do
         let(:new_notes) { 'to make locks' }
 
         it 'raises an error' do
-          expect { update_item }.to raise_error(Aggregatable::AggregateListError)
+          expect { update_item }
+            .to raise_error(Aggregatable::AggregateListError)
         end
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,26 +7,27 @@ RSpec.describe User, type: :model do
     subject(:create_or_update) { described_class.create_or_update_for_google(payload) }
     let(:payload) do
       {
-        'exp' => (Time.now + 2.days).to_i,
-        'email' => 'jane.doe@gmail.com',
-        'name' => 'Jane Doe',
+        'exp'     => (Time.now + 2.days).to_i,
+        'email'   => 'jane.doe@gmail.com',
+        'name'    => 'Jane Doe',
         'picture' => 'https://example.com/user_images/89'
       }
     end
 
     context 'when a user with that email as uid does not exist' do
       it 'creates a user' do
-        expect { create_or_update }.to change(User, :count).from(0).to(1)
+        expect { create_or_update }
+          .to change(User, :count).from(0).to(1)
       end
 
       it 'sets the attributes' do
         create_or_update
         expect(User.last.attributes).to include(
-          'uid' => 'jane.doe@gmail.com',
-          'email' => 'jane.doe@gmail.com',
-          'name' => 'Jane Doe',
-          'image_url' => 'https://example.com/user_images/89'
-        )
+                                          'uid'       => 'jane.doe@gmail.com',
+                                          'email'     => 'jane.doe@gmail.com',
+                                          'name'      => 'Jane Doe',
+                                          'image_url' => 'https://example.com/user_images/89'
+                                        )
       end
     end
 
@@ -34,7 +35,8 @@ RSpec.describe User, type: :model do
       let!(:user) { create(:user, uid: 'jane.doe@gmail.com', email: 'jane.doe@gmail.com', name: 'Jane Doe', image_url: nil) }
 
       it 'does not create a new user' do
-        expect { create_or_update }.not_to change(User, :count)
+        expect { create_or_update }
+          .not_to change(User, :count)
       end
 
       it 'updates the attributes' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -66,7 +66,7 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
-  
+
   config.around do |example|
     DatabaseCleaner.cleaning { example.run }
   end

--- a/spec/requests/games_spec.rb
+++ b/spec/requests/games_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Games', type: :request do
   let(:headers) do
     {
-      'Content-Type' => 'application/json',
+      'Content-Type'  => 'application/json',
       'Authorization' => 'Bearer xxxxxxx'
     }
   end
@@ -17,9 +17,9 @@ RSpec.describe 'Games', type: :request do
       let(:user) { create(:user) }
       let(:validation_data) do
         {
-          'exp' => (Time.now + 1.year).to_i,
+          'exp'   => (Time.now + 1.year).to_i,
           'email' => user.email,
-          'name' => user.name
+          'name'  => user.name
         }
       end
 
@@ -95,9 +95,9 @@ RSpec.describe 'Games', type: :request do
       let(:user) { create(:user) }
       let(:validation_data) do
         {
-          'exp' => (Time.now + 1.year).to_i,
+          'exp'   => (Time.now + 1.year).to_i,
           'email' => user.email,
-          'name' => user.name
+          'name'  => user.name
         }
       end
 
@@ -111,7 +111,8 @@ RSpec.describe 'Games', type: :request do
         let(:params) { { game: { name: 'My Game' } } }
 
         it 'creates a game' do
-          expect { create_game }.to change(user.games, :count).by(1)
+          expect { create_game }
+            .to change(user.games, :count).by(1)
         end
 
         it 'returns status 201' do
@@ -129,7 +130,8 @@ RSpec.describe 'Games', type: :request do
         let(:params) { { game: { name: '@#*!)&' } } }
 
         it "doesn't create a game" do
-          expect { create_game }.not_to change(user.games, :count)
+          expect { create_game }
+            .not_to change(user.games, :count)
         end
 
         it 'returns status 422' do
@@ -184,9 +186,9 @@ RSpec.describe 'Games', type: :request do
       let(:user) { create(:user) }
       let(:validation_data) do
         {
-          'exp' => (Time.now + 1.year).to_i,
+          'exp'   => (Time.now + 1.year).to_i,
           'email' => user.email,
-          'name' => user.name
+          'name'  => user.name
         }
       end
 
@@ -217,7 +219,7 @@ RSpec.describe 'Games', type: :request do
           # on the deserialised response body differs from those on the model by '+0000' This is
           # the only way I've found to fix the tests.
           game_attributes_without_timestamps = game.reload.attributes.except('created_at', 'updated_at')
-          response_body_without_timestamps = JSON.parse(response.body).except('created_at', 'updated_at')
+          response_body_without_timestamps   = JSON.parse(response.body).except('created_at', 'updated_at')
 
           expect(response_body_without_timestamps).to eq game_attributes_without_timestamps
         end
@@ -313,9 +315,9 @@ RSpec.describe 'Games', type: :request do
       let(:user) { create(:user) }
       let(:validation_data) do
         {
-          'exp' => (Time.now + 1.year).to_i,
+          'exp'   => (Time.now + 1.year).to_i,
           'email' => user.email,
-          'name' => user.name
+          'name'  => user.name
         }
       end
 
@@ -346,7 +348,7 @@ RSpec.describe 'Games', type: :request do
           # on the deserialised response body differs from those on the model by '+0000' This is
           # the only way I've found to fix the tests.
           game_attributes_without_timestamps = game.reload.attributes.except('created_at', 'updated_at')
-          response_body_without_timestamps = JSON.parse(response.body).except('created_at', 'updated_at')
+          response_body_without_timestamps   = JSON.parse(response.body).except('created_at', 'updated_at')
 
           expect(response_body_without_timestamps).to eq game_attributes_without_timestamps
         end
@@ -442,9 +444,9 @@ RSpec.describe 'Games', type: :request do
       let(:user) { create(:user) }
       let(:validation_data) do
         {
-          'exp' => (Time.now + 1.year).to_i,
+          'exp'   => (Time.now + 1.year).to_i,
           'email' => user.email,
-          'name' => user.name
+          'name'  => user.name
         }
       end
 
@@ -458,7 +460,8 @@ RSpec.describe 'Games', type: :request do
         let!(:game) { create(:game, user: user) }
 
         it 'destroys the game' do
-          expect { destroy_game }.to change(user.games, :count).from(1).to(0)
+          expect { destroy_game }
+            .to change(user.games, :count).from(1).to(0)
         end
 
         it 'returns status 204' do

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'ShoppingLists', type: :request do
   let(:headers) do
     {
-      'Content-Type' => 'application/json',
+      'Content-Type'  => 'application/json',
       'Authorization' => 'Bearer xxxxxxx'
     }
   end
@@ -17,9 +17,9 @@ RSpec.describe 'ShoppingLists', type: :request do
       let!(:user) { create(:user) }
       let(:validation_data) do
         {
-          'exp' => (Time.now + 1.year).to_i,
+          'exp'   => (Time.now + 1.year).to_i,
           'email' => user.email,
-          'name' => user.name
+          'name'  => user.name
         }
       end
 
@@ -34,7 +34,8 @@ RSpec.describe 'ShoppingLists', type: :request do
 
         context 'when an aggregate list has also been created' do
           it 'creates a new shopping list' do
-            expect { create_shopping_list }.to change(game.shopping_lists, :count).from(0).to(2) # because of the aggregate list
+            expect { create_shopping_list }
+              .to change(game.shopping_lists, :count).from(0).to(2) # because of the aggregate list
           end
 
           it 'returns the aggregate list as well as the new list' do
@@ -52,7 +53,8 @@ RSpec.describe 'ShoppingLists', type: :request do
           let!(:aggregate_list) { create(:aggregate_shopping_list, game: game, created_at: 2.seconds.ago, updated_at: 2.seconds.ago) }
 
           it 'creates one list' do
-            expect{ create_shopping_list }.to change(game.shopping_lists, :count).from(1).to(2)
+            expect { create_shopping_list }
+              .to change(game.shopping_lists, :count).from(1).to(2)
           end
 
           it 'returns only the newly created list' do
@@ -68,7 +70,7 @@ RSpec.describe 'ShoppingLists', type: :request do
             # let's not have this request create an aggregate list too
             create(:aggregate_shopping_list, game: game)
           end
-          
+
           it 'returns status 201' do
             create_shopping_list
             expect(response.status).to eq 201
@@ -131,7 +133,8 @@ RSpec.describe 'ShoppingLists', type: :request do
         let(:game) { create(:game, user: user) }
 
         it "doesn't create a list" do
-          expect { create_shopping_list }.not_to change(game.shopping_lists, :count)
+          expect { create_shopping_list }
+            .not_to change(game.shopping_lists, :count)
         end
 
         it 'returns an error' do
@@ -163,9 +166,9 @@ RSpec.describe 'ShoppingLists', type: :request do
       let!(:user) { create(:user) }
       let(:validation_data) do
         {
-          'exp' => (Time.now + 1.year).to_i,
+          'exp'   => (Time.now + 1.year).to_i,
           'email' => user.email,
-          'name' => user.name
+          'name'  => user.name
         }
       end
 
@@ -257,7 +260,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       context 'when the client attempts to change a regular list to an aggregate list' do
         subject(:update_shopping_list) { put "/shopping_lists/#{shopping_list.id}", params: { shopping_list: { aggregate: true } }.to_json, headers: headers }
-        
+
         let!(:shopping_list) { create(:shopping_list, game: game) }
         let(:game) { create(:game, user: user) }
 
@@ -279,7 +282,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       context 'when something unexpected goes wrong' do
         subject(:update_shopping_list) { put "/shopping_lists/#{shopping_list.id}", params: { shopping_list: { title: 'Some New Title' } }.to_json, headers: headers }
-        
+
         let!(:shopping_list) { create(:shopping_list, game: game) }
         let(:game) { create(:game, user: user) }
 
@@ -316,9 +319,9 @@ RSpec.describe 'ShoppingLists', type: :request do
       let!(:user) { create(:user) }
       let(:validation_data) do
         {
-          'exp' => (Time.now + 1.year).to_i,
+          'exp'   => (Time.now + 1.year).to_i,
           'email' => user.email,
-          'name' => user.name
+          'name'  => user.name
         }
       end
 
@@ -410,7 +413,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       context 'when the client attempts to change a regular list to an aggregate list' do
         subject(:update_shopping_list) { patch "/shopping_lists/#{shopping_list.id}", params: { shopping_list: { aggregate: true } }.to_json, headers: headers }
-        
+
         let!(:shopping_list) { create(:shopping_list, game: game) }
         let(:game) { create(:game, user: user) }
 
@@ -432,7 +435,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       context 'when something unexpected goes wrong' do
         subject(:update_shopping_list) { patch "/shopping_lists/#{shopping_list.id}", params: { shopping_list: { title: 'Some New Title' } }.to_json, headers: headers }
-        
+
         let!(:shopping_list) { create(:shopping_list, game: game) }
         let(:game) { create(:game, user: user) }
 
@@ -465,7 +468,6 @@ RSpec.describe 'ShoppingLists', type: :request do
   describe 'GET /shopping_lists' do
     subject(:get_index) { get "/games/#{game.id}/shopping_lists", headers: headers }
 
-    
     context 'when unauthenticated' do
       let(:game) { create(:game) }
 
@@ -489,14 +491,14 @@ RSpec.describe 'ShoppingLists', type: :request do
       let(:authenticated_user) { create(:user) }
       let(:validation_data) do
         {
-          'exp' => (Time.now + 1.year).to_i,
+          'exp'   => (Time.now + 1.year).to_i,
           'email' => authenticated_user.email,
-          'name' => authenticated_user.name
+          'name'  => authenticated_user.name
         }
       end
 
       let(:validator) { instance_double(GoogleIDToken::Validator, check: validation_data) }
-      
+
       before do
         allow(GoogleIDToken::Validator).to receive(:new).and_return(validator)
       end
@@ -545,7 +547,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       context 'when there are shopping lists for that game' do
         let(:game) { create(:game_with_shopping_lists, user: authenticated_user) }
-        
+
         it 'returns status 200' do
           get_index
           expect(response.status).to eq 200
@@ -571,7 +573,8 @@ RSpec.describe 'ShoppingLists', type: :request do
       end
 
       it 'does not delete the shopping list' do
-        expect { delete_shopping_list }.not_to change(ShoppingList, :count)
+        expect { delete_shopping_list }
+          .not_to change(ShoppingList, :count)
       end
 
       it 'returns an error in the body' do
@@ -589,9 +592,9 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       let(:validation_data) do
         {
-          'exp' => (Time.now + 1.year).to_i,
+          'exp'   => (Time.now + 1.year).to_i,
           'email' => user1.email,
-          'name' => user1.name
+          'name'  => user1.name
         }
       end
 
@@ -610,7 +613,8 @@ RSpec.describe 'ShoppingLists', type: :request do
       end
 
       it 'does not delete any shopping lists' do
-        expect { delete_shopping_list }.not_to change(ShoppingList, :count)
+        expect { delete_shopping_list }
+          .not_to change(ShoppingList, :count)
       end
     end
 
@@ -621,16 +625,16 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       let(:validation_data) do
         {
-          'exp' => (Time.now + 1.year).to_i,
+          'exp'   => (Time.now + 1.year).to_i,
           'email' => user.email,
-          'name' => user.name
+          'name'  => user.name
         }
       end
 
       before do
         allow(GoogleIDToken::Validator).to receive(:new).and_return(validator)
       end
-      
+
       it 'returns 404' do
         delete_shopping_list
         expect(response.status).to eq 404
@@ -652,9 +656,9 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       let(:validation_data) do
         {
-          'exp' => (Time.now + 1.year).to_i,
+          'exp'   => (Time.now + 1.year).to_i,
           'email' => user.email,
-          'name' => user.name
+          'name'  => user.name
         }
       end
 
@@ -664,7 +668,8 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       context "when this is the game's last regular shopping list" do
         it 'deletes the shopping list' do
-          expect { delete_shopping_list }.to change(game.shopping_lists, :count).from(2).to(0)
+          expect { delete_shopping_list }
+            .to change(game.shopping_lists, :count).from(2).to(0)
         end
 
         it 'returns status 204' do
@@ -686,7 +691,8 @@ RSpec.describe 'ShoppingLists', type: :request do
         end
 
         it 'deletes the shopping list' do
-          expect { delete_shopping_list }.to change(game.shopping_lists, :count).from(3).to(2)
+          expect { delete_shopping_list }
+            .to change(game.shopping_lists, :count).from(3).to(2)
         end
 
         it 'returns status 200' do
@@ -708,9 +714,9 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       let(:validation_data) do
         {
-          'exp' => (Time.now + 1.year).to_i,
+          'exp'   => (Time.now + 1.year).to_i,
           'email' => user.email,
-          'name' => user.name
+          'name'  => user.name
         }
       end
 
@@ -723,7 +729,8 @@ RSpec.describe 'ShoppingLists', type: :request do
         let(:list_id) { shopping_list.id }
 
         it 'does not delete anything' do
-          expect { delete_shopping_list }.not_to change(ShoppingList, :count)
+          expect { delete_shopping_list }
+            .not_to change(ShoppingList, :count)
         end
 
         it 'returns status 405 (Method Not Allowed)' do

--- a/spec/requests/verifications_spec.rb
+++ b/spec/requests/verifications_spec.rb
@@ -33,15 +33,16 @@ RSpec.describe "Verifications", type: :request do
     context 'when no existing user matches' do
       let(:expected_user_attributes) do
         {
-          'uid'        => 'foobar@gmail.com',
-          'email'      => 'foobar@gmail.com',
-          'name'       => 'Foo Bar',
-          'image_url'  => nil,
+          'uid'       => 'foobar@gmail.com',
+          'email'     => 'foobar@gmail.com',
+          'name'      => 'Foo Bar',
+          'image_url' => nil,
         }
       end
 
       it 'creates a new user with the data from the payload', :aggregate_failures do
-        expect { verify_token }.to change(User, :count).from(0).to(1)
+        expect { verify_token }
+          .to change(User, :count).from(0).to(1)
         expect(User.last.attributes).to include(**(expected_user_attributes.merge({ 'id' => User.last.id })))
       end
     end
@@ -51,16 +52,17 @@ RSpec.describe "Verifications", type: :request do
 
       let(:expected_user_attributes) do
         {
-          'id'         => user.id,
-          'uid'        => 'foobar@gmail.com',
-          'email'      => 'foobar@gmail.com',
-          'name'       => 'Foo Bar',
-          'image_url'  => nil
+          'id'        => user.id,
+          'uid'       => 'foobar@gmail.com',
+          'email'     => 'foobar@gmail.com',
+          'name'      => 'Foo Bar',
+          'image_url' => nil
         }
       end
 
       it "doesn't create a new user" do
-        expect { verify_token }.not_to change(User, :count)
+        expect { verify_token }
+          .not_to change(User, :count)
       end
 
       it 'updates the attributes' do


### PR DESCRIPTION
## Context

[**Add Rubocop for linting**](https://trello.com/c/nb6hbkVa/100-add-rubocop-for-linting)

We're in the process of adding Rubocop, primarily for linting/style purposes. This is the first of a few PRs fixing Rubocop violations that already existed in the code.

## Changes

* Run `rails rubocop:auto_correct` with everything but Bundler and Layout cops commented out

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~

## Considerations

All the violations here were autocorrectable, so all I really did was run Rubocop (with only the subset of cops enabled).