### PR TITLE
Index endpoint for inventory lists

### DIFF
--- a/app/controller_services/inventory_lists_controller/index_service.rb
+++ b/app/controller_services/inventory_lists_controller/index_service.rb
@@ -14,6 +14,8 @@ class InventoryListsController < ApplicationController
       Service::OKResult.new(resource: game.inventory_lists)
     rescue ActiveRecord::RecordNotFound
       Service::NotFoundResult.new
+    rescue StandardError => e
+      Service::InternalServerErrorResult.new(errors: [e.message])
     end
 
     private

--- a/app/controller_services/inventory_lists_controller/index_service.rb
+++ b/app/controller_services/inventory_lists_controller/index_service.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'service/ok_result'
+require 'service/not_found_result'
+
+class InventoryListsController < ApplicationController
+  class IndexService
+    def initialize(user, game_id)
+      @user    = user
+      @game_id = game_id
+    end
+
+    def perform
+      Service::OKResult.new(resource: game.inventory_lists)
+    rescue ActiveRecord::RecordNotFound
+      Service::NotFoundResult.new
+    end
+
+    private
+
+    attr_reader :user, :game_id
+
+    def game
+      @game ||= user.games.find(game_id)
+    end
+  end
+end

--- a/app/controllers/inventory_lists_controller.rb
+++ b/app/controllers/inventory_lists_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'controller/response'
+
+class InventoryListsController < ApplicationController
+  def index
+    result = IndexService.new(current_user, params[:game_id]).perform
+
+    ::Controller::Response.new(self, result).execute
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,8 @@ Rails.application.routes.draw do
     resources :shopping_lists, shallow: true, except: %i[show] do
       resources :shopping_list_items, shallow: true, except: %i[index show]
     end
+
+    resources :inventory_lists, shallow: true, only: %i[index]
   end
 
   get '/privacy', to: 'utilities#privacy'

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -16,10 +16,11 @@ See docs:
 
 ## Resources
 
-* [Users](/docs/api/resources/users.md)
 * [Games](/docs/api/resources/games.md)
+* [Inventory Lists](/docs/api/resources/inventory-lists.md)
 * [Shopping Lists](/docs/api/resources/shopping-lists.md)
 * [Shopping List Items](/docs/api/resources/shopping-list-items.md)
+* [Users](/docs/api/resources/users.md)
 
 ### Object Modelling Hierarchy
 

--- a/docs/api/resources/inventory-lists.md
+++ b/docs/api/resources/inventory-lists.md
@@ -6,7 +6,7 @@ Each list contains [inventory list items](/docs/api/resources/inventory-list-ite
 
 When making requests to update the title of an inventory list, there are some validations and automatic transformations to keep in mind.
 
-* Titles must be unique per game - you cannot namee two lists the same thing within the same game
+* Titles must be unique per game - you cannot name two lists the same thing within the same game
 * Only an aggregate list can be called "All Items"
 * All aggregate lists are called "All Items" and there is no way to rename them something else
 * Titles are saved with headline casing regardless of the case submitted in the request (for example, "lOrd of the rINgS" will be saved as "Lord of the Rings")

--- a/docs/api/resources/inventory-lists.md
+++ b/docs/api/resources/inventory-lists.md
@@ -10,7 +10,7 @@ When making requests to update the title of an inventory list, there are some va
 * Only an aggregate list can be called "All Items"
 * All aggregate lists are called "All Items" and there is no way to rename them something else
 * Titles are saved with headline casing regardless of the case submitted in the request (for example, "lOrd of the rINgS" will be saved as "Lord of the Rings")
-* If the request includes a blank title, then the title will be saved as "My List N", where N is the integer above the highest nonnegative integer used in an existing "My List" title (so if the game has "My List -4" and "My List 3", the next time the user tries to save a list without a title it will be called "My List 4")
+* If the request includes a blank title, then the title will be saved as "My List N", where N is the integer above the highest nonnegative integer used in an existing "My List" title (so if the game has "My List -4" and "My List 3", the next time the user tries to save a list for that game without a title it will be called "My List 4")
 * Leading and trailing whitespace will be stripped from titles before they are saved, so " My List 2  " becomes "My List 2"
 * Titles may only contain alphanumeric characters, spaces, hyphens, apostrophes, and commas - any other characters (other than leading or trailing whitespace, which will be stripped regardless) cause the API to return a 422 response
 

--- a/docs/api/resources/inventory-lists.md
+++ b/docs/api/resources/inventory-lists.md
@@ -1,0 +1,147 @@
+# Inventory Lists
+
+Inventory lists represent lists of items a user has, whether carried or stored at one of the user's properties. Users can have different lists corresponding to different locations or carried inventory within each game. Games with inventory lists also have an aggregate list that includes the combined list items and quantities from all the other lists for that game. Aggregate lists are created, updated, and destroyed automatically. They cannot be created, updated, or destroyed through the API (including to change attributes or to add, remove, or update list items).
+
+Each list contains [inventory list items](/docs/api/resources/inventory-list-items.md), which are returned with the list in any response that includes it.
+
+When making requests to update the title of an inventory list, there are some validations and automatic transformations to keep in mind.
+
+* Titles must be unique per game - you cannot namee two lists the same thing within the same game
+* Only an aggregate list can be called "All Items"
+* All aggregate lists are called "All Items" and there is no way to rename them something else
+* Titles are saved with headline casing regardless of the case submitted in the request (for example, "lOrd of the rINgS" will be saved as "Lord of the Rings")
+* If the request includes a blank title, then the title will be saved as "My List N", where N is the integer above the highest nonnegative integer used in an existing "My List" title (so if the game has "My List -4" and "My List 3", the next time the user tries to save a list without a title it will be called "My List 4")
+* Leading and trailing whitespace will be stripped from titles before they are saved, so " My List 2  " becomes "My List 2"
+* Titles may only contain alphanumeric characters, spaces, hyphens, apostrophes, and commas - any other characters (other than leading or trailing whitespace, which will be stripped regardless) cause the API to return a 422 response
+
+Like other resources in SIM, inventory lists are scoped to the authenticated user. There is no way to retrieve or manage inventory lists for any other user through the API.
+
+## Endpoints
+
+* [`GET /games/:game_id/inventory_lists`](#get-gamesgame_idinventory_lists)
+
+## GET /games/:game_id/inventory_lists
+
+Returns all inventory lists for the game indicated by the `:game_id` param, provided the game exists and is owned by the authenticated user. The aggregate inventory list will be returned first, followed by the game's other inventory lists in reverse chronological order by `updated_at` (i.e., the lists that were edited most recently will be first).
+
+### Example Request
+
+```
+GET /inventory_lists
+Authorization: Bearer xxxxxxxxxxxxx
+```
+
+### Success Responses
+
+#### Statuses
+
+* 200 OK
+
+#### Example Bodies
+
+For a game with no lists:
+```json
+[]
+```
+For a game with multiple lists:
+```json
+[
+  {
+    "id": 43,
+    "game_id": 8234,
+    "aggregate": true,
+    "title": "All Items",
+    "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "list_items": [
+      {
+        "list_id": 43,
+        "description": "Ebony sword",
+        "quantity": 1,
+        "notes": "Enchanted with Absorb Health",
+        "unit_weight": 14,
+        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      },
+      {
+        "list_id": 43,
+        "description": "Iron ingot",
+        "quantity": 4,
+        "notes": null,
+        "unit_weight": 1,
+        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      }
+    ]
+  },
+  {
+    "id": 46,
+    "game_id": 8234,
+    "aggregate": false,
+    "aggregate_list_id": 43,
+    "title": "Lakeview Manor",
+    "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "list_items": [
+      {
+        "list_id": 46,
+        "description": "Ebony sword",
+        "quantity": 1,
+        "notes": "Enchanted with Absorb Health",
+        "unit_weight": 14,
+        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      },
+      {
+        "list_id": 46,
+        "description": "Iron ingot",
+        "quantity": 3,
+        "notes": null,
+        "unit_weight": 1,
+        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      }
+    ]
+  },
+  {
+    "id": 52,
+    "game_id": 8234,
+    "aggregate": false,
+    "aggregate_list_id": 43,
+    "title": "Severin Manor",
+    "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "list_items": [
+      {
+        "list_id": 52,
+        "description": "Iron ingot",
+        "quantity": 1,
+        "notes": null,
+        "unit_weight": 1,
+        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      }
+    ]
+  }
+]
+```
+
+### Error Responses
+
+In general, no errors are expected to be returned from this endpoint. However, unanticipated problems can always come up.
+
+#### Statuses
+
+* 404 Not Found
+* 500 Internal Server Error
+
+#### Example Bodies
+
+A 404 error is the result of the game not being found or not belonging to the authenticated user. It does not include a response body.
+
+A 500 error response, which is always a result of an unforeseen problem, includes the error message:
+```json
+{
+  "errors": ["Something went horribly wrong"]
+}
+```

--- a/docs/api/resources/shopping-lists.md
+++ b/docs/api/resources/shopping-lists.md
@@ -2,19 +2,19 @@
 
 Shopping lists represent lists of items a user needs in a given game. Users can have different lists corresponding to different property locations within each game. Games with shopping lists also have an aggregate list that includes the combined list items and quantities from all the other lists for that game. Aggregate lists are created, updated, and destroyed automatically. They cannot be created, updated, or destroyed through the API (including to change attributes or to add, remove, or update list items).
 
-Each list contains list items, which are returned with each response that includes the list.
+Each list contains [shopping list items](/docs/api/resources/shopping-list-items.md), which are returned with each response that includes the list.
 
-When making requests to update the title of a list, there are some validations and automatic transformations to keep in mind:
+When making requests to update the title of a shopping list, there are some validations and automatic transformations to keep in mind:
 
-* Titles must be unique per user - you cannot name two of your lists the same thing
+* Titles must be unique per game - you cannot name two lists the same thing within the same game
 * Only an aggregate list can be called "All Items"
 * All aggregate lists are called "All Items" and there is no way to rename them something else
 * Titles are saved with headline casing regardless of the case submitted in the request (for example, "lOrd of the rINgS" will be saved as "Lord of the Rings")
-* If the request includes a blank title, then the title will be saved as "My List N", where N is the integer above the highest integer used in an existing "My List" title (so if the user has "My List 1" and "My List 3", the next time they try to save a list without a title it will be called "My List 4")
+* If the request includes a blank title, then the title will be saved as "My List N", where N is the integer above the highest nonnegative integer used in an existing "My List" title (so if the game has "My List 1" and "My List 3", the next time the user tries to save a list without a title it will be called "My List 4")
 * Leading and trailing whitespace will be stripped from titles before they are saved, so " My List 2  " becomes "My List 2"
-* Titles may only contain alphanumeric characters and spaces - any other characters (that aren't leading or trailing whitespace, which will be stripped regardless) cause the API to return a 422 response
+* Titles may only contain alphanumeric characters, spaces, hyphens, apostrophes, and commas - any other characters (that aren't leading or trailing whitespace, which will be stripped regardless) cause the API to return a 422 response
 
-Like other resources in SIM, shopping lists are scoped to the authenticated user. There is no way to retrieve shopping lists for any other user through the API.
+Like other resources in SIM, shopping lists are scoped to the authenticated user. There is no way to retrieve or manage shopping lists for any other user through the API.
 
 ## Endpoints
 

--- a/docs/api/resources/shopping-lists.md
+++ b/docs/api/resources/shopping-lists.md
@@ -10,7 +10,7 @@ When making requests to update the title of a shopping list, there are some vali
 * Only an aggregate list can be called "All Items"
 * All aggregate lists are called "All Items" and there is no way to rename them something else
 * Titles are saved with headline casing regardless of the case submitted in the request (for example, "lOrd of the rINgS" will be saved as "Lord of the Rings")
-* If the request includes a blank title, then the title will be saved as "My List N", where N is the integer above the highest nonnegative integer used in an existing "My List" title (so if the game has "My List 1" and "My List 3", the next time the user tries to save a list without a title it will be called "My List 4")
+* If the request includes a blank title, then the title will be saved as "My List N", where N is the integer above the highest nonnegative integer used in an existing "My List" title (so if the game has "My List 1" and "My List 3", the next time the user tries to save a list for that game without a title it will be called "My List 4")
 * Leading and trailing whitespace will be stripped from titles before they are saved, so " My List 2  " becomes "My List 2"
 * Titles may only contain alphanumeric characters, spaces, hyphens, apostrophes, and commas - any other characters (that aren't leading or trailing whitespace, which will be stripped regardless) cause the API to return a 422 response
 

--- a/spec/controller_services/inventory_lists_controller/index_service_spec.rb
+++ b/spec/controller_services/inventory_lists_controller/index_service_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'service/ok_result'
+require 'service/not_found_result'
+require 'service/internal_server_error_result'
+
+RSpec.describe InventoryListsController::IndexService do
+  describe '#perform' do
+    subject(:perform) { described_class.new(user, game.id).perform }
+
+    let(:user) { create(:user) }
+
+    context 'when there are no inventory lists for that game' do
+      let(:game) { create(:game, user: user) }
+
+      it 'returns a Service::OKResult' do
+        expect(perform).to be_a(Service::OKResult)
+      end
+
+      it 'returns the empty list' do
+        expect(perform.resource).to eq []
+      end
+    end
+
+    context 'when there are inventory lists for that game' do
+      let(:game) { create(:game_with_inventory_lists, user: user) }
+
+      it 'returns a Service::OKResult' do
+        expect(perform).to be_a(Service::OKResult)
+      end
+
+      it 'returns the inventory lists' do
+        expect(perform.resource).to eq game.inventory_lists
+      end
+    end
+
+    context 'when the game is not found' do
+      let(:game) { double(id: 2389) }
+
+      it 'returns a Service::NotFoundResult' do
+        expect(perform).to be_a(Service::NotFoundResult)
+      end
+
+      it "doesn't return any error messages" do
+        expect(perform.errors).to be_empty
+      end
+    end
+
+    context "when the game doesn't belong to the user"
+
+    context 'when something unexpected goes wrong'
+  end
+end

--- a/spec/controller_services/inventory_lists_controller/index_service_spec.rb
+++ b/spec/controller_services/inventory_lists_controller/index_service_spec.rb
@@ -47,8 +47,32 @@ RSpec.describe InventoryListsController::IndexService do
       end
     end
 
-    context "when the game doesn't belong to the user"
+    context "when the game doesn't belong to the user" do
+      let(:game) { create(:game) }
 
-    context 'when something unexpected goes wrong'
+      it 'returns a Service::NotFoundResult' do
+        expect(perform).to be_a(Service::NotFoundResult)
+      end
+
+      it "doesn't return any error messages" do
+        expect(perform.errors).to be_empty
+      end
+    end
+
+    context 'when something unexpected goes wrong' do
+      let(:game) { create(:game, user: user) }
+
+      before do
+        allow(user.games).to receive(:find).and_raise(StandardError.new('Something went horribly wrong'))
+      end
+
+      it 'returns a Service::InternalServerErrorResult' do
+        expect(perform).to be_a(Service::InternalServerErrorResult)
+      end
+
+      it 'returns an array with the error message' do
+        expect(perform.errors).to eq ['Something went horribly wrong']
+      end
+    end
   end
 end

--- a/spec/requests/inventory_lists_spec.rb
+++ b/spec/requests/inventory_lists_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'InventoryLists', type: :request do
+  let(:headers) do
+    {
+      'Content-Type'  => 'application/json',
+      'Authorization' => 'Bearer xxxxxxx',
+    }
+  end
+
+  describe 'GET /games/:game_id/inventory_lists' do
+    subject(:get_index) { get "/games/#{game.id}/inventory_lists", headers: headers }
+
+    context 'when unauthenticated' do
+      let(:game) { create(:game) }
+
+      before do
+        # create some data to not be returned
+        create_list(:inventory_list, 3, game: game)
+      end
+
+      it 'returns 401' do
+        get_index
+        expect(response.status).to eq 401
+      end
+
+      it 'returns an error body indicating authorisation failed' do
+        get_index
+        expect(JSON.parse(response.body)).to eq({ 'errors' => ['Google OAuth token validation failed'] })
+      end
+    end
+
+    context 'when authenticated' do
+      let(:authenticated_user) { create(:user) }
+      let(:validation_data) do
+        {
+          'exp'   => (Time.zone.now + 1.year).to_i,
+          'email' => authenticated_user.email,
+          'name'  => authenticated_user.name,
+        }
+      end
+
+      let(:validator) { instance_double(GoogleIDToken::Validator, check: validation_data) }
+
+      before do
+        allow(GoogleIDToken::Validator).to receive(:new).and_return(validator)
+      end
+
+      context 'when the game is not found' do
+        let(:game) { double(id: 491_349_759) }
+
+        it 'returns status 404' do
+          get_index
+          expect(response.status).to eq 404
+        end
+
+        it 'returns no data' do
+          get_index
+          expect(response.body).to be_empty
+        end
+      end
+
+      context "when the game doesn't belong to the authenticated user" do
+        let(:game) { create(:game) }
+
+        it 'returns status 404' do
+          get_index
+          expect(response.status).to eq 404
+        end
+
+        it 'returns no data' do
+          get_index
+          expect(response.body).to be_empty
+        end
+      end
+
+      context 'when there are no inventory lists for that game' do
+        let(:game) { create(:game, user: authenticated_user) }
+
+        it 'returns status 200' do
+          get_index
+          expect(response.status).to eq 200
+        end
+
+        it 'returns an empty array' do
+          get_index
+          expect(JSON.parse(response.body)).to eq []
+        end
+      end
+
+      context 'when there are inventory lists for that game' do
+        let(:game) { create(:game_with_inventory_lists, user: authenticated_user) }
+
+        it 'returns status 200' do
+          get_index
+          expect(response.status).to eq 200
+        end
+
+        it 'returns the inventory lists in index order' do
+          get_index
+          expect(response.body).to eq game.inventory_lists.index_order.to_json
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'ShoppingLists', type: :request do
     }
   end
 
-  describe 'POST /shopping_lists' do
+  describe 'POST games/:game_id/shopping_lists' do
     subject(:create_shopping_list) { post "/games/#{game.id}/shopping_lists", params: { shopping_list: {} }.to_json, headers: headers }
 
     context 'when authenticated' do
@@ -467,7 +467,7 @@ RSpec.describe 'ShoppingLists', type: :request do
     end
   end
 
-  describe 'GET /shopping_lists' do
+  describe 'GET games/:game_id/shopping_lists' do
     subject(:get_index) { get "/games/#{game.id}/shopping_lists", headers: headers }
 
     context 'when unauthenticated' do


### PR DESCRIPTION
## Context

[**GET /games/:game_id/inventory_lists endpoint**](https://trello.com/c/KYs5v4eY/137-get-games-gameid-inventorylists-endpoint)

Now that the inventory list/inventory list item models are up and running and the `Listable` and `Aggregatable` concerns can handle the new `unit_weight` column, it's time to start building out the routes for the new models. The first step is the `index` route for inventory lists, which returns all inventory lists for the specified game.

## Changes

* Create new `InventoryListsController` to handle requests for inventory lists
* Create `InventoryListsController::IndexService` class to handle `GET index` requests
* Wire up the resource routes
* Add request specs and unit specs for the controller service

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

I followed the existing controller service pattern. This service turns out to be basically identical to the `ShoppingListsController::IndexService`, making me wonder if there's a good way to DRY it up. 