### PR TITLE
Fixes for Rubocop Naming, Style and Security violations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -614,8 +614,6 @@ Naming/MethodParameterName:
     - to
 Naming/PredicateName:
   Enabled: true
-Naming/PredicateName:
-  Enabled: true
   NamePrefix:
     - is_
     - has_
@@ -643,974 +641,974 @@ Naming/VariableNumber:
 ### Security Requirements ###
 #############################
 
-# Security/Eval:
-#   Enabled: true
-# Security/JSONLoad:
-#   Enabled: true
-# Security/MarshalLoad:
-#   Enabled: true
-# Security/Open:
-#   Enabled: true
-# Security/YAMLLoad:
-#   Enabled: true
+Security/Eval:
+  Enabled: true
+Security/JSONLoad:
+  Enabled: true
+Security/MarshalLoad:
+  Enabled: true
+Security/Open:
+  Enabled: true
+Security/YAMLLoad:
+  Enabled: true
 
-# ##########################
-# ### Style Requirements ###
-# ##########################
+##########################
+### Style Requirements ###
+##########################
 
-# Style/AccessModifierDeclarations:
-#   Enabled: true
-#   EnforcedStyle: group
-# Style/AccessorGrouping:
-#   Enabled: true
-#   EnforcedStyle: grouped
-# Style/Alias:
-#   Enabled: true
-#   EnforcedStyle: prefer_alias_method
-# Style/AndOr:
-#   Enabled: true
-#   EnforcedStyle: always
-# Style/ArgumentsForwarding:
-#   Enabled: true
-#   AllowOnlyRestArgument: true
-# Style/ArrayJoin:
-#   Enabled: true
-# Style/Attr:
-#   Enabled: true
-# Style/AutoResourceCleanup:
-#   Enabled: true
-# Style/BarePercentLiterals:
-#   Enabled: true
-#   EnforcedStyle: bare_percent
-# Style/BeginBlock:
-#   Enabled: true
-# Style/BisectedAttrAccessor:
-#   Enabled: true
-# Style/BlockComments:
-#   Enabled: true
-# Style/BlockDelimiters:
-#   Enabled: true
-#   EnforcedStyle: line_count_based
-#   ProceduralMethods:
-#     # Methods that are known to be procedural in nature but look functional from
-#     # their usage, e.g.
-#     #
-#     #   time = Benchmark.realtime do
-#     #     foo.bar
-#     #   end
-#     #
-#     # Here, the return value of the block is discarded but the return value of
-#     # `Benchmark.realtime` is used.
-#     - benchmark
-#     - bm
-#     - bmbm
-#     - create
-#     - each_with_object
-#     - measure
-#     - new
-#     - realtime
-#     - tap
-#     - with_object
-#   FunctionalMethods:
-#     # Methods that are known to be functional in nature but look procedural from
-#     # their usage, e.g.
-#     #
-#     #   let(:foo) { Foo.new }
-#     #
-#     # Here, the return value of `Foo.new` is used to define a `foo` helper but
-#     # doesn't appear to be used from the return value of `let`.
-#     - let
-#     - let!
-#     - subject
-#     - watch
-#   IgnoredMethods:
-#     # Methods that can be either procedural or functional and cannot be
-#     # categorised from their usage alone, e.g.
-#     #
-#     #   foo = lambda do |x|
-#     #     puts "Hello, #{x}"
-#     #   end
-#     #
-#     #   foo = lambda do |x|
-#     #     x * 100
-#     #   end
-#     #
-#     # Here, it is impossible to tell from the return value of `lambda` whether
-#     # the inner block's return value is significant.
-#     - lambda
-#     - proc
-#     - it
-# Style/CaseEquality:
-#   Enabled: true
-#   AllowOnConstant: false
-# Style/CharacterLiteral:
-#   Enabled: true
-# Style/ClassCheck:
-#   Enabled: true
-#   EnforcedStyle: is_a?
-# Style/ClassEqualityComparison:
-#   Enabled: true
-#   IgnoredMethods:
-#     - ==
-#     - equal?
-#     - eql?
-# Style/ClassMethods:
-#   Enabled: true
-# Style/ClassMethodsDefinitions:
-#   Enabled: true
-#   EnforcedStyle: def_self
-# Style/CollectionCompact:
-#   Enabled: true
-# Style/CollectionMethods:
-#   Enabled: true
-#   PreferredMethods:
-#     collect: 'map'
-#     collect!: 'map!'
-#     inject: 'reduce'
-#     detect: 'find'
-#     find_all: 'select'
-#     member?: 'include?'
-#   MethodsAcceptingSymbol:
-#     - inject
-#     - reduce
-#     - map
-#     - map!
-# Style/ColonMethodCall:
-#   Enabled: true
-# Style/ColonMethodDefinition:
-#   Enabled: true
-# Style/CombinableLoops:
-#   Enabled: true
-# Style/CommandLiteral:
-#   Enabled: true
-#   EnforcedStyle: percent_x
-# Style/CommentAnnotation:
-#   Enabled: true
-#   Keywords:
-#     - TODO
-#     - FIXME
-#   RequireColon: true
-# Style/CommentedKeyword:
-#   Enabled: true
-# Style/ConditionalAssignment:
-#   Enabled: true
-#   EnforcedStyle: assign_to_condition
-#   IncludeTernaryExpressions: true
-#   SingleLineConditionsOnly: true
-# Style/DefWithParentheses:
-#   Enabled: true
-# Style/Dir:
-#   Enabled: true
-# Style/DocumentDynamicEvalDefinition:
-#   Enabled: true
-# Style/DoubleCopDisableDirective:
-#   Enabled: true
-# Style/DoubleNegation:
-#   Enabled: true
-#   EnforcedStyle: allowed_in_returns
-# Style/EachForSimpleLoop:
-#   Enabled: true
-# Style/EmptyBlockParameter:
-#   Enabled: true
-# Style/EmptyCaseCondition:
-#   Enabled: true
-# Style/EmptyElse:
-#   Enabled: true
-#   EnforcedStyle: both
-# Style/EmptyLambdaParameter:
-#   Enabled: true
-# Style/EmptyLiteral:
-#   Enabled: true
-# Style/EmptyMethod:
-#   Enabled: true
-#   EnforcedStyle: compact
-# Style/Encoding:
-#   Enabled: true
-# Style/EndBlock:
-#   Enabled: true
-# Style/EvalWithLocation:
-#   Enabled: true
-# Style/EvenOdd:
-#   Enabled: true
-# Style/ExpandPathArguments:
-#   Enabled: true
-# Style/ExplicitBlockArgument:
-#   Enabled: true
-# Style/ExponentialNotation:
-#   Enabled: true
-#   EnforcedStyle: scientific
-# Style/FloatDivision:
-#   Enabled: true
-#   EnforcedStyle: single_coerce
-# Style/For:
-#   Enabled: true
-#   EnforcedStyle: each
-# Style/FrozenStringLiteralComment:
-#   Enabled: true
-#   EnforcedStyle: always
-# Style/GlobalStdStream:
-#   Enabled: true
-# Style/GlobalVars:
-#   Enabled: true
-# Style/GuardClause:
-#   Enabled: true
-# Style/HashAsLastArrayItem:
-#   Enabled: true
-#   EnforcedStyle: braces
-# Style/HashEachMethods:
-#   Enabled: true
-# Style/HashExcept:
-#   Enabled: true
-# Style/HashLikeCase:
-#   Enabled: true
-# Style/HashSyntax:
-#   Enabled: true
-#   EnforcedStyle: ruby19
-#   UseHashRocketsWithSymbolValues: false
-#   PreferHashRocketsForNonAlnumEndingSymbols: false
-# Style/HashTransformKeys:
-#   Enabled: true
-# Style/HashTransformValues:
-#   Enabled: true
-# Style/IdenticalConditionalBranches:
-#   Enabled: true
-# Style/IfInsideElse:
-#   Enabled: true
-# Style/IfUnlessModifier:
-#   Enabled: true
-# Style/IfUnlessModifierOfIfUnless:
-#   Enabled: true
-# Style/IfWithBooleanLiteralBranches:
-#   Enabled: true
-# Style/IfWithSemicolon:
-#   Enabled: true
-# Style/ImplicitRuntimeError:
-#   Enabled: true
-# Style/InverseMethods:
-#   Enabled: true
-#   InverseMethods:
-#     :any?: :none?
-#     :even?: :odd?
-#     :==: :!=
-#     :=~: :!~
-#     :<: :>=
-#     :>: :<=
-#   InverseBlocks:
-#     :select: :reject
-#     :select!: :reject!
-# Style/IpAddresses:
-#   Enabled: true
-#   AllowedAddresses:
-#     - '::'
-#   Exclude:
-#     - '**/Gemfile'
-# Style/KeywordParametersOrder:
-#   Enabled: true
-# Style/Lambda:
-#   Enabled: true
-#   EnforcedStyle: line_count_dependent
-# Style/LambdaCall:
-#   Enabled: true
-#   EnforcedStyle: call
-# Style/LineEndConcatenation:
-#   Enabled: true
-# Style/MethodCallWithoutArgsParentheses:
-#   Enabled: true
-# Style/MethodDefParentheses:
-#   Enabled: true
-#   EnforcedStyle: require_parentheses
-# Style/MinMax:
-#   Enabled: true
-# Style/MissingRespondToMissing:
-#   Enabled: true
-# Style/MixinGrouping:
-#   Enabled: true
-#   EnforcedStyle: separated
-# Style/MixinUsage:
-#   Enabled: true
-# Style/ModuleFunction:
-#   Enabled: true
-#   EnforcedStyle: module_function
-# Style/MultilineIfModifier:
-#   Enabled: true
-# Style/MultilineIfThen:
-#   Enabled: true
-# Style/MultilineInPatternThen:
-#   Enabled: true
-# Style/MultilineMemoization:
-#   Enabled: true
-#   EnforcedStyle: keyword
-# Style/MultilineMethodSignature:
-#   Enabled: true
-# Style/MultilineTernaryOperator:
-#   Enabled: true
-# Style/MultilineWhenThen:
-#   Enabled: true
-# Style/MultipleComparison:
-#   Enabled: true
-# Style/MutableConstant:
-#   Enabled: true
-#   EnforcedStyle: literals
-# Style/NegatedIf:
-#   Enabled: true
-#   EnforcedStyle: postfix
-# Style/NegatedIfElseCondition:
-#   Enabled: true
-# Style/NegatedUnless:
-#   Enabled: true
-#   EnforcedStyle: both
-# Style/NegatedWhile:
-#   Enabled: true
-# Style/NestedModifier:
-#   Enabled: true
-# Style/NestedParenthesizedCalls:
-#   Enabled: true
-#   AllowedMethods:
-#     - be
-#     - be_a
-#     - be_an
-#     - be_between
-#     - be_falsey
-#     - be_kind_of
-#     - be_instance_of
-#     - be_truthy
-#     - be_within
-#     - eq
-#     - eql
-#     - end_with
-#     - include
-#     - match
-#     - raise_error
-#     - respond_to
-#     - start_with
-# Style/NestedTernaryOperator:
-#   Enabled: true
-# Style/Next:
-#   Enabled: true
-#   EnforcedStyle: skip_modifier_ifs
-# Style/NilComparison:
-#   Enabled: true
-#   EnforcedStyle: predicate
-# Style/NilLambda:
-#   Enabled: true
-# Style/NonNilCheck:
-#   Enabled: true
-#   IncludeSemanticChanges: false
-# Style/Not:
-#   Enabled: true
-# Style/NumericLiteralPrefix:
-#   Enabled: true
-#   EnforcedStyle: zero_with_o
-# Style/NumericLiterals:
-#   Enabled: true
-#   MinDigits: 5
-# Style/OneLineConditional:
-#   Enabled: true
-# Style/OptionalArguments:
-#   Enabled: true
-# Style/OrAssignment:
-#   Enabled: true
-# Style/ParallelAssignment:
-#   Enabled: true
-# Style/ParenthesesAroundCondition:
-#   Enabled: true
-#   AllowSafeAssignment: false
-#   AllowInMultilineConditionals: false
-# Style/PercentLiteralDelimiters:
-#   Enabled: true
-#   PreferredDelimiters:
-#     default: ()
-#     '%i': '[]'
-#     '%I': '[]'
-#     '%r': '{}'
-#     '%w': '[]'
-#     '%W': '[]'
-# Style/PercentQLiterals:
-#   Enabled: true
-#   EnforcedStyle: lower_case_q
-# Style/PerlBackrefs:
-#   Enabled: true
-# Style/PreferredHashMethods:
-#   Enabled: true
-#   EnforcedStyle: verbose
-# Style/Proc:
-#   Enabled: true
-# Style/QuotedSymbols:
-#   Enabled: true
-#   EnforcedStyle: same_as_string_literals
-# Style/RaiseArgs:
-#   Enabled: true
-#   EnforcedStyle: compact
-# Style/RandomWithOffset:
-#   Enabled: true
-# Style/RedundantAssignment:
-#   Enabled: true
-# Style/RedundantBegin:
-#   Enabled: true
-# Style/RedundantCapitalW:
-#   Enabled: true
-# Style/RedundantCondition:
-#   Enabled: true
-# Style/RedundantConditional:
-#   Enabled: true
-# Style/RedundantFileExtensionInRequire:
-#   Enabled: true
-# Style/RedundantFreeze:
-#   Enabled: true
-# Style/RedundantInterpolation:
-#   Enabled: true
-# Style/RedundantParentheses:
-#   Enabled: true
-# Style/RedundantPercentQ:
-#   Enabled: true
-# Style/RedundantRegexpCharacterClass:
-#   Enabled: true
-# Style/RedundantRegexpEscape:
-#   Enabled: true
-# Style/RedundantReturn:
-#   Enabled: true
-# Style/RedundantSelf:
-#   Enabled: true
-# Style/RedundantSort:
-#   Enabled: true
-# Style/RedundantSortBy:
-#   Enabled: true
-# Style/RegexpLiteral:
-#   Enabled: true
-#   EnforcedStyle: mixed
-#   AllowInnerSlashes: true
-# Style/RescueModifier:
-#   Enabled: true
-# Style/RescueStandardError:
-#   Enabled: true
-#   EnforcedStyle: explicit
-# Style/ReturnNil:
-#   Enabled: true
-#   EnforcedStyle: return
-# Style/Sample:
-#   Enabled: true
-# Style/SelfAssignment:
-#   Enabled: true
-# Style/Semicolon:
-#   Enabled: true
-# Style/SignalException:
-#   Enabled: true
-#   EnforcedStyle: only_raise
-# Style/SingleArgumentDig:
-#   Enabled: true
-# Style/SingleLineMethods:
-#   Enabled: true
-#   AllowIfMethodIsEmpty: true
-# Style/SpecialGlobalVars:
-#   Enabled: true
-#   EnforcedStyle: use_english_names
-# Style/StabbyLambdaParentheses:
-#   Enabled: true
-#   EnforcedStyle: require_parentheses
-# Style/StaticClass:
-#   Enabled: true
-# Style/StderrPuts:
-#   Enabled: true
-# Style/StringConcatenation:
-#   Enabled: true
-# Style/StringLiterals:
-#   Enabled: true
-#   EnforcedStyle: single_quotes
-#   ConsistentQuotesInMultiline: false # good if only one line has interpolation
-# Style/StringLiteralsInInterpolation:
-#   Enabled: true
-#   EnforcedStyle: single_quotes
-# Style/Strip:
-#   Enabled: true
-# Style/StructInheritance:
-#   Enabled: true
-# Style/SymbolArray:
-#   Enabled: true
-#   EnforcedStyle: percent
-# Style/SymbolLiteral:
-#   Enabled: true
-# Style/SymbolProc:
-#   Enabled: true
-#   AllowMethodsWithArguments: false
-#   IgnoredMethods:
-#     - respond_to
-#     - define_method
-# Style/TernaryParentheses:
-#   Enabled: true
-#   EnforcedStyle: require_no_parentheses
-#   AllowSafeAssignment: false
-# Style/TrailingBodyOnClass:
-#   Enabled: true
-# Style/TrailingBodyOnMethodDefinition:
-#   Enabled: true
-# Style/TrailingBodyOnModule:
-#   Enabled: true
-# Style/TrailingCommaInArguments:
-#   Enabled: true
-#   EnforcedStyleForMultiline: consistent_comma
-# Style/TrailingCommaInArrayLiteral:
-#   Enabled: true
-#   EnforcedStyleForMultiline: consistent_comma
-# Style/TrailingCommaInHashLiteral:
-#   Enabled: true
-#   EnforcedStyleForMultiline: consistent_comma
-# Style/TrailingMethodEndStatement:
-#   Enabled: true
-# Style/TrailingUnderscoreVariable:
-#   Enabled: true
-#   AllowNamedUnderscoreVariables: false
-# Style/TrivialAccessors:
-#   Enabled: true
-#   ExactNameMatch: true
-#   AllowPredicates: true
-#   AllowDSLWriters: true
-#   IgnoreClassMethods: false
-#   AllowedMethods:
-#     - to_ary
-#     - to_a
-#     - to_c
-#     - to_enum
-#     - to_h
-#     - to_hash
-#     - to_i
-#     - to_int
-#     - to_io
-#     - to_open
-#     - to_path
-#     - to_proc
-#     - to_r
-#     - to_regexp
-#     - to_str
-#     - to_s
-#     - to_sym
-# Style/UnlessElse:
-#   Enabled: true
-# Style/UnlessLogicalOperators:
-#   Enabled: true
-#   EnforcedStyle: forbid_mixed_logical_operators
-# Style/UnpackFirst:
-#   Enabled: true
-# Style/VariableInterpolation:
-#   Enabled: true
-# Style/WhenThen:
-#   Enabled: true
-# Style/WhileUntilDo:
-#   Enabled: true
-# Style/WhileUntilModifier:
-#   Enabled: true
-# Style/WordArray:
-#   Enabled: true
-#   EnforcedStyle: percent
-#   MinSize: 1
-# Style/YodaCondition:
-#   Enabled: true
-#   EnforcedStyle: forbid_for_all_comparison_operators
-# Style/ZeroLengthPredicate:
-#   Enabled: true
+Style/AccessModifierDeclarations:
+  Enabled: true
+  EnforcedStyle: group
+Style/AccessorGrouping:
+  Enabled: true
+  EnforcedStyle: grouped
+Style/Alias:
+  Enabled: true
+  EnforcedStyle: prefer_alias_method
+Style/AndOr:
+  Enabled: true
+  EnforcedStyle: always
+Style/ArgumentsForwarding:
+  Enabled: true
+  AllowOnlyRestArgument: true
+Style/ArrayJoin:
+  Enabled: true
+Style/Attr:
+  Enabled: true
+Style/AutoResourceCleanup:
+  Enabled: true
+Style/BarePercentLiterals:
+  Enabled: true
+  EnforcedStyle: bare_percent
+Style/BeginBlock:
+  Enabled: true
+Style/BisectedAttrAccessor:
+  Enabled: true
+Style/BlockComments:
+  Enabled: true
+Style/BlockDelimiters:
+  Enabled: true
+  EnforcedStyle: line_count_based
+  ProceduralMethods:
+    # Methods that are known to be procedural in nature but look functional from
+    # their usage, e.g.
+    #
+    #   time = Benchmark.realtime do
+    #     foo.bar
+    #   end
+    #
+    # Here, the return value of the block is discarded but the return value of
+    # `Benchmark.realtime` is used.
+    - benchmark
+    - bm
+    - bmbm
+    - create
+    - each_with_object
+    - measure
+    - new
+    - realtime
+    - tap
+    - with_object
+  FunctionalMethods:
+    # Methods that are known to be functional in nature but look procedural from
+    # their usage, e.g.
+    #
+    #   let(:foo) { Foo.new }
+    #
+    # Here, the return value of `Foo.new` is used to define a `foo` helper but
+    # doesn't appear to be used from the return value of `let`.
+    - let
+    - let!
+    - subject
+    - watch
+  IgnoredMethods:
+    # Methods that can be either procedural or functional and cannot be
+    # categorised from their usage alone, e.g.
+    #
+    #   foo = lambda do |x|
+    #     puts "Hello, #{x}"
+    #   end
+    #
+    #   foo = lambda do |x|
+    #     x * 100
+    #   end
+    #
+    # Here, it is impossible to tell from the return value of `lambda` whether
+    # the inner block's return value is significant.
+    - lambda
+    - proc
+    - it
+Style/CaseEquality:
+  Enabled: true
+  AllowOnConstant: false
+Style/CharacterLiteral:
+  Enabled: true
+Style/ClassCheck:
+  Enabled: true
+  EnforcedStyle: is_a?
+Style/ClassEqualityComparison:
+  Enabled: true
+  IgnoredMethods:
+    - ==
+    - equal?
+    - eql?
+Style/ClassMethods:
+  Enabled: true
+Style/ClassMethodsDefinitions:
+  Enabled: true
+  EnforcedStyle: def_self
+Style/CollectionCompact:
+  Enabled: true
+Style/CollectionMethods:
+  Enabled: true
+  PreferredMethods:
+    collect: 'map'
+    collect!: 'map!'
+    inject: 'reduce'
+    detect: 'find'
+    find_all: 'select'
+    member?: 'include?'
+  MethodsAcceptingSymbol:
+    - inject
+    - reduce
+    - map
+    - map!
+Style/ColonMethodCall:
+  Enabled: true
+Style/ColonMethodDefinition:
+  Enabled: true
+Style/CombinableLoops:
+  Enabled: true
+Style/CommandLiteral:
+  Enabled: true
+  EnforcedStyle: percent_x
+Style/CommentAnnotation:
+  Enabled: true
+  Keywords:
+    - TODO
+    - FIXME
+  RequireColon: true
+Style/CommentedKeyword:
+  Enabled: true
+Style/ConditionalAssignment:
+  Enabled: true
+  EnforcedStyle: assign_to_condition
+  IncludeTernaryExpressions: true
+  SingleLineConditionsOnly: true
+Style/DefWithParentheses:
+  Enabled: true
+Style/Dir:
+  Enabled: true
+Style/DocumentDynamicEvalDefinition:
+  Enabled: true
+Style/DoubleCopDisableDirective:
+  Enabled: true
+Style/DoubleNegation:
+  Enabled: true
+  EnforcedStyle: allowed_in_returns
+Style/EachForSimpleLoop:
+  Enabled: true
+Style/EmptyBlockParameter:
+  Enabled: true
+Style/EmptyCaseCondition:
+  Enabled: true
+Style/EmptyElse:
+  Enabled: true
+  EnforcedStyle: both
+Style/EmptyLambdaParameter:
+  Enabled: true
+Style/EmptyLiteral:
+  Enabled: true
+Style/EmptyMethod:
+  Enabled: true
+  EnforcedStyle: compact
+Style/Encoding:
+  Enabled: true
+Style/EndBlock:
+  Enabled: true
+Style/EvalWithLocation:
+  Enabled: true
+Style/EvenOdd:
+  Enabled: true
+Style/ExpandPathArguments:
+  Enabled: true
+Style/ExplicitBlockArgument:
+  Enabled: true
+Style/ExponentialNotation:
+  Enabled: true
+  EnforcedStyle: scientific
+Style/FloatDivision:
+  Enabled: true
+  EnforcedStyle: single_coerce
+Style/For:
+  Enabled: true
+  EnforcedStyle: each
+Style/FrozenStringLiteralComment:
+  Enabled: true
+  EnforcedStyle: always
+Style/GlobalStdStream:
+  Enabled: true
+Style/GlobalVars:
+  Enabled: true
+Style/GuardClause:
+  Enabled: true
+Style/HashAsLastArrayItem:
+  Enabled: true
+  EnforcedStyle: braces
+Style/HashEachMethods:
+  Enabled: true
+Style/HashExcept:
+  Enabled: true
+Style/HashLikeCase:
+  Enabled: true
+Style/HashSyntax:
+  Enabled: true
+  EnforcedStyle: ruby19
+  UseHashRocketsWithSymbolValues: false
+  PreferHashRocketsForNonAlnumEndingSymbols: false
+Style/HashTransformKeys:
+  Enabled: true
+Style/HashTransformValues:
+  Enabled: true
+Style/IdenticalConditionalBranches:
+  Enabled: true
+Style/IfInsideElse:
+  Enabled: true
+Style/IfUnlessModifier:
+  Enabled: true
+Style/IfUnlessModifierOfIfUnless:
+  Enabled: true
+Style/IfWithBooleanLiteralBranches:
+  Enabled: true
+Style/IfWithSemicolon:
+  Enabled: true
+Style/ImplicitRuntimeError:
+  Enabled: true
+Style/InverseMethods:
+  Enabled: true
+  InverseMethods:
+    :any?: :none?
+    :even?: :odd?
+    :==: :!=
+    :=~: :!~
+    :<: :>=
+    :>: :<=
+  InverseBlocks:
+    :select: :reject
+    :select!: :reject!
+Style/IpAddresses:
+  Enabled: true
+  AllowedAddresses:
+    - '::'
+  Exclude:
+    - '**/Gemfile'
+Style/KeywordParametersOrder:
+  Enabled: true
+Style/Lambda:
+  Enabled: true
+  EnforcedStyle: line_count_dependent
+Style/LambdaCall:
+  Enabled: true
+  EnforcedStyle: call
+Style/LineEndConcatenation:
+  Enabled: true
+Style/MethodCallWithoutArgsParentheses:
+  Enabled: true
+Style/MethodDefParentheses:
+  Enabled: true
+  EnforcedStyle: require_parentheses
+Style/MinMax:
+  Enabled: true
+Style/MissingRespondToMissing:
+  Enabled: true
+Style/MixinGrouping:
+  Enabled: true
+  EnforcedStyle: separated
+Style/MixinUsage:
+  Enabled: true
+Style/ModuleFunction:
+  Enabled: true
+  EnforcedStyle: module_function
+Style/MultilineIfModifier:
+  Enabled: true
+Style/MultilineIfThen:
+  Enabled: true
+Style/MultilineInPatternThen:
+  Enabled: true
+Style/MultilineMemoization:
+  Enabled: true
+  EnforcedStyle: keyword
+Style/MultilineMethodSignature:
+  Enabled: true
+Style/MultilineTernaryOperator:
+  Enabled: true
+Style/MultilineWhenThen:
+  Enabled: true
+Style/MultipleComparison:
+  Enabled: true
+Style/MutableConstant:
+  Enabled: true
+  EnforcedStyle: literals
+Style/NegatedIf:
+  Enabled: true
+  EnforcedStyle: postfix
+Style/NegatedIfElseCondition:
+  Enabled: true
+Style/NegatedUnless:
+  Enabled: true
+  EnforcedStyle: both
+Style/NegatedWhile:
+  Enabled: true
+Style/NestedModifier:
+  Enabled: true
+Style/NestedParenthesizedCalls:
+  Enabled: true
+  AllowedMethods:
+    - be
+    - be_a
+    - be_an
+    - be_between
+    - be_falsey
+    - be_kind_of
+    - be_instance_of
+    - be_truthy
+    - be_within
+    - eq
+    - eql
+    - end_with
+    - include
+    - match
+    - raise_error
+    - respond_to
+    - start_with
+Style/NestedTernaryOperator:
+  Enabled: true
+Style/Next:
+  Enabled: true
+  EnforcedStyle: skip_modifier_ifs
+Style/NilComparison:
+  Enabled: true
+  EnforcedStyle: predicate
+Style/NilLambda:
+  Enabled: true
+Style/NonNilCheck:
+  Enabled: true
+  IncludeSemanticChanges: false
+Style/Not:
+  Enabled: true
+Style/NumericLiteralPrefix:
+  Enabled: true
+  EnforcedOctalStyle: zero_with_o
+Style/NumericLiterals:
+  Enabled: true
+  MinDigits: 5
+Style/OneLineConditional:
+  Enabled: true
+Style/OptionalArguments:
+  Enabled: true
+Style/OrAssignment:
+  Enabled: true
+Style/ParallelAssignment:
+  Enabled: true
+Style/ParenthesesAroundCondition:
+  Enabled: true
+  AllowSafeAssignment: false
+  AllowInMultilineConditions: false
+Style/PercentLiteralDelimiters:
+  Enabled: true
+  PreferredDelimiters:
+    default: ()
+    '%i': '[]'
+    '%I': '[]'
+    '%r': '{}'
+    '%w': '[]'
+    '%W': '[]'
+Style/PercentQLiterals:
+  Enabled: true
+  EnforcedStyle: lower_case_q
+Style/PerlBackrefs:
+  Enabled: true
+Style/PreferredHashMethods:
+  Enabled: true
+  EnforcedStyle: verbose
+Style/Proc:
+  Enabled: true
+Style/QuotedSymbols:
+  Enabled: true
+  EnforcedStyle: same_as_string_literals
+Style/RaiseArgs:
+  Enabled: true
+  EnforcedStyle: compact
+Style/RandomWithOffset:
+  Enabled: true
+Style/RedundantAssignment:
+  Enabled: true
+Style/RedundantBegin:
+  Enabled: true
+Style/RedundantCapitalW:
+  Enabled: true
+Style/RedundantCondition:
+  Enabled: true
+Style/RedundantConditional:
+  Enabled: true
+Style/RedundantFileExtensionInRequire:
+  Enabled: true
+Style/RedundantFreeze:
+  Enabled: true
+Style/RedundantInterpolation:
+  Enabled: true
+Style/RedundantParentheses:
+  Enabled: true
+Style/RedundantPercentQ:
+  Enabled: true
+Style/RedundantRegexpCharacterClass:
+  Enabled: true
+Style/RedundantRegexpEscape:
+  Enabled: true
+Style/RedundantReturn:
+  Enabled: true
+Style/RedundantSelf:
+  Enabled: true
+Style/RedundantSort:
+  Enabled: true
+Style/RedundantSortBy:
+  Enabled: true
+Style/RegexpLiteral:
+  Enabled: true
+  EnforcedStyle: mixed
+  AllowInnerSlashes: true
+Style/RescueModifier:
+  Enabled: true
+Style/RescueStandardError:
+  Enabled: true
+  EnforcedStyle: explicit
+Style/ReturnNil:
+  Enabled: true
+  EnforcedStyle: return
+Style/Sample:
+  Enabled: true
+Style/SelfAssignment:
+  Enabled: true
+Style/Semicolon:
+  Enabled: true
+Style/SignalException:
+  Enabled: true
+  EnforcedStyle: only_raise
+Style/SingleArgumentDig:
+  Enabled: true
+Style/SingleLineMethods:
+  Enabled: true
+  AllowIfMethodIsEmpty: true
+Style/SpecialGlobalVars:
+  Enabled: true
+  EnforcedStyle: use_english_names
+Style/StabbyLambdaParentheses:
+  Enabled: true
+  EnforcedStyle: require_parentheses
+Style/StaticClass:
+  Enabled: true
+Style/StderrPuts:
+  Enabled: true
+Style/StringConcatenation:
+  Enabled: true
+Style/StringLiterals:
+  Enabled: true
+  EnforcedStyle: single_quotes
+  ConsistentQuotesInMultiline: false # good if only one line has interpolation
+Style/StringLiteralsInInterpolation:
+  Enabled: true
+  EnforcedStyle: single_quotes
+Style/Strip:
+  Enabled: true
+Style/StructInheritance:
+  Enabled: true
+Style/SymbolArray:
+  Enabled: true
+  EnforcedStyle: percent
+Style/SymbolLiteral:
+  Enabled: true
+Style/SymbolProc:
+  Enabled: true
+  AllowMethodsWithArguments: false
+  IgnoredMethods:
+    - respond_to
+    - define_method
+Style/TernaryParentheses:
+  Enabled: true
+  EnforcedStyle: require_no_parentheses
+  AllowSafeAssignment: false
+Style/TrailingBodyOnClass:
+  Enabled: true
+Style/TrailingBodyOnMethodDefinition:
+  Enabled: true
+Style/TrailingBodyOnModule:
+  Enabled: true
+Style/TrailingCommaInArguments:
+  Enabled: true
+  EnforcedStyleForMultiline: consistent_comma
+Style/TrailingCommaInArrayLiteral:
+  Enabled: true
+  EnforcedStyleForMultiline: consistent_comma
+Style/TrailingCommaInHashLiteral:
+  Enabled: true
+  EnforcedStyleForMultiline: consistent_comma
+Style/TrailingMethodEndStatement:
+  Enabled: true
+Style/TrailingUnderscoreVariable:
+  Enabled: true
+  AllowNamedUnderscoreVariables: false
+Style/TrivialAccessors:
+  Enabled: true
+  ExactNameMatch: true
+  AllowPredicates: true
+  AllowDSLWriters: true
+  IgnoreClassMethods: false
+  AllowedMethods:
+    - to_ary
+    - to_a
+    - to_c
+    - to_enum
+    - to_h
+    - to_hash
+    - to_i
+    - to_int
+    - to_io
+    - to_open
+    - to_path
+    - to_proc
+    - to_r
+    - to_regexp
+    - to_str
+    - to_s
+    - to_sym
+Style/UnlessElse:
+  Enabled: true
+Style/UnlessLogicalOperators:
+  Enabled: true
+  EnforcedStyle: forbid_mixed_logical_operators
+Style/UnpackFirst:
+  Enabled: true
+Style/VariableInterpolation:
+  Enabled: true
+Style/WhenThen:
+  Enabled: true
+Style/WhileUntilDo:
+  Enabled: true
+Style/WhileUntilModifier:
+  Enabled: true
+Style/WordArray:
+  Enabled: true
+  EnforcedStyle: percent
+  MinSize: 1
+Style/YodaCondition:
+  Enabled: true
+  EnforcedStyle: forbid_for_all_comparison_operators
+Style/ZeroLengthPredicate:
+  Enabled: true
 
-# ##########################
-# ### Rails Requirements ###
-# ##########################
+##########################
+### Rails Requirements ###
+##########################
 
-# Rails/ActionFilter:
-#   Enabled: true
-#   EnforcedStyle: action
-# Rails/ActiveRecordCallbacksOrder:
-#   Enabled: true
-# Rails/ActiveSupportAliases:
-#   Enabled: true
-# Rails/AddColumnIndex:
-#   Enabled: true
-# Rails/AfterCommitOverride:
-#   Enabled: true
-# Rails/ApplicationController:
-#   Enabled: true
-# Rails/ApplicationRecord:
-#   Enabled: true
-# Rails/ArelStar:
-#   Enabled: true
-# Rails/AttributeDefaultBlockValue:
-#   Enabled: true
-# Rails/BelongsTo:
-#   Enabled: true
-# Rails/Blank:
-#   Enabled: true
-#   NilOrEmpty: true
-#   NotPresent: true
-#   UnlessPresent: true
-# Rails/BulkChangeTable:
-#   Enabled: true
-# Rails/CreateTableWithTimestamps:
-#   Enabled: true
-# Rails/Date:
-#   Enabled: true
-# Rails/DefaultScope:
-#   Enabled: true
-# Rails/Delegate:
-#   Enabled: true
-# Rails/DelegateAllowBlank:
-#   Enabled: true
-# Rails/DynamicFindBy:
-#   Enabled: true
-# Rails/EagerEvaluationLogMessage:
-#   Enabled: true
-# Rails/EnumHash:
-#   Enabled: true
-# Rails/EnumUniqueness:
-#   Enabled: true
-# Rails/EnvironmentComparison:
-#   Enabled: true
-# Rails/EnvironmentVariableAccess:
-#   Enabled: true
-# Rails/Exit:
-#   Enabled: true
-# Rails/ExpandedDateRange:
-#   Enabled: true
-# Rails/FilePath:
-#   Enabled: true
-#   EnforcedStyle: arguments
-# Rails/FindBy:
-#   Enabled: true
-#   IgnoreWhereFirst: false
-# Rails/FindById:
-#   Enabled: true
-# Rails/FindEach:
-#   Enabled: true
-# Rails/HasManyOrHasOneDependent:
-#   Enabled: true
-# Rails/HttpPositionalArguments:
-#   Enabled: true
-# Rails/HttpStatus:
-#   Enabled: true
-#   EnforcedStyle: symbolic
-# Rails/IgnoredSkipActionFilterOption:
-#   Enabled: true
-# Rails/IndexBy:
-#   Enabled: true
-# Rails/IndexWith:
-#   Enabled: true
-# Rails/Inquiry:
-#   Enabled: true
-# Rails/InverseOf:
-#   Enabled: true
-# Rails/LexicallyScopedActionFilter:
-#   Enabled: true
-# Rails/MatchRoute:
-#   Enabled: true
-# Rails/NegateInclude:
-#   Enabled: true
-# Rails/OrderById:
-#   Enabled: true
-# Rails/Output:
-#   Enabled: true
-# Rails/Pick:
-#   Enabled: true
-# Rails/Pluck:
-#   Enabled: true
-# Rails/PluckId:
-#   Enabled: true
-# Rails/PluckInWhere:
-#   Enabled: true
-#   EnforcedStyle: conservative
-# Rails/PluralizationGrammar:
-#   Enabled: true
-# Rails/Presence:
-#   Enabled: true
-# Rails/Present:
-#   Enabled: true
-#   NotNilAndNotEmpty: true
-#   NotBlank: true
-#   UnlessBlank: true
-# Rails/ReadWriteAttribute:
-#   Enabled: true
-# Rails/RedundantAllowNil:
-#   Enabled: true
-# Rails/RedundantForeignKey:
-#   Enabled: true
-# Rails/RedundantReceiverInWithOptions:
-#   Enabled: true
-# Rails/ReflectionClassName:
-#   Enabled: true
-# Rails/RelativeDateConstant:
-#   Enabled: true
-# Rails/RenderPlainText:
-#   Enabled: true
-# Rails/RequestReferer:
-#   Enabled: true
-#   EnforcedStyle: referrer
-# Rails/SafeNavigation:
-#   Enabled: true
-#   ConvertTry: true
-# Rails/SafeNavigationWithBlank:
-#   Enabled: true
-# Rails/SaveBang:
-#   Enabled: true
-#   AllowImplicitReturn: true
-# Rails/ScopeArgs:
-#   Enabled: true
-# Rails/SkipsModelValidations:
-#   Enabled: true
-#   AllowedMethods:
-#     - touch
-# Rails/TimeZone:
-#   Enabled: true
-# Rails/UniqBeforePluck:
-#   Enabled: true
-#   EnforcedStyle: conservative
-# Rails/UniqueValidationWithoutIndex:
-#   Enabled: true
-# Rails/UnknownEnv:
-#   Enabled: true
-#   Environments:
-#     - development
-#     - test
-#     - staging
-#     - production
-# Rails/Validation:
-#   Enabled: true
-# Rails/WhereEquals:
-#   Enabled: true
-# Rails/WhereNot:
-#   Enabled: true
+Rails/ActionFilter:
+  Enabled: true
+  EnforcedStyle: action
+Rails/ActiveRecordCallbacksOrder:
+  Enabled: true
+Rails/ActiveSupportAliases:
+  Enabled: true
+Rails/AddColumnIndex:
+  Enabled: true
+Rails/AfterCommitOverride:
+  Enabled: true
+Rails/ApplicationController:
+  Enabled: true
+Rails/ApplicationRecord:
+  Enabled: true
+Rails/ArelStar:
+  Enabled: true
+Rails/AttributeDefaultBlockValue:
+  Enabled: true
+Rails/BelongsTo:
+  Enabled: true
+Rails/Blank:
+  Enabled: true
+  NilOrEmpty: true
+  NotPresent: true
+  UnlessPresent: true
+Rails/BulkChangeTable:
+  Enabled: true
+Rails/CreateTableWithTimestamps:
+  Enabled: true
+Rails/Date:
+  Enabled: true
+Rails/DefaultScope:
+  Enabled: true
+Rails/Delegate:
+  Enabled: true
+Rails/DelegateAllowBlank:
+  Enabled: true
+Rails/DynamicFindBy:
+  Enabled: true
+Rails/EagerEvaluationLogMessage:
+  Enabled: true
+Rails/EnumHash:
+  Enabled: true
+Rails/EnumUniqueness:
+  Enabled: true
+Rails/EnvironmentComparison:
+  Enabled: true
+Rails/EnvironmentVariableAccess:
+  Enabled: true
+Rails/Exit:
+  Enabled: true
+Rails/ExpandedDateRange:
+  Enabled: true
+Rails/FilePath:
+  Enabled: true
+  EnforcedStyle: arguments
+Rails/FindBy:
+  Enabled: true
+  IgnoreWhereFirst: false
+Rails/FindById:
+  Enabled: true
+Rails/FindEach:
+  Enabled: true
+Rails/HasManyOrHasOneDependent:
+  Enabled: true
+Rails/HttpPositionalArguments:
+  Enabled: true
+Rails/HttpStatus:
+  Enabled: true
+  EnforcedStyle: symbolic
+Rails/IgnoredSkipActionFilterOption:
+  Enabled: true
+Rails/IndexBy:
+  Enabled: true
+Rails/IndexWith:
+  Enabled: true
+Rails/Inquiry:
+  Enabled: true
+Rails/InverseOf:
+  Enabled: true
+Rails/LexicallyScopedActionFilter:
+  Enabled: true
+Rails/MatchRoute:
+  Enabled: true
+Rails/NegateInclude:
+  Enabled: true
+Rails/OrderById:
+  Enabled: true
+Rails/Output:
+  Enabled: true
+Rails/Pick:
+  Enabled: true
+Rails/Pluck:
+  Enabled: true
+Rails/PluckId:
+  Enabled: true
+Rails/PluckInWhere:
+  Enabled: true
+  EnforcedStyle: conservative
+Rails/PluralizationGrammar:
+  Enabled: true
+Rails/Presence:
+  Enabled: true
+Rails/Present:
+  Enabled: true
+  NotNilAndNotEmpty: true
+  NotBlank: true
+  UnlessBlank: true
+Rails/ReadWriteAttribute:
+  Enabled: true
+Rails/RedundantAllowNil:
+  Enabled: true
+Rails/RedundantForeignKey:
+  Enabled: true
+Rails/RedundantReceiverInWithOptions:
+  Enabled: true
+Rails/ReflectionClassName:
+  Enabled: true
+Rails/RelativeDateConstant:
+  Enabled: true
+Rails/RenderPlainText:
+  Enabled: true
+Rails/RequestReferer:
+  Enabled: true
+  EnforcedStyle: referrer
+Rails/SafeNavigation:
+  Enabled: true
+  ConvertTry: true
+Rails/SafeNavigationWithBlank:
+  Enabled: true
+Rails/SaveBang:
+  Enabled: true
+  AllowImplicitReturn: true
+Rails/ScopeArgs:
+  Enabled: true
+Rails/SkipsModelValidations:
+  Enabled: true
+  AllowedMethods:
+    - touch
+Rails/TimeZone:
+  Enabled: true
+Rails/UniqBeforePluck:
+  Enabled: true
+  EnforcedStyle: conservative
+Rails/UniqueValidationWithoutIndex:
+  Enabled: true
+Rails/UnknownEnv:
+  Enabled: true
+  Environments:
+    - development
+    - test
+    - staging
+    - production
+Rails/Validation:
+  Enabled: true
+Rails/WhereEquals:
+  Enabled: true
+Rails/WhereNot:
+  Enabled: true
 
-# ##########################
-# ### RSpec Requirements ###
-# ##########################
+##########################
+### RSpec Requirements ###
+##########################
 
-# RSpec/AlignLetLeftBrace:
-#   Enabled: true
-# RSpec/AroundBlock:
-#   Enabled: true
-# RSpec/Be:
-#   Enabled: true
-# RSpec/BeEql:
-#   Enabled: true
-# RSpec/BeforeAfterAll:
-#   Enabled: true
-# RSpec/ContextMethod:
-#   Enabled: true
-# RSpec/ContextWording:
-#   Enabled: true
-#   Prefixes:
-#     - when
-#     - with
-#     - without
-# RSpec/DescribeClass:
-#   Enabled: true
-#   IgnoredMetadata:
-#     type:
-#       - request
-# RSpec/DescribedClass:
-#   Enabled: true
-#   EnforcedStyle: described_class
-# RSpec/DescribedClassModuleWrapping:
-#   Enabled: true
-# RSpec/EmptyExampleGroup:
-#   Enabled: true
-# RSpec/EmptyHook:
-#   Enabled: true
-# RSpec/EmptyLineAfterExample:
-#   Enabled: true
-#   AllowConsecutiveOneLiners: true
-# RSpec/EmptyLineAfterExampleGroup:
-#   Enabled: true
-# RSpec/EmptyLineAfterFinalLet:
-#   Enabled: true
-# RSpec/EmptyLineAfterHook:
-#   Enabled: true
-# RSpec/EmptyLineAfterSubject:
-#   Enabled: true
-# RSpec/ExampleWithoutDescription:
-#   Enabled: true
-#   EnforcedStyle: single_line_only
-# RSpec/ExampleWording:
-#   Enabled: true
-# RSpec/ExpectActual:
-#   Enabled: true
-# RSpec/ExpectChange:
-#   Enabled: true
-#   EnforcedStyle: method_call
-# RSpec/ExpectInHook:
-#   Enabled: true
-# RSpec/FilePath:
-#   Enabled: true
-#   IgnoreMethods: true
-# RSpec/Focus:
-#   Enabled: true
-# RSpec/HookArgument:
-#   Enabled: true
-#   EnforcedStyle: implicit
-# RSpec/HooksBeforeExamples:
-#   Enabled: true
-# RSpec/IdenticalEqualityAssertion:
-#   Enabled: true
-# RSpec/ImplicitBlockExpectation:
-#   Enabled: true
-# RSpec/ImplicitExpect:
-#   Enabled: true
-#   EnforcedStyle: is_expected
-# RSpec/ImplicitSubject:
-#   Enabled: true
-#   EnforcedStyle: single_line_only
-# RSpec/InstanceSpy:
-#   Enabled: true
-# RSpec/InstanceVariable:
-#   Enabled: true
-# RSpec/IteratedExpectation:
-#   Enabled: true
-# RSpec/LeadingSubject:
-#   Enabled: true
-# RSpec/LeakyConstantDeclaration:
-#   Enabled: true
-# RSpec/LetBeforeExamples:
-#   Enabled: true
-# RSpec/MessageSpies:
-#   Enabled: true
-#   EnforcedStyle: have_received
-# RSpec/MissingExampleGroupArgument:
-#   Enabled: true
-# RSpec/MultipleDescribes:
-#   Enabled: true
-# RSpec/MultipleExpectations:
-#   Enabled: true
-#   Max: 3
-# RSpec/MultipleSubjects:
-#   Enabled: true
-# RSpec/NamedSubject:
-#   Enabled: true
-#   IgnoreSharedExamples: true
-# RSpec/NotToNot:
-#   Enabled: true
-#   EnforcedStyle: not_to
-# RSpec/PredicateMatcher:
-#   Enabled: true
-#   Strict: false
-#   EnforcedStyle: inflected
-# RSpec/ReceiveCounts:
-#   Enabled: true
-# RSpec/ReceiveNever:
-#   Enabled: true
-# RSpec/RepeatedDescription:
-#   Enabled: true
-# RSpec/RepeatedExample:
-#   Enabled: true
-# RSpec/RepeatedExampleGroupDescription:
-#   Enabled: true
-# RSpec/RepeatedIncludeExample:
-#   Enabled: true
-# RSpec/ReturnFromStub:
-#   Enabled: true
-#   EnforcedStyle: and_return
-# RSpec/ScatteredLet:
-#   Enabled: true
-# RSpec/ScatteredSetup:
-#   Enabled: true
-# RSpec/SharedContext:
-#   Enabled: true
-# RSpec/SharedExamples:
-#   Enabled: true
-# RSpec/SingleArgumentMessageChain:
-#   Enabled: true
-# RSpec/StubbedMock:
-#   Enabled: true
-# RSpec/SubjectStub:
-#   Enabled: true
-# RSpec/UnspecifiedException:
-#   Enabled: true
-# RSpec/VariableDefinition:
-#   Enabled: true
-#   EnforcedStyle: symbols
-# RSpec/VariableName:
-#   Enabled: true
-#   EnforcedStyle: snake_case
-# RSpec/VoidExpect:
-#   Enabled: true
-# RSpec/Yield:
-#   Enabled: true
+RSpec/AlignLetLeftBrace:
+  Enabled: true
+RSpec/AroundBlock:
+  Enabled: true
+RSpec/Be:
+  Enabled: true
+RSpec/BeEql:
+  Enabled: true
+RSpec/BeforeAfterAll:
+  Enabled: true
+RSpec/ContextMethod:
+  Enabled: true
+RSpec/ContextWording:
+  Enabled: true
+  Prefixes:
+    - when
+    - with
+    - without
+RSpec/DescribeClass:
+  Enabled: true
+  IgnoredMetadata:
+    type:
+      - request
+RSpec/DescribedClass:
+  Enabled: true
+  EnforcedStyle: described_class
+RSpec/DescribedClassModuleWrapping:
+  Enabled: true
+RSpec/EmptyExampleGroup:
+  Enabled: true
+RSpec/EmptyHook:
+  Enabled: true
+RSpec/EmptyLineAfterExample:
+  Enabled: true
+  AllowConsecutiveOneLiners: true
+RSpec/EmptyLineAfterExampleGroup:
+  Enabled: true
+RSpec/EmptyLineAfterFinalLet:
+  Enabled: true
+RSpec/EmptyLineAfterHook:
+  Enabled: true
+RSpec/EmptyLineAfterSubject:
+  Enabled: true
+RSpec/ExampleWithoutDescription:
+  Enabled: true
+  EnforcedStyle: single_line_only
+RSpec/ExampleWording:
+  Enabled: true
+RSpec/ExpectActual:
+  Enabled: true
+RSpec/ExpectChange:
+  Enabled: true
+  EnforcedStyle: method_call
+RSpec/ExpectInHook:
+  Enabled: true
+RSpec/FilePath:
+  Enabled: true
+  IgnoreMethods: true
+RSpec/Focus:
+  Enabled: true
+RSpec/HookArgument:
+  Enabled: true
+  EnforcedStyle: implicit
+RSpec/HooksBeforeExamples:
+  Enabled: true
+RSpec/IdenticalEqualityAssertion:
+  Enabled: true
+RSpec/ImplicitBlockExpectation:
+  Enabled: true
+RSpec/ImplicitExpect:
+  Enabled: true
+  EnforcedStyle: is_expected
+RSpec/ImplicitSubject:
+  Enabled: true
+  EnforcedStyle: single_line_only
+RSpec/InstanceSpy:
+  Enabled: true
+RSpec/InstanceVariable:
+  Enabled: true
+RSpec/IteratedExpectation:
+  Enabled: true
+RSpec/LeadingSubject:
+  Enabled: true
+RSpec/LeakyConstantDeclaration:
+  Enabled: true
+RSpec/LetBeforeExamples:
+  Enabled: true
+RSpec/MessageSpies:
+  Enabled: true
+  EnforcedStyle: have_received
+RSpec/MissingExampleGroupArgument:
+  Enabled: true
+RSpec/MultipleDescribes:
+  Enabled: true
+RSpec/MultipleExpectations:
+  Enabled: true
+  Max: 3
+RSpec/MultipleSubjects:
+  Enabled: true
+RSpec/NamedSubject:
+  Enabled: true
+  IgnoreSharedExamples: true
+RSpec/NotToNot:
+  Enabled: true
+  EnforcedStyle: not_to
+RSpec/PredicateMatcher:
+  Enabled: true
+  Strict: false
+  EnforcedStyle: inflected
+RSpec/ReceiveCounts:
+  Enabled: true
+RSpec/ReceiveNever:
+  Enabled: true
+RSpec/RepeatedDescription:
+  Enabled: true
+RSpec/RepeatedExample:
+  Enabled: true
+RSpec/RepeatedExampleGroupDescription:
+  Enabled: true
+RSpec/RepeatedIncludeExample:
+  Enabled: true
+RSpec/ReturnFromStub:
+  Enabled: true
+  EnforcedStyle: and_return
+RSpec/ScatteredLet:
+  Enabled: true
+RSpec/ScatteredSetup:
+  Enabled: true
+RSpec/SharedContext:
+  Enabled: true
+RSpec/SharedExamples:
+  Enabled: true
+RSpec/SingleArgumentMessageChain:
+  Enabled: true
+RSpec/StubbedMock:
+  Enabled: true
+RSpec/SubjectStub:
+  Enabled: true
+RSpec/UnspecifiedException:
+  Enabled: true
+RSpec/VariableDefinition:
+  Enabled: true
+  EnforcedStyle: symbols
+RSpec/VariableName:
+  Enabled: true
+  EnforcedStyle: snake_case
+RSpec/VoidExpect:
+  Enabled: true
+RSpec/Yield:
+  Enabled: true
 
-# ################################
-# ### Performance Requirements ###
-# ################################
+################################
+### Performance Requirements ###
+################################
 
 
-# Performance/BindCall:
-#   Enabled: true
-# Performance/BlockGivenWithExplicitBlock:
-#   Enabled: true
-# Performance/Caller:
-#   Enabled: true
-# Performance/CaseWhenSplat:
-#   Enabled: true
-# Performance/Casecmp:
-#   Enabled: true
-# Performance/ChainArrayAllocation:
-#   Enabled: true
-# Performance/CollectionLiteralInLoop:
-#   Enabled: true
-# Performance/CompareWithBlock:
-#   Enabled: true
-# Performance/Count:
-#   Enabled: true
-# Performance/DeletePrefix:
-#   Enabled: true
-#   SafeMultiline: true
-# Performance/DeleteSuffix:
-#   Enabled: true
-#   SafeMultiline: true
-# Performance/Detect:
-#   Enabled: true
-# Performance/DoubleStartEndWith:
-#   Enabled: true
-# Performance/EndWith:
-#   Enabled: true
-# Performance/FixedSize:
-#   Enabled: true
-# Performance/FlatMap:
-#   Enabled: true
-# Performance/InefficientHashSearch:
-#   Enabled: true
-# Performance/IoReadlines:
-#   Enabled: true
-# Performance/RangeInclude:
-#   Enabled: true
-# Performance/RedundantBlockCall:
-#   Enabled: true
-# Performance/RedundantMatch:
-#   Enabled: true
-# Performance/RedundantMerge:
-#   Enabled: true
-# Performance/RedundantSortBlock:
-#   Enabled: true
-# Performance/RedundantSplitRegexpArgument:
-#   Enabled: true
-# Performance/RedundantStringChars:
-#   Enabled: true
-# Performance/RegexpMatch:
-#   Enabled: true
-# Performance/ReverseEach:
-#   Enabled: true
-# Performance/ReverseFirst:
-#   Enabled: true
-# Performance/SelectMap:
-#   Enabled: true
-# Performance/Size:
-#   Enabled: true
-# Performance/SortReverse:
-#   Enabled: true
-# Performance/Squeeze:
-#   Enabled: true
-# Performance/StartWith:
-#   Enabled: true
-#   SafeMultiline: true
-# Performance/StringInclude:
-#   Enabled: true
-# Performance/StringReplacement:
-#   Enabled: true
-# Performance/Sum:
-#   Enabled: true
-# Performance/TimesMap:
-#   Enabled: true
-# Performance/UnfreezeString:
-#   Enabled: true
-# Performance/UriDefaultParser:
-#   Enabled: true
+Performance/BindCall:
+  Enabled: true
+Performance/BlockGivenWithExplicitBlock:
+  Enabled: true
+Performance/Caller:
+  Enabled: true
+Performance/CaseWhenSplat:
+  Enabled: true
+Performance/Casecmp:
+  Enabled: true
+Performance/ChainArrayAllocation:
+  Enabled: true
+Performance/CollectionLiteralInLoop:
+  Enabled: true
+Performance/CompareWithBlock:
+  Enabled: true
+Performance/Count:
+  Enabled: true
+Performance/DeletePrefix:
+  Enabled: true
+  SafeMultiline: true
+Performance/DeleteSuffix:
+  Enabled: true
+  SafeMultiline: true
+Performance/Detect:
+  Enabled: true
+Performance/DoubleStartEndWith:
+  Enabled: true
+Performance/EndWith:
+  Enabled: true
+Performance/FixedSize:
+  Enabled: true
+Performance/FlatMap:
+  Enabled: true
+Performance/InefficientHashSearch:
+  Enabled: true
+Performance/IoReadlines:
+  Enabled: true
+Performance/RangeInclude:
+  Enabled: true
+Performance/RedundantBlockCall:
+  Enabled: true
+Performance/RedundantMatch:
+  Enabled: true
+Performance/RedundantMerge:
+  Enabled: true
+Performance/RedundantSortBlock:
+  Enabled: true
+Performance/RedundantSplitRegexpArgument:
+  Enabled: true
+Performance/RedundantStringChars:
+  Enabled: true
+Performance/RegexpMatch:
+  Enabled: true
+Performance/ReverseEach:
+  Enabled: true
+Performance/ReverseFirst:
+  Enabled: true
+Performance/SelectMap:
+  Enabled: true
+Performance/Size:
+  Enabled: true
+Performance/SortReverse:
+  Enabled: true
+Performance/Squeeze:
+  Enabled: true
+Performance/StartWith:
+  Enabled: true
+  SafeMultiline: true
+Performance/StringInclude:
+  Enabled: true
+Performance/StringReplacement:
+  Enabled: true
+Performance/Sum:
+  Enabled: true
+Performance/TimesMap:
+  Enabled: true
+Performance/UnfreezeString:
+  Enabled: true
+Performance/UriDefaultParser:
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -554,58 +554,14 @@ Naming/ClassAndModuleCamelCase:
   Enabled: true
 Naming/ConstantName:
   Enabled: true
-Naming/FileName:
-  Enabled: true
-  ExpectMatchingDefinition: true # might be redundant w/Zeitwerk
-  CheckDefinitionPathHierarchy: true
-  IgnoreExecutableScripts: true
-  AllowedAcronyms:
-    - CLI
-    - DSL
-    - ACL
-    - API
-    - ASCII
-    - CPU
-    - CSS
-    - CSV
-    - DNS
-    - EOF
-    - GUID
-    - HTML
-    - HTTP
-    - HTTPS
-    - ID
-    - IP
-    - JSON
-    - LHS
-    - QPS
-    - RAM
-    - RHS
-    - RPC
-    - SLA
-    - SMTP
-    - SQL
-    - SSH
-    - TCP
-    - TLS
-    - TTL
-    - UDP
-    - UI
-    - UID
-    - UUID
-    - URI
-    - URL
-    - UTF8
-    - VM
-    - XML
-    - XMPP
-    - XSRF
-    - XSS
 Naming/HeredocDelimiterCase:
   Enabled: true
   EnforcedStyle: uppercase
 Naming/InclusiveLanguage:
   Enabled: true
+  Exclude:
+    - 'db/migrate/**/*' # migrations include the word 'master'
+    - 'config/environments/production.rb' # requires RAILS_MASTER_KEY env variable
   CheckIdentifiers: true
   CheckConstants: true
   CheckVariables: true
@@ -687,974 +643,974 @@ Naming/VariableNumber:
 ### Security Requirements ###
 #############################
 
-Security/Eval:
-  Enabled: true
-Security/JSONLoad:
-  Enabled: true
-Security/MarshalLoad:
-  Enabled: true
-Security/Open:
-  Enabled: true
-Security/YAMLLoad:
-  Enabled: true
+# Security/Eval:
+#   Enabled: true
+# Security/JSONLoad:
+#   Enabled: true
+# Security/MarshalLoad:
+#   Enabled: true
+# Security/Open:
+#   Enabled: true
+# Security/YAMLLoad:
+#   Enabled: true
 
-##########################
-### Style Requirements ###
-##########################
+# ##########################
+# ### Style Requirements ###
+# ##########################
 
-Style/AccessModifierDeclarations:
-  Enabled: true
-  EnforcedStyle: group
-Style/AccessorGrouping:
-  Enabled: true
-  EnforcedStyle: grouped
-Style/Alias:
-  Enabled: true
-  EnforcedStyle: prefer_alias_method
-Style/AndOr:
-  Enabled: true
-  EnforcedStyle: always
-Style/ArgumentsForwarding:
-  Enabled: true
-  AllowOnlyRestArgument: true
-Style/ArrayJoin:
-  Enabled: true
-Style/Attr:
-  Enabled: true
-Style/AutoResourceCleanup:
-  Enabled: true
-Style/BarePercentLiterals:
-  Enabled: true
-  EnforcedStyle: bare_percent
-Style/BeginBlock:
-  Enabled: true
-Style/BisectedAttrAccessor:
-  Enabled: true
-Style/BlockComments:
-  Enabled: true
-Style/BlockDelimiters:
-  Enabled: true
-  EnforcedStyle: line_count_based
-  ProceduralMethods:
-    # Methods that are known to be procedural in nature but look functional from
-    # their usage, e.g.
-    #
-    #   time = Benchmark.realtime do
-    #     foo.bar
-    #   end
-    #
-    # Here, the return value of the block is discarded but the return value of
-    # `Benchmark.realtime` is used.
-    - benchmark
-    - bm
-    - bmbm
-    - create
-    - each_with_object
-    - measure
-    - new
-    - realtime
-    - tap
-    - with_object
-  FunctionalMethods:
-    # Methods that are known to be functional in nature but look procedural from
-    # their usage, e.g.
-    #
-    #   let(:foo) { Foo.new }
-    #
-    # Here, the return value of `Foo.new` is used to define a `foo` helper but
-    # doesn't appear to be used from the return value of `let`.
-    - let
-    - let!
-    - subject
-    - watch
-  IgnoredMethods:
-    # Methods that can be either procedural or functional and cannot be
-    # categorised from their usage alone, e.g.
-    #
-    #   foo = lambda do |x|
-    #     puts "Hello, #{x}"
-    #   end
-    #
-    #   foo = lambda do |x|
-    #     x * 100
-    #   end
-    #
-    # Here, it is impossible to tell from the return value of `lambda` whether
-    # the inner block's return value is significant.
-    - lambda
-    - proc
-    - it
-Style/CaseEquality:
-  Enabled: true
-  AllowOnConstant: false
-Style/CharacterLiteral:
-  Enabled: true
-Style/ClassCheck:
-  Enabled: true
-  EnforcedStyle: is_a?
-Style/ClassEqualityComparison:
-  Enabled: true
-  IgnoredMethods:
-    - ==
-    - equal?
-    - eql?
-Style/ClassMethods:
-  Enabled: true
-Style/ClassMethodsDefinitions:
-  Enabled: true
-  EnforcedStyle: def_self
-Style/CollectionCompact:
-  Enabled: true
-Style/CollectionMethods:
-  Enabled: true
-  PreferredMethods:
-    collect: 'map'
-    collect!: 'map!'
-    inject: 'reduce'
-    detect: 'find'
-    find_all: 'select'
-    member?: 'include?'
-  MethodsAcceptingSymbol:
-    - inject
-    - reduce
-    - map
-    - map!
-Style/ColonMethodCall:
-  Enabled: true
-Style/ColonMethodDefinition:
-  Enabled: true
-Style/CombinableLoops:
-  Enabled: true
-Style/CommandLiteral:
-  Enabled: true
-  EnforcedStyle: percent_x
-Style/CommentAnnotation:
-  Enabled: true
-  Keywords:
-    - TODO
-    - FIXME
-  RequireColon: true
-Style/CommentedKeyword:
-  Enabled: true
-Style/ConditionalAssignment:
-  Enabled: true
-  EnforcedStyle: assign_to_condition
-  IncludeTernaryExpressions: true
-  SingleLineConditionsOnly: true
-Style/DefWithParentheses:
-  Enabled: true
-Style/Dir:
-  Enabled: true
-Style/DocumentDynamicEvalDefinition:
-  Enabled: true
-Style/DoubleCopDisableDirective:
-  Enabled: true
-Style/DoubleNegation:
-  Enabled: true
-  EnforcedStyle: allowed_in_returns
-Style/EachForSimpleLoop:
-  Enabled: true
-Style/EmptyBlockParameter:
-  Enabled: true
-Style/EmptyCaseCondition:
-  Enabled: true
-Style/EmptyElse:
-  Enabled: true
-  EnforcedStyle: both
-Style/EmptyLambdaParameter:
-  Enabled: true
-Style/EmptyLiteral:
-  Enabled: true
-Style/EmptyMethod:
-  Enabled: true
-  EnforcedStyle: compact
-Style/Encoding:
-  Enabled: true
-Style/EndBlock:
-  Enabled: true
-Style/EvalWithLocation:
-  Enabled: true
-Style/EvenOdd:
-  Enabled: true
-Style/ExpandPathArguments:
-  Enabled: true
-Style/ExplicitBlockArgument:
-  Enabled: true
-Style/ExponentialNotation:
-  Enabled: true
-  EnforcedStyle: scientific
-Style/FloatDivision:
-  Enabled: true
-  EnforcedStyle: single_coerce
-Style/For:
-  Enabled: true
-  EnforcedStyle: each
-Style/FrozenStringLiteralComment:
-  Enabled: true
-  EnforcedStyle: always
-Style/GlobalStdStream:
-  Enabled: true
-Style/GlobalVars:
-  Enabled: true
-Style/GuardClause:
-  Enabled: true
-Style/HashAsLastArrayItem:
-  Enabled: true
-  EnforcedStyle: braces
-Style/HashEachMethods:
-  Enabled: true
-Style/HashExcept:
-  Enabled: true
-Style/HashLikeCase:
-  Enabled: true
-Style/HashSyntax:
-  Enabled: true
-  EnforcedStyle: ruby19
-  UseHashRocketsWithSymbolValues: false
-  PreferHashRocketsForNonAlnumEndingSymbols: false
-Style/HashTransformKeys:
-  Enabled: true
-Style/HashTransformValues:
-  Enabled: true
-Style/IdenticalConditionalBranches:
-  Enabled: true
-Style/IfInsideElse:
-  Enabled: true
-Style/IfUnlessModifier:
-  Enabled: true
-Style/IfUnlessModifierOfIfUnless:
-  Enabled: true
-Style/IfWithBooleanLiteralBranches:
-  Enabled: true
-Style/IfWithSemicolon:
-  Enabled: true
-Style/ImplicitRuntimeError:
-  Enabled: true
-Style/InverseMethods:
-  Enabled: true
-  InverseMethods:
-    :any?: :none?
-    :even?: :odd?
-    :==: :!=
-    :=~: :!~
-    :<: :>=
-    :>: :<=
-  InverseBlocks:
-    :select: :reject
-    :select!: :reject!
-Style/IpAddresses:
-  Enabled: true
-  AllowedAddresses:
-    - '::'
-  Exclude:
-    - '**/Gemfile'
-Style/KeywordParametersOrder:
-  Enabled: true
-Style/Lambda:
-  Enabled: true
-  EnforcedStyle: line_count_dependent
-Style/LambdaCall:
-  Enabled: true
-  EnforcedStyle: call
-Style/LineEndConcatenation:
-  Enabled: true
-Style/MethodCallWithoutArgsParentheses:
-  Enabled: true
-Style/MethodDefParentheses:
-  Enabled: true
-  EnforcedStyle: require_parentheses
-Style/MinMax:
-  Enabled: true
-Style/MissingRespondToMissing:
-  Enabled: true
-Style/MixinGrouping:
-  Enabled: true
-  EnforcedStyle: separated
-Style/MixinUsage:
-  Enabled: true
-Style/ModuleFunction:
-  Enabled: true
-  EnforcedStyle: module_function
-Style/MultilineIfModifier:
-  Enabled: true
-Style/MultilineIfThen:
-  Enabled: true
-Style/MultilineInPatternThen:
-  Enabled: true
-Style/MultilineMemoization:
-  Enabled: true
-  EnforcedStyle: keyword
-Style/MultilineMethodSignature:
-  Enabled: true
-Style/MultilineTernaryOperator:
-  Enabled: true
-Style/MultilineWhenThen:
-  Enabled: true
-Style/MultipleComparison:
-  Enabled: true
-Style/MutableConstant:
-  Enabled: true
-  EnforcedStyle: literals
-Style/NegatedIf:
-  Enabled: true
-  EnforcedStyle: postfix
-Style/NegatedIfElseCondition:
-  Enabled: true
-Style/NegatedUnless:
-  Enabled: true
-  EnforcedStyle: both
-Style/NegatedWhile:
-  Enabled: true
-Style/NestedModifier:
-  Enabled: true
-Style/NestedParenthesizedCalls:
-  Enabled: true
-  AllowedMethods:
-    - be
-    - be_a
-    - be_an
-    - be_between
-    - be_falsey
-    - be_kind_of
-    - be_instance_of
-    - be_truthy
-    - be_within
-    - eq
-    - eql
-    - end_with
-    - include
-    - match
-    - raise_error
-    - respond_to
-    - start_with
-Style/NestedTernaryOperator:
-  Enabled: true
-Style/Next:
-  Enabled: true
-  EnforcedStyle: skip_modifier_ifs
-Style/NilComparison:
-  Enabled: true
-  EnforcedStyle: predicate
-Style/NilLambda:
-  Enabled: true
-Style/NonNilCheck:
-  Enabled: true
-  IncludeSemanticChanges: false
-Style/Not:
-  Enabled: true
-Style/NumericLiteralPrefix:
-  Enabled: true
-  EnforcedStyle: zero_with_o
-Style/NumericLiterals:
-  Enabled: true
-  MinDigits: 5
-Style/OneLineConditional:
-  Enabled: true
-Style/OptionalArguments:
-  Enabled: true
-Style/OrAssignment:
-  Enabled: true
-Style/ParallelAssignment:
-  Enabled: true
-Style/ParenthesesAroundCondition:
-  Enabled: true
-  AllowSafeAssignment: false
-  AllowInMultilineConditionals: false
-Style/PercentLiteralDelimiters:
-  Enabled: true
-  PreferredDelimiters:
-    default: ()
-    '%i': '[]'
-    '%I': '[]'
-    '%r': '{}'
-    '%w': '[]'
-    '%W': '[]'
-Style/PercentQLiterals:
-  Enabled: true
-  EnforcedStyle: lower_case_q
-Style/PerlBackrefs:
-  Enabled: true
-Style/PreferredHashMethods:
-  Enabled: true
-  EnforcedStyle: verbose
-Style/Proc:
-  Enabled: true
-Style/QuotedSymbols:
-  Enabled: true
-  EnforcedStyle: same_as_string_literals
-Style/RaiseArgs:
-  Enabled: true
-  EnforcedStyle: compact
-Style/RandomWithOffset:
-  Enabled: true
-Style/RedundantAssignment:
-  Enabled: true
-Style/RedundantBegin:
-  Enabled: true
-Style/RedundantCapitalW:
-  Enabled: true
-Style/RedundantCondition:
-  Enabled: true
-Style/RedundantConditional:
-  Enabled: true
-Style/RedundantFileExtensionInRequire:
-  Enabled: true
-Style/RedundantFreeze:
-  Enabled: true
-Style/RedundantInterpolation:
-  Enabled: true
-Style/RedundantParentheses:
-  Enabled: true
-Style/RedundantPercentQ:
-  Enabled: true
-Style/RedundantRegexpCharacterClass:
-  Enabled: true
-Style/RedundantRegexpEscape:
-  Enabled: true
-Style/RedundantReturn:
-  Enabled: true
-Style/RedundantSelf:
-  Enabled: true
-Style/RedundantSort:
-  Enabled: true
-Style/RedundantSortBy:
-  Enabled: true
-Style/RegexpLiteral:
-  Enabled: true
-  EnforcedStyle: mixed
-  AllowInnerSlashes: true
-Style/RescueModifier:
-  Enabled: true
-Style/RescueStandardError:
-  Enabled: true
-  EnforcedStyle: explicit
-Style/ReturnNil:
-  Enabled: true
-  EnforcedStyle: return
-Style/Sample:
-  Enabled: true
-Style/SelfAssignment:
-  Enabled: true
-Style/Semicolon:
-  Enabled: true
-Style/SignalException:
-  Enabled: true
-  EnforcedStyle: only_raise
-Style/SingleArgumentDig:
-  Enabled: true
-Style/SingleLineMethods:
-  Enabled: true
-  AllowIfMethodIsEmpty: true
-Style/SpecialGlobalVars:
-  Enabled: true
-  EnforcedStyle: use_english_names
-Style/StabbyLambdaParentheses:
-  Enabled: true
-  EnforcedStyle: require_parentheses
-Style/StaticClass:
-  Enabled: true
-Style/StderrPuts:
-  Enabled: true
-Style/StringConcatenation:
-  Enabled: true
-Style/StringLiterals:
-  Enabled: true
-  EnforcedStyle: single_quotes
-  ConsistentQuotesInMultiline: false # good if only one line has interpolation
-Style/StringLiteralsInInterpolation:
-  Enabled: true
-  EnforcedStyle: single_quotes
-Style/Strip:
-  Enabled: true
-Style/StructInheritance:
-  Enabled: true
-Style/SymbolArray:
-  Enabled: true
-  EnforcedStyle: percent
-Style/SymbolLiteral:
-  Enabled: true
-Style/SymbolProc:
-  Enabled: true
-  AllowMethodsWithArguments: false
-  IgnoredMethods:
-    - respond_to
-    - define_method
-Style/TernaryParentheses:
-  Enabled: true
-  EnforcedStyle: require_no_parentheses
-  AllowSafeAssignment: false
-Style/TrailingBodyOnClass:
-  Enabled: true
-Style/TrailingBodyOnMethodDefinition:
-  Enabled: true
-Style/TrailingBodyOnModule:
-  Enabled: true
-Style/TrailingCommaInArguments:
-  Enabled: true
-  EnforcedStyleForMultiline: consistent_comma
-Style/TrailingCommaInArrayLiteral:
-  Enabled: true
-  EnforcedStyleForMultiline: consistent_comma
-Style/TrailingCommaInHashLiteral:
-  Enabled: true
-  EnforcedStyleForMultiline: consistent_comma
-Style/TrailingMethodEndStatement:
-  Enabled: true
-Style/TrailingUnderscoreVariable:
-  Enabled: true
-  AllowNamedUnderscoreVariables: false
-Style/TrivialAccessors:
-  Enabled: true
-  ExactNameMatch: true
-  AllowPredicates: true
-  AllowDSLWriters: true
-  IgnoreClassMethods: false
-  AllowedMethods:
-    - to_ary
-    - to_a
-    - to_c
-    - to_enum
-    - to_h
-    - to_hash
-    - to_i
-    - to_int
-    - to_io
-    - to_open
-    - to_path
-    - to_proc
-    - to_r
-    - to_regexp
-    - to_str
-    - to_s
-    - to_sym
-Style/UnlessElse:
-  Enabled: true
-Style/UnlessLogicalOperators:
-  Enabled: true
-  EnforcedStyle: forbid_mixed_logical_operators
-Style/UnpackFirst:
-  Enabled: true
-Style/VariableInterpolation:
-  Enabled: true
-Style/WhenThen:
-  Enabled: true
-Style/WhileUntilDo:
-  Enabled: true
-Style/WhileUntilModifier:
-  Enabled: true
-Style/WordArray:
-  Enabled: true
-  EnforcedStyle: percent
-  MinSize: 1
-Style/YodaCondition:
-  Enabled: true
-  EnforcedStyle: forbid_for_all_comparison_operators
-Style/ZeroLengthPredicate:
-  Enabled: true
+# Style/AccessModifierDeclarations:
+#   Enabled: true
+#   EnforcedStyle: group
+# Style/AccessorGrouping:
+#   Enabled: true
+#   EnforcedStyle: grouped
+# Style/Alias:
+#   Enabled: true
+#   EnforcedStyle: prefer_alias_method
+# Style/AndOr:
+#   Enabled: true
+#   EnforcedStyle: always
+# Style/ArgumentsForwarding:
+#   Enabled: true
+#   AllowOnlyRestArgument: true
+# Style/ArrayJoin:
+#   Enabled: true
+# Style/Attr:
+#   Enabled: true
+# Style/AutoResourceCleanup:
+#   Enabled: true
+# Style/BarePercentLiterals:
+#   Enabled: true
+#   EnforcedStyle: bare_percent
+# Style/BeginBlock:
+#   Enabled: true
+# Style/BisectedAttrAccessor:
+#   Enabled: true
+# Style/BlockComments:
+#   Enabled: true
+# Style/BlockDelimiters:
+#   Enabled: true
+#   EnforcedStyle: line_count_based
+#   ProceduralMethods:
+#     # Methods that are known to be procedural in nature but look functional from
+#     # their usage, e.g.
+#     #
+#     #   time = Benchmark.realtime do
+#     #     foo.bar
+#     #   end
+#     #
+#     # Here, the return value of the block is discarded but the return value of
+#     # `Benchmark.realtime` is used.
+#     - benchmark
+#     - bm
+#     - bmbm
+#     - create
+#     - each_with_object
+#     - measure
+#     - new
+#     - realtime
+#     - tap
+#     - with_object
+#   FunctionalMethods:
+#     # Methods that are known to be functional in nature but look procedural from
+#     # their usage, e.g.
+#     #
+#     #   let(:foo) { Foo.new }
+#     #
+#     # Here, the return value of `Foo.new` is used to define a `foo` helper but
+#     # doesn't appear to be used from the return value of `let`.
+#     - let
+#     - let!
+#     - subject
+#     - watch
+#   IgnoredMethods:
+#     # Methods that can be either procedural or functional and cannot be
+#     # categorised from their usage alone, e.g.
+#     #
+#     #   foo = lambda do |x|
+#     #     puts "Hello, #{x}"
+#     #   end
+#     #
+#     #   foo = lambda do |x|
+#     #     x * 100
+#     #   end
+#     #
+#     # Here, it is impossible to tell from the return value of `lambda` whether
+#     # the inner block's return value is significant.
+#     - lambda
+#     - proc
+#     - it
+# Style/CaseEquality:
+#   Enabled: true
+#   AllowOnConstant: false
+# Style/CharacterLiteral:
+#   Enabled: true
+# Style/ClassCheck:
+#   Enabled: true
+#   EnforcedStyle: is_a?
+# Style/ClassEqualityComparison:
+#   Enabled: true
+#   IgnoredMethods:
+#     - ==
+#     - equal?
+#     - eql?
+# Style/ClassMethods:
+#   Enabled: true
+# Style/ClassMethodsDefinitions:
+#   Enabled: true
+#   EnforcedStyle: def_self
+# Style/CollectionCompact:
+#   Enabled: true
+# Style/CollectionMethods:
+#   Enabled: true
+#   PreferredMethods:
+#     collect: 'map'
+#     collect!: 'map!'
+#     inject: 'reduce'
+#     detect: 'find'
+#     find_all: 'select'
+#     member?: 'include?'
+#   MethodsAcceptingSymbol:
+#     - inject
+#     - reduce
+#     - map
+#     - map!
+# Style/ColonMethodCall:
+#   Enabled: true
+# Style/ColonMethodDefinition:
+#   Enabled: true
+# Style/CombinableLoops:
+#   Enabled: true
+# Style/CommandLiteral:
+#   Enabled: true
+#   EnforcedStyle: percent_x
+# Style/CommentAnnotation:
+#   Enabled: true
+#   Keywords:
+#     - TODO
+#     - FIXME
+#   RequireColon: true
+# Style/CommentedKeyword:
+#   Enabled: true
+# Style/ConditionalAssignment:
+#   Enabled: true
+#   EnforcedStyle: assign_to_condition
+#   IncludeTernaryExpressions: true
+#   SingleLineConditionsOnly: true
+# Style/DefWithParentheses:
+#   Enabled: true
+# Style/Dir:
+#   Enabled: true
+# Style/DocumentDynamicEvalDefinition:
+#   Enabled: true
+# Style/DoubleCopDisableDirective:
+#   Enabled: true
+# Style/DoubleNegation:
+#   Enabled: true
+#   EnforcedStyle: allowed_in_returns
+# Style/EachForSimpleLoop:
+#   Enabled: true
+# Style/EmptyBlockParameter:
+#   Enabled: true
+# Style/EmptyCaseCondition:
+#   Enabled: true
+# Style/EmptyElse:
+#   Enabled: true
+#   EnforcedStyle: both
+# Style/EmptyLambdaParameter:
+#   Enabled: true
+# Style/EmptyLiteral:
+#   Enabled: true
+# Style/EmptyMethod:
+#   Enabled: true
+#   EnforcedStyle: compact
+# Style/Encoding:
+#   Enabled: true
+# Style/EndBlock:
+#   Enabled: true
+# Style/EvalWithLocation:
+#   Enabled: true
+# Style/EvenOdd:
+#   Enabled: true
+# Style/ExpandPathArguments:
+#   Enabled: true
+# Style/ExplicitBlockArgument:
+#   Enabled: true
+# Style/ExponentialNotation:
+#   Enabled: true
+#   EnforcedStyle: scientific
+# Style/FloatDivision:
+#   Enabled: true
+#   EnforcedStyle: single_coerce
+# Style/For:
+#   Enabled: true
+#   EnforcedStyle: each
+# Style/FrozenStringLiteralComment:
+#   Enabled: true
+#   EnforcedStyle: always
+# Style/GlobalStdStream:
+#   Enabled: true
+# Style/GlobalVars:
+#   Enabled: true
+# Style/GuardClause:
+#   Enabled: true
+# Style/HashAsLastArrayItem:
+#   Enabled: true
+#   EnforcedStyle: braces
+# Style/HashEachMethods:
+#   Enabled: true
+# Style/HashExcept:
+#   Enabled: true
+# Style/HashLikeCase:
+#   Enabled: true
+# Style/HashSyntax:
+#   Enabled: true
+#   EnforcedStyle: ruby19
+#   UseHashRocketsWithSymbolValues: false
+#   PreferHashRocketsForNonAlnumEndingSymbols: false
+# Style/HashTransformKeys:
+#   Enabled: true
+# Style/HashTransformValues:
+#   Enabled: true
+# Style/IdenticalConditionalBranches:
+#   Enabled: true
+# Style/IfInsideElse:
+#   Enabled: true
+# Style/IfUnlessModifier:
+#   Enabled: true
+# Style/IfUnlessModifierOfIfUnless:
+#   Enabled: true
+# Style/IfWithBooleanLiteralBranches:
+#   Enabled: true
+# Style/IfWithSemicolon:
+#   Enabled: true
+# Style/ImplicitRuntimeError:
+#   Enabled: true
+# Style/InverseMethods:
+#   Enabled: true
+#   InverseMethods:
+#     :any?: :none?
+#     :even?: :odd?
+#     :==: :!=
+#     :=~: :!~
+#     :<: :>=
+#     :>: :<=
+#   InverseBlocks:
+#     :select: :reject
+#     :select!: :reject!
+# Style/IpAddresses:
+#   Enabled: true
+#   AllowedAddresses:
+#     - '::'
+#   Exclude:
+#     - '**/Gemfile'
+# Style/KeywordParametersOrder:
+#   Enabled: true
+# Style/Lambda:
+#   Enabled: true
+#   EnforcedStyle: line_count_dependent
+# Style/LambdaCall:
+#   Enabled: true
+#   EnforcedStyle: call
+# Style/LineEndConcatenation:
+#   Enabled: true
+# Style/MethodCallWithoutArgsParentheses:
+#   Enabled: true
+# Style/MethodDefParentheses:
+#   Enabled: true
+#   EnforcedStyle: require_parentheses
+# Style/MinMax:
+#   Enabled: true
+# Style/MissingRespondToMissing:
+#   Enabled: true
+# Style/MixinGrouping:
+#   Enabled: true
+#   EnforcedStyle: separated
+# Style/MixinUsage:
+#   Enabled: true
+# Style/ModuleFunction:
+#   Enabled: true
+#   EnforcedStyle: module_function
+# Style/MultilineIfModifier:
+#   Enabled: true
+# Style/MultilineIfThen:
+#   Enabled: true
+# Style/MultilineInPatternThen:
+#   Enabled: true
+# Style/MultilineMemoization:
+#   Enabled: true
+#   EnforcedStyle: keyword
+# Style/MultilineMethodSignature:
+#   Enabled: true
+# Style/MultilineTernaryOperator:
+#   Enabled: true
+# Style/MultilineWhenThen:
+#   Enabled: true
+# Style/MultipleComparison:
+#   Enabled: true
+# Style/MutableConstant:
+#   Enabled: true
+#   EnforcedStyle: literals
+# Style/NegatedIf:
+#   Enabled: true
+#   EnforcedStyle: postfix
+# Style/NegatedIfElseCondition:
+#   Enabled: true
+# Style/NegatedUnless:
+#   Enabled: true
+#   EnforcedStyle: both
+# Style/NegatedWhile:
+#   Enabled: true
+# Style/NestedModifier:
+#   Enabled: true
+# Style/NestedParenthesizedCalls:
+#   Enabled: true
+#   AllowedMethods:
+#     - be
+#     - be_a
+#     - be_an
+#     - be_between
+#     - be_falsey
+#     - be_kind_of
+#     - be_instance_of
+#     - be_truthy
+#     - be_within
+#     - eq
+#     - eql
+#     - end_with
+#     - include
+#     - match
+#     - raise_error
+#     - respond_to
+#     - start_with
+# Style/NestedTernaryOperator:
+#   Enabled: true
+# Style/Next:
+#   Enabled: true
+#   EnforcedStyle: skip_modifier_ifs
+# Style/NilComparison:
+#   Enabled: true
+#   EnforcedStyle: predicate
+# Style/NilLambda:
+#   Enabled: true
+# Style/NonNilCheck:
+#   Enabled: true
+#   IncludeSemanticChanges: false
+# Style/Not:
+#   Enabled: true
+# Style/NumericLiteralPrefix:
+#   Enabled: true
+#   EnforcedStyle: zero_with_o
+# Style/NumericLiterals:
+#   Enabled: true
+#   MinDigits: 5
+# Style/OneLineConditional:
+#   Enabled: true
+# Style/OptionalArguments:
+#   Enabled: true
+# Style/OrAssignment:
+#   Enabled: true
+# Style/ParallelAssignment:
+#   Enabled: true
+# Style/ParenthesesAroundCondition:
+#   Enabled: true
+#   AllowSafeAssignment: false
+#   AllowInMultilineConditionals: false
+# Style/PercentLiteralDelimiters:
+#   Enabled: true
+#   PreferredDelimiters:
+#     default: ()
+#     '%i': '[]'
+#     '%I': '[]'
+#     '%r': '{}'
+#     '%w': '[]'
+#     '%W': '[]'
+# Style/PercentQLiterals:
+#   Enabled: true
+#   EnforcedStyle: lower_case_q
+# Style/PerlBackrefs:
+#   Enabled: true
+# Style/PreferredHashMethods:
+#   Enabled: true
+#   EnforcedStyle: verbose
+# Style/Proc:
+#   Enabled: true
+# Style/QuotedSymbols:
+#   Enabled: true
+#   EnforcedStyle: same_as_string_literals
+# Style/RaiseArgs:
+#   Enabled: true
+#   EnforcedStyle: compact
+# Style/RandomWithOffset:
+#   Enabled: true
+# Style/RedundantAssignment:
+#   Enabled: true
+# Style/RedundantBegin:
+#   Enabled: true
+# Style/RedundantCapitalW:
+#   Enabled: true
+# Style/RedundantCondition:
+#   Enabled: true
+# Style/RedundantConditional:
+#   Enabled: true
+# Style/RedundantFileExtensionInRequire:
+#   Enabled: true
+# Style/RedundantFreeze:
+#   Enabled: true
+# Style/RedundantInterpolation:
+#   Enabled: true
+# Style/RedundantParentheses:
+#   Enabled: true
+# Style/RedundantPercentQ:
+#   Enabled: true
+# Style/RedundantRegexpCharacterClass:
+#   Enabled: true
+# Style/RedundantRegexpEscape:
+#   Enabled: true
+# Style/RedundantReturn:
+#   Enabled: true
+# Style/RedundantSelf:
+#   Enabled: true
+# Style/RedundantSort:
+#   Enabled: true
+# Style/RedundantSortBy:
+#   Enabled: true
+# Style/RegexpLiteral:
+#   Enabled: true
+#   EnforcedStyle: mixed
+#   AllowInnerSlashes: true
+# Style/RescueModifier:
+#   Enabled: true
+# Style/RescueStandardError:
+#   Enabled: true
+#   EnforcedStyle: explicit
+# Style/ReturnNil:
+#   Enabled: true
+#   EnforcedStyle: return
+# Style/Sample:
+#   Enabled: true
+# Style/SelfAssignment:
+#   Enabled: true
+# Style/Semicolon:
+#   Enabled: true
+# Style/SignalException:
+#   Enabled: true
+#   EnforcedStyle: only_raise
+# Style/SingleArgumentDig:
+#   Enabled: true
+# Style/SingleLineMethods:
+#   Enabled: true
+#   AllowIfMethodIsEmpty: true
+# Style/SpecialGlobalVars:
+#   Enabled: true
+#   EnforcedStyle: use_english_names
+# Style/StabbyLambdaParentheses:
+#   Enabled: true
+#   EnforcedStyle: require_parentheses
+# Style/StaticClass:
+#   Enabled: true
+# Style/StderrPuts:
+#   Enabled: true
+# Style/StringConcatenation:
+#   Enabled: true
+# Style/StringLiterals:
+#   Enabled: true
+#   EnforcedStyle: single_quotes
+#   ConsistentQuotesInMultiline: false # good if only one line has interpolation
+# Style/StringLiteralsInInterpolation:
+#   Enabled: true
+#   EnforcedStyle: single_quotes
+# Style/Strip:
+#   Enabled: true
+# Style/StructInheritance:
+#   Enabled: true
+# Style/SymbolArray:
+#   Enabled: true
+#   EnforcedStyle: percent
+# Style/SymbolLiteral:
+#   Enabled: true
+# Style/SymbolProc:
+#   Enabled: true
+#   AllowMethodsWithArguments: false
+#   IgnoredMethods:
+#     - respond_to
+#     - define_method
+# Style/TernaryParentheses:
+#   Enabled: true
+#   EnforcedStyle: require_no_parentheses
+#   AllowSafeAssignment: false
+# Style/TrailingBodyOnClass:
+#   Enabled: true
+# Style/TrailingBodyOnMethodDefinition:
+#   Enabled: true
+# Style/TrailingBodyOnModule:
+#   Enabled: true
+# Style/TrailingCommaInArguments:
+#   Enabled: true
+#   EnforcedStyleForMultiline: consistent_comma
+# Style/TrailingCommaInArrayLiteral:
+#   Enabled: true
+#   EnforcedStyleForMultiline: consistent_comma
+# Style/TrailingCommaInHashLiteral:
+#   Enabled: true
+#   EnforcedStyleForMultiline: consistent_comma
+# Style/TrailingMethodEndStatement:
+#   Enabled: true
+# Style/TrailingUnderscoreVariable:
+#   Enabled: true
+#   AllowNamedUnderscoreVariables: false
+# Style/TrivialAccessors:
+#   Enabled: true
+#   ExactNameMatch: true
+#   AllowPredicates: true
+#   AllowDSLWriters: true
+#   IgnoreClassMethods: false
+#   AllowedMethods:
+#     - to_ary
+#     - to_a
+#     - to_c
+#     - to_enum
+#     - to_h
+#     - to_hash
+#     - to_i
+#     - to_int
+#     - to_io
+#     - to_open
+#     - to_path
+#     - to_proc
+#     - to_r
+#     - to_regexp
+#     - to_str
+#     - to_s
+#     - to_sym
+# Style/UnlessElse:
+#   Enabled: true
+# Style/UnlessLogicalOperators:
+#   Enabled: true
+#   EnforcedStyle: forbid_mixed_logical_operators
+# Style/UnpackFirst:
+#   Enabled: true
+# Style/VariableInterpolation:
+#   Enabled: true
+# Style/WhenThen:
+#   Enabled: true
+# Style/WhileUntilDo:
+#   Enabled: true
+# Style/WhileUntilModifier:
+#   Enabled: true
+# Style/WordArray:
+#   Enabled: true
+#   EnforcedStyle: percent
+#   MinSize: 1
+# Style/YodaCondition:
+#   Enabled: true
+#   EnforcedStyle: forbid_for_all_comparison_operators
+# Style/ZeroLengthPredicate:
+#   Enabled: true
 
-##########################
-### Rails Requirements ###
-##########################
+# ##########################
+# ### Rails Requirements ###
+# ##########################
 
-Rails/ActionFilter:
-  Enabled: true
-  EnforcedStyle: action
-Rails/ActiveRecordCallbacksOrder:
-  Enabled: true
-Rails/ActiveSupportAliases:
-  Enabled: true
-Rails/AddColumnIndex:
-  Enabled: true
-Rails/AfterCommitOverride:
-  Enabled: true
-Rails/ApplicationController:
-  Enabled: true
-Rails/ApplicationRecord:
-  Enabled: true
-Rails/ArelStar:
-  Enabled: true
-Rails/AttributeDefaultBlockValue:
-  Enabled: true
-Rails/BelongsTo:
-  Enabled: true
-Rails/Blank:
-  Enabled: true
-  NilOrEmpty: true
-  NotPresent: true
-  UnlessPresent: true
-Rails/BulkChangeTable:
-  Enabled: true
-Rails/CreateTableWithTimestamps:
-  Enabled: true
-Rails/Date:
-  Enabled: true
-Rails/DefaultScope:
-  Enabled: true
-Rails/Delegate:
-  Enabled: true
-Rails/DelegateAllowBlank:
-  Enabled: true
-Rails/DynamicFindBy:
-  Enabled: true
-Rails/EagerEvaluationLogMessage:
-  Enabled: true
-Rails/EnumHash:
-  Enabled: true
-Rails/EnumUniqueness:
-  Enabled: true
-Rails/EnvironmentComparison:
-  Enabled: true
-Rails/EnvironmentVariableAccess:
-  Enabled: true
-Rails/Exit:
-  Enabled: true
-Rails/ExpandedDateRange:
-  Enabled: true
-Rails/FilePath:
-  Enabled: true
-  EnforcedStyle: arguments
-Rails/FindBy:
-  Enabled: true
-  IgnoreWhereFirst: false
-Rails/FindById:
-  Enabled: true
-Rails/FindEach:
-  Enabled: true
-Rails/HasManyOrHasOneDependent:
-  Enabled: true
-Rails/HttpPositionalArguments:
-  Enabled: true
-Rails/HttpStatus:
-  Enabled: true
-  EnforcedStyle: symbolic
-Rails/IgnoredSkipActionFilterOption:
-  Enabled: true
-Rails/IndexBy:
-  Enabled: true
-Rails/IndexWith:
-  Enabled: true
-Rails/Inquiry:
-  Enabled: true
-Rails/InverseOf:
-  Enabled: true
-Rails/LexicallyScopedActionFilter:
-  Enabled: true
-Rails/MatchRoute:
-  Enabled: true
-Rails/NegateInclude:
-  Enabled: true
-Rails/OrderById:
-  Enabled: true
-Rails/Output:
-  Enabled: true
-Rails/Pick:
-  Enabled: true
-Rails/Pluck:
-  Enabled: true
-Rails/PluckId:
-  Enabled: true
-Rails/PluckInWhere:
-  Enabled: true
-  EnforcedStyle: conservative
-Rails/PluralizationGrammar:
-  Enabled: true
-Rails/Presence:
-  Enabled: true
-Rails/Present:
-  Enabled: true
-  NotNilAndNotEmpty: true
-  NotBlank: true
-  UnlessBlank: true
-Rails/ReadWriteAttribute:
-  Enabled: true
-Rails/RedundantAllowNil:
-  Enabled: true
-Rails/RedundantForeignKey:
-  Enabled: true
-Rails/RedundantReceiverInWithOptions:
-  Enabled: true
-Rails/ReflectionClassName:
-  Enabled: true
-Rails/RelativeDateConstant:
-  Enabled: true
-Rails/RenderPlainText:
-  Enabled: true
-Rails/RequestReferer:
-  Enabled: true
-  EnforcedStyle: referrer
-Rails/SafeNavigation:
-  Enabled: true
-  ConvertTry: true
-Rails/SafeNavigationWithBlank:
-  Enabled: true
-Rails/SaveBang:
-  Enabled: true
-  AllowImplicitReturn: true
-Rails/ScopeArgs:
-  Enabled: true
-Rails/SkipsModelValidations:
-  Enabled: true
-  AllowedMethods:
-    - touch
-Rails/TimeZone:
-  Enabled: true
-Rails/UniqBeforePluck:
-  Enabled: true
-  EnforcedStyle: conservative
-Rails/UniqueValidationWithoutIndex:
-  Enabled: true
-Rails/UnknownEnv:
-  Enabled: true
-  Environments:
-    - development
-    - test
-    - staging
-    - production
-Rails/Validation:
-  Enabled: true
-Rails/WhereEquals:
-  Enabled: true
-Rails/WhereNot:
-  Enabled: true
+# Rails/ActionFilter:
+#   Enabled: true
+#   EnforcedStyle: action
+# Rails/ActiveRecordCallbacksOrder:
+#   Enabled: true
+# Rails/ActiveSupportAliases:
+#   Enabled: true
+# Rails/AddColumnIndex:
+#   Enabled: true
+# Rails/AfterCommitOverride:
+#   Enabled: true
+# Rails/ApplicationController:
+#   Enabled: true
+# Rails/ApplicationRecord:
+#   Enabled: true
+# Rails/ArelStar:
+#   Enabled: true
+# Rails/AttributeDefaultBlockValue:
+#   Enabled: true
+# Rails/BelongsTo:
+#   Enabled: true
+# Rails/Blank:
+#   Enabled: true
+#   NilOrEmpty: true
+#   NotPresent: true
+#   UnlessPresent: true
+# Rails/BulkChangeTable:
+#   Enabled: true
+# Rails/CreateTableWithTimestamps:
+#   Enabled: true
+# Rails/Date:
+#   Enabled: true
+# Rails/DefaultScope:
+#   Enabled: true
+# Rails/Delegate:
+#   Enabled: true
+# Rails/DelegateAllowBlank:
+#   Enabled: true
+# Rails/DynamicFindBy:
+#   Enabled: true
+# Rails/EagerEvaluationLogMessage:
+#   Enabled: true
+# Rails/EnumHash:
+#   Enabled: true
+# Rails/EnumUniqueness:
+#   Enabled: true
+# Rails/EnvironmentComparison:
+#   Enabled: true
+# Rails/EnvironmentVariableAccess:
+#   Enabled: true
+# Rails/Exit:
+#   Enabled: true
+# Rails/ExpandedDateRange:
+#   Enabled: true
+# Rails/FilePath:
+#   Enabled: true
+#   EnforcedStyle: arguments
+# Rails/FindBy:
+#   Enabled: true
+#   IgnoreWhereFirst: false
+# Rails/FindById:
+#   Enabled: true
+# Rails/FindEach:
+#   Enabled: true
+# Rails/HasManyOrHasOneDependent:
+#   Enabled: true
+# Rails/HttpPositionalArguments:
+#   Enabled: true
+# Rails/HttpStatus:
+#   Enabled: true
+#   EnforcedStyle: symbolic
+# Rails/IgnoredSkipActionFilterOption:
+#   Enabled: true
+# Rails/IndexBy:
+#   Enabled: true
+# Rails/IndexWith:
+#   Enabled: true
+# Rails/Inquiry:
+#   Enabled: true
+# Rails/InverseOf:
+#   Enabled: true
+# Rails/LexicallyScopedActionFilter:
+#   Enabled: true
+# Rails/MatchRoute:
+#   Enabled: true
+# Rails/NegateInclude:
+#   Enabled: true
+# Rails/OrderById:
+#   Enabled: true
+# Rails/Output:
+#   Enabled: true
+# Rails/Pick:
+#   Enabled: true
+# Rails/Pluck:
+#   Enabled: true
+# Rails/PluckId:
+#   Enabled: true
+# Rails/PluckInWhere:
+#   Enabled: true
+#   EnforcedStyle: conservative
+# Rails/PluralizationGrammar:
+#   Enabled: true
+# Rails/Presence:
+#   Enabled: true
+# Rails/Present:
+#   Enabled: true
+#   NotNilAndNotEmpty: true
+#   NotBlank: true
+#   UnlessBlank: true
+# Rails/ReadWriteAttribute:
+#   Enabled: true
+# Rails/RedundantAllowNil:
+#   Enabled: true
+# Rails/RedundantForeignKey:
+#   Enabled: true
+# Rails/RedundantReceiverInWithOptions:
+#   Enabled: true
+# Rails/ReflectionClassName:
+#   Enabled: true
+# Rails/RelativeDateConstant:
+#   Enabled: true
+# Rails/RenderPlainText:
+#   Enabled: true
+# Rails/RequestReferer:
+#   Enabled: true
+#   EnforcedStyle: referrer
+# Rails/SafeNavigation:
+#   Enabled: true
+#   ConvertTry: true
+# Rails/SafeNavigationWithBlank:
+#   Enabled: true
+# Rails/SaveBang:
+#   Enabled: true
+#   AllowImplicitReturn: true
+# Rails/ScopeArgs:
+#   Enabled: true
+# Rails/SkipsModelValidations:
+#   Enabled: true
+#   AllowedMethods:
+#     - touch
+# Rails/TimeZone:
+#   Enabled: true
+# Rails/UniqBeforePluck:
+#   Enabled: true
+#   EnforcedStyle: conservative
+# Rails/UniqueValidationWithoutIndex:
+#   Enabled: true
+# Rails/UnknownEnv:
+#   Enabled: true
+#   Environments:
+#     - development
+#     - test
+#     - staging
+#     - production
+# Rails/Validation:
+#   Enabled: true
+# Rails/WhereEquals:
+#   Enabled: true
+# Rails/WhereNot:
+#   Enabled: true
 
-##########################
-### RSpec Requirements ###
-##########################
+# ##########################
+# ### RSpec Requirements ###
+# ##########################
 
-RSpec/AlignLetLeftBrace:
-  Enabled: true
-RSpec/AroundBlock:
-  Enabled: true
-RSpec/Be:
-  Enabled: true
-RSpec/BeEql:
-  Enabled: true
-RSpec/BeforeAfterAll:
-  Enabled: true
-RSpec/ContextMethod:
-  Enabled: true
-RSpec/ContextWording:
-  Enabled: true
-  Prefixes:
-    - when
-    - with
-    - without
-RSpec/DescribeClass:
-  Enabled: true
-  IgnoredMetadata:
-    type:
-      - request
-RSpec/DescribedClass:
-  Enabled: true
-  EnforcedStyle: described_class
-RSpec/DescribedClassModuleWrapping:
-  Enabled: true
-RSpec/EmptyExampleGroup:
-  Enabled: true
-RSpec/EmptyHook:
-  Enabled: true
-RSpec/EmptyLineAfterExample:
-  Enabled: true
-  AllowConsecutiveOneLiners: true
-RSpec/EmptyLineAfterExampleGroup:
-  Enabled: true
-RSpec/EmptyLineAfterFinalLet:
-  Enabled: true
-RSpec/EmptyLineAfterHook:
-  Enabled: true
-RSpec/EmptyLineAfterSubject:
-  Enabled: true
-RSpec/ExampleWithoutDescription:
-  Enabled: true
-  EnforcedStyle: single_line_only
-RSpec/ExampleWording:
-  Enabled: true
-RSpec/ExpectActual:
-  Enabled: true
-RSpec/ExpectChange:
-  Enabled: true
-  EnforcedStyle: method_call
-RSpec/ExpectInHook:
-  Enabled: true
-RSpec/FilePath:
-  Enabled: true
-  IgnoreMethods: true
-RSpec/Focus:
-  Enabled: true
-RSpec/HookArgument:
-  Enabled: true
-  EnforcedStyle: implicit
-RSpec/HooksBeforeExamples:
-  Enabled: true
-RSpec/IdenticalEqualityAssertion:
-  Enabled: true
-RSpec/ImplicitBlockExpectation:
-  Enabled: true
-RSpec/ImplicitExpect:
-  Enabled: true
-  EnforcedStyle: is_expected
-RSpec/ImplicitSubject:
-  Enabled: true
-  EnforcedStyle: single_line_only
-RSpec/InstanceSpy:
-  Enabled: true
-RSpec/InstanceVariable:
-  Enabled: true
-RSpec/IteratedExpectation:
-  Enabled: true
-RSpec/LeadingSubject:
-  Enabled: true
-RSpec/LeakyConstantDeclaration:
-  Enabled: true
-RSpec/LetBeforeExamples:
-  Enabled: true
-RSpec/MessageSpies:
-  Enabled: true
-  EnforcedStyle: have_received
-RSpec/MissingExampleGroupArgument:
-  Enabled: true
-RSpec/MultipleDescribes:
-  Enabled: true
-RSpec/MultipleExpectations:
-  Enabled: true
-  Max: 3
-RSpec/MultipleSubjects:
-  Enabled: true
-RSpec/NamedSubject:
-  Enabled: true
-  IgnoreSharedExamples: true
-RSpec/NotToNot:
-  Enabled: true
-  EnforcedStyle: not_to
-RSpec/PredicateMatcher:
-  Enabled: true
-  Strict: false
-  EnforcedStyle: inflected
-RSpec/ReceiveCounts:
-  Enabled: true
-RSpec/ReceiveNever:
-  Enabled: true
-RSpec/RepeatedDescription:
-  Enabled: true
-RSpec/RepeatedExample:
-  Enabled: true
-RSpec/RepeatedExampleGroupDescription:
-  Enabled: true
-RSpec/RepeatedIncludeExample:
-  Enabled: true
-RSpec/ReturnFromStub:
-  Enabled: true
-  EnforcedStyle: and_return
-RSpec/ScatteredLet:
-  Enabled: true
-RSpec/ScatteredSetup:
-  Enabled: true
-RSpec/SharedContext:
-  Enabled: true
-RSpec/SharedExamples:
-  Enabled: true
-RSpec/SingleArgumentMessageChain:
-  Enabled: true
-RSpec/StubbedMock:
-  Enabled: true
-RSpec/SubjectStub:
-  Enabled: true
-RSpec/UnspecifiedException:
-  Enabled: true
-RSpec/VariableDefinition:
-  Enabled: true
-  EnforcedStyle: symbols
-RSpec/VariableName:
-  Enabled: true
-  EnforcedStyle: snake_case
-RSpec/VoidExpect:
-  Enabled: true
-RSpec/Yield:
-  Enabled: true
+# RSpec/AlignLetLeftBrace:
+#   Enabled: true
+# RSpec/AroundBlock:
+#   Enabled: true
+# RSpec/Be:
+#   Enabled: true
+# RSpec/BeEql:
+#   Enabled: true
+# RSpec/BeforeAfterAll:
+#   Enabled: true
+# RSpec/ContextMethod:
+#   Enabled: true
+# RSpec/ContextWording:
+#   Enabled: true
+#   Prefixes:
+#     - when
+#     - with
+#     - without
+# RSpec/DescribeClass:
+#   Enabled: true
+#   IgnoredMetadata:
+#     type:
+#       - request
+# RSpec/DescribedClass:
+#   Enabled: true
+#   EnforcedStyle: described_class
+# RSpec/DescribedClassModuleWrapping:
+#   Enabled: true
+# RSpec/EmptyExampleGroup:
+#   Enabled: true
+# RSpec/EmptyHook:
+#   Enabled: true
+# RSpec/EmptyLineAfterExample:
+#   Enabled: true
+#   AllowConsecutiveOneLiners: true
+# RSpec/EmptyLineAfterExampleGroup:
+#   Enabled: true
+# RSpec/EmptyLineAfterFinalLet:
+#   Enabled: true
+# RSpec/EmptyLineAfterHook:
+#   Enabled: true
+# RSpec/EmptyLineAfterSubject:
+#   Enabled: true
+# RSpec/ExampleWithoutDescription:
+#   Enabled: true
+#   EnforcedStyle: single_line_only
+# RSpec/ExampleWording:
+#   Enabled: true
+# RSpec/ExpectActual:
+#   Enabled: true
+# RSpec/ExpectChange:
+#   Enabled: true
+#   EnforcedStyle: method_call
+# RSpec/ExpectInHook:
+#   Enabled: true
+# RSpec/FilePath:
+#   Enabled: true
+#   IgnoreMethods: true
+# RSpec/Focus:
+#   Enabled: true
+# RSpec/HookArgument:
+#   Enabled: true
+#   EnforcedStyle: implicit
+# RSpec/HooksBeforeExamples:
+#   Enabled: true
+# RSpec/IdenticalEqualityAssertion:
+#   Enabled: true
+# RSpec/ImplicitBlockExpectation:
+#   Enabled: true
+# RSpec/ImplicitExpect:
+#   Enabled: true
+#   EnforcedStyle: is_expected
+# RSpec/ImplicitSubject:
+#   Enabled: true
+#   EnforcedStyle: single_line_only
+# RSpec/InstanceSpy:
+#   Enabled: true
+# RSpec/InstanceVariable:
+#   Enabled: true
+# RSpec/IteratedExpectation:
+#   Enabled: true
+# RSpec/LeadingSubject:
+#   Enabled: true
+# RSpec/LeakyConstantDeclaration:
+#   Enabled: true
+# RSpec/LetBeforeExamples:
+#   Enabled: true
+# RSpec/MessageSpies:
+#   Enabled: true
+#   EnforcedStyle: have_received
+# RSpec/MissingExampleGroupArgument:
+#   Enabled: true
+# RSpec/MultipleDescribes:
+#   Enabled: true
+# RSpec/MultipleExpectations:
+#   Enabled: true
+#   Max: 3
+# RSpec/MultipleSubjects:
+#   Enabled: true
+# RSpec/NamedSubject:
+#   Enabled: true
+#   IgnoreSharedExamples: true
+# RSpec/NotToNot:
+#   Enabled: true
+#   EnforcedStyle: not_to
+# RSpec/PredicateMatcher:
+#   Enabled: true
+#   Strict: false
+#   EnforcedStyle: inflected
+# RSpec/ReceiveCounts:
+#   Enabled: true
+# RSpec/ReceiveNever:
+#   Enabled: true
+# RSpec/RepeatedDescription:
+#   Enabled: true
+# RSpec/RepeatedExample:
+#   Enabled: true
+# RSpec/RepeatedExampleGroupDescription:
+#   Enabled: true
+# RSpec/RepeatedIncludeExample:
+#   Enabled: true
+# RSpec/ReturnFromStub:
+#   Enabled: true
+#   EnforcedStyle: and_return
+# RSpec/ScatteredLet:
+#   Enabled: true
+# RSpec/ScatteredSetup:
+#   Enabled: true
+# RSpec/SharedContext:
+#   Enabled: true
+# RSpec/SharedExamples:
+#   Enabled: true
+# RSpec/SingleArgumentMessageChain:
+#   Enabled: true
+# RSpec/StubbedMock:
+#   Enabled: true
+# RSpec/SubjectStub:
+#   Enabled: true
+# RSpec/UnspecifiedException:
+#   Enabled: true
+# RSpec/VariableDefinition:
+#   Enabled: true
+#   EnforcedStyle: symbols
+# RSpec/VariableName:
+#   Enabled: true
+#   EnforcedStyle: snake_case
+# RSpec/VoidExpect:
+#   Enabled: true
+# RSpec/Yield:
+#   Enabled: true
 
-################################
-### Performance Requirements ###
-################################
+# ################################
+# ### Performance Requirements ###
+# ################################
 
 
-Performance/BindCall:
-  Enabled: true
-Performance/BlockGivenWithExplicitBlock:
-  Enabled: true
-Performance/Caller:
-  Enabled: true
-Performance/CaseWhenSplat:
-  Enabled: true
-Performance/Casecmp:
-  Enabled: true
-Performance/ChainArrayAllocation:
-  Enabled: true
-Performance/CollectionLiteralInLoop:
-  Enabled: true
-Performance/CompareWithBlock:
-  Enabled: true
-Performance/Count:
-  Enabled: true
-Performance/DeletePrefix:
-  Enabled: true
-  SafeMultiline: true
-Performance/DeleteSuffix:
-  Enabled: true
-  SafeMultiline: true
-Performance/Detect:
-  Enabled: true
-Performance/DoubleStartEndWith:
-  Enabled: true
-Performance/EndWith:
-  Enabled: true
-Performance/FixedSize:
-  Enabled: true
-Performance/FlatMap:
-  Enabled: true
-Performance/InefficientHashSearch:
-  Enabled: true
-Performance/IoReadlines:
-  Enabled: true
-Performance/RangeInclude:
-  Enabled: true
-Performance/RedundantBlockCall:
-  Enabled: true
-Performance/RedundantMatch:
-  Enabled: true
-Performance/RedundantMerge:
-  Enabled: true
-Performance/RedundantSortBlock:
-  Enabled: true
-Performance/RedundantSplitRegexpArgument:
-  Enabled: true
-Performance/RedundantStringChars:
-  Enabled: true
-Performance/RegexpMatch:
-  Enabled: true
-Performance/ReverseEach:
-  Enabled: true
-Performance/ReverseFirst:
-  Enabled: true
-Performance/SelectMap:
-  Enabled: true
-Performance/Size:
-  Enabled: true
-Performance/SortReverse:
-  Enabled: true
-Performance/Squeeze:
-  Enabled: true
-Performance/StartWith:
-  Enabled: true
-  SafeMultiline: true
-Performance/StringInclude:
-  Enabled: true
-Performance/StringReplacement:
-  Enabled: true
-Performance/Sum:
-  Enabled: true
-Performance/TimesMap:
-  Enabled: true
-Performance/UnfreezeString:
-  Enabled: true
-Performance/UriDefaultParser:
-  Enabled: true
+# Performance/BindCall:
+#   Enabled: true
+# Performance/BlockGivenWithExplicitBlock:
+#   Enabled: true
+# Performance/Caller:
+#   Enabled: true
+# Performance/CaseWhenSplat:
+#   Enabled: true
+# Performance/Casecmp:
+#   Enabled: true
+# Performance/ChainArrayAllocation:
+#   Enabled: true
+# Performance/CollectionLiteralInLoop:
+#   Enabled: true
+# Performance/CompareWithBlock:
+#   Enabled: true
+# Performance/Count:
+#   Enabled: true
+# Performance/DeletePrefix:
+#   Enabled: true
+#   SafeMultiline: true
+# Performance/DeleteSuffix:
+#   Enabled: true
+#   SafeMultiline: true
+# Performance/Detect:
+#   Enabled: true
+# Performance/DoubleStartEndWith:
+#   Enabled: true
+# Performance/EndWith:
+#   Enabled: true
+# Performance/FixedSize:
+#   Enabled: true
+# Performance/FlatMap:
+#   Enabled: true
+# Performance/InefficientHashSearch:
+#   Enabled: true
+# Performance/IoReadlines:
+#   Enabled: true
+# Performance/RangeInclude:
+#   Enabled: true
+# Performance/RedundantBlockCall:
+#   Enabled: true
+# Performance/RedundantMatch:
+#   Enabled: true
+# Performance/RedundantMerge:
+#   Enabled: true
+# Performance/RedundantSortBlock:
+#   Enabled: true
+# Performance/RedundantSplitRegexpArgument:
+#   Enabled: true
+# Performance/RedundantStringChars:
+#   Enabled: true
+# Performance/RegexpMatch:
+#   Enabled: true
+# Performance/ReverseEach:
+#   Enabled: true
+# Performance/ReverseFirst:
+#   Enabled: true
+# Performance/SelectMap:
+#   Enabled: true
+# Performance/Size:
+#   Enabled: true
+# Performance/SortReverse:
+#   Enabled: true
+# Performance/Squeeze:
+#   Enabled: true
+# Performance/StartWith:
+#   Enabled: true
+#   SafeMultiline: true
+# Performance/StringInclude:
+#   Enabled: true
+# Performance/StringReplacement:
+#   Enabled: true
+# Performance/Sum:
+#   Enabled: true
+# Performance/TimesMap:
+#   Enabled: true
+# Performance/UnfreezeString:
+#   Enabled: true
+# Performance/UriDefaultParser:
+#   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 git_source(:github) {|repo| "https://github.com/#{repo}.git" }
 
@@ -29,7 +31,7 @@ gem 'configatron', '~> 4.5.1'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', '~> 11.1', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'byebug', '~> 11.1', platforms: %i[mri mingw x64_mingw]
 
   # Use RSpec for unit and integration testing
   gem 'rspec-rails', '~> 5.0.1'

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 

--- a/app/controller_services/application_controller/authorization_service.rb
+++ b/app/controller_services/application_controller/authorization_service.rb
@@ -26,7 +26,7 @@ class ApplicationController < ActionController::API
     rescue GoogleIDToken::CertificateError => e
       Rails.logger.error "Problem with OAuth certificate -- #{e.message}"
       Service::UnauthorizedResult.new(errors: ['Invalid OAuth certificate'])
-    rescue => e
+    rescue StandardError => e
       Rails.logger.error "Internal Server Error: #{e.message}"
       Service::InternalServerErrorResult.new(errors: [e.message])
     end

--- a/app/controller_services/games_controller/create_service.rb
+++ b/app/controller_services/games_controller/create_service.rb
@@ -18,7 +18,7 @@ class GamesController < ApplicationController
       else
         Service::UnprocessableEntityResult.new(errors: game.error_array)
       end
-    rescue => e
+    rescue StandardError => e
       Service::InternalServerErrorResult.new(errors: [e.message])
     end
 

--- a/app/controller_services/games_controller/destroy_service.rb
+++ b/app/controller_services/games_controller/destroy_service.rb
@@ -16,7 +16,7 @@ class GamesController < ApplicationController
       Service::NoContentResult.new
     rescue ActiveRecord::RecordNotFound
       Service::NotFoundResult.new
-    rescue => e
+    rescue StandardError => e
       Service::InternalServerErrorResult.new(errors: [e.message])
     end
 

--- a/app/controller_services/games_controller/index_service.rb
+++ b/app/controller_services/games_controller/index_service.rb
@@ -11,7 +11,7 @@ class GamesController < ApplicationController
 
     def perform
       Service::OKResult.new(resource: user.games)
-    rescue => e
+    rescue StandardError => e
       Service::InternalServerErrorResult.new(errors: [e.message])
     end
 

--- a/app/controller_services/games_controller/update_service.rb
+++ b/app/controller_services/games_controller/update_service.rb
@@ -20,7 +20,7 @@ class GamesController < ApplicationController
       end
     rescue ActiveRecord::RecordNotFound
       Service::NotFoundResult.new
-    rescue => e
+    rescue StandardError => e
       Service::InternalServerErrorResult.new(errors: [e.message])
     end
 

--- a/app/controller_services/shopping_list_items_controller/create_service.rb
+++ b/app/controller_services/shopping_list_items_controller/create_service.rb
@@ -37,7 +37,7 @@ class ShoppingListItemsController < ApplicationController
       Service::UnprocessableEntityResult.new(errors: item.error_array)
     rescue ActiveRecord::RecordNotFound
       Service::NotFoundResult.new
-    rescue => e
+    rescue StandardError => e
       Rails.logger.error "Internal Server Error: #{e.message}"
       Service::InternalServerErrorResult.new(errors: [e.message])
     end

--- a/app/controller_services/shopping_list_items_controller/destroy_service.rb
+++ b/app/controller_services/shopping_list_items_controller/destroy_service.rb
@@ -28,7 +28,7 @@ class ShoppingListItemsController < ApplicationController
       aggregate_list_item.nil? ? Service::NoContentResult.new : Service::OKResult.new(resource: aggregate_list_item)
     rescue ActiveRecord::RecordNotFound
       Service::NotFoundResult.new
-    rescue => e
+    rescue StandardError => e
       Rails.logger.error "Internal Server Error: #{e.message}"
       Service::InternalServerErrorResult.new(errors: [e.message])
     end

--- a/app/controller_services/shopping_list_items_controller/update_service.rb
+++ b/app/controller_services/shopping_list_items_controller/update_service.rb
@@ -34,7 +34,7 @@ class ShoppingListItemsController < ApplicationController
       Service::UnprocessableEntityResult.new(errors: list_item.error_array)
     rescue ActiveRecord::RecordNotFound
       Service::NotFoundResult.new
-    rescue => e
+    rescue StandardError => e
       Rails.logger.error "Internal Server Error: #{e.message}"
       Service::InternalServerErrorResult.new(errors: [e.message])
     end

--- a/app/controller_services/shopping_lists_controller/create_service.rb
+++ b/app/controller_services/shopping_lists_controller/create_service.rb
@@ -32,7 +32,7 @@ class ShoppingListsController < ApplicationController
       end
     rescue ActiveRecord::RecordNotFound
       Service::NotFoundResult.new
-    rescue => e
+    rescue StandardError => e
       Rails.logger.error "Internal Server Error: #{e.message}"
       Service::InternalServerErrorResult.new(errors: [e.message])
     end

--- a/app/controller_services/shopping_lists_controller/destroy_service.rb
+++ b/app/controller_services/shopping_lists_controller/destroy_service.rb
@@ -22,7 +22,7 @@ class ShoppingListsController < ApplicationController
       aggregate_list.nil? ? Service::NoContentResult.new : Service::OKResult.new(resource: aggregate_list)
     rescue ActiveRecord::RecordNotFound
       Service::NotFoundResult.new
-    rescue => e
+    rescue StandardError => e
       Rails.logger.error "Internal Server Error: #{e.message}"
       Service::InternalServerErrorResult.new(errors: [e.message])
     end

--- a/app/controller_services/shopping_lists_controller/index_service.rb
+++ b/app/controller_services/shopping_lists_controller/index_service.rb
@@ -15,7 +15,7 @@ class ShoppingListsController < ApplicationController
       Service::OKResult.new(resource: game.shopping_lists.index_order)
     rescue ActiveRecord::RecordNotFound
       Service::NotFoundResult.new
-    rescue => e
+    rescue StandardError => e
       Rails.logger.error "Internal Server Error: #{e.message}"
       Service::InternalServerErrorResult.new(errors: [e.message])
     end

--- a/app/controller_services/shopping_lists_controller/update_service.rb
+++ b/app/controller_services/shopping_lists_controller/update_service.rb
@@ -28,7 +28,7 @@ class ShoppingListsController < ApplicationController
       end
     rescue ActiveRecord::RecordNotFound
       Service::NotFoundResult.new
-    rescue => e
+    rescue StandardError => e
       Rails.logger.error "Internal Server Error: #{e.message}"
       Service::InternalServerErrorResult.new(errors: [e.message])
     end

--- a/app/controllers/shopping_list_items_controller.rb
+++ b/app/controllers/shopping_list_items_controller.rb
@@ -27,7 +27,7 @@ class ShoppingListItemsController < ApplicationController
     params.require(:shopping_list_item).permit(
       :description,
       :quantity,
-      :notes
+      :notes,
     )
   end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
-  layout 'mailer'
-end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationMailer < ActionMailer::Base
   default from: 'from@example.com'
   layout 'mailer'

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -9,8 +9,8 @@ class Game < ApplicationRecord
   validates :name,
             uniqueness: { scope: :user_id, message: 'must be unique' },
             format:     {
-                          with:    /\A\s*[a-z0-9 \-'\,]*\s*\z/i,
-                          message: "can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')"
+                          with:    /\A\s*[a-z0-9 \-',]*\s*\z/i,
+                          message: "can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')",
                         }
 
   before_save :format_name

--- a/app/models/shopping_list.rb
+++ b/app/models/shopping_list.rb
@@ -10,8 +10,8 @@ class ShoppingList < ApplicationRecord
   validates :title,
             uniqueness: { scope: :game_id },
             format:     {
-                          with:    /\A\s*[a-z0-9 \-'\,]*\s*\z/i,
-                          message: "can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')"
+                          with:    /\A\s*[a-z0-9 \-',]*\s*\z/i,
+                          message: "can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')",
                         }
 
   before_save :format_title

--- a/app/models/shopping_list_item.rb
+++ b/app/models/shopping_list_item.rb
@@ -54,6 +54,6 @@ class ShoppingListItem < ApplicationRecord
   def clean_up_notes
     return true unless notes
 
-    self.notes = notes.strip.gsub(/^(\-\- ?)*/, '').gsub(/( ?\-\-)*$/, '').gsub(/( \-\- ){2,}/, ' -- ').presence
+    self.notes = notes.strip.gsub(/^(-- ?)*/, '').gsub(/( ?--)*$/, '').gsub(/( -- ){2,}/, ' -- ').presence
   end
 end

--- a/config.ru
+++ b/config.ru
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 # This file is used by Rack-based servers to start the application.
 
-require_relative "config/environment"
+require_relative 'config/environment'
 
 run Rails.application
 Rails.application.load_server

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,16 +1,18 @@
-require_relative "boot"
+# frozen_string_literal: true
 
-require "rails"
+require_relative 'boot'
+
+require 'rails'
 # Pick the frameworks you want:
-require "active_model/railtie"
+require 'active_model/railtie'
 # require "active_job/railtie"
-require "active_record/railtie"
+require 'active_record/railtie'
 # require "active_storage/engine"
-require "action_controller/railtie"
-require "action_mailer/railtie"
+require 'action_controller/railtie'
+require 'action_mailer/railtie'
 # require "action_mailbox/engine"
 # require "action_text/engine"
-require "action_view/railtie"
+require 'action_view/railtie'
 # require "action_cable/engine"
 # require "sprockets/railtie"
 # require "rails/test_unit/railtie"

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,6 @@
+# frozen_string_literal: true
+
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
-require "bundler/setup" # Set up gems listed in the Gemfile.
-require "bootsnap/setup" # Speed up boot time by caching expensive operations.
+require 'bundler/setup' # Set up gems listed in the Gemfile.
+require 'bootsnap/setup' # Speed up boot time by caching expensive operations.

--- a/config/configatron/development.rb
+++ b/config/configatron/development.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Override your default settings for the Development environment here.
 #
 configatron.client_origin = 'http://localhost:3001'

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 # Load the Rails application.
-require_relative "application"
+require_relative 'application'
 
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,4 +1,6 @@
-require "active_support/core_ext/integer/time"
+# frozen_string_literal: true
+
+require 'active_support/core_ext/integer/time'
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -19,7 +21,7 @@ Rails.application.configure do
   if Rails.root.join('tmp', 'caching-dev.txt').exist?
     config.cache_store                = :memory_store
     config.public_file_server.headers = {
-                                          'Cache-Control' => "public, max-age=#{2.days.to_i}"
+                                          'Cache-Control' => "public, max-age=#{2.days.to_i}",
                                         }
   else
     config.action_controller.perform_caching = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,6 @@
-require "active_support/core_ext/integer/time"
+# frozen_string_literal: true
+
+require 'active_support/core_ext/integer/time'
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -69,8 +71,8 @@ Rails.application.configure do
   # require "syslog/logger"
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
+  if ENV['RAILS_LOG_TO_STDOUT'].present?
+    logger           = ActiveSupport::Logger.new($stdout)
     logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
   end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,4 +1,6 @@
-require "active_support/core_ext/integer/time"
+# frozen_string_literal: true
+
+require 'active_support/core_ext/integer/time'
 
 # The test environment is used exclusively to run your application's
 # test suite. You never need to work with it otherwise. Remember that
@@ -19,7 +21,7 @@ Rails.application.configure do
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-                                        'Cache-Control' => "public, max-age=#{1.hour.to_i}"
+                                        'Cache-Control' => "public, max-age=#{1.hour.to_i}",
                                       }
 
   # Show full error reports and disable caching.

--- a/config/initializers/application_controller_renderer.rb
+++ b/config/initializers/application_controller_renderer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # ActiveSupport::Reloader.to_prepare do

--- a/config/initializers/backtrace_silencers.rb
+++ b/config/initializers/backtrace_silencers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.
@@ -5,4 +7,4 @@
 
 # You can also remove all the silencers if you're trying to debug a problem that might stem from framework code
 # by setting BACKTRACE=1 before calling your invocation, like "BACKTRACE=1 ./bin/rails runner 'MyClass.perform'".
-Rails.backtrace_cleaner.remove_silencers! if ENV["BACKTRACE"]
+Rails.backtrace_cleaner.remove_silencers! if ENV['BACKTRACE']

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [
-                                                :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn
+Rails.application.config.filter_parameters += %i[
+                                                passw secret token _key crypt salt certificate otp ssn
                                               ]

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format. Inflections

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Add new mime types for use in respond_to blocks:

--- a/config/initializers/wrap_parameters.rb
+++ b/config/initializers/wrap_parameters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # This file contains settings for ActionController::ParamsWrapper which

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,28 +1,30 @@
+# frozen_string_literal: true
+
 # Puma can serve each request in a thread from an internal thread pool.
 # The `threads` method setting takes two numbers: a minimum and maximum.
 # Any libraries that use thread pools should be configured to match
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
-min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
+max_threads_count = ENV.fetch('RAILS_MAX_THREADS') { 5 }
+min_threads_count = ENV.fetch('RAILS_MIN_THREADS') { max_threads_count }
 threads min_threads_count, max_threads_count
 
 # Specifies the `worker_timeout` threshold that Puma will use to wait before
 # terminating a worker in development environments.
 #
-worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
+worker_timeout 3600 if ENV.fetch('RAILS_ENV', 'development') == 'development'
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port ENV.fetch("PORT") { 3000 }
+port ENV.fetch('PORT') { 3000 }
 
 # Specifies the `environment` that Puma will run in.
 #
-environment ENV.fetch("RAILS_ENV") { "development" }
+environment ENV.fetch('RAILS_ENV') { 'development' }
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
+pidfile ENV.fetch('PIDFILE') { 'tmp/pids/server.pid' }
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked web server processes. If using threads and workers together

--- a/config/spring.rb
+++ b/config/spring.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 Spring.watch(
-  ".ruby-version",
-  ".rbenv-vars",
-  "tmp/restart.txt",
-  "tmp/caching-dev.txt"
+  '.ruby-version',
+  '.rbenv-vars',
+  'tmp/restart.txt',
+  'tmp/caching-dev.txt',
 )

--- a/db/migrate/20210617115605_add_image_url_to_users.rb
+++ b/db/migrate/20210617115605_add_image_url_to_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # frozen_string_ligeral: true
 
 class AddImageUrlToUsers < ActiveRecord::Migration[6.1]

--- a/db/migrate/20210617115605_add_image_url_to_users.rb
+++ b/db/migrate/20210617115605_add_image_url_to_users.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# frozen_string_ligeral: true
-
 class AddImageUrlToUsers < ActiveRecord::Migration[6.1]
   def change
     add_column :users, :image_url, :string

--- a/db/migrate/20210704215647_add_master_list_id_to_shopping_lists.rb
+++ b/db/migrate/20210704215647_add_master_list_id_to_shopping_lists.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddMasterListIdToShoppingLists < ActiveRecord::Migration[6.1]
   def change
     add_column :shopping_lists, :master_list_id, :integer

--- a/db/migrate/20210705020129_change_shopping_list_id_to_list_id_on_shopping_list_items.rb
+++ b/db/migrate/20210705020129_change_shopping_list_id_to_list_id_on_shopping_list_items.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ChangeShoppingListIdToListIdOnShoppingListItems < ActiveRecord::Migration[6.1]
   def change
     rename_column :shopping_list_items, :shopping_list_id, :list_id

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
 #

--- a/lib/titlecase.rb
+++ b/lib/titlecase.rb
@@ -71,7 +71,7 @@ module Titlecase
                       on
                       without
                       within
-                    ]
+                    ].freeze
 
   module_function
 

--- a/spec/controller_services/application_controller/authorization_service_spec.rb
+++ b/spec/controller_services/application_controller/authorization_service_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ApplicationController::AuthorizationService do
           'exp'     => (Time.now + 1.day).to_i,
           'email'   => 'jane.doe@gmail.com',
           'name'    => 'Jane Doe',
-          'picture' => nil
+          'picture' => nil,
         }
       end
 
@@ -52,7 +52,7 @@ RSpec.describe ApplicationController::AuthorizationService do
           'exp'     => (Time.now - 1.day).to_i,
           'email'   => 'jane.doe@gmail.com',
           'name'    => 'Jane Doe',
-          'picture' => nil
+          'picture' => nil,
         }
       end
 

--- a/spec/controller_services/games_controller/destroy_service_spec.rb
+++ b/spec/controller_services/games_controller/destroy_service_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe GamesController::DestroyService do
     end
 
     context 'when the game does not exist' do
-      let(:game) { double(id: 43598) }
+      let(:game) { double(id: 43_598) }
       let(:user) { create(:user) }
 
       it 'returns a Service::NotFoundResult' do

--- a/spec/controller_services/games_controller/update_service_spec.rb
+++ b/spec/controller_services/games_controller/update_service_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe GamesController::UpdateService do
     end
 
     context "when the game doesn't exist" do
-      let(:game) { double(id: 823589) }
+      let(:game) { double(id: 823_589) }
       let(:user) { create(:user) }
       let(:params) { { description: 'New description' } }
 

--- a/spec/controller_services/shopping_list_items_controller/destroy_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/destroy_service_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe ShoppingListItemsController::DestroyService do
                  list:        second_list,
                  description: list_item.description.upcase, # make sure comparison is case insensitive
                  quantity:    2,
-                 notes:       'some other notes')
+                 notes:       'some other notes',)
         end
 
         before do

--- a/spec/controller_services/shopping_lists_controller/create_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/create_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ShoppingListsController::CreateService do
     let(:user) { create(:user) }
 
     context 'when the game is not found' do
-      let(:game) { double(id: 898243) }
+      let(:game) { double(id: 898_243) }
       let(:params) { { title: 'My Shopping List' } }
 
       it 'returns a Service::NotFoundResult' do
@@ -43,7 +43,7 @@ RSpec.describe ShoppingListsController::CreateService do
       let(:params) do
         {
           title:     'All Items',
-          aggregate: true
+          aggregate: true,
         }
       end
 

--- a/spec/controller_services/shopping_lists_controller/index_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/index_service_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ShoppingListsController::IndexService do
     let(:user) { create(:user) }
 
     context 'when the game is not found' do
-      let(:game_id) { 455315 }
+      let(:game_id) { 455_315 }
 
       it 'returns a Service::NotFoundResult' do
         expect(perform).to be_a(Service::NotFoundResult)

--- a/spec/lib/controller/response_spec.rb
+++ b/spec/lib/controller/response_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Controller::Response do
           user_id:    72,
           title:      'My List 2',
           created_at: Time.now - 2.days,
-          updated_at: Time.now
+          updated_at: Time.now,
         }
       end
 

--- a/spec/lib/created_result_spec.rb
+++ b/spec/lib/created_result_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Service::CreatedResult do
 
   let(:options) do
     {
-      resource: { foo: 'bar' }
+      resource: { foo: 'bar' },
     }
   end
 

--- a/spec/lib/service/ok_result_spec.rb
+++ b/spec/lib/service/ok_result_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Service::OKResult do
 
   let(:options) do
     {
-      resource: { foo: 'bar' }
+      resource: { foo: 'bar' },
     }
   end
 

--- a/spec/lib/service/result_spec.rb
+++ b/spec/lib/service/result_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe Service::Result do
                       uid:       'jane.doe@gmail.com',
                       email:     'jane.doe@gmail.com',
                       name:      'Jane Doe',
-                      image_url: nil
-                    }
+                      image_url: nil,
+                    },
         }
       end
 
@@ -34,7 +34,7 @@ RSpec.describe Service::Result do
                                         uid:       'jane.doe@gmail.com',
                                         email:     'jane.doe@gmail.com',
                                         name:      'Jane Doe',
-                                        image_url: nil
+                                        image_url: nil,
                                       })
       end
     end
@@ -50,7 +50,7 @@ RSpec.describe Service::Result do
     context 'when there are errors' do
       let(:options) do
         {
-          errors: ['foo', ['bar', ['baz', 'qux']]]
+          errors: ['foo', ['bar', %w[baz qux]]],
         }
       end
 
@@ -62,7 +62,7 @@ RSpec.describe Service::Result do
     context 'when there is one error' do
       let(:options) do
         {
-          error: 'foobar'
+          error: 'foobar',
         }
       end
 

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Game, type: :model do
 
       context 'when there is a game called "My Game <non-integer>"' do
         before do
-          create(:game, user: user, name: "My Game Is the Best Game")
+          create(:game, user: user, name: 'My Game Is the Best Game')
           create_list(:game, 2, user: user, name: nil)
         end
 

--- a/spec/models/shopping_list_item_spec.rb
+++ b/spec/models/shopping_list_item_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe ShoppingListItem, type: :model do
         expect(ShoppingListItem.belonging_to_game(game).to_a.sort).to eq([
                                                                            list1.list_items.to_a,
                                                                            list2.list_items.to_a,
-                                                                           list3.list_items.to_a
+                                                                           list3.list_items.to_a,
                                                                          ].flatten.sort)
       end
     end

--- a/spec/models/shopping_list_spec.rb
+++ b/spec/models/shopping_list_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe ShoppingList, type: :model do
                                                                   agg_list2,
                                                                   game1_list1,
                                                                   game1_list2,
-                                                                  agg_list1
+                                                                  agg_list1,
                                                                 ])
       end
     end
@@ -178,7 +178,7 @@ RSpec.describe ShoppingList, type: :model do
     let!(:aggregate_list) { create(:aggregate_shopping_list) }
     let(:shopping_list) { create(:shopping_list, game: aggregate_list.game) }
 
-    it "returns the aggregate list that tracks it" do
+    it 'returns the aggregate list that tracks it' do
       expect(shopping_list.aggregate_list).to eq aggregate_list
     end
   end
@@ -242,7 +242,7 @@ RSpec.describe ShoppingList, type: :model do
 
           context 'when there is a shopping list called "My List <non-integer>"' do
             before do
-              create(:shopping_list, game: game, title: "My List Is the Best List")
+              create(:shopping_list, game: game, title: 'My List Is the Best List')
               create_list(:shopping_list, 2, game: game, title: nil)
             end
 
@@ -386,7 +386,7 @@ RSpec.describe ShoppingList, type: :model do
           expect(aggregate_list.list_items.last.attributes).to include(
                                                                  'description' => list_item.description,
                                                                  'quantity'    => list_item.quantity,
-                                                                 'notes'       => list_item.notes
+                                                                 'notes'       => list_item.notes,
                                                                )
         end
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe User, type: :model do
         'exp'     => (Time.now + 2.days).to_i,
         'email'   => 'jane.doe@gmail.com',
         'name'    => 'Jane Doe',
-        'picture' => 'https://example.com/user_images/89'
+        'picture' => 'https://example.com/user_images/89',
       }
     end
 
@@ -26,7 +26,7 @@ RSpec.describe User, type: :model do
                                           'uid'       => 'jane.doe@gmail.com',
                                           'email'     => 'jane.doe@gmail.com',
                                           'name'      => 'Jane Doe',
-                                          'image_url' => 'https://example.com/user_images/89'
+                                          'image_url' => 'https://example.com/user_images/89',
                                         )
       end
     end
@@ -64,7 +64,7 @@ RSpec.describe User, type: :model do
                                            shopping_list4,
                                            shopping_list3,
                                            shopping_list2,
-                                           shopping_list1
+                                           shopping_list1,
                                          ])
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 

--- a/spec/requests/games_spec.rb
+++ b/spec/requests/games_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Games', type: :request do
   let(:headers) do
     {
       'Content-Type'  => 'application/json',
-      'Authorization' => 'Bearer xxxxxxx'
+      'Authorization' => 'Bearer xxxxxxx',
     }
   end
 
@@ -19,7 +19,7 @@ RSpec.describe 'Games', type: :request do
         {
           'exp'   => (Time.now + 1.year).to_i,
           'email' => user.email,
-          'name'  => user.name
+          'name'  => user.name,
         }
       end
 
@@ -97,7 +97,7 @@ RSpec.describe 'Games', type: :request do
         {
           'exp'   => (Time.now + 1.year).to_i,
           'email' => user.email,
-          'name'  => user.name
+          'name'  => user.name,
         }
       end
 
@@ -188,7 +188,7 @@ RSpec.describe 'Games', type: :request do
         {
           'exp'   => (Time.now + 1.year).to_i,
           'email' => user.email,
-          'name'  => user.name
+          'name'  => user.name,
         }
       end
 
@@ -242,7 +242,7 @@ RSpec.describe 'Games', type: :request do
       end
 
       context 'when the game does not exist' do
-        let(:game) { double(id: 829315) }
+        let(:game) { double(id: 829_315) }
         let(:user) { create(:user) }
         let(:params) { { game: { name: 'New Name' } } }
 
@@ -317,7 +317,7 @@ RSpec.describe 'Games', type: :request do
         {
           'exp'   => (Time.now + 1.year).to_i,
           'email' => user.email,
-          'name'  => user.name
+          'name'  => user.name,
         }
       end
 
@@ -371,7 +371,7 @@ RSpec.describe 'Games', type: :request do
       end
 
       context 'when the game does not exist' do
-        let(:game) { double(id: 829315) }
+        let(:game) { double(id: 829_315) }
         let(:user) { create(:user) }
         let(:params) { { game: { name: 'New Name' } } }
 
@@ -446,7 +446,7 @@ RSpec.describe 'Games', type: :request do
         {
           'exp'   => (Time.now + 1.year).to_i,
           'email' => user.email,
-          'name'  => user.name
+          'name'  => user.name,
         }
       end
 
@@ -476,7 +476,7 @@ RSpec.describe 'Games', type: :request do
       end
 
       context 'when the game does not exist' do
-        let(:game) { double(id: 752809) }
+        let(:game) { double(id: 752_809) }
 
         it 'returns status 404' do
           destroy_game

--- a/spec/requests/shopping_list_items_spec.rb
+++ b/spec/requests/shopping_list_items_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
   let(:headers) do
     {
       'Content-Type'  => 'application/json',
-      'Authorization' => 'Bearer xxxxxxx'
+      'Authorization' => 'Bearer xxxxxxx',
     }
   end
 
@@ -27,7 +27,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
         {
           'exp'   => (Time.now + 1.year).to_i,
           'email' => user.email,
-          'name'  => user.name
+          'name'  => user.name,
         }
       end
 
@@ -57,7 +57,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
             expect(aggregate_list.list_items.last.attributes).to include(
                                                                    'description' => item.description,
                                                                    'quantity'    => item.quantity,
-                                                                   'notes'       => item.notes
+                                                                   'notes'       => item.notes,
                                                                  )
           end
 
@@ -102,7 +102,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
             second_list.list_items.create!(
               description: 'Corundum ingot',
               quantity:    1,
-              notes:       'some other notes'
+              notes:       'some other notes',
             )
             aggregate_list.add_item_from_child_list(second_list.list_items.last)
           end
@@ -113,7 +113,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
             expect(aggregate_list.list_items.last.attributes).to include(
                                                                    'description' => 'Corundum ingot',
                                                                    'quantity'    => 6,
-                                                                   'notes'       => 'some other notes -- To make locks'
+                                                                   'notes'       => 'some other notes -- To make locks',
                                                                  )
           end
 
@@ -198,7 +198,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
             expect(shopping_list.list_items.first.attributes).to include(
                                                                    'description' => 'Corundum ingot',
                                                                    'quantity'    => 7,
-                                                                   'notes'       => 'To make locks -- To make locks'
+                                                                   'notes'       => 'To make locks -- To make locks',
                                                                  )
           end
 
@@ -344,7 +344,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
         {
           'exp'   => (Time.now + 1.year).to_i,
           'email' => user.email,
-          'name'  => user.name
+          'name'  => user.name,
         }
       end
 
@@ -371,7 +371,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
           update_item
           expect(list_item.reload.attributes).to include(
                                                    'quantity' => 5,
-                                                   'notes'    => 'To make locks'
+                                                   'notes'    => 'To make locks',
                                                  )
         end
 
@@ -380,7 +380,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
           expect(aggregate_list.list_items.first.attributes).to include(
                                                                   'description' => list_item.description,
                                                                   'quantity'    => 7,
-                                                                  'notes'       => 'To make locks'
+                                                                  'notes'       => 'To make locks',
                                                                 )
         end
 
@@ -541,7 +541,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
         {
           'exp'   => (Time.now + 1.year).to_i,
           'email' => user.email,
-          'name'  => user.name
+          'name'  => user.name,
         }
       end
 
@@ -568,7 +568,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
           update_item
           expect(list_item.reload.attributes).to include(
                                                    'quantity' => 5,
-                                                   'notes'    => 'To make locks'
+                                                   'notes'    => 'To make locks',
                                                  )
         end
 
@@ -577,7 +577,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
           expect(aggregate_list.list_items.first.attributes).to include(
                                                                   'description' => list_item.description,
                                                                   'quantity'    => 7,
-                                                                  'notes'       => 'To make locks'
+                                                                  'notes'       => 'To make locks',
                                                                 )
         end
 
@@ -736,7 +736,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
         {
           'exp'   => (Time.now + 1.year).to_i,
           'email' => game.user.email,
-          'name'  => game.user.name
+          'name'  => game.user.name,
         }
       end
 
@@ -853,7 +853,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
         expect(response.status).to eq 401
       end
 
-      it "indicates the request was unauthenticated" do
+      it 'indicates the request was unauthenticated' do
         destroy_item
         expect(JSON.parse(response.body)).to eq({ 'errors' => ['Google OAuth token validation failed'] })
       end

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'ShoppingLists', type: :request do
   let(:headers) do
     {
       'Content-Type'  => 'application/json',
-      'Authorization' => 'Bearer xxxxxxx'
+      'Authorization' => 'Bearer xxxxxxx',
     }
   end
 
@@ -19,7 +19,7 @@ RSpec.describe 'ShoppingLists', type: :request do
         {
           'exp'   => (Time.now + 1.year).to_i,
           'email' => user.email,
-          'name'  => user.name
+          'name'  => user.name,
         }
       end
 
@@ -85,7 +85,7 @@ RSpec.describe 'ShoppingLists', type: :request do
       end
 
       context 'when the game is not found' do
-        let(:game) { double(id: 84968294) }
+        let(:game) { double(id: 84_968_294) }
 
         it 'returns status 404' do
           create_shopping_list
@@ -122,7 +122,7 @@ RSpec.describe 'ShoppingLists', type: :request do
           expect(response.status).to eq 422
         end
 
-        it "returns the errors" do
+        it 'returns the errors' do
           create_shopping_list
           expect(JSON.parse(response.body)).to eq({ 'errors' => ['Title has already been taken'] })
         end
@@ -168,7 +168,7 @@ RSpec.describe 'ShoppingLists', type: :request do
         {
           'exp'   => (Time.now + 1.year).to_i,
           'email' => user.email,
-          'name'  => user.name
+          'name'  => user.name,
         }
       end
 
@@ -215,7 +215,7 @@ RSpec.describe 'ShoppingLists', type: :request do
           expect(response.status).to eq 422
         end
 
-        it "returns the errors" do
+        it 'returns the errors' do
           update_shopping_list
           expect(JSON.parse(response.body)).to eq({ 'errors' => ['Title has already been taken'] })
         end
@@ -321,7 +321,7 @@ RSpec.describe 'ShoppingLists', type: :request do
         {
           'exp'   => (Time.now + 1.year).to_i,
           'email' => user.email,
-          'name'  => user.name
+          'name'  => user.name,
         }
       end
 
@@ -368,7 +368,7 @@ RSpec.describe 'ShoppingLists', type: :request do
           expect(response.status).to eq 422
         end
 
-        it "returns the errors" do
+        it 'returns the errors' do
           update_shopping_list
           expect(JSON.parse(response.body)).to eq({ 'errors' => ['Title has already been taken'] })
         end
@@ -493,7 +493,7 @@ RSpec.describe 'ShoppingLists', type: :request do
         {
           'exp'   => (Time.now + 1.year).to_i,
           'email' => authenticated_user.email,
-          'name'  => authenticated_user.name
+          'name'  => authenticated_user.name,
         }
       end
 
@@ -504,7 +504,7 @@ RSpec.describe 'ShoppingLists', type: :request do
       end
 
       context 'when the game is not found' do
-        let(:game) { double(id: 491349759) }
+        let(:game) { double(id: 491_349_759) }
 
         it 'returns status 404' do
           get_index
@@ -594,7 +594,7 @@ RSpec.describe 'ShoppingLists', type: :request do
         {
           'exp'   => (Time.now + 1.year).to_i,
           'email' => user1.email,
-          'name'  => user1.name
+          'name'  => user1.name,
         }
       end
 
@@ -620,14 +620,14 @@ RSpec.describe 'ShoppingLists', type: :request do
 
     context 'when the shopping list does not exist' do
       let(:user) { create(:user) }
-      let(:shopping_list) { double(id: 982498) } # could be anything
+      let(:shopping_list) { double(id: 982_498) } # could be anything
       let(:validator) { instance_double(GoogleIDToken::Validator, check: validation_data) }
 
       let(:validation_data) do
         {
           'exp'   => (Time.now + 1.year).to_i,
           'email' => user.email,
-          'name'  => user.name
+          'name'  => user.name,
         }
       end
 
@@ -658,7 +658,7 @@ RSpec.describe 'ShoppingLists', type: :request do
         {
           'exp'   => (Time.now + 1.year).to_i,
           'email' => user.email,
-          'name'  => user.name
+          'name'  => user.name,
         }
       end
 
@@ -716,7 +716,7 @@ RSpec.describe 'ShoppingLists', type: :request do
         {
           'exp'   => (Time.now + 1.year).to_i,
           'email' => user.email,
-          'name'  => user.name
+          'name'  => user.name,
         }
       end
 

--- a/spec/requests/verifications_spec.rb
+++ b/spec/requests/verifications_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe "Verifications", type: :request do
+RSpec.describe 'Verifications', type: :request do
   subject(:verify_token) { get '/auth/verify_token', headers: { 'Authorization' => "Bearer #{token}" } }
 
   let(:token) { 'xxxxxxxx' }
@@ -17,7 +17,7 @@ RSpec.describe "Verifications", type: :request do
       {
         'exp'   => (Time.now + 1.year).to_i,
         'email' => 'foobar@gmail.com',
-        'name'  => 'Foo Bar'
+        'name'  => 'Foo Bar',
       }
     end
 
@@ -43,7 +43,7 @@ RSpec.describe "Verifications", type: :request do
       it 'creates a new user with the data from the payload', :aggregate_failures do
         expect { verify_token }
           .to change(User, :count).from(0).to(1)
-        expect(User.last.attributes).to include(**(expected_user_attributes.merge({ 'id' => User.last.id })))
+        expect(User.last.attributes).to include(**expected_user_attributes.merge({ 'id' => User.last.id }))
       end
     end
 
@@ -56,7 +56,7 @@ RSpec.describe "Verifications", type: :request do
           'uid'       => 'foobar@gmail.com',
           'email'     => 'foobar@gmail.com',
           'name'      => 'Foo Bar',
-          'image_url' => nil
+          'image_url' => nil,
         }
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -69,7 +69,7 @@ RSpec.configure do |config|
     # Use the documentation formatter for detailed output,
     # unless a formatter has already been configured
     # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
+    config.default_formatter = 'doc'
   end
 
   # Print the 10 slowest examples and example groups at the


### PR DESCRIPTION
## Context

[**Add Rubocop for linting**](https://trello.com/c/nb6hbkVa/100-add-rubocop-for-linting)

The largest group of [Rubocop](https://github.com/rubocop/rubocop) cops is the `Style` group. This PR is the result of correcting violations in these cops as well as the `Security` and `Naming` groups, primarily using Rubocop's autocorrect feature.

## Changes

* Run style and security cops against existing codebase
* Remove `Naming/FileName` cop, which quickly proved to be more trouble than it was worth

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~

## Considerations

I ended up removing the `Naming/FileName` cop, even though I like the idea of it, because it kept saying that spec files, `routes.rb`, etc. should define classes with certain names. I could've excluded all those files from that cop but at that point it would've been barely better than `rubocop:disable` comments.
