### PR TITLE
Endpoint to create an inventory list

### DIFF
--- a/app/controller_services/inventory_lists_controller/create_service.rb
+++ b/app/controller_services/inventory_lists_controller/create_service.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'service/created_result'
+require 'service/unprocessable_entity_result'
+require 'service/not_found_result'
+require 'service/internal_server_error_result'
+
+class InventoryListsController < ApplicationController
+  class CreateService
+    AGGREGATE_LIST_ERROR = 'Cannot manually create an aggregate inventory list'
+
+    def initialize(user, game_id, params)
+      @user    = user
+      @game_id = game_id
+      @params  = params
+    end
+
+    def perform
+      return Service::UnprocessableEntityResult.new(errors: [AGGREGATE_LIST_ERROR]) if params[:aggregate]
+
+      inventory_list             = game.inventory_lists.new(params)
+      preexisting_aggregate_list = game.aggregate_inventory_list
+
+      if inventory_list.save
+        resource = preexisting_aggregate_list ? inventory_list : [game.aggregate_inventory_list, inventory_list]
+        Service::CreatedResult.new(resource: resource)
+      else
+        Service::UnprocessableEntityResult.new(errors: inventory_list.error_array)
+      end
+    rescue ActiveRecord::RecordNotFound
+      Service::NotFoundResult.new
+    rescue StandardError => e
+      Service::InternalServerErrorResult.new(errors: [e.message])
+    end
+
+    private
+
+    attr_reader :user, :game_id, :params
+
+    def game
+      @game ||= user.games.find(game_id)
+    end
+  end
+end

--- a/app/controllers/inventory_lists_controller.rb
+++ b/app/controllers/inventory_lists_controller.rb
@@ -8,4 +8,16 @@ class InventoryListsController < ApplicationController
 
     ::Controller::Response.new(self, result).execute
   end
+
+  def create
+    result = CreateService.new(current_user, params[:game_id], inventory_list_params).perform
+
+    ::Controller::Response.new(self, result).execute
+  end
+
+  private
+
+  def inventory_list_params
+    params[:inventory_list].present? ? params.require(:inventory_list).permit(:title, :aggregate) : {}
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
       resources :shopping_list_items, shallow: true, except: %i[index show]
     end
 
-    resources :inventory_lists, shallow: true, only: %i[index]
+    resources :inventory_lists, shallow: true, only: %i[index create]
   end
 
   get '/privacy', to: 'utilities#privacy'

--- a/docs/api/resources/inventory-lists.md
+++ b/docs/api/resources/inventory-lists.md
@@ -19,6 +19,7 @@ Like other resources in SIM, inventory lists are scoped to the authenticated use
 ## Endpoints
 
 * [`GET /games/:game_id/inventory_lists`](#get-gamesgame_idinventory_lists)
+* [`POST /games/:game_id/inventory_lists`](#post-gamesgame_idinventory_lists)
 
 ## GET /games/:game_id/inventory_lists
 
@@ -138,6 +139,126 @@ In general, no errors are expected to be returned from this endpoint. However, u
 #### Example Bodies
 
 A 404 error is the result of the game not being found or not belonging to the authenticated user. It does not include a response body.
+
+A 500 error response, which is always a result of an unforeseen problem, includes the error message:
+```json
+{
+  "errors": ["Something went horribly wrong"]
+}
+```
+
+## POST /games/:game_id/inventory_lists
+
+Creates a new inventory list for the specified game if it exists and belongs to the authenticated user. If the game does not already have an aggregate list, an aggregate list will also be created automatically. The response is an array that includes the newly created inventory list(s).
+
+The request does not have to include a body. If it does, the body should include an `"inventory_list"` object with an optional `"title"` key, the only attribute that can be set on an inventory list via request data. If you don't include a title, your list will be titled "My List N", where _N_ is an integer equal to the highest numbered default list title you have for that game. For example, if one of your games has lists titled "My List 1", "My List 3", and "My List 4" and you don't specify a title for the new list you're requesting for the game, your new list will be titled "My List 5".
+
+There are a few validations and automatic changes made to titles:
+
+* Titles must be unique per game - you cannot name two of one game's lists the same thing
+* Only an aggregate list can be called "All Items"
+* All aggregate lists are called "All Items" and there is no way to rename them something else
+* Titles are saved with headline casing regardless of the case submitted in the request (for example, "lOrd of the rINgS" will be saved as "Lord of the Rings")
+* If the request includes a blank title, then the title will be saved as "My List N", where N is the integer above the highest integer used in an existing "My List" title (so if the user has "My List 1" and "My List 3", the next time the client creates a list without a title, it will be called "My List 4")
+
+### Example Requests
+
+Request specifying a title:
+```
+POST games/1455/inventory_lists
+Authorization: Bearer xxxxxxxxxx
+Content-Type: application/json
+{
+  "inventory_list": {
+    "title": "Custom Title"
+  }
+}
+```
+
+Request not specifying a title (list will be given a default title as defined above):
+```
+POST /games/8928/inventory_lists
+Authorization: Bearer xxxxxxxxxx
+Content-Type: application/json
+{ "inventory_list": {} }
+```
+
+Request with no request body (the list will be given a default title as defined above):
+```
+POST /games/8928/inventory_lists
+Authorization: Bearer xxxxxxxxxx
+```
+
+### Success Responses
+
+#### Statuses
+
+* 201 Created
+
+#### Example Bodies
+
+When there hasn't been an aggregate list created:
+```json
+{
+  "id": 4,
+  "user_id": 6,
+  "aggregate": false,
+  "aggregate_list_id": 3,
+  "title": "My List 1",
+  "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+  "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+  "list_items": []
+}
+```
+
+When the aggregate list has also been created:
+```json
+[
+  {
+    "id": 4,
+    "user_id": 6,
+    "aggregate": true,
+    "title": "All Items",
+    "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+  },
+  {
+    "id": 5,
+    "user_id": 6,
+    "aggregate": false,
+    "aggregate_list_id": 4,
+    "title": "My List 1",
+    "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+  }
+]
+```
+
+### Error Responses
+
+#### Statuses
+
+* 404 Not Found
+* 422 Unprocessable Entity
+* 500 Internal Server Error
+
+#### Example Bodies
+
+If the game with the given `game_id` is not found or does not belong to the authenticated user, a 404 response will be returned. This response will have no body.
+
+If duplicate title is given:
+```json
+{
+  "errors": ["Title must be unique per game"]
+}
+```
+
+If request attempts to create an aggregate list:
+```json
+{
+  "errors": ["Cannot manually create an aggregate inventory list"]
+}
+```
 
 A 500 error response, which is always a result of an unforeseen problem, includes the error message:
 ```json

--- a/spec/controller_services/inventory_lists_controller/create_service_spec.rb
+++ b/spec/controller_services/inventory_lists_controller/create_service_spec.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'service/created_result'
+require 'service/unprocessable_entity_result'
+require 'service/not_found_result'
+require 'service/internal_server_error_result'
+
+RSpec.describe InventoryListsController::CreateService do
+  describe '#perform' do
+    subject(:perform) { described_class.new(user, game.id, params).perform }
+
+    let(:user) { create(:user) }
+
+    context 'when the params are valid' do
+      let!(:game)  { create(:game, user: user) }
+      let(:params) { { title: 'Hjerim' } }
+
+      context 'when the game has no aggregate inventory list' do
+        it 'creates two lists' do
+          expect { perform }
+            .to change(game.inventory_lists, :count).from(0).to(2)
+        end
+
+        it 'creates an aggregate inventory list for the given game' do
+          perform
+          expect(game.aggregate_inventory_list).to be_present
+        end
+
+        it 'creates a regular inventory list for the given game' do
+          perform
+          expect(game.inventory_lists.last.title).to eq 'Hjerim'
+        end
+
+        it 'updates the game' do
+          t = Time.zone.now + 3.days
+          Timecop.freeze(t) do
+            perform
+            expect(game.reload.updated_at).to be_within(0.005.seconds).of(t)
+          end
+        end
+
+        it 'returns a Service::CreatedResult' do
+          expect(perform).to be_a(Service::CreatedResult)
+        end
+
+        it 'sets the resource to include both lists' do
+          expect(perform.resource).to eq [game.aggregate_inventory_list, game.inventory_lists.last]
+        end
+      end
+
+      context 'when the game has an aggregate inventory list' do
+        before do
+          create(:aggregate_inventory_list, game: game)
+        end
+
+        it 'creates an inventory list for the given game' do
+          expect { perform }
+            .to change(game.inventory_lists, :count).from(1).to(2)
+        end
+
+        it 'returns a Service::CreatedResult' do
+          expect(perform).to be_a(Service::CreatedResult)
+        end
+
+        it 'sets the resource to the created list' do
+          expect(perform.resource).to eq game.inventory_lists.last
+        end
+      end
+    end
+
+    context 'when the params are invalid' do
+      let(:game)    { create(:game, user: user) }
+      let(:game_id) { game.id }
+      let(:params)  { { title: '|nvalid Tit|e' } }
+
+      it "doesn't create an inventory list" do
+        expect { perform }
+          .not_to change(game.inventory_lists, :count)
+      end
+
+      it 'returns a Service::UnprocessableEntityResult' do
+        expect(perform).to be_a(Service::UnprocessableEntityResult)
+      end
+
+      it 'sets the errors' do
+        expect(perform.errors).to eq ["Title can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')"]
+      end
+    end
+
+    context 'when the game is not found' do
+      let(:game)   { double(id: 898_243) }
+      let(:params) { { title: 'My Inventory List' } }
+
+      it 'returns a Service::NotFoundResult' do
+        expect(perform).to be_a(Service::NotFoundResult)
+      end
+
+      it "doesn't return any data" do
+        expect(perform.errors).to be_empty
+      end
+    end
+
+    context "when the game doesn't belong to the given user" do
+      let(:game)   { create(:game) }
+      let(:params) { { title: 'My Inventory List' } }
+
+      it 'returns a Service::NotFoundResult' do
+        expect(perform).to be_a(Service::NotFoundResult)
+      end
+
+      it "doesn't return any data" do
+        expect(perform.errors).to be_empty
+      end
+    end
+
+    context 'when the request tries to create an aggregate list' do
+      let(:game) { create(:game, user: user) }
+      let(:params) do
+        {
+          title:     'All Items',
+          aggregate: true,
+        }
+      end
+
+      it 'returns a Service::UnprocessableEntityResult' do
+        expect(perform).to be_a(Service::UnprocessableEntityResult)
+      end
+
+      it 'sets an error' do
+        expect(perform.errors).to eq(['Cannot manually create an aggregate inventory list'])
+      end
+    end
+
+    context 'when something unexpected goes wrong' do
+      let(:game)   { create(:game, user: user) }
+      let(:params) { { title: 'Foobar' } }
+
+      before do
+        allow_any_instance_of(InventoryList).to receive(:save).and_raise(StandardError, 'Something went horribly wrong')
+      end
+
+      it 'returns a Service::InternalServerErrorResult' do
+        expect(perform).to be_a(Service::InternalServerErrorResult)
+      end
+
+      it 'sets the errors' do
+        expect(perform.errors).to eq ['Something went horribly wrong']
+      end
+    end
+  end
+end

--- a/spec/requests/inventory_lists_spec.rb
+++ b/spec/requests/inventory_lists_spec.rb
@@ -206,6 +206,11 @@ RSpec.describe 'InventoryLists', type: :request do
           create_inventory_list
           expect(response.body).to be_empty
         end
+
+        it "doesn't create an inventory list" do
+          expect { create_inventory_list }
+            .not_to change(InventoryList, :count)
+        end
       end
 
       context 'when the params are invalid' do

--- a/spec/requests/inventory_lists_spec.rb
+++ b/spec/requests/inventory_lists_spec.rb
@@ -105,4 +105,155 @@ RSpec.describe 'InventoryLists', type: :request do
       end
     end
   end
+
+  describe 'POST games/:game_id/inventory_lists' do
+    subject(:create_inventory_list) { post "/games/#{game.id}/inventory_lists", params: { inventory_list: {} }.to_json, headers: headers }
+
+    context 'when authenticated' do
+      let!(:user) { create(:user) }
+      let(:validation_data) do
+        {
+          'exp'   => (Time.zone.now + 1.year).to_i,
+          'email' => user.email,
+          'name'  => user.name,
+        }
+      end
+
+      let(:validator) { instance_double(GoogleIDToken::Validator, check: validation_data) }
+
+      before do
+        allow(GoogleIDToken::Validator).to receive(:new).and_return(validator)
+      end
+
+      context 'when all goes well' do
+        let(:game) { create(:game, user: user) }
+
+        context 'when an aggregate list has also been created' do
+          it 'creates a new inventory list' do
+            expect { create_inventory_list }
+              .to change(game.inventory_lists, :count).from(0).to(2) # because of the aggregate list
+          end
+
+          it 'returns the aggregate list as well as the new list' do
+            create_inventory_list
+            expect(response.body).to eq([game.aggregate_inventory_list, game.inventory_lists.last].to_json)
+          end
+
+          it 'returns status 201' do
+            create_inventory_list
+            expect(response.status).to eq 201
+          end
+        end
+
+        context 'when only the new inventory list has been created' do
+          let!(:aggregate_list) { create(:aggregate_inventory_list, game: game, created_at: 2.seconds.ago, updated_at: 2.seconds.ago) }
+
+          it 'creates one list' do
+            expect { create_inventory_list }
+              .to change(game.inventory_lists, :count).from(1).to(2)
+          end
+
+          it 'returns only the newly created list' do
+            create_inventory_list
+            expect(response.body).to eq(game.inventory_lists.last.to_json)
+          end
+        end
+
+        context 'when the request does not include a body' do
+          subject(:create_inventory_list) { post "/games/#{game.id}/inventory_lists", headers: headers }
+
+          before do
+            # let's not have this request create an aggregate list too
+            create(:aggregate_inventory_list, game: game)
+          end
+
+          it 'returns status 201' do
+            create_inventory_list
+            expect(response.status).to eq 201
+          end
+
+          it 'creates the inventory list with a default title' do
+            create_inventory_list
+            list_attributes = JSON.parse(response.body)
+            expect(list_attributes['title']).to eq 'My List 1'
+          end
+        end
+      end
+
+      context 'when the game is not found' do
+        let(:game) { double(id: 84_968_294) }
+
+        it 'returns status 404' do
+          create_inventory_list
+          expect(response.status).to eq 404
+        end
+
+        it "doesn't return any data" do
+          create_inventory_list
+          expect(response.body).to be_empty
+        end
+      end
+
+      context "when the game doesn't belong to the authenticated user" do
+        let(:game) { create(:game) }
+
+        it 'returns status 404' do
+          create_inventory_list
+          expect(response.status).to eq 404
+        end
+
+        it "doesn't return any data" do
+          create_inventory_list
+          expect(response.body).to be_empty
+        end
+      end
+
+      context 'when the params are invalid' do
+        subject(:create_inventory_list) { post "/games/#{game.id}/inventory_lists", params: { inventory_list: { title: existing_list.title } }.to_json, headers: headers }
+
+        let(:game)          { create(:game, user: user) }
+        let(:existing_list) { create(:inventory_list, game: game) }
+
+        it 'returns status 422' do
+          create_inventory_list
+          expect(response.status).to eq 422
+        end
+
+        it 'returns the errors' do
+          create_inventory_list
+          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Title must be unique per game'] })
+        end
+      end
+
+      context 'when the client attempts to create an aggregate list' do
+        subject(:create_inventory_list) { post "/games/#{game.id}/inventory_lists", params: { inventory_list: { aggregate: true } }.to_json, headers: headers }
+
+        let(:game) { create(:game, user: user) }
+
+        it "doesn't create a list" do
+          expect { create_inventory_list }
+            .not_to change(game.inventory_lists, :count)
+        end
+
+        it 'returns an error' do
+          create_inventory_list
+          expect(response.status).to eq 422
+        end
+
+        it 'returns a helpful error body' do
+          create_inventory_list
+          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Cannot manually create an aggregate inventory list'] })
+        end
+      end
+    end
+
+    context 'when unauthenticated' do
+      let(:game) { create(:game) }
+
+      it 'returns 401' do
+        create_inventory_list
+        expect(response.status).to eq 401
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

[**POST /games/:game_id/inventory_lists endpoint**](https://trello.com/c/xFugq2X6/138-post-games-gameid-inventorylists-endpoint)

We need to build out an endpoint that creates inventory lists. Its behaviour should be the same as the endpoint that creates shopping lists.

## Changes

* Add `POST /games/:game_id/inventory_lists` route and define method in controller
* Create `InventoryListsController::CreateService` to handle requests to this route
* Add request specs and unit specs for the service
* Add docs for the new endpoint

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

There is again a lot of duplication with the `ShoppingListsController` services, but I think it's best to not refactor out code until it is duplicated more places. I want to make sure that the `InventoryList` and `ShoppingList` routes are not too tightly coupled in case behaviour for one of them needs to change.
