### PR TITLE
Run rubocop-rails and make it pass

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1291,6 +1291,8 @@ Rails/IndexWith:
   Enabled: true
 Rails/Inquiry:
   Enabled: true
+Rails/InverseOf:
+  Enabled: true
 Rails/LexicallyScopedActionFilter:
   Enabled: true
 Rails/MatchRoute:
@@ -1373,7 +1375,7 @@ Rails/WhereNot:
 ### RSpec Requirements ###
 ##########################
 
-RSpec/AlignLetLeftBrace:
+RSpec/AlignLeftLetBrace:
   Enabled: true
 RSpec/AroundBlock:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1373,240 +1373,240 @@ Rails/WhereNot:
 ### RSpec Requirements ###
 ##########################
 
-# RSpec/AlignLetLeftBrace:
-#   Enabled: true
-# RSpec/AroundBlock:
-#   Enabled: true
-# RSpec/Be:
-#   Enabled: true
-# RSpec/BeEql:
-#   Enabled: true
-# RSpec/BeforeAfterAll:
-#   Enabled: true
-# RSpec/ContextMethod:
-#   Enabled: true
-# RSpec/ContextWording:
-#   Enabled: true
-#   Prefixes:
-#     - when
-#     - with
-#     - without
-# RSpec/DescribeClass:
-#   Enabled: true
-#   IgnoredMetadata:
-#     type:
-#       - request
-# RSpec/DescribedClass:
-#   Enabled: true
-#   EnforcedStyle: described_class
-# RSpec/DescribedClassModuleWrapping:
-#   Enabled: true
-# RSpec/EmptyExampleGroup:
-#   Enabled: true
-# RSpec/EmptyHook:
-#   Enabled: true
-# RSpec/EmptyLineAfterExample:
-#   Enabled: true
-#   AllowConsecutiveOneLiners: true
-# RSpec/EmptyLineAfterExampleGroup:
-#   Enabled: true
-# RSpec/EmptyLineAfterFinalLet:
-#   Enabled: true
-# RSpec/EmptyLineAfterHook:
-#   Enabled: true
-# RSpec/EmptyLineAfterSubject:
-#   Enabled: true
-# RSpec/ExampleWithoutDescription:
-#   Enabled: true
-#   EnforcedStyle: single_line_only
-# RSpec/ExampleWording:
-#   Enabled: true
-# RSpec/ExpectActual:
-#   Enabled: true
-# RSpec/ExpectChange:
-#   Enabled: true
-#   EnforcedStyle: method_call
-# RSpec/ExpectInHook:
-#   Enabled: true
-# RSpec/FilePath:
-#   Enabled: true
-#   IgnoreMethods: true
-# RSpec/Focus:
-#   Enabled: true
-# RSpec/HookArgument:
-#   Enabled: true
-#   EnforcedStyle: implicit
-# RSpec/HooksBeforeExamples:
-#   Enabled: true
-# RSpec/IdenticalEqualityAssertion:
-#   Enabled: true
-# RSpec/ImplicitBlockExpectation:
-#   Enabled: true
-# RSpec/ImplicitExpect:
-#   Enabled: true
-#   EnforcedStyle: is_expected
-# RSpec/ImplicitSubject:
-#   Enabled: true
-#   EnforcedStyle: single_line_only
-# RSpec/InstanceSpy:
-#   Enabled: true
-# RSpec/InstanceVariable:
-#   Enabled: true
-# RSpec/IteratedExpectation:
-#   Enabled: true
-# RSpec/LeadingSubject:
-#   Enabled: true
-# RSpec/LeakyConstantDeclaration:
-#   Enabled: true
-# RSpec/LetBeforeExamples:
-#   Enabled: true
-# RSpec/MessageSpies:
-#   Enabled: true
-#   EnforcedStyle: have_received
-# RSpec/MissingExampleGroupArgument:
-#   Enabled: true
-# RSpec/MultipleDescribes:
-#   Enabled: true
-# RSpec/MultipleExpectations:
-#   Enabled: true
-#   Max: 3
-# RSpec/MultipleSubjects:
-#   Enabled: true
-# RSpec/NamedSubject:
-#   Enabled: true
-#   IgnoreSharedExamples: true
-# RSpec/NotToNot:
-#   Enabled: true
-#   EnforcedStyle: not_to
-# RSpec/PredicateMatcher:
-#   Enabled: true
-#   Strict: false
-#   EnforcedStyle: inflected
-# RSpec/ReceiveCounts:
-#   Enabled: true
-# RSpec/ReceiveNever:
-#   Enabled: true
-# RSpec/RepeatedDescription:
-#   Enabled: true
-# RSpec/RepeatedExample:
-#   Enabled: true
-# RSpec/RepeatedExampleGroupDescription:
-#   Enabled: true
-# RSpec/RepeatedIncludeExample:
-#   Enabled: true
-# RSpec/ReturnFromStub:
-#   Enabled: true
-#   EnforcedStyle: and_return
-# RSpec/ScatteredLet:
-#   Enabled: true
-# RSpec/ScatteredSetup:
-#   Enabled: true
-# RSpec/SharedContext:
-#   Enabled: true
-# RSpec/SharedExamples:
-#   Enabled: true
-# RSpec/SingleArgumentMessageChain:
-#   Enabled: true
-# RSpec/StubbedMock:
-#   Enabled: true
-# RSpec/SubjectStub:
-#   Enabled: true
-# RSpec/UnspecifiedException:
-#   Enabled: true
-# RSpec/VariableDefinition:
-#   Enabled: true
-#   EnforcedStyle: symbols
-# RSpec/VariableName:
-#   Enabled: true
-#   EnforcedStyle: snake_case
-# RSpec/VoidExpect:
-#   Enabled: true
-# RSpec/Yield:
-#   Enabled: true
+RSpec/AlignLetLeftBrace:
+  Enabled: true
+RSpec/AroundBlock:
+  Enabled: true
+RSpec/Be:
+  Enabled: true
+RSpec/BeEql:
+  Enabled: true
+RSpec/BeforeAfterAll:
+  Enabled: true
+RSpec/ContextMethod:
+  Enabled: true
+RSpec/ContextWording:
+  Enabled: true
+  Prefixes:
+    - when
+    - with
+    - without
+RSpec/DescribeClass:
+  Enabled: true
+  IgnoredMetadata:
+    type:
+      - request
+RSpec/DescribedClass:
+  Enabled: true
+  EnforcedStyle: described_class
+RSpec/DescribedClassModuleWrapping:
+  Enabled: true
+RSpec/EmptyExampleGroup:
+  Enabled: true
+RSpec/EmptyHook:
+  Enabled: true
+RSpec/EmptyLineAfterExample:
+  Enabled: true
+  AllowConsecutiveOneLiners: true
+RSpec/EmptyLineAfterExampleGroup:
+  Enabled: true
+RSpec/EmptyLineAfterFinalLet:
+  Enabled: true
+RSpec/EmptyLineAfterHook:
+  Enabled: true
+RSpec/EmptyLineAfterSubject:
+  Enabled: true
+RSpec/ExampleWithoutDescription:
+  Enabled: true
+  EnforcedStyle: single_line_only
+RSpec/ExampleWording:
+  Enabled: true
+RSpec/ExpectActual:
+  Enabled: true
+RSpec/ExpectChange:
+  Enabled: true
+  EnforcedStyle: method_call
+RSpec/ExpectInHook:
+  Enabled: true
+RSpec/FilePath:
+  Enabled: true
+  IgnoreMethods: true
+RSpec/Focus:
+  Enabled: true
+RSpec/HookArgument:
+  Enabled: true
+  EnforcedStyle: implicit
+RSpec/HooksBeforeExamples:
+  Enabled: true
+RSpec/IdenticalEqualityAssertion:
+  Enabled: true
+RSpec/ImplicitBlockExpectation:
+  Enabled: true
+RSpec/ImplicitExpect:
+  Enabled: true
+  EnforcedStyle: is_expected
+RSpec/ImplicitSubject:
+  Enabled: true
+  EnforcedStyle: single_line_only
+RSpec/InstanceSpy:
+  Enabled: true
+RSpec/InstanceVariable:
+  Enabled: true
+RSpec/IteratedExpectation:
+  Enabled: true
+RSpec/LeadingSubject:
+  Enabled: true
+RSpec/LeakyConstantDeclaration:
+  Enabled: true
+RSpec/LetBeforeExamples:
+  Enabled: true
+RSpec/MessageSpies:
+  Enabled: true
+  EnforcedStyle: have_received
+RSpec/MissingExampleGroupArgument:
+  Enabled: true
+RSpec/MultipleDescribes:
+  Enabled: true
+RSpec/MultipleExpectations:
+  Enabled: true
+  Max: 3
+RSpec/MultipleSubjects:
+  Enabled: true
+RSpec/NamedSubject:
+  Enabled: true
+  IgnoreSharedExamples: true
+RSpec/NotToNot:
+  Enabled: true
+  EnforcedStyle: not_to
+RSpec/PredicateMatcher:
+  Enabled: true
+  Strict: false
+  EnforcedStyle: inflected
+RSpec/ReceiveCounts:
+  Enabled: true
+RSpec/ReceiveNever:
+  Enabled: true
+RSpec/RepeatedDescription:
+  Enabled: true
+RSpec/RepeatedExample:
+  Enabled: true
+RSpec/RepeatedExampleGroupDescription:
+  Enabled: true
+RSpec/RepeatedIncludeExample:
+  Enabled: true
+RSpec/ReturnFromStub:
+  Enabled: true
+  EnforcedStyle: and_return
+RSpec/ScatteredLet:
+  Enabled: true
+RSpec/ScatteredSetup:
+  Enabled: true
+RSpec/SharedContext:
+  Enabled: true
+RSpec/SharedExamples:
+  Enabled: true
+RSpec/SingleArgumentMessageChain:
+  Enabled: true
+RSpec/StubbedMock:
+  Enabled: true
+RSpec/SubjectStub:
+  Enabled: true
+RSpec/UnspecifiedException:
+  Enabled: true
+RSpec/VariableDefinition:
+  Enabled: true
+  EnforcedStyle: symbols
+RSpec/VariableName:
+  Enabled: true
+  EnforcedStyle: snake_case
+RSpec/VoidExpect:
+  Enabled: true
+RSpec/Yield:
+  Enabled: true
 
-# ################################
-# ### Performance Requirements ###
-# ################################
+################################
+### Performance Requirements ###
+################################
 
 
-# Performance/BindCall:
-#   Enabled: true
-# Performance/BlockGivenWithExplicitBlock:
-#   Enabled: true
-# Performance/Caller:
-#   Enabled: true
-# Performance/CaseWhenSplat:
-#   Enabled: true
-# Performance/Casecmp:
-#   Enabled: true
-# Performance/ChainArrayAllocation:
-#   Enabled: true
-# Performance/CollectionLiteralInLoop:
-#   Enabled: true
-# Performance/CompareWithBlock:
-#   Enabled: true
-# Performance/Count:
-#   Enabled: true
-# Performance/DeletePrefix:
-#   Enabled: true
-#   SafeMultiline: true
-# Performance/DeleteSuffix:
-#   Enabled: true
-#   SafeMultiline: true
-# Performance/Detect:
-#   Enabled: true
-# Performance/DoubleStartEndWith:
-#   Enabled: true
-# Performance/EndWith:
-#   Enabled: true
-# Performance/FixedSize:
-#   Enabled: true
-# Performance/FlatMap:
-#   Enabled: true
-# Performance/InefficientHashSearch:
-#   Enabled: true
-# Performance/IoReadlines:
-#   Enabled: true
-# Performance/RangeInclude:
-#   Enabled: true
-# Performance/RedundantBlockCall:
-#   Enabled: true
-# Performance/RedundantMatch:
-#   Enabled: true
-# Performance/RedundantMerge:
-#   Enabled: true
-# Performance/RedundantSortBlock:
-#   Enabled: true
-# Performance/RedundantSplitRegexpArgument:
-#   Enabled: true
-# Performance/RedundantStringChars:
-#   Enabled: true
-# Performance/RegexpMatch:
-#   Enabled: true
-# Performance/ReverseEach:
-#   Enabled: true
-# Performance/ReverseFirst:
-#   Enabled: true
-# Performance/SelectMap:
-#   Enabled: true
-# Performance/Size:
-#   Enabled: true
-# Performance/SortReverse:
-#   Enabled: true
-# Performance/Squeeze:
-#   Enabled: true
-# Performance/StartWith:
-#   Enabled: true
-#   SafeMultiline: true
-# Performance/StringInclude:
-#   Enabled: true
-# Performance/StringReplacement:
-#   Enabled: true
-# Performance/Sum:
-#   Enabled: true
-# Performance/TimesMap:
-#   Enabled: true
-# Performance/UnfreezeString:
-#   Enabled: true
-# Performance/UriDefaultParser:
-#   Enabled: true
+Performance/BindCall:
+  Enabled: true
+Performance/BlockGivenWithExplicitBlock:
+  Enabled: true
+Performance/Caller:
+  Enabled: true
+Performance/CaseWhenSplat:
+  Enabled: true
+Performance/Casecmp:
+  Enabled: true
+Performance/ChainArrayAllocation:
+  Enabled: true
+Performance/CollectionLiteralInLoop:
+  Enabled: true
+Performance/CompareWithBlock:
+  Enabled: true
+Performance/Count:
+  Enabled: true
+Performance/DeletePrefix:
+  Enabled: true
+  SafeMultiline: true
+Performance/DeleteSuffix:
+  Enabled: true
+  SafeMultiline: true
+Performance/Detect:
+  Enabled: true
+Performance/DoubleStartEndWith:
+  Enabled: true
+Performance/EndWith:
+  Enabled: true
+Performance/FixedSize:
+  Enabled: true
+Performance/FlatMap:
+  Enabled: true
+Performance/InefficientHashSearch:
+  Enabled: true
+Performance/IoReadlines:
+  Enabled: true
+Performance/RangeInclude:
+  Enabled: true
+Performance/RedundantBlockCall:
+  Enabled: true
+Performance/RedundantMatch:
+  Enabled: true
+Performance/RedundantMerge:
+  Enabled: true
+Performance/RedundantSortBlock:
+  Enabled: true
+Performance/RedundantSplitRegexpArgument:
+  Enabled: true
+Performance/RedundantStringChars:
+  Enabled: true
+Performance/RegexpMatch:
+  Enabled: true
+Performance/ReverseEach:
+  Enabled: true
+Performance/ReverseFirst:
+  Enabled: true
+Performance/SelectMap:
+  Enabled: true
+Performance/Size:
+  Enabled: true
+Performance/SortReverse:
+  Enabled: true
+Performance/Squeeze:
+  Enabled: true
+Performance/StartWith:
+  Enabled: true
+  SafeMultiline: true
+Performance/StringInclude:
+  Enabled: true
+Performance/StringReplacement:
+  Enabled: true
+Performance/Sum:
+  Enabled: true
+Performance/TimesMap:
+  Enabled: true
+Performance/UnfreezeString:
+  Enabled: true
+Performance/UriDefaultParser:
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1276,6 +1276,8 @@ Rails/FindEach:
   Enabled: true
 Rails/HasManyOrHasOneDependent:
   Enabled: true
+  Exclude:
+    - 'app/models/concerns/aggregatable.rb'
 Rails/HttpPositionalArguments:
   Enabled: true
 Rails/HttpStatus:
@@ -1288,8 +1290,6 @@ Rails/IndexBy:
 Rails/IndexWith:
   Enabled: true
 Rails/Inquiry:
-  Enabled: true
-Rails/InverseOf:
   Enabled: true
 Rails/LexicallyScopedActionFilter:
   Enabled: true
@@ -1326,8 +1326,6 @@ Rails/RedundantAllowNil:
 Rails/RedundantForeignKey:
   Enabled: true
 Rails/RedundantReceiverInWithOptions:
-  Enabled: true
-Rails/ReflectionClassName:
   Enabled: true
 Rails/RelativeDateConstant:
   Enabled: true
@@ -1375,240 +1373,240 @@ Rails/WhereNot:
 ### RSpec Requirements ###
 ##########################
 
-RSpec/AlignLetLeftBrace:
-  Enabled: true
-RSpec/AroundBlock:
-  Enabled: true
-RSpec/Be:
-  Enabled: true
-RSpec/BeEql:
-  Enabled: true
-RSpec/BeforeAfterAll:
-  Enabled: true
-RSpec/ContextMethod:
-  Enabled: true
-RSpec/ContextWording:
-  Enabled: true
-  Prefixes:
-    - when
-    - with
-    - without
-RSpec/DescribeClass:
-  Enabled: true
-  IgnoredMetadata:
-    type:
-      - request
-RSpec/DescribedClass:
-  Enabled: true
-  EnforcedStyle: described_class
-RSpec/DescribedClassModuleWrapping:
-  Enabled: true
-RSpec/EmptyExampleGroup:
-  Enabled: true
-RSpec/EmptyHook:
-  Enabled: true
-RSpec/EmptyLineAfterExample:
-  Enabled: true
-  AllowConsecutiveOneLiners: true
-RSpec/EmptyLineAfterExampleGroup:
-  Enabled: true
-RSpec/EmptyLineAfterFinalLet:
-  Enabled: true
-RSpec/EmptyLineAfterHook:
-  Enabled: true
-RSpec/EmptyLineAfterSubject:
-  Enabled: true
-RSpec/ExampleWithoutDescription:
-  Enabled: true
-  EnforcedStyle: single_line_only
-RSpec/ExampleWording:
-  Enabled: true
-RSpec/ExpectActual:
-  Enabled: true
-RSpec/ExpectChange:
-  Enabled: true
-  EnforcedStyle: method_call
-RSpec/ExpectInHook:
-  Enabled: true
-RSpec/FilePath:
-  Enabled: true
-  IgnoreMethods: true
-RSpec/Focus:
-  Enabled: true
-RSpec/HookArgument:
-  Enabled: true
-  EnforcedStyle: implicit
-RSpec/HooksBeforeExamples:
-  Enabled: true
-RSpec/IdenticalEqualityAssertion:
-  Enabled: true
-RSpec/ImplicitBlockExpectation:
-  Enabled: true
-RSpec/ImplicitExpect:
-  Enabled: true
-  EnforcedStyle: is_expected
-RSpec/ImplicitSubject:
-  Enabled: true
-  EnforcedStyle: single_line_only
-RSpec/InstanceSpy:
-  Enabled: true
-RSpec/InstanceVariable:
-  Enabled: true
-RSpec/IteratedExpectation:
-  Enabled: true
-RSpec/LeadingSubject:
-  Enabled: true
-RSpec/LeakyConstantDeclaration:
-  Enabled: true
-RSpec/LetBeforeExamples:
-  Enabled: true
-RSpec/MessageSpies:
-  Enabled: true
-  EnforcedStyle: have_received
-RSpec/MissingExampleGroupArgument:
-  Enabled: true
-RSpec/MultipleDescribes:
-  Enabled: true
-RSpec/MultipleExpectations:
-  Enabled: true
-  Max: 3
-RSpec/MultipleSubjects:
-  Enabled: true
-RSpec/NamedSubject:
-  Enabled: true
-  IgnoreSharedExamples: true
-RSpec/NotToNot:
-  Enabled: true
-  EnforcedStyle: not_to
-RSpec/PredicateMatcher:
-  Enabled: true
-  Strict: false
-  EnforcedStyle: inflected
-RSpec/ReceiveCounts:
-  Enabled: true
-RSpec/ReceiveNever:
-  Enabled: true
-RSpec/RepeatedDescription:
-  Enabled: true
-RSpec/RepeatedExample:
-  Enabled: true
-RSpec/RepeatedExampleGroupDescription:
-  Enabled: true
-RSpec/RepeatedIncludeExample:
-  Enabled: true
-RSpec/ReturnFromStub:
-  Enabled: true
-  EnforcedStyle: and_return
-RSpec/ScatteredLet:
-  Enabled: true
-RSpec/ScatteredSetup:
-  Enabled: true
-RSpec/SharedContext:
-  Enabled: true
-RSpec/SharedExamples:
-  Enabled: true
-RSpec/SingleArgumentMessageChain:
-  Enabled: true
-RSpec/StubbedMock:
-  Enabled: true
-RSpec/SubjectStub:
-  Enabled: true
-RSpec/UnspecifiedException:
-  Enabled: true
-RSpec/VariableDefinition:
-  Enabled: true
-  EnforcedStyle: symbols
-RSpec/VariableName:
-  Enabled: true
-  EnforcedStyle: snake_case
-RSpec/VoidExpect:
-  Enabled: true
-RSpec/Yield:
-  Enabled: true
+# RSpec/AlignLetLeftBrace:
+#   Enabled: true
+# RSpec/AroundBlock:
+#   Enabled: true
+# RSpec/Be:
+#   Enabled: true
+# RSpec/BeEql:
+#   Enabled: true
+# RSpec/BeforeAfterAll:
+#   Enabled: true
+# RSpec/ContextMethod:
+#   Enabled: true
+# RSpec/ContextWording:
+#   Enabled: true
+#   Prefixes:
+#     - when
+#     - with
+#     - without
+# RSpec/DescribeClass:
+#   Enabled: true
+#   IgnoredMetadata:
+#     type:
+#       - request
+# RSpec/DescribedClass:
+#   Enabled: true
+#   EnforcedStyle: described_class
+# RSpec/DescribedClassModuleWrapping:
+#   Enabled: true
+# RSpec/EmptyExampleGroup:
+#   Enabled: true
+# RSpec/EmptyHook:
+#   Enabled: true
+# RSpec/EmptyLineAfterExample:
+#   Enabled: true
+#   AllowConsecutiveOneLiners: true
+# RSpec/EmptyLineAfterExampleGroup:
+#   Enabled: true
+# RSpec/EmptyLineAfterFinalLet:
+#   Enabled: true
+# RSpec/EmptyLineAfterHook:
+#   Enabled: true
+# RSpec/EmptyLineAfterSubject:
+#   Enabled: true
+# RSpec/ExampleWithoutDescription:
+#   Enabled: true
+#   EnforcedStyle: single_line_only
+# RSpec/ExampleWording:
+#   Enabled: true
+# RSpec/ExpectActual:
+#   Enabled: true
+# RSpec/ExpectChange:
+#   Enabled: true
+#   EnforcedStyle: method_call
+# RSpec/ExpectInHook:
+#   Enabled: true
+# RSpec/FilePath:
+#   Enabled: true
+#   IgnoreMethods: true
+# RSpec/Focus:
+#   Enabled: true
+# RSpec/HookArgument:
+#   Enabled: true
+#   EnforcedStyle: implicit
+# RSpec/HooksBeforeExamples:
+#   Enabled: true
+# RSpec/IdenticalEqualityAssertion:
+#   Enabled: true
+# RSpec/ImplicitBlockExpectation:
+#   Enabled: true
+# RSpec/ImplicitExpect:
+#   Enabled: true
+#   EnforcedStyle: is_expected
+# RSpec/ImplicitSubject:
+#   Enabled: true
+#   EnforcedStyle: single_line_only
+# RSpec/InstanceSpy:
+#   Enabled: true
+# RSpec/InstanceVariable:
+#   Enabled: true
+# RSpec/IteratedExpectation:
+#   Enabled: true
+# RSpec/LeadingSubject:
+#   Enabled: true
+# RSpec/LeakyConstantDeclaration:
+#   Enabled: true
+# RSpec/LetBeforeExamples:
+#   Enabled: true
+# RSpec/MessageSpies:
+#   Enabled: true
+#   EnforcedStyle: have_received
+# RSpec/MissingExampleGroupArgument:
+#   Enabled: true
+# RSpec/MultipleDescribes:
+#   Enabled: true
+# RSpec/MultipleExpectations:
+#   Enabled: true
+#   Max: 3
+# RSpec/MultipleSubjects:
+#   Enabled: true
+# RSpec/NamedSubject:
+#   Enabled: true
+#   IgnoreSharedExamples: true
+# RSpec/NotToNot:
+#   Enabled: true
+#   EnforcedStyle: not_to
+# RSpec/PredicateMatcher:
+#   Enabled: true
+#   Strict: false
+#   EnforcedStyle: inflected
+# RSpec/ReceiveCounts:
+#   Enabled: true
+# RSpec/ReceiveNever:
+#   Enabled: true
+# RSpec/RepeatedDescription:
+#   Enabled: true
+# RSpec/RepeatedExample:
+#   Enabled: true
+# RSpec/RepeatedExampleGroupDescription:
+#   Enabled: true
+# RSpec/RepeatedIncludeExample:
+#   Enabled: true
+# RSpec/ReturnFromStub:
+#   Enabled: true
+#   EnforcedStyle: and_return
+# RSpec/ScatteredLet:
+#   Enabled: true
+# RSpec/ScatteredSetup:
+#   Enabled: true
+# RSpec/SharedContext:
+#   Enabled: true
+# RSpec/SharedExamples:
+#   Enabled: true
+# RSpec/SingleArgumentMessageChain:
+#   Enabled: true
+# RSpec/StubbedMock:
+#   Enabled: true
+# RSpec/SubjectStub:
+#   Enabled: true
+# RSpec/UnspecifiedException:
+#   Enabled: true
+# RSpec/VariableDefinition:
+#   Enabled: true
+#   EnforcedStyle: symbols
+# RSpec/VariableName:
+#   Enabled: true
+#   EnforcedStyle: snake_case
+# RSpec/VoidExpect:
+#   Enabled: true
+# RSpec/Yield:
+#   Enabled: true
 
-################################
-### Performance Requirements ###
-################################
+# ################################
+# ### Performance Requirements ###
+# ################################
 
 
-Performance/BindCall:
-  Enabled: true
-Performance/BlockGivenWithExplicitBlock:
-  Enabled: true
-Performance/Caller:
-  Enabled: true
-Performance/CaseWhenSplat:
-  Enabled: true
-Performance/Casecmp:
-  Enabled: true
-Performance/ChainArrayAllocation:
-  Enabled: true
-Performance/CollectionLiteralInLoop:
-  Enabled: true
-Performance/CompareWithBlock:
-  Enabled: true
-Performance/Count:
-  Enabled: true
-Performance/DeletePrefix:
-  Enabled: true
-  SafeMultiline: true
-Performance/DeleteSuffix:
-  Enabled: true
-  SafeMultiline: true
-Performance/Detect:
-  Enabled: true
-Performance/DoubleStartEndWith:
-  Enabled: true
-Performance/EndWith:
-  Enabled: true
-Performance/FixedSize:
-  Enabled: true
-Performance/FlatMap:
-  Enabled: true
-Performance/InefficientHashSearch:
-  Enabled: true
-Performance/IoReadlines:
-  Enabled: true
-Performance/RangeInclude:
-  Enabled: true
-Performance/RedundantBlockCall:
-  Enabled: true
-Performance/RedundantMatch:
-  Enabled: true
-Performance/RedundantMerge:
-  Enabled: true
-Performance/RedundantSortBlock:
-  Enabled: true
-Performance/RedundantSplitRegexpArgument:
-  Enabled: true
-Performance/RedundantStringChars:
-  Enabled: true
-Performance/RegexpMatch:
-  Enabled: true
-Performance/ReverseEach:
-  Enabled: true
-Performance/ReverseFirst:
-  Enabled: true
-Performance/SelectMap:
-  Enabled: true
-Performance/Size:
-  Enabled: true
-Performance/SortReverse:
-  Enabled: true
-Performance/Squeeze:
-  Enabled: true
-Performance/StartWith:
-  Enabled: true
-  SafeMultiline: true
-Performance/StringInclude:
-  Enabled: true
-Performance/StringReplacement:
-  Enabled: true
-Performance/Sum:
-  Enabled: true
-Performance/TimesMap:
-  Enabled: true
-Performance/UnfreezeString:
-  Enabled: true
-Performance/UriDefaultParser:
-  Enabled: true
+# Performance/BindCall:
+#   Enabled: true
+# Performance/BlockGivenWithExplicitBlock:
+#   Enabled: true
+# Performance/Caller:
+#   Enabled: true
+# Performance/CaseWhenSplat:
+#   Enabled: true
+# Performance/Casecmp:
+#   Enabled: true
+# Performance/ChainArrayAllocation:
+#   Enabled: true
+# Performance/CollectionLiteralInLoop:
+#   Enabled: true
+# Performance/CompareWithBlock:
+#   Enabled: true
+# Performance/Count:
+#   Enabled: true
+# Performance/DeletePrefix:
+#   Enabled: true
+#   SafeMultiline: true
+# Performance/DeleteSuffix:
+#   Enabled: true
+#   SafeMultiline: true
+# Performance/Detect:
+#   Enabled: true
+# Performance/DoubleStartEndWith:
+#   Enabled: true
+# Performance/EndWith:
+#   Enabled: true
+# Performance/FixedSize:
+#   Enabled: true
+# Performance/FlatMap:
+#   Enabled: true
+# Performance/InefficientHashSearch:
+#   Enabled: true
+# Performance/IoReadlines:
+#   Enabled: true
+# Performance/RangeInclude:
+#   Enabled: true
+# Performance/RedundantBlockCall:
+#   Enabled: true
+# Performance/RedundantMatch:
+#   Enabled: true
+# Performance/RedundantMerge:
+#   Enabled: true
+# Performance/RedundantSortBlock:
+#   Enabled: true
+# Performance/RedundantSplitRegexpArgument:
+#   Enabled: true
+# Performance/RedundantStringChars:
+#   Enabled: true
+# Performance/RegexpMatch:
+#   Enabled: true
+# Performance/ReverseEach:
+#   Enabled: true
+# Performance/ReverseFirst:
+#   Enabled: true
+# Performance/SelectMap:
+#   Enabled: true
+# Performance/Size:
+#   Enabled: true
+# Performance/SortReverse:
+#   Enabled: true
+# Performance/Squeeze:
+#   Enabled: true
+# Performance/StartWith:
+#   Enabled: true
+#   SafeMultiline: true
+# Performance/StringInclude:
+#   Enabled: true
+# Performance/StringReplacement:
+#   Enabled: true
+# Performance/Sum:
+#   Enabled: true
+# Performance/TimesMap:
+#   Enabled: true
+# Performance/UnfreezeString:
+#   Enabled: true
+# Performance/UriDefaultParser:
+#   Enabled: true

--- a/app/controller_services/application_controller/authorization_service.rb
+++ b/app/controller_services/application_controller/authorization_service.rb
@@ -34,7 +34,7 @@ class ApplicationController < ActionController::API
     private
 
     def current?(seconds_since_unix_epoch)
-      Time.at(seconds_since_unix_epoch) >= Time.now
+      Time.zone.at(seconds_since_unix_epoch) >= Time.zone.now
     end
 
     attr_reader :controller, :token

--- a/app/models/concerns/aggregatable.rb
+++ b/app/models/concerns/aggregatable.rb
@@ -36,7 +36,7 @@ module Aggregatable
   included do
     belongs_to :game, touch: true
     has_many :list_items, -> { index_order }, class_name: list_item_class_name, dependent: :destroy, foreign_key: :list_id
-    belongs_to :aggregate_list, class_name: to_s, foreign_key: :aggregate_list_id, optional: true
+    belongs_to :aggregate_list, class_name: to_s, optional: true
     has_many :child_lists, class_name: to_s, foreign_key: :aggregate_list_id, inverse_of: :aggregate_list
 
     serialize :list_items, class_name: 'Array'
@@ -145,7 +145,7 @@ module Aggregatable
   def one_aggregate_list_per_game
     scope = self.class.where(game: game, aggregate: true)
 
-    errors.add(:aggregate, 'can only be one list per game') if scope.count > 1 || (scope.count > 0 && !scope.include?(self))
+    errors.add(:aggregate, 'can only be one list per game') if scope.count > 1 || (scope.count > 0 && scope.exclude?(self))
   end
 
   def remove_aggregate_list_id

--- a/app/models/concerns/aggregatable.rb
+++ b/app/models/concerns/aggregatable.rb
@@ -35,7 +35,12 @@ module Aggregatable
 
   included do
     belongs_to :game, touch: true
-    has_many :list_items, -> { index_order }, class_name: list_item_class_name, dependent: :destroy, foreign_key: :list_id
+    has_many :list_items,
+             -> { index_order },
+             class_name:  list_item_class_name,
+             dependent:   :destroy,
+             foreign_key: :list_id,
+             inverse_of:  :list
     belongs_to :aggregate_list, class_name: to_s, optional: true
     has_many :child_lists, class_name: to_s, foreign_key: :aggregate_list_id, inverse_of: :aggregate_list
 

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -4,7 +4,7 @@ require 'titlecase'
 
 class Game < ApplicationRecord
   belongs_to :user
-  has_many :shopping_lists, -> { index_order }, dependent: :destroy
+  has_many :shopping_lists, -> { index_order }, dependent: :destroy, inverse_of: :game
 
   validates :name,
             uniqueness: { scope: :user_id, message: 'must be unique' },

--- a/app/models/shopping_list.rb
+++ b/app/models/shopping_list.rb
@@ -25,7 +25,7 @@ class ShoppingList < ApplicationRecord
   include Aggregatable
 
   scope :index_order, -> { includes_items.aggregate_first.order(updated_at: :desc) }
-  scope :belonging_to_user, ->(user) { joins(:game).where('games.user_id = ?', user.id).order('shopping_lists.updated_at DESC') }
+  scope :belonging_to_user, ->(user) { joins(:game).where(games: { user_id: user.id }).order('shopping_lists.updated_at DESC') }
 
   private
 

--- a/app/models/shopping_list_item.rb
+++ b/app/models/shopping_list_item.rb
@@ -12,11 +12,11 @@ class ShoppingListItem < ApplicationRecord
   delegate :game, :user, to: :list
 
   scope :index_order, -> { order(updated_at: :desc) }
-  scope :belonging_to_game, ->(game) { joins(:list).where('shopping_lists.game_id = ?', game.id).order('shopping_lists.updated_at DESC') }
+  scope :belonging_to_game, ->(game) { joins(:list).where(shopping_lists: { game_id: game.id }).order('shopping_lists.updated_at DESC') }
 
   def self.belonging_to_user(user)
-    shopping_list_ids = ShoppingList.belonging_to_user(user).pluck(:id)
-    joins(:list).where('shopping_lists.id IN (?)', shopping_list_ids).order('shopping_lists.updated_at DESC')
+    shopping_list_ids = ShoppingList.belonging_to_user(user).ids
+    joins(:list).where(shopping_lists: { id: shopping_list_ids }).order('shopping_lists.updated_at DESC')
   end
 
   def self.combine_or_create!(attrs)

--- a/db/migrate/20210717103254_add_unique_index_to_description_on_shopping_list_item.rb
+++ b/db/migrate/20210717103254_add_unique_index_to_description_on_shopping_list_item.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexToDescriptionOnShoppingListItem < ActiveRecord::Migration[6.1]
+  def change
+    add_index :shopping_list_items, %i[description list_id], unique: true
+  end
+end

--- a/db/migrate/20210717103526_add_unique_index_to_title_on_shopping_lists.rb
+++ b/db/migrate/20210717103526_add_unique_index_to_title_on_shopping_lists.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexToTitleOnShoppingLists < ActiveRecord::Migration[6.1]
+  def change
+    add_index :shopping_lists, %i[title game_id], unique: true
+  end
+end

--- a/db/migrate/20210717103734_add_unique_index_to_name_on_games.rb
+++ b/db/migrate/20210717103734_add_unique_index_to_name_on_games.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexToNameOnGames < ActiveRecord::Migration[6.1]
+  def change
+    add_index :games, %i[name user_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_17_003004) do
+ActiveRecord::Schema.define(version: 2021_07_17_103734) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2021_07_17_003004) do
     t.string "description"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["name", "user_id"], name: "index_games_on_name_and_user_id", unique: true
     t.index ["user_id"], name: "index_games_on_user_id"
   end
 
@@ -31,6 +32,7 @@ ActiveRecord::Schema.define(version: 2021_07_17_003004) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "list_id", null: false
+    t.index ["description", "list_id"], name: "index_shopping_list_items_on_description_and_list_id", unique: true
     t.index ["list_id"], name: "index_shopping_list_items_on_list_id"
   end
 
@@ -43,6 +45,7 @@ ActiveRecord::Schema.define(version: 2021_07_17_003004) do
     t.bigint "aggregate_list_id"
     t.index ["aggregate_list_id"], name: "index_shopping_lists_on_aggregate_list_id"
     t.index ["game_id"], name: "index_shopping_lists_on_game_id"
+    t.index ["title", "game_id"], name: "index_shopping_lists_on_title_and_game_id", unique: true
   end
 
   create_table "users", force: :cascade do |t|

--- a/lib/titlecase.rb
+++ b/lib/titlecase.rb
@@ -79,7 +79,7 @@ module Titlecase
     words = string.downcase.split(' ')
 
     words.map.with_index(1) do |word, index|
-      LOWERCASE_WORDS.include?(word) && ![1, words.length].include?(index) ? word : word.capitalize
+      LOWERCASE_WORDS.include?(word) && [1, words.length].exclude?(index) ? word : word.capitalize
     end.join(' ')
   end
 end

--- a/spec/controller_services/application_controller/authorization_service_spec.rb
+++ b/spec/controller_services/application_controller/authorization_service_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe ApplicationController::AuthorizationService do
       let(:user) { create(:user, name: 'Jane Doe', email: 'jane.doe@gmail.com', uid: 'jane.doe@gmail.com') }
       let(:payload) do
         {
-          'exp'     => (Time.now + 1.day).to_i,
+          'exp'     => (Time.zone.now + 1.day).to_i,
           'email'   => 'jane.doe@gmail.com',
           'name'    => 'Jane Doe',
           'picture' => nil,
@@ -49,7 +49,7 @@ RSpec.describe ApplicationController::AuthorizationService do
     context 'when the token is invalid' do
       let(:payload) do
         {
-          'exp'     => (Time.now - 1.day).to_i,
+          'exp'     => (Time.zone.now - 1.day).to_i,
           'email'   => 'jane.doe@gmail.com',
           'name'    => 'Jane Doe',
           'picture' => nil,

--- a/spec/controller_services/shopping_list_items_controller/create_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/create_service_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe ShoppingListItemsController::CreateService do
         end
 
         it 'updates the list model itself' do
-          t = Time.now + 3.days
+          t = Time.zone.now + 3.days
           Timecop.freeze(t) do
             perform
             expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
@@ -59,7 +59,7 @@ RSpec.describe ShoppingListItemsController::CreateService do
         end
 
         it 'updates the game' do
-          t = Time.now + 3.days
+          t = Time.zone.now + 3.days
           Timecop.freeze(t) do
             perform
             expect(game.reload.updated_at).to be_within(0.005.seconds).of(t)
@@ -93,7 +93,7 @@ RSpec.describe ShoppingListItemsController::CreateService do
         end
 
         it 'updates the list itself' do
-          t = Time.now + 3.days
+          t = Time.zone.now + 3.days
           Timecop.freeze(t) do
             perform
             expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
@@ -101,7 +101,7 @@ RSpec.describe ShoppingListItemsController::CreateService do
         end
 
         it 'updates the game' do
-          t = Time.now + 3.days
+          t = Time.zone.now + 3.days
           Timecop.freeze(t) do
             perform
             expect(game.reload.updated_at).to be_within(0.005.seconds).of(t)
@@ -159,7 +159,7 @@ RSpec.describe ShoppingListItemsController::CreateService do
       end
 
       it 'updates the shopping list' do
-        t = Time.now + 3.days
+        t = Time.zone.now + 3.days
         Timecop.freeze(t) do
           perform
           expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
@@ -167,7 +167,7 @@ RSpec.describe ShoppingListItemsController::CreateService do
       end
 
       it 'updates the game' do
-        t = Time.now + 3.days
+        t = Time.zone.now + 3.days
         Timecop.freeze(t) do
           perform
           expect(game.reload.updated_at).to be_within(0.005.seconds).of(t)

--- a/spec/controller_services/shopping_list_items_controller/destroy_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/destroy_service_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe ShoppingListItemsController::DestroyService do
         end
 
         it 'sets the updated_at timestamp on the shopping list' do
-          t = Time.now + 3.days
+          t = Time.zone.now + 3.days
           Timecop.freeze(t) do
             perform
             # use `be_within` even though the time will be set to the time Timecop
@@ -89,7 +89,7 @@ RSpec.describe ShoppingListItemsController::DestroyService do
         end
 
         it 'sets the updated_at timestamp on the shopping list' do
-          t = Time.now + 3.days
+          t = Time.zone.now + 3.days
           Timecop.freeze(t) do
             perform
             # use `be_within` even though the time will be set to the time Timecop

--- a/spec/controller_services/shopping_list_items_controller/update_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/update_service_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe ShoppingListItemsController::UpdateService do
       end
 
       it 'updates the updated_at timestamp on the list' do
-        t = Time.now + 3.days
+        t = Time.zone.now + 3.days
         Timecop.freeze(t) do
           perform
           # This is another case of a rounding error in the CI environment. The server where
@@ -110,7 +110,7 @@ RSpec.describe ShoppingListItemsController::UpdateService do
       end
 
       it 'does not update the shopping list itself' do
-        t = Time.now + 3.days
+        t = Time.zone.now + 3.days
         Timecop.freeze(t) do
           perform
           expect(shopping_list.reload.updated_at).not_to be_within(71.hours).of(t)

--- a/spec/controller_services/shopping_lists_controller/create_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/create_service_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe ShoppingListsController::CreateService do
         end
 
         it 'updates the game' do
-          t = Time.now + 3.days
+          t = Time.zone.now + 3.days
           Timecop.freeze(t) do
             perform
             expect(game.reload.updated_at).to be_within(0.005.seconds).of(t)
@@ -104,7 +104,7 @@ RSpec.describe ShoppingListsController::CreateService do
         end
 
         it 'updates the game' do
-          t = Time.now + 3.days
+          t = Time.zone.now + 3.days
           Timecop.freeze(t) do
             perform
             expect(game.reload.updated_at).to be_within(0.005.seconds).of(t)

--- a/spec/controller_services/shopping_lists_controller/destroy_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/destroy_service_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe ShoppingListsController::DestroyService do
         end
 
         it 'updates the game' do
-          t = Time.now + 3.days
+          t = Time.zone.now + 3.days
           Timecop.freeze(t) do
             perform
             expect(game.reload.updated_at).to be_within(0.005.seconds).of(t)
@@ -85,7 +85,7 @@ RSpec.describe ShoppingListsController::DestroyService do
         end
 
         it 'updates the game' do
-          t = Time.now + 3.days
+          t = Time.zone.now + 3.days
           Timecop.freeze(t) do
             perform
             expect(game.reload.updated_at).to be_within(0.005.seconds).of(t)

--- a/spec/controller_services/shopping_lists_controller/update_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/update_service_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe ShoppingListsController::UpdateService do
       end
 
       it 'updates the game' do
-        t = Time.now + 3.days
+        t = Time.zone.now + 3.days
         Timecop.freeze(t) do
           perform
           expect(game.reload.updated_at).to be_within(0.005.seconds).of(t)

--- a/spec/lib/controller/response_spec.rb
+++ b/spec/lib/controller/response_spec.rb
@@ -43,8 +43,8 @@ RSpec.describe Controller::Response do
           id:         927,
           user_id:    72,
           title:      'My List 2',
-          created_at: Time.now - 2.days,
-          updated_at: Time.now,
+          created_at: Time.zone.now - 2.days,
+          updated_at: Time.zone.now,
         }
       end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe User, type: :model do
     subject(:create_or_update) { described_class.create_or_update_for_google(payload) }
     let(:payload) do
       {
-        'exp'     => (Time.now + 2.days).to_i,
+        'exp'     => (Time.zone.now + 2.days).to_i,
         'email'   => 'jane.doe@gmail.com',
         'name'    => 'Jane Doe',
         'picture' => 'https://example.com/user_images/89',

--- a/spec/requests/games_spec.rb
+++ b/spec/requests/games_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Games', type: :request do
       let(:user) { create(:user) }
       let(:validation_data) do
         {
-          'exp'   => (Time.now + 1.year).to_i,
+          'exp'   => (Time.zone.now + 1.year).to_i,
           'email' => user.email,
           'name'  => user.name,
         }
@@ -95,7 +95,7 @@ RSpec.describe 'Games', type: :request do
       let(:user) { create(:user) }
       let(:validation_data) do
         {
-          'exp'   => (Time.now + 1.year).to_i,
+          'exp'   => (Time.zone.now + 1.year).to_i,
           'email' => user.email,
           'name'  => user.name,
         }
@@ -186,7 +186,7 @@ RSpec.describe 'Games', type: :request do
       let(:user) { create(:user) }
       let(:validation_data) do
         {
-          'exp'   => (Time.now + 1.year).to_i,
+          'exp'   => (Time.zone.now + 1.year).to_i,
           'email' => user.email,
           'name'  => user.name,
         }
@@ -315,7 +315,7 @@ RSpec.describe 'Games', type: :request do
       let(:user) { create(:user) }
       let(:validation_data) do
         {
-          'exp'   => (Time.now + 1.year).to_i,
+          'exp'   => (Time.zone.now + 1.year).to_i,
           'email' => user.email,
           'name'  => user.name,
         }
@@ -444,7 +444,7 @@ RSpec.describe 'Games', type: :request do
       let(:user) { create(:user) }
       let(:validation_data) do
         {
-          'exp'   => (Time.now + 1.year).to_i,
+          'exp'   => (Time.zone.now + 1.year).to_i,
           'email' => user.email,
           'name'  => user.name,
         }

--- a/spec/requests/shopping_list_items_spec.rb
+++ b/spec/requests/shopping_list_items_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
       let(:validation_data) do
         {
-          'exp'   => (Time.now + 1.year).to_i,
+          'exp'   => (Time.zone.now + 1.year).to_i,
           'email' => user.email,
           'name'  => user.name,
         }
@@ -62,7 +62,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
           end
 
           it 'updates the regular list' do
-            t = Time.now + 3.days
+            t = Time.zone.now + 3.days
             Timecop.freeze(t) do
               create_item
               # use `be_within` even though the time will be set to the time Timecop
@@ -74,7 +74,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
           end
 
           it 'updates the game' do
-            t = Time.now + 3.days
+            t = Time.zone.now + 3.days
             Timecop.freeze(t) do
               create_item
               # use `be_within` even though the time will be set to the time Timecop
@@ -141,7 +141,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
           end
 
           it 'updates the regular list' do
-            t = Time.now + 3.days
+            t = Time.zone.now + 3.days
             Timecop.freeze(t) do
               create_item
               # use `be_within` even though the time will be set to the time Timecop
@@ -153,7 +153,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
           end
 
           it 'updates the game' do
-            t = Time.now + 3.days
+            t = Time.zone.now + 3.days
             Timecop.freeze(t) do
               create_item
               # use `be_within` even though the time will be set to the time Timecop
@@ -165,7 +165,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
           end
 
           it 'updates the game' do
-            t = Time.now + 3.days
+            t = Time.zone.now + 3.days
             Timecop.freeze(t) do
               create_item
               # use `be_within` even though the time will be set to the time Timecop
@@ -209,7 +209,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
           end
 
           it 'updates the regular list' do
-            t = Time.now + 3.days
+            t = Time.zone.now + 3.days
             Timecop.freeze(t) do
               create_item
               # use `be_within` even though the time will be set to the time Timecop
@@ -235,7 +235,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
           end
 
           it 'updates the game' do
-            t = Time.now + 3.days
+            t = Time.zone.now + 3.days
             Timecop.freeze(t) do
               create_item
               # use `be_within` even though the time will be set to the time Timecop
@@ -342,7 +342,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
       let(:validation_data) do
         {
-          'exp'   => (Time.now + 1.year).to_i,
+          'exp'   => (Time.zone.now + 1.year).to_i,
           'email' => user.email,
           'name'  => user.name,
         }
@@ -385,7 +385,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
         end
 
         it 'updates the regular list' do
-          t = Time.now + 3.days
+          t = Time.zone.now + 3.days
           Timecop.freeze(t) do
             update_item
             # use `be_within` even though the time will be set to the time Timecop
@@ -539,7 +539,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
       let(:validation_data) do
         {
-          'exp'   => (Time.now + 1.year).to_i,
+          'exp'   => (Time.zone.now + 1.year).to_i,
           'email' => user.email,
           'name'  => user.name,
         }
@@ -582,7 +582,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
         end
 
         it 'updates the regular list' do
-          t = Time.now + 3.days
+          t = Time.zone.now + 3.days
           Timecop.freeze(t) do
             update_item
             # use `be_within` even though the time will be set to the time Timecop
@@ -734,7 +734,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
       let(:validator) { instance_double(GoogleIDToken::Validator, check: validation_data) }
       let(:validation_data) do
         {
-          'exp'   => (Time.now + 1.year).to_i,
+          'exp'   => (Time.zone.now + 1.year).to_i,
           'email' => game.user.email,
           'name'  => game.user.name,
         }

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'ShoppingLists', type: :request do
       let!(:user) { create(:user) }
       let(:validation_data) do
         {
-          'exp'   => (Time.now + 1.year).to_i,
+          'exp'   => (Time.zone.now + 1.year).to_i,
           'email' => user.email,
           'name'  => user.name,
         }
@@ -166,7 +166,7 @@ RSpec.describe 'ShoppingLists', type: :request do
       let!(:user) { create(:user) }
       let(:validation_data) do
         {
-          'exp'   => (Time.now + 1.year).to_i,
+          'exp'   => (Time.zone.now + 1.year).to_i,
           'email' => user.email,
           'name'  => user.name,
         }
@@ -319,7 +319,7 @@ RSpec.describe 'ShoppingLists', type: :request do
       let!(:user) { create(:user) }
       let(:validation_data) do
         {
-          'exp'   => (Time.now + 1.year).to_i,
+          'exp'   => (Time.zone.now + 1.year).to_i,
           'email' => user.email,
           'name'  => user.name,
         }
@@ -491,7 +491,7 @@ RSpec.describe 'ShoppingLists', type: :request do
       let(:authenticated_user) { create(:user) }
       let(:validation_data) do
         {
-          'exp'   => (Time.now + 1.year).to_i,
+          'exp'   => (Time.zone.now + 1.year).to_i,
           'email' => authenticated_user.email,
           'name'  => authenticated_user.name,
         }
@@ -592,7 +592,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       let(:validation_data) do
         {
-          'exp'   => (Time.now + 1.year).to_i,
+          'exp'   => (Time.zone.now + 1.year).to_i,
           'email' => user1.email,
           'name'  => user1.name,
         }
@@ -625,7 +625,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       let(:validation_data) do
         {
-          'exp'   => (Time.now + 1.year).to_i,
+          'exp'   => (Time.zone.now + 1.year).to_i,
           'email' => user.email,
           'name'  => user.name,
         }
@@ -656,7 +656,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       let(:validation_data) do
         {
-          'exp'   => (Time.now + 1.year).to_i,
+          'exp'   => (Time.zone.now + 1.year).to_i,
           'email' => user.email,
           'name'  => user.name,
         }
@@ -714,7 +714,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       let(:validation_data) do
         {
-          'exp'   => (Time.now + 1.year).to_i,
+          'exp'   => (Time.zone.now + 1.year).to_i,
           'email' => user.email,
           'name'  => user.name,
         }

--- a/spec/requests/verifications_spec.rb
+++ b/spec/requests/verifications_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe 'Verifications', type: :request do
   let(:validator) { instance_double(GoogleIDToken::Validator, check: validator_data) }
 
   around do |example|
-    Timecop.freeze(Time.now) { example.run }
+    Timecop.freeze(Time.zone.now) { example.run }
   end
 
   context 'when the token is valid and verified' do
     let(:validator_data) do
       {
-        'exp'   => (Time.now + 1.year).to_i,
+        'exp'   => (Time.zone.now + 1.year).to_i,
         'email' => 'foobar@gmail.com',
         'name'  => 'Foo Bar',
       }


### PR DESCRIPTION
## Context

[**Add Rubocop for linting**](https://trello.com/c/nb6hbkVa/100-add-rubocop-for-linting)

After installing and configuring Rubocop-Rails, we still had to run it. This PR runs Rubocop-Rails and fixes the violations. Note that fixing some of these violations involved database migrations.

## Changes

* Run rubocop-rails cops with autocorrect
* Add DB migrations to add (scoped) unique indexes to `Game`, `ShoppingList`, and `ShoppingListItem` models
* Make other changes to make Rubocop pass

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~

## Considerations

I had forgotten that scoped indexes could be added at a database level. Rubocop reminded me.