### PR TITLE
Make uniqueness validation case insensitive

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -7,7 +7,7 @@ class Game < ApplicationRecord
   has_many :shopping_lists, -> { index_order }, dependent: :destroy, inverse_of: :game
 
   validates :name,
-            uniqueness: { scope: :user_id, message: 'must be unique' },
+            uniqueness: { scope: :user_id, message: 'must be unique', case_sensitive: false },
             format:     {
                           with:    /\A\s*[a-z0-9 \-',]*\s*\z/i,
                           message: "can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')",

--- a/app/models/shopping_list.rb
+++ b/app/models/shopping_list.rb
@@ -8,7 +8,7 @@ class ShoppingList < ApplicationRecord
   # other than spaces. Leading or trailing whitespace is stripped anyway so the validation
   # ignores any leading or trailing whitespace characters.
   validates :title,
-            uniqueness: { scope: :game_id },
+            uniqueness: { scope: :game_id, message: 'must be unique per game', case_sensitive: false },
             format:     {
                           with:    /\A\s*[a-z0-9 \-',]*\s*\z/i,
                           message: "can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')",

--- a/docs/api/resources/shopping-lists.md
+++ b/docs/api/resources/shopping-lists.md
@@ -247,7 +247,7 @@ If the game with the given `game_id` is not found or does not belong to the auth
 If duplicate title is given:
 ```json
 {
-  "errors": ["Title has already been taken"]
+  "errors": ["Title must be unique per game"]
 }
 ```
 
@@ -345,7 +345,7 @@ For a 404 response, no response body is returned.
 For a 422 response due to title uniqueness constraint:
 ```json
 {
-  "errors": ["Title has already been taken"]
+  "errors": ["Title must be unique per game"]
 }
 ```
 

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
         it 'returns the errors' do
           create_shopping_list
-          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Title has already been taken'] })
+          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Title must be unique per game'] })
         end
       end
 
@@ -219,7 +219,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
         it 'returns the errors' do
           update_shopping_list
-          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Title has already been taken'] })
+          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Title must be unique per game'] })
         end
       end
 
@@ -372,7 +372,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
         it 'returns the errors' do
           update_shopping_list
-          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Title has already been taken'] })
+          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Title must be unique per game'] })
         end
       end
 


### PR DESCRIPTION
## Context

This PR fixes a bug where the `Game` model was raising Postgres uniqueness constraint errors because the ActiveRecord validation was case-sensitive.

## Changes

* Make ActiveRecord uniqueness validations case-insensitive to fix internal server errors

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~

## Considerations

It was the `Game` model that was causing these errors when I was working with the front end, but I saw the issue existed on the `ShoppingList` model for the same reason and fixed it there too. The reason is that the ActiveRecord validations run before the `before_save` hook that corrects/standardises casing in game names and shopping list titles. The alternative would be to make these into `before_validation` callbacks, but I didn't want to mess with callback order too much. It seemed less risky, and functionally equivalent, to make the comparisons case-insensitive.