### PR TITLE
Fix bug in shopping list deletion

### DIFF
--- a/docs/api/resources/shopping-lists.md
+++ b/docs/api/resources/shopping-lists.md
@@ -19,7 +19,6 @@ Like other resources in SIM, shopping lists are scoped to the authenticated user
 ## Endpoints
 
 * [`GET /games/:game_id/shopping_lists`](#get-gamesgame_idshopping_lists)
-* [`GET /shopping_lists/:id`](#get-shopping_listsid)
 * [`POST /games/:game_id/shopping_lists`](#post-gamesgame_idshopping_lists)
 * [`PATCH|PUT /shopping_lists/:id`](#patchput-shopping_listsid)
 * [`DELETE /shopping_lists/:id`](#delete-shopping_listsid)

--- a/spec/factories/games.rb
+++ b/spec/factories/games.rb
@@ -23,12 +23,11 @@ FactoryBot.define do
       end
 
       after(:create) do |game, evaluator|
-        aggregate_list = create(:aggregate_shopping_list, game: game)
         shopping_lists = create_list(:shopping_list_with_list_items, evaluator.shopping_list_count, game: game)
 
         shopping_lists.each do |list|
           list.list_items.each do |item|
-            aggregate_list.add_item_from_child_list(item)
+            list.aggregate_list.add_item_from_child_list(item)
           end
         end
       end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -60,7 +60,9 @@ RSpec.describe Game, type: :model do
     # aggregate list wasn't necessarily destroyed last. The Aggregatable concern
     # prevents aggregate lists from being destroyed if they have child lists.
     # However, since the index_order scope puts the aggregate list first, it is
-    # the first list the game attempts to destroy.
+    # the first list the game attempts to destroy. We had to implement another
+    # `before_destroy` callback to ensure this behaviour didn't make it impossible
+    # to destroy a game with shopping lists.
 
     it "destroys all the game's shopping lists" do
       expect { game.destroy! }

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -62,12 +62,12 @@ RSpec.describe Game, type: :model do
     # However, since the index_order scope puts the aggregate list first, it is
     # the first list the game attempts to destroy.
 
-    it 'destroys all shopping lists' do
+    it "destroys all the game's shopping lists" do
       expect { game.destroy! }
         .to change(ShoppingList, :count).from(3).to(0)
     end
 
-    it 'destroys all shopping list items' do
+    it "destroys all the game's shopping list items" do
       expect { game.destroy! }
         .to change(ShoppingListItem, :count).from(8).to(0)
     end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -52,6 +52,27 @@ RSpec.describe Game, type: :model do
     end
   end
 
+  describe 'relations' do
+    let!(:game) { create(:game_with_shopping_lists_and_items, user: user) }
+
+    # This is a regression test. Games were failing to be destroyed because, when
+    # destroying their child models (i.e., shopping lists, at this point), the
+    # aggregate list wasn't necessarily destroyed last. The Aggregatable concern
+    # prevents aggregate lists from being destroyed if they have child lists.
+    # However, since the index_order scope puts the aggregate list first, it is
+    # the first list the game attempts to destroy.
+
+    it 'destroys all shopping lists' do
+      expect { game.destroy! }
+        .to change(ShoppingList, :count).from(3).to(0)
+    end
+
+    it 'destroys all shopping list items' do
+      expect { game.destroy! }
+        .to change(ShoppingListItem, :count).from(8).to(0)
+    end
+  end
+
   describe 'name transformations' do
     context 'when the user has set a name' do
       subject(:name) { user.games.create!(name: 'Skyrim, Baby').name }
@@ -139,7 +160,7 @@ RSpec.describe Game, type: :model do
   describe '#aggregate_shopping_list' do
     subject(:aggregate_shopping_list) { game.aggregate_shopping_list }
 
-    let(:game) { create(:game) }
+    let(:game)            { create(:game) }
     let!(:aggregate_list) { create(:aggregate_shopping_list, game: game) }
 
     before do


### PR DESCRIPTION
## Context

The `Game` model defines its association to shopping lists as `has_many :shopping_lists, dependent: :destroy`. `dependent: :destroy` is implemented internally as a `before_destroy` callback that iterates through child models in the order they appear when called with whatever scope is used. In the case of these models, that order is `index_order`, in which the aggregate shopping list comes first, followed by other shopping lists in descending order of `:updated_at`.

This was resulting in an issue where game models with shopping lists could never be destroyed. The reason is that, in the `Aggregatable` concern, there is another `before_destroy` callback that, before destroying a list, ensures that the list is either not an aggregate list or, if it is an aggregate list, that it has no remaining child lists. In other words, all regular lists belonging to a particular game have to be destroyed before the aggregate list can be.

## Changes

* Add `before_destroy` callback to `Game` model to destroy any shopping lists belonging to the game before `dependent: :destroy` is called
* Add regression tests 

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [ ] ~~Added and updated API docs and developer docs as appropriate~~

## Considerations

This is not a common issue in ActiveRecord since usually child models are independent of each other, so I wasn't able to find any docs, blog posts, or StackOverflow answers detailing whether or how one could specify the order in which child models are destroyed. Consequently, I had to find another way to ensure the models were destroyed in an order that didn't cause errors to be raised.

Ordinarily, I like to define all model associations at the top of the model class. However, since `dependent: :destroy` is implemented as a `before_destroy` callback and these are executed in the order in which they're defined, the callbacks needed to come before this association was defined. The `before_save` callback then had to be moved to be above the `before_destroy` callback.