### PR TITLE
Endpoint to update inventory lists

### DIFF
--- a/app/controller_services/inventory_lists_controller/update_service.rb
+++ b/app/controller_services/inventory_lists_controller/update_service.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'service/ok_result'
+
+class InventoryListsController < ApplicationController
+  class UpdateService
+    def initialize(user, list_id, params)
+      @user    = user
+      @list_id = list_id
+      @params  = params
+    end
+
+    def perform
+      inventory_list.update!(params)
+      Service::OKResult.new(resource: inventory_list)
+    end
+
+    private
+
+    attr_reader :user, :list_id, :params
+
+    def inventory_list
+      @inventory_list ||= InventoryList.find(list_id)
+    end
+  end
+end

--- a/app/controller_services/inventory_lists_controller/update_service.rb
+++ b/app/controller_services/inventory_lists_controller/update_service.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'service/ok_result'
+require 'service/unprocessable_entity_result'
 
 class InventoryListsController < ApplicationController
   class UpdateService
@@ -11,8 +12,11 @@ class InventoryListsController < ApplicationController
     end
 
     def perform
-      inventory_list.update!(params)
-      Service::OKResult.new(resource: inventory_list)
+      if inventory_list.update(params)
+        Service::OKResult.new(resource: inventory_list)
+      else
+        Service::UnprocessableEntityResult.new(errors: inventory_list.error_array)
+      end
     end
 
     private

--- a/app/controller_services/inventory_lists_controller/update_service.rb
+++ b/app/controller_services/inventory_lists_controller/update_service.rb
@@ -18,7 +18,7 @@ class InventoryListsController < ApplicationController
     end
 
     def perform
-      return Service::MethodNotAllowedResult.new(errors: [AGGREGATE_LIST_ERROR]) if inventory_list.aggregate
+      return Service::MethodNotAllowedResult.new(errors: [AGGREGATE_LIST_ERROR]) if inventory_list.aggregate == true
       return Service::UnprocessableEntityResult.new(errors: [DISALLOWED_UPDATE_ERROR]) if params[:aggregate] == true
 
       if inventory_list.update(params)
@@ -29,6 +29,7 @@ class InventoryListsController < ApplicationController
     rescue ActiveRecord::RecordNotFound
       Service::NotFoundResult.new
     rescue StandardError => e
+      Rails.logger.error "Internal Server Error: #{e.message}"
       Service::InternalServerErrorResult.new(errors: [e.message])
     end
 

--- a/app/controller_services/inventory_lists_controller/update_service.rb
+++ b/app/controller_services/inventory_lists_controller/update_service.rb
@@ -2,9 +2,15 @@
 
 require 'service/ok_result'
 require 'service/unprocessable_entity_result'
+require 'service/not_found_result'
+require 'service/method_not_allowed_result'
+require 'service/internal_server_error_result'
 
 class InventoryListsController < ApplicationController
   class UpdateService
+    AGGREGATE_LIST_ERROR    = 'Cannot manually update an aggregate inventory list'
+    DISALLOWED_UPDATE_ERROR = 'Cannot make a regular inventory list an aggregate list'
+
     def initialize(user, list_id, params)
       @user    = user
       @list_id = list_id
@@ -12,11 +18,18 @@ class InventoryListsController < ApplicationController
     end
 
     def perform
+      return Service::MethodNotAllowedResult.new(errors: [AGGREGATE_LIST_ERROR]) if inventory_list.aggregate
+      return Service::UnprocessableEntityResult.new(errors: [DISALLOWED_UPDATE_ERROR]) if params[:aggregate] == true
+
       if inventory_list.update(params)
         Service::OKResult.new(resource: inventory_list)
       else
         Service::UnprocessableEntityResult.new(errors: inventory_list.error_array)
       end
+    rescue ActiveRecord::RecordNotFound
+      Service::NotFoundResult.new
+    rescue StandardError => e
+      Service::InternalServerErrorResult.new(errors: [e.message])
     end
 
     private
@@ -24,7 +37,7 @@ class InventoryListsController < ApplicationController
     attr_reader :user, :list_id, :params
 
     def inventory_list
-      @inventory_list ||= InventoryList.find(list_id)
+      @inventory_list ||= user.inventory_lists.find(list_id)
     end
   end
 end

--- a/app/controllers/inventory_lists_controller.rb
+++ b/app/controllers/inventory_lists_controller.rb
@@ -15,6 +15,12 @@ class InventoryListsController < ApplicationController
     ::Controller::Response.new(self, result).execute
   end
 
+  def update
+    result = UpdateService.new(current_user, params[:id], inventory_list_params).perform
+
+    ::Controller::Response.new(self, result).execute
+  end
+
   private
 
   def inventory_list_params

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
       resources :shopping_list_items, shallow: true, except: %i[index show]
     end
 
-    resources :inventory_lists, shallow: true, only: %i[index create]
+    resources :inventory_lists, shallow: true, only: %i[index create update]
   end
 
   get '/privacy', to: 'utilities#privacy'

--- a/docs/api/resources/inventory-lists.md
+++ b/docs/api/resources/inventory-lists.md
@@ -266,3 +266,101 @@ A 500 error response, which is always a result of an unforeseen problem, include
   "errors": ["Something went horribly wrong"]
 }
 ```
+
+## PATCH|PUT /inventory_lists/:id
+
+If the specified inventory list exists, belongs to the authenticated user, and is not an aggregate list, updates the title and returns the inventory list. Title is the only inventory list attribute that can be modified using this endpoint. This endpoint also supports the `PUT` method.
+
+### Example Requests
+
+Requests must include a `"inventory_list"` object with a `"title"` key.
+
+Using a `PATCH` request:
+```
+PATCH /inventory_lists/3
+Authorization: Bearer xxxxxxxxxx
+Content-Type: application/json
+{
+  "inventory_list": {
+    "title": "New List Title"
+  }
+}
+```
+
+Using a `PUT` request:
+```
+PUT /inventory_lists/3
+Authorization: Bearer xxxxxxxxxxx
+Content-Type: application/json
+{
+  "inventory_list": {
+    "title": "New List Title"
+  }
+}
+```
+
+### Success Response
+
+#### Statuses
+
+* 200 OK
+
+#### Example Body
+
+```json
+{
+  "id": 834,
+  "user_id": 16,
+  "aggregate": false,
+  "aggregate_list_id": 833,
+  "title": "New List Title",
+  "created_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00",
+  "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+  "list_items": [
+    {
+      "id": 32,
+      "list_id": 834,
+      "description": "Ebony sword",
+      "quantity": 1,
+      "notes": "To enchant with Soul Trap",
+      "unit_weight": 14,
+      "created_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00",
+      "updated_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00"
+    }
+  ]
+}
+```
+
+### Error Responses
+
+#### Statuses
+
+* 404 Not Found
+* 405 Method Not Allowed
+* 422 Unprocessable Entity
+* 500 Internal Server Error
+
+#### Example Bodies
+
+For a 404 response, no response body is returned.
+
+For a 422 response due to title uniqueness constraint:
+```json
+{
+  "errors": ["Title must be unique per game"]
+}
+```
+
+For a 405 response due to attempting to update an aggregate list or convert a regular list to an aggregate list:
+```json
+{
+  "errors": ["Cannot manually update an aggregate inventory list"]
+}
+```
+
+A 500 error response, which is always a result of an unforeseen problem, includes the error message:
+```json
+{
+  "errors": ["Something went horribly wrong"]
+}
+```

--- a/docs/api/resources/shopping-lists.md
+++ b/docs/api/resources/shopping-lists.md
@@ -338,7 +338,6 @@ Content-Type: application/json
 
 #### Example Bodies
 
-
 For a 404 response, no response body is returned.
 
 For a 422 response due to title uniqueness constraint:

--- a/spec/controller_services/inventory_lists_controller/update_service_spec.rb
+++ b/spec/controller_services/inventory_lists_controller/update_service_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 require 'service/ok_result'
+require 'service/unprocessable_entity_result'
 
 RSpec.describe InventoryListsController::UpdateService do
   describe '#perform' do
@@ -34,6 +35,19 @@ RSpec.describe InventoryListsController::UpdateService do
           perform
           expect(game.reload.updated_at).to be_within(0.005.seconds).of(t)
         end
+      end
+    end
+
+    context 'when the params are invalid' do
+      let(:inventory_list) { create(:inventory_list, game: game) }
+      let(:params)         { { title: '|nvalid Tit|e' } }
+
+      it 'returns a Service::UnprocessableEntityResult' do
+        expect(perform).to be_a(Service::UnprocessableEntityResult)
+      end
+
+      it 'sets the errors' do
+        expect(perform.errors).to eq(["Title can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')"])
       end
     end
   end

--- a/spec/controller_services/inventory_lists_controller/update_service_spec.rb
+++ b/spec/controller_services/inventory_lists_controller/update_service_spec.rb
@@ -3,6 +3,9 @@
 require 'rails_helper'
 require 'service/ok_result'
 require 'service/unprocessable_entity_result'
+require 'service/not_found_result'
+require 'service/method_not_allowed_result'
+require 'service/internal_server_error_result'
 
 RSpec.describe InventoryListsController::UpdateService do
   describe '#perform' do
@@ -48,6 +51,83 @@ RSpec.describe InventoryListsController::UpdateService do
 
       it 'sets the errors' do
         expect(perform.errors).to eq(["Title can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')"])
+      end
+    end
+
+    context "when the inventory list doesn't exist" do
+      let(:inventory_list) { double(id: 23_859) }
+      let(:params)         { { title: 'Valid New Title' } }
+
+      it 'returns a Service::NotFoundResult' do
+        expect(perform).to be_a(Service::NotFoundResult)
+      end
+
+      it "doesn't return any data", :aggregate_failures do
+        expect(perform.resource).to be_blank
+        expect(perform.errors).to be_blank
+      end
+    end
+
+    context "when the inventory list doesn't belong to the user" do
+      let(:inventory_list) { create(:inventory_list, game: game) }
+      let(:game)           { create(:game) }
+      let(:params)         { { title: 'Valid New Title' } }
+
+      it "doesn't update the list" do
+        perform
+        expect(inventory_list.reload.title).not_to eq 'Valid New Title'
+      end
+
+      it 'returns a Service::NotFoundResult' do
+        expect(perform).to be_a(Service::NotFoundResult)
+      end
+
+      it "doesn't return any data", :aggregate_failures do
+        expect(perform.resource).to be_blank
+        expect(perform.errors).to be_blank
+      end
+    end
+
+    context 'when the inventory list is an aggregate list' do
+      let(:inventory_list) { aggregate_list }
+      let(:params)         { { title: 'New Title' } }
+
+      it 'returns a Service::MethodNotAllowedResult' do
+        expect(perform).to be_a(Service::MethodNotAllowedResult)
+      end
+
+      it 'sets the error message' do
+        expect(perform.errors).to eq(['Cannot manually update an aggregate inventory list'])
+      end
+    end
+
+    context 'when the request tries to set aggregate to true' do
+      let(:inventory_list) { create(:inventory_list, game: game) }
+      let(:params)         { { aggregate: true } }
+
+      it 'returns a Service::UnprocessableEntityResult' do
+        expect(perform).to be_a(Service::UnprocessableEntityResult)
+      end
+
+      it 'sets the error message' do
+        expect(perform.errors).to eq(['Cannot make a regular inventory list an aggregate list'])
+      end
+    end
+
+    context 'when something unexpected goes wrong' do
+      let(:inventory_list) { create(:inventory_list, game: game) }
+      let(:params)         { { title: 'New Title' } }
+
+      before do
+        allow_any_instance_of(InventoryList).to receive(:update).and_raise(StandardError, 'Something went horribly wrong')
+      end
+
+      it 'returns a Service::InternalServerErrorResult' do
+        expect(perform).to be_a(Service::InternalServerErrorResult)
+      end
+
+      it 'sets the errors' do
+        expect(perform.errors).to eq ['Something went horribly wrong']
       end
     end
   end

--- a/spec/controller_services/inventory_lists_controller/update_service_spec.rb
+++ b/spec/controller_services/inventory_lists_controller/update_service_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'service/ok_result'
+
+RSpec.describe InventoryListsController::UpdateService do
+  describe '#perform' do
+    subject(:perform) { described_class.new(user, inventory_list.id, params).perform }
+
+    let!(:aggregate_list) { create(:aggregate_inventory_list, game: game) }
+    let(:user)            { create(:user) }
+    let(:game)            { create(:game, user: user) }
+
+    context 'when all goes well' do
+      let(:inventory_list) { create(:inventory_list, game: game, aggregate_list: aggregate_list) }
+      let(:params)         { { title: 'My New Title' } }
+
+      it 'updates the inventory list' do
+        perform
+        expect(inventory_list.reload.title).to eq 'My New Title'
+      end
+
+      it 'returns a Service::OKResult' do
+        expect(perform).to be_a(Service::OKResult)
+      end
+
+      it 'sets the resource to the updated inventory list' do
+        expect(perform.resource).to eq inventory_list
+      end
+
+      it 'updates the game' do
+        t = Time.zone.now + 3.days
+        Timecop.freeze(t) do
+          perform
+          expect(game.reload.updated_at).to be_within(0.005.seconds).of(t)
+        end
+      end
+    end
+  end
+end

--- a/spec/controller_services/shopping_lists_controller/update_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/update_service_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe ShoppingListsController::UpdateService do
 
     context "when the shopping list doesn't exist" do
       let(:shopping_list) { double(id: 23_859) }
+      let(:game)          { create(:game) }
       let(:params)        { { title: 'Valid New Title' } }
 
       it 'returns a Service::NotFoundResult' do

--- a/spec/controller_services/shopping_lists_controller/update_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/update_service_spec.rb
@@ -55,13 +55,37 @@ RSpec.describe ShoppingListsController::UpdateService do
       end
     end
 
+    context "when the shopping list doesn't exist" do
+      let(:shopping_list) { double(id: 23_859) }
+      let(:params)        { { title: 'Valid New Title' } }
+
+      it 'returns a Service::NotFoundResult' do
+        expect(perform).to be_a(Service::NotFoundResult)
+      end
+
+      it "doesn't return any data", :aggregate_failures do
+        expect(perform.resource).to be_blank
+        expect(perform.errors).to be_blank
+      end
+    end
+
     context 'when the shopping list does not belong to the user' do
       let(:shopping_list) { create(:shopping_list, game: game) }
       let(:game)          { create(:game) }
       let(:params)        { { title: 'Valid New Title' } }
 
+      it "doesn't update the list" do
+        perform
+        expect(shopping_list.reload.title).not_to eq 'Valid New Title'
+      end
+
       it 'returns a Service::NotFoundResult' do
         expect(perform).to be_a(Service::NotFoundResult)
+      end
+
+      it "doesn't return any data", :aggregate_failures do
+        expect(perform.resource).to be_blank
+        expect(perform.errors).to be_blank
       end
     end
 

--- a/spec/controller_services/shopping_lists_controller/update_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/update_service_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ShoppingListsController::UpdateService do
     let(:user)            { create(:user) }
 
     context 'when all goes well' do
-      let(:shopping_list) { create(:shopping_list, game: game, aggregate_list_id: aggregate_list.id) }
+      let(:shopping_list) { create(:shopping_list, game: game, aggregate_list: aggregate_list) }
       let(:game)   { create(:game, user: user) }
       let(:params) { { title: 'My New Title' } }
 

--- a/spec/requests/inventory_lists_spec.rb
+++ b/spec/requests/inventory_lists_spec.rb
@@ -324,9 +324,8 @@ RSpec.describe 'InventoryLists', type: :request do
         end
       end
 
-      context 'when the list belongs to a different user' do
-        let!(:inventory_list) { create(:inventory_list) }
-        let(:list_id)         { inventory_list.id }
+      context 'when the list does not exist' do
+        let(:list_id) { 245_285 }
 
         it 'returns status 404' do
           update_inventory_list
@@ -335,7 +334,27 @@ RSpec.describe 'InventoryLists', type: :request do
 
         it "doesn't return data" do
           update_inventory_list
-          expect(response.body).to be_empty
+          expect(response.body).to be_blank
+        end
+      end
+
+      context 'when the list belongs to a different user' do
+        let!(:inventory_list) { create(:inventory_list) }
+        let(:list_id)         { inventory_list.id }
+
+        it "doesn't update the inventory list" do
+          update_inventory_list
+          expect(inventory_list.reload.title).not_to eq 'Severin Manor'
+        end
+
+        it 'returns status 404' do
+          update_inventory_list
+          expect(response.status).to eq 404
+        end
+
+        it "doesn't return data" do
+          update_inventory_list
+          expect(response.body).to be_blank
         end
       end
 
@@ -477,9 +496,8 @@ RSpec.describe 'InventoryLists', type: :request do
         end
       end
 
-      context 'when the list belongs to a different user' do
-        let!(:inventory_list) { create(:inventory_list) }
-        let(:list_id)         { inventory_list.id }
+      context 'when the list does not exist' do
+        let(:list_id) { 245_285 }
 
         it 'returns status 404' do
           update_inventory_list
@@ -488,7 +506,27 @@ RSpec.describe 'InventoryLists', type: :request do
 
         it "doesn't return data" do
           update_inventory_list
-          expect(response.body).to be_empty
+          expect(response.body).to be_blank
+        end
+      end
+
+      context 'when the list belongs to a different user' do
+        let!(:inventory_list) { create(:inventory_list) }
+        let(:list_id)         { inventory_list.id }
+
+        it "doesn't update the inventory list" do
+          update_inventory_list
+          expect(inventory_list.reload.title).not_to eq 'Severin Manor'
+        end
+
+        it 'returns status 404' do
+          update_inventory_list
+          expect(response.status).to eq 404
+        end
+
+        it "doesn't return data" do
+          update_inventory_list
+          expect(response.body).to be_blank
         end
       end
 

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -182,8 +182,8 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       context 'when all goes well' do
         let!(:shopping_list) { create(:shopping_list, game: game) }
-        let(:game)    { create(:game, user: user) }
-        let(:list_id) { shopping_list.id }
+        let(:game)           { create(:game, user: user) }
+        let(:list_id)        { shopping_list.id }
 
         it 'updates the title' do
           update_shopping_list
@@ -225,7 +225,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       context 'when the list belongs to a different user' do
         let!(:shopping_list) { create(:shopping_list) }
-        let(:list_id) { shopping_list.id }
+        let(:list_id)        { shopping_list.id }
 
         it 'returns status 404' do
           update_shopping_list
@@ -378,7 +378,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       context 'when the list belongs to a different user' do
         let!(:shopping_list) { create(:shopping_list) }
-        let(:list_id) { shopping_list.id }
+        let(:list_id)        { shopping_list.id }
 
         it 'returns status 404' do
           update_shopping_list

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -223,9 +223,8 @@ RSpec.describe 'ShoppingLists', type: :request do
         end
       end
 
-      context 'when the list belongs to a different user' do
-        let!(:shopping_list) { create(:shopping_list) }
-        let(:list_id)        { shopping_list.id }
+      context 'when the list does not exist' do
+        let(:list_id) { 245_285 }
 
         it 'returns status 404' do
           update_shopping_list
@@ -234,7 +233,27 @@ RSpec.describe 'ShoppingLists', type: :request do
 
         it "doesn't return data" do
           update_shopping_list
-          expect(response.body).to be_empty
+          expect(response.body).to be_blank
+        end
+      end
+
+      context 'when the list belongs to a different user' do
+        let!(:shopping_list) { create(:shopping_list) }
+        let(:list_id)        { shopping_list.id }
+
+        it "doesn't update the shopping list" do
+          update_shopping_list
+          expect(shopping_list.reload.title).not_to eq 'Severin Manor'
+        end
+
+        it 'returns status 404' do
+          update_shopping_list
+          expect(response.status).to eq 404
+        end
+
+        it "doesn't return data" do
+          update_shopping_list
+          expect(response.body).to be_blank
         end
       end
 
@@ -376,9 +395,8 @@ RSpec.describe 'ShoppingLists', type: :request do
         end
       end
 
-      context 'when the list belongs to a different user' do
-        let!(:shopping_list) { create(:shopping_list) }
-        let(:list_id)        { shopping_list.id }
+      context 'when the list does not exist' do
+        let(:list_id) { 245_285 }
 
         it 'returns status 404' do
           update_shopping_list
@@ -387,7 +405,27 @@ RSpec.describe 'ShoppingLists', type: :request do
 
         it "doesn't return data" do
           update_shopping_list
-          expect(response.body).to be_empty
+          expect(response.body).to be_blank
+        end
+      end
+
+      context 'when the list belongs to a different user' do
+        let!(:shopping_list) { create(:shopping_list) }
+        let(:list_id)        { shopping_list.id }
+
+        it "doesn't update the shopping list" do
+          update_shopping_list
+          expect(shopping_list.reload.title).not_to eq 'Severin Manor'
+        end
+
+        it 'returns status 404' do
+          update_shopping_list
+          expect(response.status).to eq 404
+        end
+
+        it "doesn't return data" do
+          update_shopping_list
+          expect(response.body).to be_blank
         end
       end
 


### PR DESCRIPTION
## Context

[**PATCH|PUT /inventory_lists/:id endpoint**](https://trello.com/c/8NougOUT/139-patchput-inventorylists-id-endpoint)

We need an endpoint users can use to update their inventory lists.

## Changes

* Add `InventoryListsController::UpdateService` class to handle update requests for inventory lists
* Add `update` route to `InventoryListsController`
* Add request specs and unit specs for new service
* Update docs

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

Like other services, this turned out to be identical to the analogous service for shopping lists. This will be the case for all controller services around inventory lists. I'm leaving it all as-is for now - if the code is duplicated in another model in the future, or if we find ourselves regularly changing it in multiple places to keep the two controllers behaving the same, then we'll extract into a shared module of some kind.
