### PR TITLE
Add setup script in dev environments and make Rubocop run in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
           cp config/database.github-actions.yml config/database.yml
           bundle exec rails db:create
           bundle exec rails db:migrate
+      - name: Run Rubocop
+        run: bundle exec rails rubocop
       - name: Run RSpec
         run: |
           bundle exec rails db:prepare

--- a/script/pre-commit
+++ b/script/pre-commit
@@ -7,9 +7,10 @@ function xargs-r() {
     { echo "$path"; cat; } | xargs $@
   fi
 }
-git diff --diff-filter=d --name-only --cached --relative -- '*.rb' 'Gemfile' '*.rake' ':(exclude)db/schema.rb' | xargs-r -E '' -t "bundle exec rails rubocop:auto_correct"
+git diff --diff-filter=d --name-only --cached --relative -- '*.rb' 'Gemfile' '*.rake' ':(exclude)db/schema.rb' | xargs-r -E '' -t "bundle exec rubocop -A"
 if [[ $? -ne 0 ]]; then
   echo 'Aborting commit because Rubocop offenses were detected.'
   echo 'Run `bundle exec rubocop -A <files>` to correct.'
+  echo 'To commit without running Rubocop, run `git commit --no-verify`. This will cause the build to break in CI.'
   exit 1
 fi

--- a/script/pre-commit
+++ b/script/pre-commit
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+function xargs-r() {
+  # Portable version of "xargs -r". The -r flag is a GNU extension that
+  # prevents xargs from running if there are no input files.
+  if IFS= read -r -d $'\n' path; then
+    { echo "$path"; cat; } | xargs $@
+  fi
+}
+git diff --diff-filter=d --name-only --cached --relative -- '*.rb' 'Gemfile' '*.rake' ':(exclude)db/schema.rb' | xargs-r -E '' -t "bundle exec rails rubocop:auto_correct"
+if [[ $? -ne 0 ]]; then
+  echo 'Aborting commit because Rubocop offenses were detected.'
+  echo 'Run `bundle exec rubocop -A <files>` to correct.'
+  exit 1
+fi

--- a/script/pre-commit
+++ b/script/pre-commit
@@ -7,7 +7,7 @@ function xargs-r() {
     { echo "$path"; cat; } | xargs $@
   fi
 }
-git diff --diff-filter=d --name-only --cached --relative -- '*.rb' 'Gemfile' '*.rake' ':(exclude)db/schema.rb' | xargs-r -E '' -t "bundle exec rubocop -A"
+git diff --diff-filter=d --name-only --cached --relative -- '*.rb' 'Gemfile' '*.rake' ':(exclude)db/schema.rb' | xargs-r -E '' -t "bundle exec rubocop"
 if [[ $? -ne 0 ]]; then
   echo 'Aborting commit because Rubocop offenses were detected.'
   echo 'Run `bundle exec rubocop -A <files>` to correct.'

--- a/script/setup.sh
+++ b/script/setup.sh
@@ -21,10 +21,10 @@ bundle exec rails db:setup
 echo "+++ Installing Git precommit hook......."
 
 # Make sure the `.git` directory has a `hooks` subdirectory
-mkdir -p ../.git/hooks
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+mkdir -p "$SCRIPT_DIR/../.git/hooks"
 
 # Copy the pre-commit hook in this directory to that directory
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-cp "$SCRIPT_DIR/pre-commit" ../.git/hooks
+cp "$SCRIPT_DIR/pre-commit" "$SCRIPT_DIR/../.git/hooks"
 
 echo "Done!"

--- a/script/setup.sh
+++ b/script/setup.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Install dependencies
+echo "+++ Installing dependencies......."
+gem install bundler
+bundle install
+
+# Set up the database - requires having Postgres and the pg
+# gem installed. The pg gem will be installed in the first
+# step of this script by Bundler.
+#
+# The `rails db:setup` command, per the ActiveRecord docs,
+# creates the databases (skyrim_inventory_management_development
+# and skyrim_inventory_management_test), loads the schema,
+# and initialises them with seed data.
+echo "+++ Setting up development and test databases......."
+bundle exec rails db:setup
+
+# Install precommit hook to run Rubocop against changed Ruby
+# files before each git commit
+echo "+++ Installing Git precommit hook......."
+
+# Make sure the `.git` directory has a `hooks` subdirectory
+mkdir -p ../.git/hooks
+
+# Copy the pre-commit hook in this directory to that directory
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cp "$SCRIPT_DIR/pre-commit" ../.git/hooks
+
+echo "Done!"


### PR DESCRIPTION
## Context

[**Add Rubocop for linting**](https://trello.com/c/nb6hbkVa/100-add-rubocop-for-linting)

Now that Rubocop has been added and the existing code has been cleaned up to its standards, we need to make Rubocop run in CI. As part of this work, we also want a precommit hook installed to run it against changed Ruby files in dev environments so developers know before committing whether their commit will break CI.

## Changes

* Setup script for dev environments that installs dependencies, sets up the database, and installs the Rubocop precommit hook
* Rubocop step in CI pipeline

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] Added and updated API docs and developer docs as appropriate

## Considerations

I have run the setup script in my local environment to make sure that it is idempotent. I've added documentation noting that the setup script will overwrite any existing precommit hooks and that this cannot be undone.
