### PR TITLE
Implement logic around list item unit weights

### DIFF
--- a/app/controller_services/shopping_list_items_controller/create_service.rb
+++ b/app/controller_services/shopping_list_items_controller/create_service.rb
@@ -28,21 +28,13 @@ class ShoppingListItemsController < ApplicationController
         if preexisting_item.blank?
           aggregate_list_item = aggregate_list.add_item_from_child_list(item)
 
-          resource = if params[:unit_weight]
-                       aggregate_list.game.shopping_list_items.where('description ILIKE ?', params[:description])
-                     else
-                       [aggregate_list_item, item]
-                     end
+          resource = params[:unit_weight] ? all_matching_list_items : [aggregate_list_item, item]
 
           Service::CreatedResult.new(resource: resource)
         else
           aggregate_list_item = aggregate_list.update_item_from_child_list(params[:description], params[:quantity], params[:unit_weight], nil, params[:notes])
 
-          resource = if params[:unit_weight]
-                       aggregate_list.game.shopping_list_items.where('description ILIKE ?', params[:description])
-                     else
-                       [aggregate_list_item, item]
-                     end
+          resource = params[:unit_weight] ? all_matching_list_items : [aggregate_list_item, item]
 
           Service::OKResult.new(resource: resource)
         end
@@ -66,6 +58,10 @@ class ShoppingListItemsController < ApplicationController
 
     def aggregate_list
       shopping_list.aggregate_list
+    end
+
+    def all_matching_list_items
+      aggregate_list.game.shopping_list_items.where('description ILIKE ?', params[:description])
     end
   end
 end

--- a/app/controller_services/shopping_list_items_controller/create_service.rb
+++ b/app/controller_services/shopping_list_items_controller/create_service.rb
@@ -27,10 +27,24 @@ class ShoppingListItemsController < ApplicationController
 
         if preexisting_item.blank?
           aggregate_list_item = aggregate_list.add_item_from_child_list(item)
-          Service::CreatedResult.new(resource: [aggregate_list_item, item])
+
+          resource = if params[:unit_weight]
+                       aggregate_list.game.shopping_list_items.where('description ILIKE ?', params[:description])
+                     else
+                       [aggregate_list_item, item]
+                     end
+
+          Service::CreatedResult.new(resource: resource)
         else
-          aggregate_list_item = aggregate_list.update_item_from_child_list(params[:description], params[:quantity], nil, params[:notes])
-          Service::OKResult.new(resource: [aggregate_list_item, item])
+          aggregate_list_item = aggregate_list.update_item_from_child_list(params[:description], params[:quantity], params[:unit_weight], nil, params[:notes])
+
+          resource = if params[:unit_weight]
+                       aggregate_list.game.shopping_list_items.where('description ILIKE ?', params[:description])
+                     else
+                       [aggregate_list_item, item]
+                     end
+
+          Service::OKResult.new(resource: resource)
         end
       end
     rescue ActiveRecord::RecordInvalid

--- a/app/controller_services/shopping_list_items_controller/update_service.rb
+++ b/app/controller_services/shopping_list_items_controller/update_service.rb
@@ -26,10 +26,16 @@ class ShoppingListItemsController < ApplicationController
       ActiveRecord::Base.transaction do
         list_item.update!(params)
 
-        aggregate_list_item = aggregate_list.update_item_from_child_list(list_item.description, delta_qty, old_notes, params[:notes])
+        aggregate_list_item = aggregate_list.update_item_from_child_list(list_item.description, delta_qty, params[:unit_weight], old_notes, params[:notes])
       end
 
-      Service::OKResult.new(resource: [aggregate_list_item, list_item])
+      resource = if params[:unit_weight]
+                   aggregate_list.game.shopping_list_items.where('description ILIKE ?', list_item.description)
+                 else
+                   [aggregate_list_item, list_item]
+                 end
+
+      Service::OKResult.new(resource: resource)
     rescue ActiveRecord::RecordInvalid
       Service::UnprocessableEntityResult.new(errors: list_item.error_array)
     rescue ActiveRecord::RecordNotFound

--- a/app/controller_services/shopping_list_items_controller/update_service.rb
+++ b/app/controller_services/shopping_list_items_controller/update_service.rb
@@ -29,11 +29,7 @@ class ShoppingListItemsController < ApplicationController
         aggregate_list_item = aggregate_list.update_item_from_child_list(list_item.description, delta_qty, params[:unit_weight], old_notes, params[:notes])
       end
 
-      resource = if params[:unit_weight]
-                   aggregate_list.game.shopping_list_items.where('description ILIKE ?', list_item.description)
-                 else
-                   [aggregate_list_item, list_item]
-                 end
+      resource = params[:unit_weight] ? all_matching_items(list_item.description) : [aggregate_list_item, list_item]
 
       Service::OKResult.new(resource: resource)
     rescue ActiveRecord::RecordInvalid
@@ -59,6 +55,10 @@ class ShoppingListItemsController < ApplicationController
 
     def list_item
       @list_item ||= user.shopping_list_items.find(item_id)
+    end
+
+    def all_matching_items(description)
+      aggregate_list.game.shopping_list_items.where('description ILIKE ?', description)
     end
   end
 end

--- a/app/models/concerns/aggregatable.rb
+++ b/app/models/concerns/aggregatable.rb
@@ -68,7 +68,7 @@ module Aggregatable
     raise AggregateListError.new('add_item_from_child_list method only available on aggregate lists') unless aggregate_list?
 
     if item.unit_weight
-      other_items = child_lists.map(&:list_items)
+      other_items = child_lists.all.map(&:list_items)
       other_items.flatten!
 
       other_items.each do |list_item|

--- a/app/models/concerns/aggregatable.rb
+++ b/app/models/concerns/aggregatable.rb
@@ -114,10 +114,10 @@ module Aggregatable
     unless unit_weight.nil?
       existing_item.unit_weight = unit_weight
 
-      other_items = child_lists.map(&:list_items)
+      other_items = child_lists.all.map(&:list_items)
       other_items.flatten!
 
-      other_items.each {|item| item.update!(unit_weight: unit_weight) }
+      other_items.each {|item| item.update!(unit_weight: unit_weight) if item.description.casecmp(description).zero? }
     end
 
     existing_item.save!

--- a/app/models/concerns/aggregatable.rb
+++ b/app/models/concerns/aggregatable.rb
@@ -104,12 +104,12 @@ module Aggregatable
 
     raise AggregateListError.new('invalid data to update aggregate list item') if existing_item.nil? || delta_quantity < (-existing_item.quantity) || (unit_weight && (!unit_weight.is_a?(Numeric) || unit_weight < 0))
 
-    existing_item.quantity   += delta_quantity
-    existing_item.notes       = if old_notes.nil? && new_notes.present?
-                                  [existing_item.notes.to_s, new_notes.to_s].join(' -- ')
-                                else
-                                  existing_item.notes&.sub(/#{old_notes}/, new_notes.to_s).presence || new_notes
-                                end
+    existing_item.quantity += delta_quantity
+    existing_item.notes     = if old_notes.nil? && new_notes.present?
+                                [existing_item.notes.to_s, new_notes.to_s].join(' -- ')
+                              else
+                                existing_item.notes&.sub(/#{old_notes}/, new_notes.to_s).presence || new_notes
+                              end
 
     unless unit_weight.nil?
       existing_item.unit_weight = unit_weight

--- a/app/models/concerns/listable.rb
+++ b/app/models/concerns/listable.rb
@@ -37,14 +37,15 @@ module Listable
       if existing_item.nil?
         new attrs
       else
-        qty       = attrs[:quantity] || attrs['quantity'] || 1
-        new_notes = attrs[:notes] || attrs['notes']
-        old_notes = existing_item.notes
+        qty        = attrs[:quantity] || attrs['quantity'] || 1
+        new_notes  = attrs[:notes] || attrs['notes']
+        new_weight = attrs[:unit_weight] || attrs['unit_weight'] || existing_item.unit_weight
+        old_notes  = existing_item.notes
 
         new_quantity = existing_item.quantity + qty
         new_notes    = [old_notes, new_notes].compact.join(' -- ').presence
 
-        existing_item.assign_attributes(quantity: new_quantity, notes: new_notes)
+        existing_item.assign_attributes(quantity: new_quantity, notes: new_notes, unit_weight: new_weight)
         existing_item
       end
     end

--- a/docs/api/resources/shopping-list-items.md
+++ b/docs/api/resources/shopping-list-items.md
@@ -16,11 +16,14 @@ Skyrim Inventory Management makes use of automatically managed aggregate lists t
 
 If the client requests a new list item be created on a regular list, one of the following things will happen:
 
-* If there is not an item with the same (case-insensitive) `description` on the aggregate list, then an item with the same `description`, `quantity`, and `notes` will be created on the aggregate list.
+* If there is not an item with the same (case-insensitive) `description` on the aggregate list, then an item with the same `description`, `quantity`, `unit_weight`, and `notes` will be created on the aggregate list.
 * If there is an item with the same (case-insensitive) `description` on the aggregate list, then that item will be updated:
   * The `description` will not be changed
   * The `quantity` will be increased by the quantity of the new list item
   * The `notes` for the two items, if any, will be concatenated and separated by ` -- `
+  * The `unit_weight` will be changed to the new item's `unit_weight` unless that value is `nil`
+
+If the new item sets a `unit_weight` that is not `nil` and is different to the `unit_weight` of any existing matching list items belonging to the same game, those items will also be updated to have the same unit weight as the new item.
 
 ### Updating a List Item
 
@@ -30,6 +33,7 @@ When a client updates a list item on a regular list for a given game, one (or tw
 * If the `quantity` is decreased, the `quantity` of the item on the aggregate list will be decreased by the same amount
 * If the `quantity` has not changed, the `quantity` of the item on the aggregate list will also be unchanged
 * If the `notes` are changed, SIM will ensure that the new (or added or removed) `notes` are reflected in the aggregate list item
+* If the `unit_weight` is changed to a non-`nil` value, the value will be updated on the aggregate list item as well as any other list items with the same (case-insensitive) description belonging to the same game
 
 ### Destroying a List Item
 
@@ -88,7 +92,7 @@ Content-Type: application/json
 
 If there is no item with a matching description on the requested shopping list, a new item will be created and the server will return a 201 response. If there is an item with a matching description, its notes and quantity will be combined with the notes and quantity in the client request and a 200 response will be returned.
 
-The body for both responses contains the updated item from the aggregate list first and the requested regular list item second.
+The body for both responses is a JSON array containing all list items that were created or updated while handling the request, including the requested item, the corresponding aggregate list item, and, if setting `unit_weight`, any other list items with the same description belonging to the same game.
 ```json
 [
   {
@@ -96,6 +100,7 @@ The body for both responses contains the updated item from the aggregate list fi
     "list_id": 238,
     "description": "Ebony sword",
     "quantity": 9,
+    "unit_weight": 14,
     "notes": "To sell -- To enchant with 'Absorb Health'",
     "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
     "updated_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00"
@@ -105,6 +110,7 @@ The body for both responses contains the updated item from the aggregate list fi
     "list_id": 237,
     "description": "Ebony sword",
     "quantity": 7,
+    "unit_weight": 14,
     "notes": "To enchant with 'Absorb Health'",
     "created_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00",
     "updated_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00"
@@ -188,7 +194,7 @@ Content-Type: application/json
 
 #### Example Body
 
-Body contains the item from the aggregate list first and the item from the regular list that you requested second.
+The body is a JSON array containing all list items that were updated while handling the request, including the requested item, the corresponding aggregate list item, and, if setting `unit_weight`, any other list items with the same description belonging to the same game.
 ```json
 [
   {
@@ -196,6 +202,7 @@ Body contains the item from the aggregate list first and the item from the regul
     "list_id": 238,
     "description": "Ebony sword",
     "quantity": 9,
+    "unit_weight": 14,
     "notes": "To sell -- To enchant with 'Absorb Health'",
     "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
     "updated_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00"
@@ -205,6 +212,7 @@ Body contains the item from the aggregate list first and the item from the regul
     "list_id": 237,
     "description": "Ebony sword",
     "quantity": 7,
+    "unit_weight": 14,
     "notes": "To enchant with 'Absorb Health'",
     "created_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00",
     "updated_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00"
@@ -287,8 +295,7 @@ Content-Type: application/json
 
 #### Example Body
 
-Body contains the item from the aggregate list first and the item from the regular list that you requested second.
-
+The body is a JSON array containing all list items that were updated while handling the request, including the requested item, the corresponding aggregate list item, and, if setting `unit_weight`, any other list items with the same description belonging to the same game.
 ```json
 [
   {
@@ -296,6 +303,7 @@ Body contains the item from the aggregate list first and the item from the regul
     "list_id": 238,
     "description": "Ebony sword",
     "quantity": 9,
+    "unit_weight": 14,
     "notes": "To sell -- To enchant with 'Absorb Health'",
     "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
     "updated_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00"
@@ -305,6 +313,7 @@ Body contains the item from the aggregate list first and the item from the regul
     "list_id": 237,
     "description": "Ebony sword",
     "quantity": 7,
+    "unit_weight": 14,
     "notes": "To enchant with 'Absorb Health'",
     "created_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00",
     "updated_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00"
@@ -387,6 +396,7 @@ Example 200 response body containing the updated aggregate list item:
   "list_id": 238,
   "description": "Ebony sword",
   "quantity": 9,
+  "unit_weight": 14,
   "notes": "To sell -- To enchant with 'Absorb Health'",
   "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
   "updated_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00"

--- a/spec/controller_services/shopping_list_items_controller/update_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/update_service_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe ShoppingListItemsController::UpdateService do
         allow(shopping_list).to receive(:aggregate_list).and_return(aggregate_list)
         allow(aggregate_list).to receive(:update_item_from_child_list)
         perform
-        expect(aggregate_list).to have_received(:update_item_from_child_list).with(list_item.description, 1, nil, nil)
+        expect(aggregate_list).to have_received(:update_item_from_child_list).with(list_item.description, 1, nil, nil, nil)
       end
 
       it 'returns a Service::OKResult' do

--- a/spec/controller_services/shopping_list_items_controller/update_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/update_service_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ShoppingListItemsController::UpdateService do
     context 'when all goes well' do
       let(:game)           { create(:game_with_shopping_lists, user: user) }
       let(:aggregate_list) { game.aggregate_shopping_list }
-      let!(:list_item)     { create(:shopping_list_item, list: shopping_list, quantity: 2) }
+      let!(:list_item)     { create(:shopping_list_item, list: shopping_list, quantity: 2, unit_weight: 2) }
       let(:params)         { { quantity: 3 } }
       let(:scope)          { ShoppingListItem.belonging_to_user(user) }
 
@@ -37,7 +37,7 @@ RSpec.describe ShoppingListItemsController::UpdateService do
         allow(scope).to receive(:find).and_return(list_item)
         allow(list_item).to receive(:list).and_return(shopping_list)
         allow(shopping_list).to receive(:aggregate_list).and_return(aggregate_list)
-        allow(aggregate_list).to receive(:update_item_from_child_list)
+        allow(aggregate_list).to receive(:update_item_from_child_list).and_call_original
         perform
         expect(aggregate_list).to have_received(:update_item_from_child_list).with(list_item.description, 1, nil, nil, nil)
       end
@@ -59,6 +59,25 @@ RSpec.describe ShoppingListItemsController::UpdateService do
           # in things being not quite equal in that environment. Since it's not that important
           # that it be that exact, I'm just using the `be_within` matcher.
           expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+        end
+      end
+
+      context 'when updating the unit_weight' do
+        let(:params) { { unit_weight: 1 } }
+        let(:other_list)  { create(:shopping_list, game: game, aggregate_list: aggregate_list) }
+        let!(:other_item) { create(:shopping_list_item, description: list_item.description, list: other_list, unit_weight: 2) }
+
+        before do
+          aggregate_list.add_item_from_child_list(other_item)
+        end
+
+        it 'updates the other item' do
+          perform
+          expect(other_item.reload.unit_weight).to eq 1
+        end
+
+        it 'returns all the items that were updated' do
+          expect(perform.resource.sort).to eq [aggregate_list.list_items.reload.first, list_item, other_item].sort
         end
       end
     end

--- a/spec/models/inventory_list_item_spec.rb
+++ b/spec/models/inventory_list_item_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe InventoryListItem, type: :model do
 
       let(:aggregate_list)  { create(:aggregate_inventory_list) }
       let!(:inventory_list) { create(:inventory_list, game: aggregate_list.game) }
-      let!(:existing_item)  { create(:inventory_list_item, description: 'ExIsTiNg ItEm', quantity: 2, list: inventory_list, notes: 'notes 1') }
+      let!(:existing_item)  { create(:inventory_list_item, description: 'ExIsTiNg ItEm', quantity: 2, unit_weight: 0.3, list: inventory_list, notes: 'notes 1') }
 
       it "doesn't create a new list item" do
         expect { combine_or_create }
@@ -133,7 +133,7 @@ RSpec.describe InventoryListItem, type: :model do
 
       let(:aggregate_list) { create(:aggregate_inventory_list) }
       let!(:inventory_list) { create(:inventory_list, game: aggregate_list.game) }
-      let!(:existing_item)  { create(:inventory_list_item, description: 'ExIsTiNg ItEm', quantity: 2, list: inventory_list, notes: 'notes 1') }
+      let!(:existing_item)  { create(:inventory_list_item, description: 'ExIsTiNg ItEm', quantity: 2, unit_weight: 0.3, list: inventory_list, notes: 'notes 1') }
 
       before do
         allow(described_class).to receive(:new)

--- a/spec/models/inventory_list_item_spec.rb
+++ b/spec/models/inventory_list_item_spec.rb
@@ -108,6 +108,22 @@ RSpec.describe InventoryListItem, type: :model do
         combine_or_create
         expect(existing_item.reload.notes).to eq 'notes 1 -- notes 2'
       end
+
+      context "when the new item doesn't have a unit_weight" do
+        it 'leaves the unit_weight as-is' do
+          combine_or_create
+          expect(existing_item.reload.unit_weight).to eq 0.3
+        end
+      end
+
+      context 'when the new item has a unit_weight' do
+        subject(:combine_or_create) { described_class.combine_or_create!(description: 'existing item', quantity: 1, list: inventory_list, unit_weight: 0.2, notes: 'notes 2') }
+
+        it 'uses the unit_weight from the new item' do
+          combine_or_create
+          expect(existing_item.reload.unit_weight).to eq 0.2
+        end
+      end
     end
   end
 
@@ -136,6 +152,20 @@ RSpec.describe InventoryListItem, type: :model do
       it 'concatenates the notes for the two items', :aggregate_failures do
         expect(combine_or_new).to eq existing_item
         expect(combine_or_new.notes).to eq 'notes 1 -- notes 2'
+      end
+
+      context "when the new item doesn't have a unit_weight" do
+        it 'leaves the unit_weight as-is' do
+          expect(combine_or_new.unit_weight).to eq 0.3
+        end
+      end
+
+      context 'when the new item has a unit_weight' do
+        subject(:combine_or_new) { described_class.combine_or_new(description: 'existing item', quantity: 1, unit_weight: 0.2, list: inventory_list, notes: 'notes 2') }
+
+        it 'updates the unit_weight' do
+          expect(combine_or_new.unit_weight).to eq 0.2
+        end
       end
     end
 

--- a/spec/models/inventory_list_spec.rb
+++ b/spec/models/inventory_list_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe InventoryList, type: :model do
       let!(:game3) { create(:game_with_inventory_lists, user: user) }
 
       it "returns all the inventory lists from all the user's games" do
-        # These are going to be rearranged in the output since game.shopping_lists
+        # These are going to be rearranged in the output since game.inventory_lists
         # comes back aggregate list first and the scope will return them in descending
         # updated_at order. There was no easy programmatic way to rearrange them so
         # I just have to pull them all out and reorder them in the expectation.
@@ -83,7 +83,7 @@ RSpec.describe InventoryList, type: :model do
     describe 'aggregate lists' do
       context 'when there are no aggregate lists' do
         let(:game)           { create(:game) }
-        let(:aggregate_list) { build(:aggregate_shopping_list, game: game) }
+        let(:aggregate_list) { build(:aggregate_inventory_list, game: game) }
 
         it 'is valid' do
           expect(aggregate_list).to be_valid
@@ -92,10 +92,10 @@ RSpec.describe InventoryList, type: :model do
 
       context 'when there is an existing aggregate list belonging to another user' do
         let(:game)           { create(:game) }
-        let(:aggregate_list) { build(:aggregate_shopping_list, game: game) }
+        let(:aggregate_list) { build(:aggregate_inventory_list, game: game) }
 
         before do
-          create(:aggregate_shopping_list)
+          create(:aggregate_inventory_list)
         end
 
         it 'is valid' do
@@ -105,10 +105,10 @@ RSpec.describe InventoryList, type: :model do
 
       context 'when the user already has an aggregate list' do
         let(:game)           { create(:game) }
-        let(:aggregate_list) { build(:aggregate_shopping_list, game: game) }
+        let(:aggregate_list) { build(:aggregate_inventory_list, game: game) }
 
         before do
-          create(:aggregate_shopping_list, game: game)
+          create(:aggregate_inventory_list, game: game)
         end
 
         it 'is invalid', :aggregate_failures do
@@ -445,8 +445,8 @@ RSpec.describe InventoryList, type: :model do
         end
 
         context 'when the new item has a unit weight' do
-          let!(:existing_list_item) { create(:inventory_list_item, description: item_on_other_list.description, list: aggregate_list) }
-          let(:list_item) { create(:inventory_list_item, description: existing_list_item.description, quantity: 2, notes: nil, unit_weight: 0.2) }
+          let!(:existing_list_item) { create(:inventory_list_item, description: 'Dwarven metal ingot', unit_weight: 0.3, list: aggregate_list) }
+          let(:list_item) { create(:inventory_list_item, description: 'Dwarven metal ingot', quantity: 2, notes: nil, unit_weight: 0.2) }
 
           it 'updates the unit weight of the existing item' do
             add_item
@@ -454,7 +454,8 @@ RSpec.describe InventoryList, type: :model do
           end
 
           it 'updates the unit weight of the item on the other list' do
-            #
+            add_item
+            expect(item_on_other_list.reload.unit_weight).to eq 0.2
           end
         end
       end
@@ -596,10 +597,11 @@ RSpec.describe InventoryList, type: :model do
     end
 
     describe '#update_item_from_child_list' do
-      subject(:update_item) { aggregate_list.update_item_from_child_list(description, delta, old_notes, new_notes) }
+      subject(:update_item) { aggregate_list.update_item_from_child_list(description, delta, unit_weight, old_notes, new_notes) }
 
       let(:aggregate_list) { create(:aggregate_inventory_list) }
       let(:description)    { 'Corundum ingot' }
+      let(:unit_weight)    { 1 }
 
       context 'when adjusting quantity up' do
         let(:delta)     { 2 }
@@ -639,6 +641,54 @@ RSpec.describe InventoryList, type: :model do
         it 'replaces the notes' do
           update_item
           expect(aggregate_list.list_items.first.notes).to eq new_notes
+        end
+      end
+
+      context "when quantity doesn't change" do
+        subject(:update_item) { aggregate_list.update_item_from_child_list(description, 0, unit_weight, 'something', 'another thing') }
+
+        before do
+          aggregate_list.list_items.create(description: description, quantity: 3, notes: 'something')
+        end
+
+        it "doesn't change the quantity" do
+          update_item
+          expect(aggregate_list.list_items.first.quantity).to eq 3
+        end
+      end
+
+      context 'when there is no unit_weight given' do
+        subject(:update_item) { aggregate_list.update_item_from_child_list(description, 1, nil, 'something', 'another thing') }
+
+        before do
+          aggregate_list.list_items.create(description: description, quantity: 3, unit_weight: 1, notes: 'something')
+        end
+
+        it 'leaves the existing unit_weight as-is' do
+          update_item
+          expect(aggregate_list.list_items.first.unit_weight).to eq 1
+        end
+      end
+
+      context 'when there is a unit_weight given' do
+        subject(:update_item) { aggregate_list.update_item_from_child_list(description, 1, 2, 'something', 'another thing') }
+
+        let(:other_list) { create(:inventory_list, game: aggregate_list.game, aggregate_list: aggregate_list) }
+        let!(:item_on_other_list)  { create(:inventory_list_item, list: other_list, description: description, unit_weight: 1) }
+        let!(:aggregate_list_item) { create(:inventory_list_item, list: aggregate_list, description: description, quantity: 3, unit_weight: 1, notes: 'something') }
+
+        before do
+          aggregate_list.list_items.create(description: description, quantity: 3, unit_weight: 1, notes: 'something')
+        end
+
+        it 'updates the unit_weight on the aggregate list' do
+          update_item
+          expect(aggregate_list_item.reload.unit_weight).to eq 2
+        end
+
+        it 'updates the other matching list item' do
+          update_item
+          expect(item_on_other_list.reload.unit_weight).to eq 2
         end
       end
 
@@ -741,6 +791,38 @@ RSpec.describe InventoryList, type: :model do
         let(:delta)     { -20 }
         let(:old_notes) { nil }
         let(:new_notes) { 'something else' }
+
+        it 'raises an error' do
+          expect { update_item }
+            .to raise_error(Aggregatable::AggregateListError)
+        end
+      end
+
+      context 'when the unit_weight is not a number' do
+        let(:unit_weight) { 'carrot' }
+        let(:delta)       { 1 }
+        let(:old_notes)   { nil }
+        let(:new_notes)   { nil }
+
+        before do
+          aggregate_list.list_items.create!(description: description)
+        end
+
+        it 'raises an error' do
+          expect { update_item }
+            .to raise_error(Aggregatable::AggregateListError)
+        end
+      end
+
+      context 'when the unit_weight value is invalid' do
+        let(:unit_weight) { -0.3 }
+        let(:delta)       { 1 }
+        let(:old_notes)   { nil }
+        let(:new_notes)   { nil }
+
+        before do
+          aggregate_list.list_items.create!(description: description, quantity: 1)
+        end
 
         it 'raises an error' do
           expect { update_item }

--- a/spec/models/inventory_list_spec.rb
+++ b/spec/models/inventory_list_spec.rb
@@ -411,7 +411,7 @@ RSpec.describe InventoryList, type: :model do
           let!(:existing_list_item) { create(:inventory_list_item, list: aggregate_list, quantity: 3, notes: nil) }
           let(:list_item)           { create(:inventory_list_item, description: existing_list_item.description, quantity: 2, notes: nil) }
 
-          it 'combines the quantities and leaves the notes nil' do
+          it 'combines the quantities and leaves the notes nil', :aggregate_failures do
             add_item
             expect(existing_list_item.reload.quantity).to eq 5
             expect(existing_list_item.reload.notes).to be nil

--- a/spec/models/shopping_list_spec.rb
+++ b/spec/models/shopping_list_spec.rb
@@ -388,15 +388,18 @@ RSpec.describe ShoppingList, type: :model do
                                                                  'description' => list_item.description,
                                                                  'quantity'    => list_item.quantity,
                                                                  'notes'       => list_item.notes,
+                                                                 'unit_weight' => list_item.unit_weight,
                                                                )
         end
       end
 
       context 'when there is a matching item on the aggregate list' do
-        let!(:existing_list_item) { create(:shopping_list_item, list: aggregate_list, quantity: 3, notes: 'notes 1 -- notes 2') }
+        let(:other_list)          { create(:shopping_list, game: aggregate_list.game, aggregate_list: aggregate_list) }
+        let!(:item_on_other_list) { create(:shopping_list_item, description: 'Dwarven metal ingot', list: other_list, unit_weight: 0.3) }
 
         context 'when both have notes' do
-          let(:list_item) { create(:shopping_list_item, description: existing_list_item.description, quantity: 2, notes: 'notes 3') }
+          let!(:existing_list_item) { create(:shopping_list_item, description: 'Dwarven metal ingot', notes: 'notes 1 -- notes 2', quantity: 3, unit_weight: 0.3, list: aggregate_list) }
+          let(:list_item)           { create(:shopping_list_item, description: 'Dwarven metal ingot', quantity: 2, notes: 'notes 3') }
 
           it 'combines the notes and quantities', :aggregate_failures do
             add_item
@@ -409,7 +412,7 @@ RSpec.describe ShoppingList, type: :model do
           let!(:existing_list_item) { create(:shopping_list_item, list: aggregate_list, quantity: 3, notes: nil) }
           let(:list_item)           { create(:shopping_list_item, description: existing_list_item.description, quantity: 2, notes: nil) }
 
-          it 'combines the quantities and leaves the notes nil' do
+          it 'combines the quantities and leaves the notes nil', :aggregate_failures do
             add_item
             expect(existing_list_item.reload.quantity).to eq 5
             expect(existing_list_item.reload.notes).to be nil
@@ -417,12 +420,42 @@ RSpec.describe ShoppingList, type: :model do
         end
 
         context 'when one has notes and the other does not' do
-          let(:list_item) { create(:shopping_list_item, description: existing_list_item.description, quantity: 2) }
+          let!(:existing_list_item) { create(:shopping_list_item, description: 'Dwarven metal ingot', quantity: 3, unit_weight: 0.3, notes: 'notes 1 -- notes 2', list: aggregate_list) }
+          let(:list_item)           { create(:shopping_list_item, description: existing_list_item.description, quantity: 2) }
 
           it 'combines the quantities and uses the existing notes value', :aggregate_failures do
             add_item
             expect(existing_list_item.reload.quantity).to eq 5
             expect(existing_list_item.reload.notes).to eq 'notes 1 -- notes 2'
+          end
+        end
+
+        context "when the new item doesn't have a unit weight" do
+          let!(:existing_list_item) { create(:shopping_list_item, description: 'Dwarven metal ingot', list: aggregate_list, unit_weight: 0.3) }
+          let(:list_item) { create(:shopping_list_item, description: existing_list_item.description, quantity: 2, notes: nil, unit_weight: nil) }
+
+          it 'leaves the unit weight as-is on the existing item' do
+            add_item
+            expect(existing_list_item.reload.unit_weight).to eq 0.3
+          end
+
+          it 'leaves the unit weight as-is on the other regular list item' do
+            add_item
+            expect(item_on_other_list.reload.unit_weight).to eq 0.3
+          end
+        end
+
+        context 'when the new item has a unit weight' do
+          let!(:existing_list_item) { create(:shopping_list_item, description: item_on_other_list.description, list: aggregate_list) }
+          let(:list_item) { create(:shopping_list_item, description: existing_list_item.description, quantity: 2, notes: nil, unit_weight: 0.2) }
+
+          it 'updates the unit weight of the existing item' do
+            add_item
+            expect(existing_list_item.reload.unit_weight).to eq 0.2
+          end
+
+          it 'updates the unit weight of the item on the other list' do
+            #
           end
         end
       end


### PR DESCRIPTION
## Context

[**Incorporate unit_weight logic into Aggregatable and Listable concerns**](https://trello.com/c/GSVOgowG/156-incorporate-unitweight-logic-into-aggregatable-and-listable-concerns)

## Changes

* Update `Listable::combine_or_new` method to update unit weight if a new, non-`nil` unit weight is included with the attributes
* Update `Aggregatable#add_item_from_child_list` and `Aggregatable#update_item_from_child_list` methods to make sure unit weight is updated on all matching items
* Modify `ShoppingListItemsController::CreateService` and `ShoppingListItemsController::UpdateService` to return all changed list items, not just the directly created/updated item and the aggregate list item

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

This PR contains breaking changes. I considered making the changes to the controller services happen in a future PR, but the more I thought about it the more I saw no good reason to wait. Not doing it now would mean that items were getting updated and not returned from the API in the meantime.

The way I've implemented this logic will preclude setting unit weight to `nil` if the item already has a unit weight. In other words, once an item has a unit weight, it can't be removed. I don't love this but I prefer it to having unit weights on aggregate list items and items on other lists changed to `nil` when someone creates a new item without assigning a `unit_weight`. The `update_item_from_child_list` method has no way of distinguishing between a value being explicitly set to `nil` versus a value just not being set. It might be possible to modify the method to take a `:set_nil_unit_weight` option that would be set to true if the `unit_weight` is explicitly defined in the params. However, using this would invariably require some mind reading on the front end as we'd need to decide when an empty value was "intended" and when it was just left empty. I don't see a good way of making this determination, so for now we'll stick with the idea that unit weights cannot be unset once they are set.
