### PR TITLE
Endpoint to delete an inventory list

### DIFF
--- a/app/controller_services/inventory_lists_controller/destroy_service.rb
+++ b/app/controller_services/inventory_lists_controller/destroy_service.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'service/ok_result'
+require 'service/no_content_result'
+require 'service/method_not_allowed_result'
+require 'service/not_found_result'
+require 'service/internal_server_error_result'
+
+class InventoryListsController < ApplicationController
+  class DestroyService
+    AGGREGATE_LIST_ERROR = 'Cannot manually delete an aggregate inventory list'
+
+    def initialize(user, list_id)
+      @user    = user
+      @list_id = list_id
+    end
+
+    def perform
+      return Service::MethodNotAllowedResult.new(errors: [AGGREGATE_LIST_ERROR]) if inventory_list.aggregate == true
+
+      aggregate_list = destroy_and_update_aggregate_list_items
+      aggregate_list.nil? ? Service::NoContentResult.new : Service::OKResult.new(resource: aggregate_list)
+    rescue ActiveRecord::RecordNotFound
+      Service::NotFoundResult.new
+    rescue StandardError => e
+      Rails.logger.error("Internal Server Error: #{e.message}")
+      Service::InternalServerErrorResult.new(errors: [e.message])
+    end
+
+    private
+
+    attr_reader :user, :list_id
+
+    def destroy_and_update_aggregate_list_items
+      aggregate_list = inventory_list.aggregate_list
+      list_items     = inventory_list.list_items.map(&:attributes)
+
+      ActiveRecord::Base.transaction do
+        # If inventory_list is the user's last regular inventory list, this will also
+        # destroy their aggregate list
+        inventory_list.destroy!
+
+        if aggregate_list&.persisted?
+          list_items.each {|item_attributes| aggregate_list.remove_item_from_child_list(item_attributes) }
+          aggregate_list
+        end
+      end
+    end
+
+    def inventory_list
+      @inventory_list ||= user.inventory_lists.find(list_id)
+    end
+  end
+end

--- a/app/controllers/inventory_lists_controller.rb
+++ b/app/controllers/inventory_lists_controller.rb
@@ -21,6 +21,12 @@ class InventoryListsController < ApplicationController
     ::Controller::Response.new(self, result).execute
   end
 
+  def destroy
+    result = DestroyService.new(current_user, params[:id]).perform
+
+    ::Controller::Response.new(self, result).execute
+  end
+
   private
 
   def inventory_list_params

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
       resources :shopping_list_items, shallow: true, except: %i[index show]
     end
 
-    resources :inventory_lists, shallow: true, only: %i[index create update]
+    resources :inventory_lists, shallow: true, except: %i[show]
   end
 
   get '/privacy', to: 'utilities#privacy'

--- a/docs/api/resources/inventory-lists.md
+++ b/docs/api/resources/inventory-lists.md
@@ -20,6 +20,8 @@ Like other resources in SIM, inventory lists are scoped to the authenticated use
 
 * [`GET /games/:game_id/inventory_lists`](#get-gamesgame_idinventory_lists)
 * [`POST /games/:game_id/inventory_lists`](#post-gamesgame_idinventory_lists)
+* [`PATCH|PUT /inventory_lists/:id`](#patchput-inventory_listsid)
+* [`DELETE /inventory_lists/:id`](#delete-inventory_listsid)
 
 ## GET /games/:game_id/inventory_lists
 
@@ -60,7 +62,7 @@ For a game with multiple lists:
         "description": "Ebony sword",
         "quantity": 1,
         "notes": "Enchanted with Absorb Health",
-        "unit_weight": 14,
+        "unit_weight": 14.0,
         "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
         "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
       },
@@ -69,7 +71,7 @@ For a game with multiple lists:
         "description": "Iron ingot",
         "quantity": 4,
         "notes": null,
-        "unit_weight": 1,
+        "unit_weight": 1.0,
         "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
         "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
       }
@@ -89,7 +91,7 @@ For a game with multiple lists:
         "description": "Ebony sword",
         "quantity": 1,
         "notes": "Enchanted with Absorb Health",
-        "unit_weight": 14,
+        "unit_weight": 14.0,
         "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
         "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
       },
@@ -98,7 +100,7 @@ For a game with multiple lists:
         "description": "Iron ingot",
         "quantity": 3,
         "notes": null,
-        "unit_weight": 1,
+        "unit_weight": 1.0,
         "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
         "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
       }
@@ -118,7 +120,7 @@ For a game with multiple lists:
         "description": "Iron ingot",
         "quantity": 1,
         "notes": null,
-        "unit_weight": 1,
+        "unit_weight": 1.0,
         "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
         "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
       }
@@ -219,6 +221,7 @@ When the aggregate list has also been created:
     "user_id": 6,
     "aggregate": true,
     "title": "All Items",
+    "list_items": [],
     "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
     "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
   },
@@ -228,6 +231,7 @@ When the aggregate list has also been created:
     "aggregate": false,
     "aggregate_list_id": 4,
     "title": "My List 1",
+    "list_items": [],
     "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
     "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
   }
@@ -323,7 +327,7 @@ Content-Type: application/json
       "description": "Ebony sword",
       "quantity": 1,
       "notes": "To enchant with Soul Trap",
-      "unit_weight": 14,
+      "unit_weight": 14.0,
       "created_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00",
       "updated_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00"
     }
@@ -355,6 +359,78 @@ For a 405 response due to attempting to update an aggregate list or convert a re
 ```json
 {
   "errors": ["Cannot manually update an aggregate inventory list"]
+}
+```
+
+A 500 error response, which is always a result of an unforeseen problem, includes the error message:
+```json
+{
+  "errors": ["Something went horribly wrong"]
+}
+```
+## DELETE /inventory_lists/:id
+
+Destroys the given inventory list, and any inventory list items on it, if it exists and belongs to the authenticated user. If the list to be destroyed is the user's only regular (non-aggregate) inventory list, the aggregate list will also be destroyed.
+
+### Example Request
+
+```
+DELETE /inventory_lists/428
+Authorization: Bearer xxxxxxxxxxxx
+```
+
+### Success Response
+
+#### Statuses
+
+* 204 No Content
+* 200 OK
+
+#### Example Body
+
+If the resource deleted was the user's last regular inventory list, the aggregate list will also be destroyed and no content will be returned in the response. If the user had at least one other regular inventory list (as well as an aggregate list), then the aggregate list will be returned with its values updated to reflect removal of the items on the list that was deleted.
+
+```json
+{
+  "id": 834,
+  "user_id": 16,
+  "aggregate": true,
+  "title": "All Items",
+  "created_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00",
+  "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+  "list_items": [
+    {
+      "id": 32,
+      "list_id": 834,
+      "description": "Ebony sword",
+      "quantity": 1,
+      "notes": "To enchant with Soul Trap",
+      "unit_weight": 14.0,
+      "created_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00",
+      "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+    }
+  ] 
+}
+```
+
+### Error Responses
+
+If the specified list does not exist or does not belong to the authenticated user, a 404 response will be returned. If the specified list is an aggregate list, a 405 response will be returned.
+
+#### Statuses
+
+* 404 Not Found
+* 405 Method Not Allowed
+* 500 Internal Server Error
+
+#### Example Bodies
+
+For a 404 response, no response body will be returned.
+
+For a 405 response:
+```json
+{
+  "errors": ["Cannot manually delete an aggregate inventory list"]
 }
 ```
 

--- a/docs/api/resources/shopping-list-items.md
+++ b/docs/api/resources/shopping-list-items.md
@@ -100,7 +100,7 @@ The body for both responses is a JSON array containing all list items that were 
     "list_id": 238,
     "description": "Ebony sword",
     "quantity": 9,
-    "unit_weight": 14,
+    "unit_weight": 14.0,
     "notes": "To sell -- To enchant with 'Absorb Health'",
     "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
     "updated_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00"
@@ -110,7 +110,7 @@ The body for both responses is a JSON array containing all list items that were 
     "list_id": 237,
     "description": "Ebony sword",
     "quantity": 7,
-    "unit_weight": 14,
+    "unit_weight": 14.0,
     "notes": "To enchant with 'Absorb Health'",
     "created_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00",
     "updated_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00"
@@ -202,7 +202,7 @@ The body is a JSON array containing all list items that were updated while handl
     "list_id": 238,
     "description": "Ebony sword",
     "quantity": 9,
-    "unit_weight": 14,
+    "unit_weight": 14.0,
     "notes": "To sell -- To enchant with 'Absorb Health'",
     "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
     "updated_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00"
@@ -212,7 +212,7 @@ The body is a JSON array containing all list items that were updated while handl
     "list_id": 237,
     "description": "Ebony sword",
     "quantity": 7,
-    "unit_weight": 14,
+    "unit_weight": 14.0,
     "notes": "To enchant with 'Absorb Health'",
     "created_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00",
     "updated_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00"
@@ -303,7 +303,7 @@ The body is a JSON array containing all list items that were updated while handl
     "list_id": 238,
     "description": "Ebony sword",
     "quantity": 9,
-    "unit_weight": 14,
+    "unit_weight": 14.0,
     "notes": "To sell -- To enchant with 'Absorb Health'",
     "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
     "updated_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00"
@@ -313,7 +313,7 @@ The body is a JSON array containing all list items that were updated while handl
     "list_id": 237,
     "description": "Ebony sword",
     "quantity": 7,
-    "unit_weight": 14,
+    "unit_weight": 14.0,
     "notes": "To enchant with 'Absorb Health'",
     "created_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00",
     "updated_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00"
@@ -396,7 +396,7 @@ Example 200 response body containing the updated aggregate list item:
   "list_id": 238,
   "description": "Ebony sword",
   "quantity": 9,
-  "unit_weight": 14,
+  "unit_weight": 14.0,
   "notes": "To sell -- To enchant with 'Absorb Health'",
   "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
   "updated_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00"

--- a/docs/api/resources/shopping-lists.md
+++ b/docs/api/resources/shopping-lists.md
@@ -62,6 +62,7 @@ For a game with multiple lists:
         "description": "Unenchanted ebony sword",
         "quantity": 1,
         "notes": "Need an unenchanted sword to start Companions questline",
+        "unit_weight": null,
         "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
         "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
       },
@@ -70,6 +71,7 @@ For a game with multiple lists:
         "description": "Iron ingot",
         "quantity": 4,
         "notes": "3 locks -- 2 hinges",
+        "unit_weight": 1.0,
         "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
         "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
       }
@@ -89,6 +91,7 @@ For a game with multiple lists:
         "description": "Unenchanted ebony sword",
         "quantity": 1,
         "notes": "Need an unenchanted sword to start Companions questline",
+        "unit_weight": null,
         "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
         "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
       },
@@ -97,6 +100,7 @@ For a game with multiple lists:
         "description": "Iron ingot",
         "quantity": 3,
         "notes": "3 locks",
+        "unit_weight": 1.0,
         "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
         "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
       }
@@ -116,6 +120,7 @@ For a game with multiple lists:
         "description": "Iron ingot",
         "quantity": 1,
         "notes": "2 hinges",
+        "unit_weight": 1.0,
         "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
         "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
       }
@@ -320,6 +325,7 @@ Content-Type: application/json
       "description": "Ebony sword",
       "quantity": 1,
       "notes": "To enchant with Soul Trap",
+      "unit_weight": 14.0,
       "created_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00",
       "updated_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00"
     }
@@ -385,25 +391,24 @@ If the resource deleted was the user's last regular list, the aggregate list wil
 
 ```json
 {
-  "aggregate_list": {
-    "id": 834,
-    "user_id": 16,
-    "aggregate": true,
-    "title": "All Items",
-    "created_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00",
-    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "list_items": [
-      {
-        "id": 32,
-        "list_id": 834,
-        "description": "Ebony sword",
-        "quantity": 1,
-        "notes": "To enchant with Soul Trap",
-        "created_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00",
-        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
-      }
-    ] 
-  }
+  "id": 834,
+  "user_id": 16,
+  "aggregate": true,
+  "title": "All Items",
+  "created_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00",
+  "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+  "list_items": [
+    {
+      "id": 32,
+      "list_id": 834,
+      "description": "Ebony sword",
+      "quantity": 1,
+      "notes": "To enchant with Soul Trap",
+      "unit_weight": 14.0,
+      "created_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00",
+      "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+    }
+  ] 
 }
 ```
 

--- a/spec/controller_services/inventory_lists_controller/destroy_service_spec.rb
+++ b/spec/controller_services/inventory_lists_controller/destroy_service_spec.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'service/ok_result'
+require 'service/no_content_result'
+require 'service/method_not_allowed_result'
+require 'service/not_found_result'
+
+RSpec.describe InventoryListsController::DestroyService do
+  describe '#perform' do
+    subject(:perform) { described_class.new(user, inventory_list.id).perform }
+
+    let(:user) { create(:user) }
+    let(:game) { create(:game, user: user) }
+
+    context 'when all goes well' do
+      let!(:aggregate_list) { create(:aggregate_inventory_list, game: game) }
+      let!(:inventory_list) { create(:inventory_list_with_list_items, game: game) }
+
+      before do
+        inventory_list.list_items.each do |list_item|
+          aggregate_list.add_item_from_child_list(list_item)
+        end
+      end
+
+      context 'when the game has additional regular lists' do
+        let!(:third_list) { create(:inventory_list_with_list_items, game: game, aggregate_list: aggregate_list) }
+
+        before do
+          third_list.list_items.each do |list_item|
+            aggregate_list.add_item_from_child_list(list_item)
+          end
+        end
+
+        it 'destroys the inventory list' do
+          expect { perform }
+            .to change(game.inventory_lists, :count).from(3).to(2)
+        end
+
+        it 'updates the list item on the aggregate list' do
+          expect { perform }
+            .to change(aggregate_list.list_items, :count).from(4).to(2)
+        end
+
+        it 'updates the game' do
+          t = Time.zone.now + 3.days
+          Timecop.freeze(t) do
+            perform
+            expect(game.reload.updated_at).to be_within(0.005.seconds).of(t)
+          end
+        end
+
+        it 'returns a Service::OKResult' do
+          expect(perform).to be_a Service::OKResult
+        end
+
+        it 'sets the resource as the aggregate list' do
+          expect(perform.resource).to eq aggregate_list
+        end
+      end
+
+      context "when this is the game's last regular list" do
+        it 'deletes the regular list and the aggregate list' do
+          expect { perform }
+            .to change(game.inventory_lists, :count).from(2).to(0)
+        end
+
+        it 'updates the game' do
+          t = Time.zone.now + 3.days
+          Timecop.freeze(t) do
+            perform
+            expect(game.reload.updated_at).to be_within(0.005.seconds).of(t)
+          end
+        end
+
+        it 'returns a Service::NoContentResult' do
+          expect(perform).to be_a(Service::NoContentResult)
+        end
+
+        it "doesn't return any data", :aggregate_failures do
+          expect(perform.resource).to be_blank
+          expect(perform.errors).to be_blank
+        end
+      end
+    end
+
+    context 'when the list is an aggregate list' do
+      let!(:inventory_list) { create(:aggregate_inventory_list, game: game) }
+
+      it 'returns a Service::MethodNotAllowedResult' do
+        expect(perform).to be_a(Service::MethodNotAllowedResult)
+      end
+
+      it 'sets the errors' do
+        expect(perform.errors).to eq ['Cannot manually delete an aggregate inventory list']
+      end
+    end
+
+    context "when the list doesn't exist" do
+      let(:inventory_list) { double(id: 234_234) }
+
+      it 'returns a Service::NotFoundResult' do
+        expect(perform).to be_a(Service::NotFoundResult)
+      end
+
+      it "doesn't return any data", :aggregate_failures do
+        expect(perform.errors).to be_blank
+        expect(perform.resource).to be_blank
+      end
+    end
+
+    context "when the list doesn't belong to the user" do
+      let!(:inventory_list) { create(:inventory_list) }
+
+      it "doesn't delete the list" do
+        expect { perform }
+          .not_to change(InventoryList, :count)
+      end
+
+      it 'returns a Service::NotFoundResult' do
+        expect(perform).to be_a(Service::NotFoundResult)
+      end
+
+      it "doesn't return any data", :aggregate_failures do
+        expect(perform.errors).to be_blank
+        expect(perform.resource).to be_blank
+      end
+    end
+
+    context 'when something unexpected goes wrong' do
+      let!(:inventory_list) { create(:inventory_list, game: game) }
+
+      before do
+        allow_any_instance_of(InventoryList).to receive(:aggregate_list).and_raise(StandardError.new('Something went horribly wrong'))
+      end
+
+      it 'returns a Service::InternalServerErrorResult' do
+        expect(perform).to be_a(Service::InternalServerErrorResult)
+      end
+
+      it 'sets the errors' do
+        expect(perform.errors).to eq ['Something went horribly wrong']
+      end
+    end
+  end
+end

--- a/spec/controller_services/inventory_lists_controller/destroy_service_spec.rb
+++ b/spec/controller_services/inventory_lists_controller/destroy_service_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe InventoryListsController::DestroyService do
             .to change(game.inventory_lists, :count).from(3).to(2)
         end
 
-        it 'updates the list item on the aggregate list' do
+        it 'updates the list items on the aggregate list' do
           expect { perform }
             .to change(aggregate_list.list_items, :count).from(4).to(2)
         end

--- a/spec/controller_services/shopping_lists_controller/destroy_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/destroy_service_spec.rb
@@ -107,15 +107,25 @@ RSpec.describe ShoppingListsController::DestroyService do
       end
 
       it 'sets the errors' do
-        expect(perform.errors).to eq(['Cannot manually delete an aggregate shopping list'])
+        expect(perform.errors).to eq ['Cannot manually delete an aggregate shopping list']
       end
     end
 
     context 'when the list does not belong to the user' do
       let(:shopping_list) { create(:shopping_list) }
 
+      it "doesn't delete the list" do
+        expect { perform }
+          .not_to change(ShoppingList, :count)
+      end
+
       it 'returns a Service::NotFoundResult' do
         expect(perform).to be_a(Service::NotFoundResult)
+      end
+
+      it "doesn't return any data", :aggregate_failures do
+        expect(perform.errors).to be_blank
+        expect(perform.resource).to be_blank
       end
     end
 
@@ -132,7 +142,7 @@ RSpec.describe ShoppingListsController::DestroyService do
       let(:game)           { create(:game, user: user) }
 
       before do
-        allow_any_instance_of(ShoppingList).to receive(:aggregate_list).and_raise(StandardError, 'Something went horribly wrong')
+        allow_any_instance_of(ShoppingList).to receive(:aggregate_list).and_raise(StandardError.new('Something went horribly wrong'))
       end
 
       it 'returns a Service::InternalServerErrorResult' do
@@ -140,7 +150,7 @@ RSpec.describe ShoppingListsController::DestroyService do
       end
 
       it 'sets the errors' do
-        expect(perform.errors).to eq(['Something went horribly wrong'])
+        expect(perform.errors).to eq ['Something went horribly wrong']
       end
     end
   end

--- a/spec/controller_services/shopping_lists_controller/destroy_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/destroy_service_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe ShoppingListsController::DestroyService do
     end
 
     context 'when the list does not belong to the user' do
-      let(:shopping_list) { create(:shopping_list) }
+      let!(:shopping_list) { create(:shopping_list) }
 
       it "doesn't delete the list" do
         expect { perform }


### PR DESCRIPTION
## Context

[**DELETE /inventory_lists/:id endpoint**](https://trello.com/c/RdqWO7ns/140-delete-inventorylists-id-endpoint)

We need an endpoint where users can destroy inventory lists.

## Changes

* `InventoryListsController::DestroyService` that handles requests to destroy inventory lists
* New route and controller method for `DELETE /inventory_lists/:id`
* Request specs and unit tests for the new controller service
* Refactor request specs for shopping lists
* Add missing tests for `ShoppingListsController::DestroyService`
* Add docs

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate
