### PR TITLE
Add unit_weight field to ShoppingListItem model

### DIFF
--- a/app/models/shopping_list_item.rb
+++ b/app/models/shopping_list_item.rb
@@ -5,6 +5,7 @@ class ShoppingListItem < ApplicationRecord
 
   validates :description, presence: true, uniqueness: { scope: :list_id, case_sensitive: false }
   validates :quantity, presence: true, numericality: { only_integer: true, greater_than: 0 }
+  validates :unit_weight, numericality: { greater_than_or_equal_to: 0, allow_nil: true }
   validate :prevent_changed_description, on: :update
 
   before_save :clean_up_notes

--- a/db/migrate/20210808013545_add_unit_weight_to_shopping_list_items.rb
+++ b/db/migrate/20210808013545_add_unit_weight_to_shopping_list_items.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUnitWeightToShoppingListItems < ActiveRecord::Migration[6.1]
+  def change
+    add_column :shopping_list_items, :unit_weight, :decimal, precision: 5, scale: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_07_224149) do
+ActiveRecord::Schema.define(version: 2021_08_08_013545) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,6 +56,7 @@ ActiveRecord::Schema.define(version: 2021_08_07_224149) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "list_id", null: false
+    t.decimal "unit_weight", precision: 5, scale: 1
     t.index ["description", "list_id"], name: "index_shopping_list_items_on_description_and_list_id", unique: true
     t.index ["list_id"], name: "index_shopping_list_items_on_list_id"
   end


### PR DESCRIPTION
## Context

[**Add unit_weight field to shopping list items**](https://trello.com/c/S2gwTYIX/154-add-unitweight-field-to-shopping-list-items)

We've just introduced the `InventoryListItem` model, which has a `unit_weight` field. Since I've considered adding such a field to the `ShoppingListItem` model and having it on both would facilitate modifying Aggregatable behaviour to work with both models, we've decided now is a good time to add this field to the `ShoppingListItem` model as well.

## Changes

* Add `unit_weight` field to `ShoppingListItem` model
* Validate `unit_weight` field value, keeping it an optional field

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~

## Considerations

A precision of 5 is generous for a game that only has weights up to about 50-some. It's the same precision I used for `InventoryListItem`, which is why I chose that value. Realistically a precision of 3 would've been adequate for both but it's not a big enough deal to change now.
