### PR TITLE
Return games most recently updated first

### DIFF
--- a/app/controller_services/games_controller/index_service.rb
+++ b/app/controller_services/games_controller/index_service.rb
@@ -10,7 +10,7 @@ class GamesController < ApplicationController
     end
 
     def perform
-      Service::OKResult.new(resource: user.games)
+      Service::OKResult.new(resource: user.games.index_order)
     rescue StandardError => e
       Service::InternalServerErrorResult.new(errors: [e.message])
     end

--- a/spec/controller_services/games_controller/index_service_spec.rb
+++ b/spec/controller_services/games_controller/index_service_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe GamesController::IndexService do
       end
 
       it 'sets the resource to the games' do
-        expect(perform.resource).to eq(user.games)
+        expect(perform.resource).to eq(user.games.index_order)
       end
     end
 

--- a/spec/requests/games_spec.rb
+++ b/spec/requests/games_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'Games', type: :request do
 
         it "returns the authenticated user's games" do
           get_games
-          expect(response.body).to eq(user.games.to_json)
+          expect(response.body).to eq(user.games.index_order.to_json)
         end
       end
 


### PR DESCRIPTION
## Context

[**Game model**](https://trello.com/c/dm3cE8ip/30-game-model)

Testing front-end functionality, I realised that the `GamesController::IndexService` was returning games in their default order instead of most recently updated first. 

## Changes

* Ensure `IndexService` returns games in order from most recently updated to least recently updated
* Fix tests

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [ ] ~~Added and updated API docs and developer docs as appropriate~~
