### PR TITLE
Update docs

### DIFF
--- a/docs/api/resources/shopping-list-items.md
+++ b/docs/api/resources/shopping-list-items.md
@@ -81,11 +81,14 @@ Content-Type: application/json
 
 #### Statuses
 
+* 201 Created
 * 200 OK
 
 #### Example Body
 
-Body contains the updated item from the aggregate list first and the item from the regular list that you requested second.
+If there is no item with a matching description on the requested shopping list, a new item will be created and the server will return a 201 response. If there is an item with a matching description, its notes and quantity will be combined with the notes and quantity in the client request and a 200 response will be returned.
+
+The body for both responses contains the updated item from the aggregate list first and the requested regular list item second.
 ```json
 [
   {


### PR DESCRIPTION
## Context

[**Make shopping list items create endpoint return 201 if item created**](https://trello.com/c/k62YLJQ6/126-make-shopping-list-items-create-endpoint-return-201-if-item-created)

The docs indicated that the only possible response from `POST /shopping_lists/:list_id/shopping_list_items` was 200. Desired behaviour, which turned out to also already be the actual behaviour, was for the back end to return a 201 if a new list item was created and 200 if it was combined with an existing list item.

## Changes

* Update docs to reflect actual behaviour of API endpoint (since that is also the desired behaviour)

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [x] Added and updated API docs and developer docs as appropriate
