### PR TITLE
Create InventoryList and InventoryListItem models

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -34,6 +34,10 @@ class Game < ApplicationRecord
     shopping_lists.find_by(aggregate: true)
   end
 
+  def aggregate_inventory_list
+    inventory_lists.find_by(aggregate: true)
+  end
+
   def shopping_list_items
     ShoppingListItem.belonging_to_game(self)
   end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -42,6 +42,10 @@ class Game < ApplicationRecord
     ShoppingListItem.belonging_to_game(self)
   end
 
+  def inventory_list_items
+    InventoryListItem.belonging_to_game(self)
+  end
+
   private
 
   def format_name

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -19,6 +19,7 @@ class Game < ApplicationRecord
   # association is defined.
   before_destroy :destroy_aggregatable_child_models
   has_many :shopping_lists, -> { index_order }, dependent: :destroy, inverse_of: :game
+  has_many :inventory_lists, -> { index_order }, dependent: :destroy, inverse_of: :game
 
   validates :name,
             uniqueness: { scope: :user_id, message: 'must be unique', case_sensitive: false },
@@ -57,5 +58,6 @@ class Game < ApplicationRecord
   # deleted, it's necessary to do it in a before hook.
   def destroy_aggregatable_child_models
     shopping_lists.reverse.each(&:destroy)
+    inventory_lists.reverse.each(&:destroy)
   end
 end

--- a/app/models/inventory_list.rb
+++ b/app/models/inventory_list.rb
@@ -1,6 +1,17 @@
 # frozen_string_literal: true
 
 class InventoryList < ApplicationRecord
+  # Titles have to be unique per game as described in the API docs. They also can only
+  # contain alphanumeric characters and spaces with no special characters or whitespace
+  # other than spaces. Leading or trailing whitespace is stripped anyway so the validation
+  # ignores any leading or trailing whitespace characters.
+  validates :title,
+            uniqueness: { scope: :game_id, message: 'must be unique per game', case_sensitive: false },
+            format:     {
+                          with:    /\A\s*[a-z0-9 \-',]*\s*\z/i,
+                          message: "can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')",
+                        }
+
   # This has to be defined before including AggregateListable because its `included` block
   # calls this method.
   def self.list_item_class_name

--- a/app/models/inventory_list.rb
+++ b/app/models/inventory_list.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class InventoryList < ApplicationRecord
+  # This has to be defined before including AggregateListable because its `included` block
+  # calls this method.
+  def self.list_item_class_name
+    'InventoryListItem'
+  end
+
+  include Aggregatable
+
+  scope :index_order, -> { includes_items.aggregate_first.order(updated_at: :desc) }
+  scope :belonging_to_user, ->(user) { joins(:game).where(games: { user_id: user.id }).order('inventory_lists.updated_at DESC') }
+end

--- a/app/models/inventory_list.rb
+++ b/app/models/inventory_list.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'titlecase'
+
 class InventoryList < ApplicationRecord
   # Titles have to be unique per game as described in the API docs. They also can only
   # contain alphanumeric characters and spaces with no special characters or whitespace
@@ -12,6 +14,8 @@ class InventoryList < ApplicationRecord
                           message: "can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')",
                         }
 
+  before_save :format_title
+
   # This has to be defined before including AggregateListable because its `included` block
   # calls this method.
   def self.list_item_class_name
@@ -22,4 +26,19 @@ class InventoryList < ApplicationRecord
 
   scope :index_order, -> { includes_items.aggregate_first.order(updated_at: :desc) }
   scope :belonging_to_user, ->(user) { joins(:game).where(games: { user_id: user.id }).order('inventory_lists.updated_at DESC') }
+
+  private
+
+  def format_title
+    return if aggregate
+
+    if title.blank?
+      max_existing_number = game.inventory_lists.where("title LIKE 'My List %'").pluck(:title).map {|t| t.gsub('My List ', '').to_i }
+                              .max || 0
+      next_number         = max_existing_number >= 0 ? max_existing_number + 1 : 1
+      self.title          = "My List #{next_number}"
+    else
+      self.title = Titlecase.titleize(title.strip)
+    end
+  end
 end

--- a/app/models/inventory_list_item.rb
+++ b/app/models/inventory_list_item.rb
@@ -5,6 +5,7 @@ class InventoryListItem < ApplicationRecord
 
   validates :description, presence: true, uniqueness: { scope: :list_id, case_sensitive: false }
   validates :quantity, presence: true, numericality: { only_integer: true, greater_than: 0 }
+  validates :unit_weight, numericality: { greater_than_or_equal_to: 0, allow_nil: true }
   validate :prevent_changed_description, on: :update
 
   before_save :clean_up_notes

--- a/app/models/inventory_list_item.rb
+++ b/app/models/inventory_list_item.rb
@@ -3,7 +3,57 @@
 class InventoryListItem < ApplicationRecord
   belongs_to :list, class_name: 'InventoryList', touch: true
 
+  validates :description, presence: true, uniqueness: { scope: :list_id, case_sensitive: false }
+  validates :quantity, presence: true, numericality: { only_integer: true, greater_than: 0 }
+  validate :prevent_changed_description, on: :update
+
+  before_save :clean_up_notes
+
   delegate :game, :user, to: :list
 
   scope :index_order, -> { order(updated_at: :desc) }
+  scope :belonging_to_game, ->(game) { joins(:list).where(inventory_lists: { game_id: game.id }).order('inventory_lists.updated_at DESC') }
+
+  def self.belonging_to_user(user)
+    inventory_list_ids = InventoryList.belonging_to_user(user).ids
+    joins(:list).where(inventory_lists: { id: inventory_list_ids }).order('inventory_lists.updated_at DESC')
+  end
+
+  def self.combine_or_create!(attrs)
+    obj = combine_or_new(attrs)
+    obj.save!
+    obj
+  end
+
+  def self.combine_or_new(attrs)
+    inventory_list = attrs[:list] || attrs['list'] || InventoryList.find(attrs[:list_id] || attrs['list_id'])
+    desc           = (attrs[:description] || attrs['description'])
+    existing_item  = inventory_list.list_items.find_by('description ILIKE ?', desc)
+
+    if existing_item.nil?
+      new attrs
+    else
+      qty       = attrs[:quantity] || attrs['quantity'] || 1
+      new_notes = attrs[:notes] || attrs['notes']
+      old_notes = existing_item.notes
+
+      new_quantity = existing_item.quantity + qty
+      new_notes    = [old_notes, new_notes].compact.join(' -- ').presence
+
+      existing_item.assign_attributes(quantity: new_quantity, notes: new_notes)
+      existing_item
+    end
+  end
+
+  private
+
+  def prevent_changed_description
+    errors.add(:description, 'cannot be updated on an existing list item') if description_changed?
+  end
+
+  def clean_up_notes
+    return true unless notes
+
+    self.notes = notes.strip.gsub(/^(-- ?)*/, '').gsub(/( ?--)*$/, '').gsub(/( -- ){2,}/, ' -- ').presence
+  end
 end

--- a/app/models/inventory_list_item.rb
+++ b/app/models/inventory_list_item.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class InventoryListItem < ApplicationRecord
+  belongs_to :list, class_name: 'InventoryList', touch: true
+
+  delegate :game, :user, to: :list
+
+  scope :index_order, -> { order(updated_at: :desc) }
+end

--- a/app/models/shopping_list.rb
+++ b/app/models/shopping_list.rb
@@ -3,7 +3,7 @@
 require 'titlecase'
 
 class ShoppingList < ApplicationRecord
-  # Titles have to be unique per user as described in the API docs. They also can only
+  # Titles have to be unique per game as described in the API docs. They also can only
   # contain alphanumeric characters and spaces with no special characters or whitespace
   # other than spaces. Leading or trailing whitespace is stripped anyway so the validation
   # ignores any leading or trailing whitespace characters.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,7 +20,15 @@ class User < ApplicationRecord
     ShoppingList.belonging_to_user(self)
   end
 
+  def inventory_lists
+    InventoryList.belonging_to_user(self)
+  end
+
   def shopping_list_items
     ShoppingListItem.belonging_to_user(self)
+  end
+
+  def inventory_list_items
+    InventoryListItem.belonging_to_user(self)
   end
 end

--- a/db/migrate/20210807222345_create_inventory_lists.rb
+++ b/db/migrate/20210807222345_create_inventory_lists.rb
@@ -11,6 +11,6 @@ class CreateInventoryLists < ActiveRecord::Migration[6.1]
       t.timestamps
     end
 
-    add_index :inventory_lists, %i[title game_id]
+    add_index :inventory_lists, %i[title game_id], unique: true
   end
 end

--- a/db/migrate/20210807222345_create_inventory_lists.rb
+++ b/db/migrate/20210807222345_create_inventory_lists.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateInventoryLists < ActiveRecord::Migration[6.1]
+  def change
+    create_table :inventory_lists do |t|
+      t.references :game, null: false, foreign_key: true
+      t.references :aggregate_list, foreign_key: { to_table: 'inventory_lists' }
+      t.string :title, null: false
+      t.boolean :aggregate, null: false, default: false
+
+      t.timestamps
+    end
+
+    add_index :inventory_lists, %i[title game_id]
+  end
+end

--- a/db/migrate/20210807224149_create_inventory_list_items.rb
+++ b/db/migrate/20210807224149_create_inventory_list_items.rb
@@ -6,6 +6,7 @@ class CreateInventoryListItems < ActiveRecord::Migration[6.1]
       t.references :list, null: false, foreign_key: { to_table: 'inventory_lists' }
       t.string :description, null: false
       t.string :notes
+      t.integer :quantity, null: false, default: 1
       t.decimal :weight, precision: 5, scale: 1
 
       t.timestamps

--- a/db/migrate/20210807224149_create_inventory_list_items.rb
+++ b/db/migrate/20210807224149_create_inventory_list_items.rb
@@ -7,7 +7,7 @@ class CreateInventoryListItems < ActiveRecord::Migration[6.1]
       t.string :description, null: false
       t.string :notes
       t.integer :quantity, null: false, default: 1
-      t.decimal :weight, precision: 5, scale: 1
+      t.decimal :unit_weight, precision: 5, scale: 1
 
       t.timestamps
     end

--- a/db/migrate/20210807224149_create_inventory_list_items.rb
+++ b/db/migrate/20210807224149_create_inventory_list_items.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateInventoryListItems < ActiveRecord::Migration[6.1]
+  def change
+    create_table :inventory_list_items do |t|
+      t.references :list, null: false, foreign_key: { to_table: 'inventory_lists' }
+      t.string :description, null: false
+      t.string :notes
+      t.decimal :weight, precision: 5, scale: 1
+
+      t.timestamps
+    end
+
+    add_index :inventory_list_items, %i[description list_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_17_103734) do
+ActiveRecord::Schema.define(version: 2021_08_07_222345) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,18 @@ ActiveRecord::Schema.define(version: 2021_07_17_103734) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["name", "user_id"], name: "index_games_on_name_and_user_id", unique: true
     t.index ["user_id"], name: "index_games_on_user_id"
+  end
+
+  create_table "inventory_lists", force: :cascade do |t|
+    t.bigint "game_id", null: false
+    t.bigint "aggregate_list_id"
+    t.string "title", null: false
+    t.boolean "aggregate", default: false, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["aggregate_list_id"], name: "index_inventory_lists_on_aggregate_list_id"
+    t.index ["game_id"], name: "index_inventory_lists_on_game_id"
+    t.index ["title", "game_id"], name: "index_inventory_lists_on_title_and_game_id"
   end
 
   create_table "shopping_list_items", force: :cascade do |t|
@@ -60,6 +72,8 @@ ActiveRecord::Schema.define(version: 2021_07_17_103734) do
   end
 
   add_foreign_key "games", "users"
+  add_foreign_key "inventory_lists", "games"
+  add_foreign_key "inventory_lists", "inventory_lists", column: "aggregate_list_id"
   add_foreign_key "shopping_list_items", "shopping_lists", column: "list_id"
   add_foreign_key "shopping_lists", "games"
   add_foreign_key "shopping_lists", "shopping_lists", column: "aggregate_list_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_07_222345) do
+ActiveRecord::Schema.define(version: 2021_08_07_224149) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,17 @@ ActiveRecord::Schema.define(version: 2021_08_07_222345) do
     t.index ["user_id"], name: "index_games_on_user_id"
   end
 
+  create_table "inventory_list_items", force: :cascade do |t|
+    t.bigint "list_id", null: false
+    t.string "description", null: false
+    t.string "notes"
+    t.decimal "weight", precision: 5, scale: 1
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["description", "list_id"], name: "index_inventory_list_items_on_description_and_list_id", unique: true
+    t.index ["list_id"], name: "index_inventory_list_items_on_list_id"
+  end
+
   create_table "inventory_lists", force: :cascade do |t|
     t.bigint "game_id", null: false
     t.bigint "aggregate_list_id"
@@ -34,7 +45,7 @@ ActiveRecord::Schema.define(version: 2021_08_07_222345) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["aggregate_list_id"], name: "index_inventory_lists_on_aggregate_list_id"
     t.index ["game_id"], name: "index_inventory_lists_on_game_id"
-    t.index ["title", "game_id"], name: "index_inventory_lists_on_title_and_game_id"
+    t.index ["title", "game_id"], name: "index_inventory_lists_on_title_and_game_id", unique: true
   end
 
   create_table "shopping_list_items", force: :cascade do |t|
@@ -72,6 +83,7 @@ ActiveRecord::Schema.define(version: 2021_08_07_222345) do
   end
 
   add_foreign_key "games", "users"
+  add_foreign_key "inventory_list_items", "inventory_lists", column: "list_id"
   add_foreign_key "inventory_lists", "games"
   add_foreign_key "inventory_lists", "inventory_lists", column: "aggregate_list_id"
   add_foreign_key "shopping_list_items", "shopping_lists", column: "list_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -29,6 +29,7 @@ ActiveRecord::Schema.define(version: 2021_08_07_224149) do
     t.bigint "list_id", null: false
     t.string "description", null: false
     t.string "notes"
+    t.integer "quantity", default: 1, null: false
     t.decimal "weight", precision: 5, scale: 1
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -30,7 +30,7 @@ ActiveRecord::Schema.define(version: 2021_08_07_224149) do
     t.string "description", null: false
     t.string "notes"
     t.integer "quantity", default: 1, null: false
-    t.decimal "weight", precision: 5, scale: 1
+    t.decimal "unit_weight", precision: 5, scale: 1
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["description", "list_id"], name: "index_inventory_list_items_on_description_and_list_id", unique: true

--- a/spec/factories/games.rb
+++ b/spec/factories/games.rb
@@ -32,5 +32,32 @@ FactoryBot.define do
         end
       end
     end
+
+    factory :game_with_inventory_lists do
+      transient do
+        inventory_list_count { 2 }
+      end
+
+      after(:create) do |game, evaluator|
+        create(:aggregate_inventory_list, game: game)
+        create_list(:inventory_list, evaluator.inventory_list_count, game: game)
+      end
+    end
+
+    factory :game_with_inventory_lists_and_items do
+      transient do
+        inventory_list_count { 2 }
+      end
+
+      after(:create) do |game, evaluator|
+        inventory_lists = create_list(:inventory_list_with_list_items, evaluator.inventory_list_count, game: game)
+
+        inventory_lists.each do |list|
+          list.list_items.each do |item|
+            list.aggregate_list.add_item_from_child_list(item)
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/factories/games.rb
+++ b/spec/factories/games.rb
@@ -59,5 +59,30 @@ FactoryBot.define do
         end
       end
     end
+
+    factory :game_with_everything do
+      transient do
+        shopping_list_count { 2 }
+        inventory_list_count { 2 }
+      end
+
+      after(:create) do |game, evaluator|
+        inventory_lists = create_list(:inventory_list_with_list_items, evaluator.inventory_list_count, game: game)
+
+        inventory_lists.each do |list|
+          list.list_items.each do |item|
+            list.aggregate_list.add_item_from_child_list(item)
+          end
+        end
+
+        shopping_lists = create_list(:shopping_list_with_list_items, evaluator.shopping_list_count, game: game)
+
+        shopping_lists.each do |list|
+          list.list_items.each do |item|
+            list.aggregate_list.add_item_from_child_list(item)
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/factories/inventory_list_items.rb
+++ b/spec/factories/inventory_list_items.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :inventory_list_item do
+    association :list, factory: :inventory_list
+
+    sequence(:description) {|n| "Item #{n}" }
+    quantity { 1 }
+  end
+end

--- a/spec/factories/inventory_lists.rb
+++ b/spec/factories/inventory_lists.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :inventory_list do
+    game
+
+    sequence(:title) {|n| "Inventory List #{n}" }
+
+    factory :aggregate_inventory_list do
+      aggregate { true }
+
+      title { 'All Items' }
+      aggregate_list_id { nil }
+    end
+
+    factory :inventory_list_with_list_items do
+      transient do
+        list_item_count { 2 }
+      end
+
+      after(:create) do |list, evaluator|
+        create_list(:inventory_list_item, evaluator.list_item_count, list: list)
+      end
+    end
+  end
+end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -174,6 +174,21 @@ RSpec.describe Game, type: :model do
     end
   end
 
+  describe '#aggregate_inventory_list' do
+    subject(:aggregate_inventory_list) { game.aggregate_inventory_list }
+
+    let(:game)            { create(:game) }
+    let!(:aggregate_list) { create(:aggregate_inventory_list, game: game) }
+
+    before do
+      create_list(:inventory_list, 2, game: game)
+    end
+
+    it "returns that game's aggregate inventory list" do
+      expect(aggregate_inventory_list).to eq aggregate_list
+    end
+  end
+
   describe '#shopping_list_items' do
     subject(:shopping_list_items) { game.shopping_list_items.to_a.sort }
 

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Game, type: :model do
   end
 
   describe 'relations' do
-    let!(:game) { create(:game_with_shopping_lists_and_items, user: user) }
+    let!(:game) { create(:game_with_everything, user: user) }
 
     # This is a regression test. Games were failing to be destroyed because, when
     # destroying their child models (i.e., shopping lists, at this point), the
@@ -72,6 +72,16 @@ RSpec.describe Game, type: :model do
     it "destroys all the game's shopping list items" do
       expect { game.destroy! }
         .to change(ShoppingListItem, :count).from(8).to(0)
+    end
+
+    it "destroys all the game's inventory lists" do
+      expect { game.destroy! }
+        .to change(InventoryList, :count).from(3).to(0)
+    end
+
+    it "destroys all the game's inventory list items" do
+      expect { game.destroy! }
+        .to change(InventoryListItem, :count).from(8).to(0)
     end
   end
 

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -52,17 +52,16 @@ RSpec.describe Game, type: :model do
     end
   end
 
-  describe 'relations' do
+  describe '#destroy!' do
     let!(:game) { create(:game_with_everything, user: user) }
 
     # This is a regression test. Games were failing to be destroyed because, when
-    # destroying their child models (i.e., shopping lists, at this point), the
-    # aggregate list wasn't necessarily destroyed last. The Aggregatable concern
-    # prevents aggregate lists from being destroyed if they have child lists.
-    # However, since the index_order scope puts the aggregate list first, it is
-    # the first list the game attempts to destroy. We had to implement another
-    # `before_destroy` callback to ensure this behaviour didn't make it impossible
-    # to destroy a game with shopping lists.
+    # destroying their shopping lists, the aggregate list wasn't necessarily
+    # destroyed last. The Aggregatable concern prevents aggregate lists from being
+    # destroyed if they have child lists. However, since the index_order scope puts
+    # the aggregate list first, it is the first list the game attempts to destroy.
+    # We had to implement another `before_destroy` callback to ensure this behaviour
+    # didn't make it impossible to destroy a game with Aggregatable child models.
 
     it "destroys all the game's shopping lists" do
       expect { game.destroy! }

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -207,4 +207,23 @@ RSpec.describe Game, type: :model do
       expect(shopping_list_items).to eq items
     end
   end
+
+  describe '#inventory_list_items' do
+    subject(:inventory_list_items) { game.inventory_list_items.to_a.sort }
+
+    let(:game) { create(:game, user: user) }
+
+    before do
+      create_list(:inventory_list_with_list_items, 2, game: game)
+      create(:game_with_inventory_lists_and_items, user: user) # one that shouldn't be included
+    end
+
+    it 'returns all list items belonging to the game' do
+      items = game.inventory_lists.map {|list| list.list_items.to_a }
+      items.flatten!
+      items.sort!
+
+      expect(inventory_list_items).to eq items
+    end
+  end
 end

--- a/spec/models/inventory_list_item_spec.rb
+++ b/spec/models/inventory_list_item_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe InventoryListItem, type: :model do
+  let!(:game) { create(:game) }
+
+  describe 'delegation' do
+    let(:inventory_list) { create(:inventory_list, game: game) }
+    let(:list_item)      { create(:inventory_list_item, list: inventory_list) }
+
+    before do
+      create(:aggregate_inventory_list, game: game)
+    end
+
+    describe '#game' do
+      it 'returns the game its InventoryList belongs to' do
+        expect(list_item.game).to eq(game)
+      end
+    end
+
+    describe '#user' do
+      it 'returns the user its game belongs to' do
+        expect(list_item.user).to eq(game.user)
+      end
+    end
+  end
+end

--- a/spec/models/inventory_list_item_spec.rb
+++ b/spec/models/inventory_list_item_spec.rb
@@ -25,4 +25,144 @@ RSpec.describe InventoryListItem, type: :model do
       end
     end
   end
+
+  describe 'scopes' do
+    describe '::index_order' do
+      let!(:aggregate_list) { create(:aggregate_shopping_list) }
+
+      let!(:list_item1) { create(:shopping_list_item, list: list) }
+      let!(:list_item2) { create(:shopping_list_item, list: list) }
+      let!(:list_item3) { create(:shopping_list_item, list: list) }
+
+      let(:list) { create(:shopping_list, game: aggregate_list.game) }
+
+      before do
+        list_item2.update!(quantity: 3)
+      end
+
+      it 'returns the list items in descending chronological order by updated_at' do
+        expect(list.list_items.index_order.to_a).to eq([list_item2, list_item3, list_item1])
+      end
+    end
+
+    describe '::belonging_to_game' do
+      let!(:list1) { create(:inventory_list_with_list_items, game: game) }
+      let!(:list2) { create(:inventory_list_with_list_items, game: game) }
+      let!(:list3) { create(:inventory_list_with_list_items, game: game) }
+
+      it 'returns all list items from all the lists for the given game' do
+        # We don't actually care what order these are in since we currently only use this
+        # scope to determine whether a given item belongs to a particular game
+        items = [
+                  list1.list_items.to_a,
+                  list2.list_items.to_a,
+                  list3.list_items.to_a,
+                ].flatten!
+
+        expect(described_class.belonging_to_game(game).to_a.sort).to eq(items.sort)
+      end
+    end
+
+    describe '::belonging_to_user' do
+      # We're going to sort these because we don't actually care what order they're in
+      subject(:belonging_to_user) { described_class.belonging_to_user(user).to_a.sort }
+
+      let(:user) { game.user }
+
+      before do
+        create(:inventory_list_with_list_items, game: game)
+        create(:game_with_inventory_lists_and_items, user: user)
+        create(:game_with_inventory_lists_and_items, user: user)
+        create(:inventory_list_with_list_items) # one from a different user
+      end
+
+      it 'returns all the list items belonging to the user', :aggregate_failures do
+        all_items = []
+        user.inventory_lists.each {|list| all_items << list.list_items }
+        all_items.flatten!.sort!
+
+        expect(belonging_to_user).to eq all_items
+      end
+    end
+  end
+
+  describe '::combine_or_create!' do
+    context 'when there is an existing item on the same list with the same (case-insensitive) description' do
+      subject(:combine_or_create) { described_class.combine_or_create!(description: 'existing item', quantity: 1, list: inventory_list, notes: 'notes 2') }
+
+      let(:aggregate_list)  { create(:aggregate_inventory_list) }
+      let!(:inventory_list) { create(:inventory_list, game: aggregate_list.game) }
+      let!(:existing_item)  { create(:inventory_list_item, description: 'ExIsTiNg ItEm', quantity: 2, list: inventory_list, notes: 'notes 1') }
+
+      it "doesn't create a new list item" do
+        expect { combine_or_create }
+          .not_to change(inventory_list.list_items, :count)
+      end
+
+      it 'adds the quantity to the existing item' do
+        combine_or_create
+        expect(existing_item.reload.quantity).to eq 3
+      end
+
+      it 'concatenates the notes for the two items' do
+        combine_or_create
+        expect(existing_item.reload.notes).to eq 'notes 1 -- notes 2'
+      end
+    end
+  end
+
+  describe '::combine_or_new' do
+    context 'when there is an existing item on the same list with the same (case-insensitive) description' do
+      subject(:combine_or_new) { described_class.combine_or_new(description: 'existing item', quantity: 1, list: inventory_list, notes: 'notes 2') }
+
+      let(:aggregate_list) { create(:aggregate_inventory_list) }
+      let!(:inventory_list) { create(:inventory_list, game: aggregate_list.game) }
+      let!(:existing_item)  { create(:inventory_list_item, description: 'ExIsTiNg ItEm', quantity: 2, list: inventory_list, notes: 'notes 1') }
+
+      before do
+        allow(described_class).to receive(:new)
+      end
+
+      it "doesn't instantiate a new item" do
+        combine_or_new
+        expect(described_class).not_to have_received(:new)
+      end
+
+      it 'returns the existing item with the quantity updated', :aggregate_failures do
+        expect(combine_or_new).to eq existing_item
+        expect(combine_or_new.quantity).to eq 3
+      end
+
+      it 'concatenates the notes for the two items', :aggregate_failures do
+        expect(combine_or_new).to eq existing_item
+        expect(combine_or_new.notes).to eq 'notes 1 -- notes 2'
+      end
+    end
+
+    context 'when there is not an existing item on the same list with that description' do
+      subject(:combine_or_create) { described_class.combine_or_create!(description: 'new item', quantity: 1, list: inventory_list) }
+
+      let(:aggregate_list) { create(:aggregate_inventory_list) }
+      let!(:inventory_list) { create(:inventory_list, game: aggregate_list.game) }
+
+      it 'creates a new item on the list' do
+        expect { combine_or_create }
+          .to change(inventory_list.list_items, :count).by(1)
+      end
+    end
+  end
+
+  describe 'notes field' do
+    it 'cleans up leading and trailing dashes or whitespace' do
+      inventory_list_item = build(:inventory_list_item, notes: ' -- some notes --')
+      expect { inventory_list_item.save }
+        .to change(inventory_list_item, :notes).to('some notes')
+    end
+
+    it 'saves as nil if it consists only of dashes' do
+      inventory_list_item = build(:inventory_list_item, notes: '--')
+      expect { inventory_list_item.save }
+        .to change(inventory_list_item, :notes).to(nil)
+    end
+  end
 end

--- a/spec/models/inventory_list_item_spec.rb
+++ b/spec/models/inventory_list_item_spec.rb
@@ -152,6 +152,30 @@ RSpec.describe InventoryListItem, type: :model do
     end
   end
 
+  describe '#update!' do
+    let(:aggregate_list) { create(:aggregate_inventory_list) }
+    let(:inventory_list) { create(:inventory_list, game: aggregate_list.game) }
+    let!(:list_item)     { create(:inventory_list_item, quantity: 1, list: inventory_list) }
+
+    context 'when updating quantity' do
+      subject(:update_item) { list_item.update!(quantity: 4) }
+
+      it 'updates as normal' do
+        expect { update_item }
+          .to change(list_item, :quantity).from(1).to(4)
+      end
+    end
+
+    context 'when updating description' do
+      subject(:update_item) { list_item.update!(description: 'Something else') }
+
+      it 'raises an error' do
+        expect { update_item }
+          .to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+  end
+
   describe 'notes field' do
     it 'cleans up leading and trailing dashes or whitespace' do
       inventory_list_item = build(:inventory_list_item, notes: ' -- some notes --')

--- a/spec/models/inventory_list_spec.rb
+++ b/spec/models/inventory_list_spec.rb
@@ -296,6 +296,24 @@ RSpec.describe InventoryList, type: :model do
     end
   end
 
+  describe 'associations' do
+    subject(:items) { inventory_list.list_items }
+
+    let!(:aggregate_list) { create(:aggregate_inventory_list) }
+    let(:inventory_list)  { create(:inventory_list, game: aggregate_list.game, aggregate_list_id: aggregate_list.id) }
+    let!(:item1)          { create(:inventory_list_item, list: inventory_list) }
+    let!(:item2)          { create(:inventory_list_item, list: inventory_list) }
+    let!(:item3)          { create(:inventory_list_item, list: inventory_list) }
+
+    before do
+      item2.update!(quantity: 2)
+    end
+
+    it 'keeps child models in descending order of updated_at' do
+      expect(inventory_list.list_items.to_a).to eq([item2, item3, item1])
+    end
+  end
+
   describe 'Aggregatable methods' do
     describe '#user' do
       let(:inventory_list) { create(:inventory_list) }

--- a/spec/models/inventory_list_spec.rb
+++ b/spec/models/inventory_list_spec.rb
@@ -314,6 +314,33 @@ RSpec.describe InventoryList, type: :model do
     end
   end
 
+  describe 'before destroy hook' do
+    # Aggregatable
+    context 'when trying to destroy the aggregate list' do
+      subject(:destroy_list) { inventory_list.destroy! }
+
+      let(:inventory_list) { create(:aggregate_inventory_list) }
+
+      context 'when the game has regular lists' do
+        before do
+          create(:inventory_list, game: inventory_list.game, aggregate_list: inventory_list)
+        end
+
+        it 'raises an error and does not destroy the list' do
+          expect { destroy_list }
+            .to raise_error(ActiveRecord::RecordNotDestroyed)
+        end
+      end
+
+      context 'when the game has no regular lists' do
+        it 'destroys the aggregate list' do
+          expect { destroy_list }
+            .to change(inventory_list.game.inventory_lists, :count).from(1).to(0)
+        end
+      end
+    end
+  end
+
   describe 'Aggregatable methods' do
     describe '#user' do
       let(:inventory_list) { create(:inventory_list) }

--- a/spec/models/inventory_list_spec.rb
+++ b/spec/models/inventory_list_spec.rb
@@ -314,8 +314,8 @@ RSpec.describe InventoryList, type: :model do
     end
   end
 
+  # Aggregatable
   describe 'before destroy hook' do
-    # Aggregatable
     context 'when trying to destroy the aggregate list' do
       subject(:destroy_list) { inventory_list.destroy! }
 
@@ -337,6 +337,33 @@ RSpec.describe InventoryList, type: :model do
           expect { destroy_list }
             .to change(inventory_list.game.inventory_lists, :count).from(1).to(0)
         end
+      end
+    end
+  end
+
+  # Aggregatable
+  describe 'after destroy hook' do
+    subject(:destroy_list) { inventory_list.destroy! }
+
+    let!(:aggregate_list) { create(:aggregate_inventory_list, game: game) }
+    let!(:inventory_list) { create(:inventory_list, game: game) }
+    let(:game)            { create(:game) }
+
+    context 'when the user has additional regular lists' do
+      before do
+        create(:inventory_list, game: game)
+      end
+
+      it "doesn't destroy the aggregate list" do
+        expect { destroy_list }
+          .not_to change(game, :aggregate_inventory_list)
+      end
+    end
+
+    context 'when the user has no additional regular lists' do
+      it 'destroys the aggregate list' do
+        expect { destroy_list }
+          .to change(game.inventory_lists, :count).from(2).to(0)
       end
     end
   end

--- a/spec/models/inventory_list_spec.rb
+++ b/spec/models/inventory_list_spec.rb
@@ -349,7 +349,7 @@ RSpec.describe InventoryList, type: :model do
     let!(:inventory_list) { create(:inventory_list, game: game) }
     let(:game)            { create(:game) }
 
-    context 'when the user has additional regular lists' do
+    context 'when the game has additional regular lists' do
       before do
         create(:inventory_list, game: game)
       end
@@ -360,7 +360,7 @@ RSpec.describe InventoryList, type: :model do
       end
     end
 
-    context 'when the user has no additional regular lists' do
+    context 'when the game has no additional regular lists' do
       it 'destroys the aggregate list' do
         expect { destroy_list }
           .to change(game.inventory_lists, :count).from(2).to(0)

--- a/spec/models/inventory_list_spec.rb
+++ b/spec/models/inventory_list_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe InventoryList, type: :model do
+  describe 'scopes' do
+    describe '::index_order' do
+      subject(:index_order) { game.inventory_lists.index_order.to_a }
+
+      let!(:game)            { create(:game) }
+      let!(:aggregate_list)  { create(:aggregate_inventory_list, game: game) }
+      let!(:inventory_list1) { create(:inventory_list, game: game) }
+      let!(:inventory_list2) { create(:inventory_list, game: game) }
+      let!(:inventory_list3) { create(:inventory_list, game: game) }
+
+      before do
+        inventory_list2.update!(title: 'Windstad Manor')
+      end
+
+      it 'is in reverse chronological order by updated_at with aggregate before anything' do
+        expect(index_order).to eq([aggregate_list, inventory_list2, inventory_list3, inventory_list1])
+      end
+    end
+
+    # Aggregatable
+    describe '::includes_items' do
+      subject(:includes_items) { game.inventory_lists.includes_items }
+
+      let!(:game)           { create(:game) }
+      let!(:aggregate_list) { create(:aggregate_inventory_list, game: game) }
+      let!(:lists)          { create_list(:inventory_list_with_list_items, 2, game: game) }
+
+      it 'includes the inventory list items' do
+        expect(includes_items).to eq game.inventory_lists.includes(:list_items)
+      end
+    end
+
+    # Aggregatable
+    describe '::aggregates_first' do
+      subject(:aggregate_first) { game.inventory_lists.aggregate_first.to_a }
+
+      let!(:game)           { create(:game) }
+      let!(:aggregate_list) { create(:aggregate_inventory_list, game: game) }
+      let!(:inventory_list) { create(:inventory_list, game: game) }
+
+      it 'returns the inventory lists with the aggregate list first' do
+        expect(aggregate_first).to eq([aggregate_list, inventory_list])
+      end
+    end
+
+    describe '::belongs_to_user' do
+      let(:user)   { create(:user) }
+      let!(:game1) { create(:game_with_inventory_lists, user: user) }
+      let!(:game2) { create(:game_with_inventory_lists, user: user) }
+      let!(:game3) { create(:game_with_inventory_lists, user: user) }
+
+      it "returns all the inventory lists from all the user's games" do
+        # These are going to be rearranged in the output since game.shopping_lists
+        # comes back aggregate list first and the scope will return them in descending
+        # updated_at order. There was no easy programmatic way to rearrange them so
+        # I just have to pull them all out and reorder them in the expectation.
+        agg_list1, game1_list1, game1_list2 = game1.inventory_lists.to_a
+        agg_list2, game2_list1, game2_list2 = game2.inventory_lists.to_a
+        agg_list3, game3_list1, game3_list2 = game3.inventory_lists.to_a
+
+        expect(described_class.belonging_to_user(user).to_a).to eq([
+                                                                     game3_list1,
+                                                                     game3_list2,
+                                                                     agg_list3,
+                                                                     game2_list1,
+                                                                     game2_list2,
+                                                                     agg_list2,
+                                                                     game1_list1,
+                                                                     game1_list2,
+                                                                     agg_list1,
+                                                                   ])
+      end
+    end
+  end
+
+  describe 'Aggregatable methods' do
+    describe '#user' do
+      let(:inventory_list) { create(:inventory_list) }
+
+      it 'delegates to the game' do
+        expect(inventory_list.user).to eq(inventory_list.game.user)
+      end
+    end
+  end
+end

--- a/spec/models/shopping_list_item_spec.rb
+++ b/spec/models/shopping_list_item_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ShoppingListItem, type: :model do
 
   describe 'delegation' do
     let(:shopping_list) { create(:shopping_list, game: game) }
-    let(:list_item) { create(:shopping_list_item, list: shopping_list) }
+    let(:list_item)     { create(:shopping_list_item, list: shopping_list) }
 
     before do
       create(:aggregate_shopping_list, game: game)

--- a/spec/models/shopping_list_spec.rb
+++ b/spec/models/shopping_list_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe ShoppingList, type: :model do
       let!(:game2) { create(:game_with_shopping_lists, user: user) }
       let!(:game3) { create(:game_with_shopping_lists, user: user) }
 
-      it "returns all list items from all the user's lists" do
+      it "returns all the shopping lists from all the user's games" do
         # These are going to be rearranged in the output since game.shopping_lists
         # comes back aggregate list first and the scope will return them in descending
         # updated_at order. There was no easy programmatic way to rearrange them so

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -70,6 +70,29 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe '#inventory_lists' do
+    let(:user1) { create(:user) }
+    let(:user2) { create(:user) }
+
+    let(:game1) { create(:game, user: user1) }
+    let(:game2) { create(:game, user: user1) }
+    let(:game3) { create(:game_with_inventory_lists, user: user2) }
+
+    let!(:inventory_list1) { create(:aggregate_inventory_list, game: game1) }
+    let!(:inventory_list2) { create(:inventory_list, game: game1) }
+    let!(:inventory_list3) { create(:aggregate_inventory_list, game: game2) }
+    let!(:inventory_list4) { create(:inventory_list, game: game2) }
+
+    it "returns all the inventory lists for the user's games" do
+      expect(user1.inventory_lists).to eq([
+                                            inventory_list4,
+                                            inventory_list3,
+                                            inventory_list2,
+                                            inventory_list1,
+                                          ])
+    end
+  end
+
   describe '#shopping_list_items' do
     subject(:shopping_list_items) { user1.shopping_list_items.to_a.sort }
 
@@ -85,6 +108,24 @@ RSpec.describe User, type: :model do
       user1_list_items.sort!
 
       expect(shopping_list_items).to eq user1_list_items
+    end
+  end
+
+  describe '#inventory_list_items' do
+    subject(:inventory_list_items) { user1.inventory_list_items.to_a.sort }
+
+    let(:user1) { create(:user) }
+    let(:user2) { create(:user) }
+
+    let(:game1) { create(:game_with_inventory_lists_and_items, user: user1) }
+    let(:game2) { create(:game_with_inventory_lists_and_items, user: user1) }
+    let(:game3) { create(:game_with_inventory_lists_and_items, user: user2) }
+
+    it 'includes the inventory list items belonging to that user' do
+      user1_list_items = game1.inventory_list_items.to_a + game2.inventory_list_items.to_a
+      user1_list_items.sort!
+
+      expect(inventory_list_items).to eq user1_list_items
     end
   end
 end


### PR DESCRIPTION
## Context

[**Create InventoryList and InventoryListItem models**](https://trello.com/c/2Tm6DBTU/136-create-inventorylist-and-inventorylistitem-models)

We're kicking off the [Inventory Lists epic](https://trello.com/c/D6opBEo2/130-inventory-lists). The first step is to create the new models needed: the inventory list and the inventory list item. These models are almost identical to the shopping list and shopping list item models, except that the `InventoryListItem` has a `unit_weight` column (which will be added to shopping list items as part of [this card](https://trello.com/c/S2gwTYIX/154-add-unitweight-field-to-shopping-list-items)).

## Changes

* Create Aggregatable `InventoryList` model with migration
* Create `InventoryListItem` model with migration
* Add factories for new models
* Add specs for new models
* Make changes to other models as needed to define associations and utility methods and manage the association lifecycle

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [ ] Added and updated API docs and developer docs as appropriate

## Considerations

There's a lot of duplication in the specs for `ShoppingList`/`InventoryList` and `ShoppingListItem`/`InventoryListItem`. Although some of the logic tested comes from the `Aggregatable` concern (and additional logic will be extracted to the `Listable` concern when that concern [is created](https://trello.com/c/3zzaSnq7/155-create-listable-concern-for-aggregatable-list-items)), it's important to test the logic in the models that include the concerns since it is core logic for them and since there is no other good way to test ActiveModel concerns.
