### PR TITLE
Endpoint to create an inventory list item

### DIFF
--- a/app/controller_services/inventory_list_items_controller/create_service.rb
+++ b/app/controller_services/inventory_list_items_controller/create_service.rb
@@ -32,7 +32,7 @@ class InventoryListItemsController < ApplicationController
           resource = params[:unit_weight] ? all_matching_list_items : [aggregate_list_item, item]
           Service::CreatedResult.new(resource: resource)
         else
-          aggregate_list_item = aggregate_list.update_item_from_child_list(params[:description], params[:quantity], params[:unit_weight], nil, params[:notese])
+          aggregate_list_item = aggregate_list.update_item_from_child_list(params[:description], params[:quantity], params[:unit_weight], nil, params[:notes])
 
           resource = params[:unit_weight] ? all_matching_list_items : [aggregate_list_item, item]
 
@@ -44,6 +44,7 @@ class InventoryListItemsController < ApplicationController
     rescue ActiveRecord::RecordNotFound
       Service::NotFoundResult.new
     rescue StandardError => e
+      Rails.logger.error("Internal Server Error: #{e.message}")
       Service::InternalServerErrorResult.new(errors: e.message)
     end
 

--- a/app/controller_services/inventory_list_items_controller/create_service.rb
+++ b/app/controller_services/inventory_list_items_controller/create_service.rb
@@ -4,9 +4,12 @@ require 'service/created_result'
 require 'service/ok_result'
 require 'service/not_found_result'
 require 'service/unprocessable_entity_result'
+require 'service/method_not_allowed_result'
 
 class InventoryListItemsController < ApplicationController
   class CreateService
+    AGGREGATE_LIST_ERROR = 'Cannot manually manage items on an aggregate inventory list'
+
     def initialize(user, list_id, params)
       @user    = user
       @list_id = list_id
@@ -14,6 +17,8 @@ class InventoryListItemsController < ApplicationController
     end
 
     def perform
+      return Service::MethodNotAllowedResult.new(errors: [AGGREGATE_LIST_ERROR]) if inventory_list.aggregate == true
+
       preexisting_item = inventory_list.list_items.find_by('description ILIKE ?', params[:description])
       item             = InventoryListItem.combine_or_new(params.merge(list_id: list_id))
 

--- a/app/controller_services/inventory_list_items_controller/create_service.rb
+++ b/app/controller_services/inventory_list_items_controller/create_service.rb
@@ -2,6 +2,7 @@
 
 require 'service/created_result'
 require 'service/ok_result'
+require 'service/not_found_result'
 
 class InventoryListItemsController < ApplicationController
   class CreateService
@@ -31,6 +32,8 @@ class InventoryListItemsController < ApplicationController
           Service::OKResult.new(resource: resource)
         end
       end
+    rescue ActiveRecord::RecordNotFound
+      Service::NotFoundResult.new
     end
 
     private

--- a/app/controller_services/inventory_list_items_controller/create_service.rb
+++ b/app/controller_services/inventory_list_items_controller/create_service.rb
@@ -44,8 +44,8 @@ class InventoryListItemsController < ApplicationController
     rescue ActiveRecord::RecordNotFound
       Service::NotFoundResult.new
     rescue StandardError => e
-      Rails.logger.error("Internal Server Error: #{e.message}")
-      Service::InternalServerErrorResult.new(errors: e.message)
+      Rails.logger.error "Internal Server Error: #{e.message}"
+      Service::InternalServerErrorResult.new(errors: [e.message])
     end
 
     private

--- a/app/controller_services/inventory_list_items_controller/create_service.rb
+++ b/app/controller_services/inventory_list_items_controller/create_service.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'service/created_result'
+require 'service/ok_result'
 
 class InventoryListItemsController < ApplicationController
   class CreateService
@@ -11,21 +12,41 @@ class InventoryListItemsController < ApplicationController
     end
 
     def perform
-      item                = inventory_list.list_items.create!(params)
-      aggregate_list_item = aggregate_list.add_item_from_child_list(item)
-      Service::CreatedResult.new(resource: [aggregate_list_item, item])
+      preexisting_item = inventory_list.list_items.find_by('description ILIKE ?', params[:description])
+      item             = InventoryListItem.combine_or_new(params.merge(list_id: list_id))
+
+      ActiveRecord::Base.transaction do
+        item.save!
+
+        if preexisting_item.blank?
+          aggregate_list_item = aggregate_list.add_item_from_child_list(item)
+
+          resource = params[:unit_weight] ? all_matching_list_items : [aggregate_list_item, item]
+          Service::CreatedResult.new(resource: resource)
+        else
+          aggregate_list_item = aggregate_list.update_item_from_child_list(params[:description], params[:quantity], params[:unit_weight], nil, params[:notese])
+
+          resource = params[:unit_weight] ? all_matching_list_items : [aggregate_list_item, item]
+
+          Service::OKResult.new(resource: resource)
+        end
+      end
     end
 
     private
 
     attr_reader :user, :list_id, :params
 
+    def inventory_list
+      @inventory_list ||= user.inventory_lists.find(list_id)
+    end
+
     def aggregate_list
       @aggregate_list ||= inventory_list.aggregate_list
     end
 
-    def inventory_list
-      @inventory_list ||= user.inventory_lists.find(list_id)
+    def all_matching_list_items
+      aggregate_list.game.inventory_list_items.where('description ILIKE ?', params[:description])
     end
   end
 end

--- a/app/controller_services/inventory_list_items_controller/create_service.rb
+++ b/app/controller_services/inventory_list_items_controller/create_service.rb
@@ -3,6 +3,7 @@
 require 'service/created_result'
 require 'service/ok_result'
 require 'service/not_found_result'
+require 'service/unprocessable_entity_result'
 
 class InventoryListItemsController < ApplicationController
   class CreateService
@@ -32,6 +33,8 @@ class InventoryListItemsController < ApplicationController
           Service::OKResult.new(resource: resource)
         end
       end
+    rescue ActiveRecord::RecordInvalid
+      Service::UnprocessableEntityResult.new(errors: item.error_array)
     rescue ActiveRecord::RecordNotFound
       Service::NotFoundResult.new
     end

--- a/app/controller_services/inventory_list_items_controller/create_service.rb
+++ b/app/controller_services/inventory_list_items_controller/create_service.rb
@@ -5,6 +5,7 @@ require 'service/ok_result'
 require 'service/not_found_result'
 require 'service/unprocessable_entity_result'
 require 'service/method_not_allowed_result'
+require 'service/internal_server_error_result'
 
 class InventoryListItemsController < ApplicationController
   class CreateService
@@ -42,6 +43,8 @@ class InventoryListItemsController < ApplicationController
       Service::UnprocessableEntityResult.new(errors: item.error_array)
     rescue ActiveRecord::RecordNotFound
       Service::NotFoundResult.new
+    rescue StandardError => e
+      Service::InternalServerErrorResult.new(errors: e.message)
     end
 
     private

--- a/app/controller_services/inventory_list_items_controller/create_service.rb
+++ b/app/controller_services/inventory_list_items_controller/create_service.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'service/created_result'
+
+class InventoryListItemsController < ApplicationController
+  class CreateService
+    def initialize(user, list_id, params)
+      @user    = user
+      @list_id = list_id
+      @params  = params
+    end
+
+    def perform
+      item                = inventory_list.list_items.create!(params)
+      aggregate_list_item = aggregate_list.add_item_from_child_list(item)
+      Service::CreatedResult.new(resource: [aggregate_list_item, item])
+    end
+
+    private
+
+    attr_reader :user, :list_id, :params
+
+    def aggregate_list
+      @aggregate_list ||= inventory_list.aggregate_list
+    end
+
+    def inventory_list
+      @inventory_list ||= user.inventory_lists.find(list_id)
+    end
+  end
+end

--- a/app/controller_services/shopping_list_items_controller/create_service.rb
+++ b/app/controller_services/shopping_list_items_controller/create_service.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 require 'service/created_result'
+require 'service/ok_result'
 require 'service/not_found_result'
 require 'service/unprocessable_entity_result'
 require 'service/method_not_allowed_result'
-require 'service/ok_result'
+require 'service/internal_server_error_result'
 
 class ShoppingListItemsController < ApplicationController
   class CreateService
@@ -44,8 +45,8 @@ class ShoppingListItemsController < ApplicationController
     rescue ActiveRecord::RecordNotFound
       Service::NotFoundResult.new
     rescue StandardError => e
-      Rails.logger.error "Internal Server Error: #{e.message}"
-      Service::InternalServerErrorResult.new(errors: [e.message])
+      Rails.logger.error("Internal Server Error: #{e.message}")
+      Service::InternalServerErrorResult.new(errors: e.message)
     end
 
     private
@@ -57,7 +58,7 @@ class ShoppingListItemsController < ApplicationController
     end
 
     def aggregate_list
-      shopping_list.aggregate_list
+      @aggregate_list ||= shopping_list.aggregate_list
     end
 
     def all_matching_list_items

--- a/app/controller_services/shopping_list_items_controller/create_service.rb
+++ b/app/controller_services/shopping_list_items_controller/create_service.rb
@@ -45,8 +45,8 @@ class ShoppingListItemsController < ApplicationController
     rescue ActiveRecord::RecordNotFound
       Service::NotFoundResult.new
     rescue StandardError => e
-      Rails.logger.error("Internal Server Error: #{e.message}")
-      Service::InternalServerErrorResult.new(errors: e.message)
+      Rails.logger.error "Internal Server Error: #{e.message}"
+      Service::InternalServerErrorResult.new(errors: [e.message])
     end
 
     private

--- a/app/controllers/inventory_list_items_controller.rb
+++ b/app/controllers/inventory_list_items_controller.rb
@@ -4,14 +4,19 @@ require 'controller/response'
 
 class InventoryListItemsController < ApplicationController
   def create
-    result = CreateService.new(current_user, params[:inventory_list_id], inventory_list_item_params).perform
+    result = CreateService.new(current_user, params[:inventory_list_id], list_item_params).perform
 
     ::Controller::Response.new(self, result).execute
   end
 
   private
 
-  def inventory_list_item_params
-    params.require(:inventory_list_item).permit(:description, :quantity, :notes, :unit_weight)
+  def list_item_params
+    params.require(:inventory_list_item).permit(
+      :description,
+      :quantity,
+      :notes,
+      :unit_weight,
+    )
   end
 end

--- a/app/controllers/inventory_list_items_controller.rb
+++ b/app/controllers/inventory_list_items_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'controller/response'
+
+class InventoryListItemsController < ApplicationController
+  def create
+    result = CreateService.new(current_user, params[:inventory_list_id], inventory_list_item_params).perform
+
+    ::Controller::Response.new(self, result).execute
+  end
+
+  private
+
+  def inventory_list_item_params
+    params.require(:inventory_list_item).permit(:description, :quantity, :notes, :unit_weight)
+  end
+end

--- a/app/controllers/shopping_list_items_controller.rb
+++ b/app/controllers/shopping_list_items_controller.rb
@@ -28,6 +28,7 @@ class ShoppingListItemsController < ApplicationController
       :description,
       :quantity,
       :notes,
+      :unit_weight,
     )
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,9 @@ Rails.application.routes.draw do
       resources :shopping_list_items, shallow: true, except: %i[index show]
     end
 
-    resources :inventory_lists, shallow: true, except: %i[show]
+    resources :inventory_lists, shallow: true, except: %i[show] do
+      resources :inventory_list_items, shallow: true, only: %i[create]
+    end
   end
 
   get '/privacy', to: 'utilities#privacy'

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -17,9 +17,10 @@ See docs:
 ## Resources
 
 * [Games](/docs/api/resources/games.md)
+* [Inventory List Items](/docs/api/resources/inventory-list-items.md)
 * [Inventory Lists](/docs/api/resources/inventory-lists.md)
-* [Shopping Lists](/docs/api/resources/shopping-lists.md)
 * [Shopping List Items](/docs/api/resources/shopping-list-items.md)
+* [Shopping Lists](/docs/api/resources/shopping-lists.md)
 * [Users](/docs/api/resources/users.md)
 
 ### Object Modelling Hierarchy

--- a/docs/api/resources/inventory-list-items.md
+++ b/docs/api/resources/inventory-list-items.md
@@ -1,0 +1,163 @@
+# Inventory List Items
+
+Inventory list items represent the items on an [inventory list](/docs/api/resources/inventory-lists.md). Inventory list items on regular lists can be created, updated, and destroyed through the API. Inventory list items on aggregate inventory lists are managed automatically as the items on their other lists change. Each inventory list item belongs to a particular list and will be destroyed if the list is destroyed.
+
+There are no read routes (`GET /inventory_list_items`, `GET /inventory_list/:inventory_list_id/inventory_list_items`, or `GET /inventory_list_items/:id`) for inventory list items since all inventory list items are returned with the lists they are on when requests are made to the list routes. There are, however, routes to create, update, and destroy inventory list items.
+
+All requests to inventory list item endpoints must be [authenticated](/docs/api/resources/authorization.md).
+
+## Automatically Managed Aggregate Lists
+
+Skyrim Inventory Management makes use of automatically managed aggregate lists to help users track an aggregate of what items they need for different properties in each game. The aggregate list is created automatically when the client creates a the first regular inventory list for a game, and is destroyed automatically when the client deletes the game's last regular inventory list. When items are added, updated, or destroyed from any of a game's regular lists, aggregate list items are updated as described in this section.
+
+(Ensuring automatic management of aggregate lists does require some work on the part of SIM developers. If you are working on lists in SIM and would like information on how to keep them synced, head over to the [`Aggregatable` docs](/docs/aggregate-lists.md).)
+
+### Creating a New List Item
+
+If the client requests a new list item be created on a regular inventory list, one of the following things will happen:
+
+* If there is not an item with the same (case-insensitive) `description` on the aggregate list, then an item with the same `description`, `quantity`, `unit_weight`, and `notes` will be created on the aggregate list.
+* If there is an item with the same (case-insensitive) `description` on the aggregate list, then that item will be updated:
+  * The `description` will not be changed
+  * The `quantity` will be increased by the quantity of the new list item
+  * The `notes` for the two items, if any, will be concatenated and separated by ` -- `
+  * The `unit_weight` will be changed to the new item's `unit_weight` unless that value is `nil`
+
+If the new item sets a `unit_weight` that is not `nil` and is different to the `unit_weight` of any existing matching list items belonging to the same game, those items will also be updated to have the same unit weight as the new item.
+
+### Updating a List Item
+
+When a client updates a list item on a regular list for a given game, one (or two) of the following things will happen:
+
+* If the `quantity` is increased, the `quantity` of the item on the aggregate list will be increased by the same amount
+* If the `quantity` is decreased, the `quantity` of the item on the aggregate list will be decreased by the same amount
+* If the `quantity` has not changed, the `quantity` of the item on the aggregate list will also be unchanged
+* If the `notes` are changed, SIM will ensure that the new (or added or removed) `notes` are reflected in the aggregate list item
+* If the `unit_weight` is changed to a non-`nil` value, the value will be updated on the aggregate list item as well as any other list items with the same (case-insensitive) description belonging to the same game
+
+### Destroying a List Item
+
+When a client destroys a list item on a regular inventory list, one of the following things will happen:
+
+* If the quantity of the item on the aggregate inventory list for the same game is higher than the quantity of the item deleted (i.e., if there is another matching item on a different list), the aggregate list item's quantity will be decreased by the amount of the quantity of the deleted item.
+* If the quantity on the aggregate inventory list is equal to the quantity of the item deleted (i.e., if there is not another matching item on a different list), the item on the aggregate inventory list will be deleted as well.
+
+## Endpoints
+
+The following endpoints are available to manage inventory list items:
+
+* [`POST /inventory_lists/:inventory_list_id/inventory_list_items`](#post-inventory_listsinventory_list_idinventory_list_items)
+
+## POST /inventory_lists/:inventory_list_id/inventory_list_items
+
+Creates an inventory list item on the given list if the inventory list with the given ID:
+
+1. Exists
+2. Belongs to the authenticated user
+3. Is not an aggregate list AND
+4. Does not have an existing inventory list item with the same description
+
+If the first three conditions are met but the list does have an existing inventory list item with a matching description, `quantity` and `notes` are updated on the existing item to aggregate the values. If the value of `unit_weight` differs from the value on the existing item and is not `nil`, the existing item and any other items with the same description belonging to the same game will have their `unit_weight` updated.
+
+In both cases, the aggregate list for the same game is also updated to reflect the new `quantity`, `notes`, and `unit_weight`.
+
+Allowed fields are:
+
+* `description` (string, required): A name or description of the item on the list
+* `quantity` (integer, required): The quantity of the item
+* `notes` (string, optional): Any notes about the item or what it is for
+* `unit_weight` (decimal, optional): The unit weight of the item as given in the game, precise to one decimal place
+
+A successful response will return a JSON array of any items created or updated while handling the request. These may come in any order and will include the item requested, the aggregate list item, and, if `unit_weight` is given in the request, any other items with the same description belonging to the same game that have had their `unit_weight` changed.
+
+### Example Request
+
+```
+POST /inventory_lists/72/inventory_list_items
+Authorization: Bearer xxxxxxxxxxx
+Content-Type: application/json
+{
+  "description": "Ebony sword",
+  "quantity": 7,
+  "notes": "To enchant with 'Absorb Health'"
+}
+```
+
+### Success Responses
+
+#### Statuses
+
+* 201 Created
+* 200 OK
+
+#### Example Body
+
+If there is no item with a matching description on the requested inventory list, a new item will be created and the server will return a 201 response. If there is an item with a matching description, its notes and quantity will be combined with the notes and quantity in the client request and a 200 response will be returned.
+
+The body for both responses is a JSON array containing all list items that were created or updated while handling the request, including the requested item, the corresponding aggregate list item, and, if setting `unit_weight`, any other list items with the same description belonging to the same game.
+```json
+[
+  {
+    "id": 87,
+    "list_id": 238,
+    "description": "Ebony sword",
+    "quantity": 9,
+    "unit_weight": 14.0,
+    "notes": "To sell -- To enchant with 'Absorb Health'",
+    "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "updated_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00"
+  },
+  {
+    "id": 126,
+    "list_id": 237,
+    "description": "Ebony sword",
+    "quantity": 7,
+    "unit_weight": 14.0,
+    "notes": "To enchant with 'Absorb Health'",
+    "created_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00",
+    "updated_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00"
+  }
+]
+```
+
+### Error Responses
+
+Four error responses are possible.
+
+#### Statuses
+
+* 404 Not Found
+* 405 Method Not Allowed
+* 422 Unprocessable Entity
+* 500 Internal Server Error
+
+#### Example Bodies
+
+No body will be returned with a 404 error, which is returned if the specified inventory list doesn't exist or doesn't belong to the authenticated user.
+
+A 405 error, which is returned if the specified inventory list is an aggregate inventory list, comes with the following body:
+```json
+{
+  "errors": [
+    "Cannot manually manage items on an aggregate inventory list"
+  ]
+}
+```
+
+A 422 error, returned as a result of a validation error, includes whichever errors prevented the list item from being created:
+```json
+{
+  "errors": [
+    "Quantity must be a number",
+    "Quantity must be greater than zero",
+    "Description is required"
+  ]
+}
+```
+
+A 500 error response, which is always a result of an unforeseen problem, includes the error message:
+```json
+{
+  "errors": ["Something went horribly wrong"]
+}
+```

--- a/docs/api/resources/shopping-list-items.md
+++ b/docs/api/resources/shopping-list-items.md
@@ -2,7 +2,7 @@
 
 Shopping list items represent the items on a [shopping list](/docs/api/resources/shopping-lists.md). Shopping list items on regular lists can be created, updated, and destroyed through the API. Shopping list items on aggregate shopping lists are managed automatically as the items on their other lists change. Each shopping list item belongs to a particular list and will be destroyed if the list is destroyed.
 
-There are no read routes (`GET /shopping_list_items`, `GET /shopping_list/:id/shopping_list_items`, or `GET /shopping_list_items/:id`) for shopping list items since all shopping list items are returned with the lists they are on when requests are made to the list routes. There are, however, routes to create, update, and destroy shopping list items.
+There are no read routes (`GET /shopping_list_items`, `GET /shopping_list/:shopping_list_id/shopping_list_items`, or `GET /shopping_list_items/:id`) for shopping list items since all shopping list items are returned with the lists they are on when requests are made to the list routes. There are, however, routes to create, update, and destroy shopping list items.
 
 All requests to shopping list item endpoints must be [authenticated](/docs/api/resources/authorization.md).
 
@@ -60,13 +60,18 @@ Creates a shopping list item on the given list if the shopping list with the giv
 3. Is not an aggregate list AND
 4. Does not have an existing shopping list item with the same description
 
-If the first three conditions are met but the list does have an existing shopping list item with a matching description, `quantity` and `notes` are updated on the existing item to aggregate the values.
+If the first three conditions are met but the list does have an existing inventory list item with a matching description, `quantity` and `notes` are updated on the existing item to aggregate the values. If the value of `unit_weight` differs from the value on the existing item and is not `nil`, the existing item and any other items with the same description belonging to the same game will have their `unit_weight` updated.
 
-In both cases, the aggregate list for the same game is also updated to reflect the new `quantity` and `notes`.
+In both cases, the aggregate list for the same game is also updated to reflect the new `quantity`, `notes`, and `unit_weight`.
 
-Requests must specify a `description` and an integer `quantity` greater than 0. The optional `notes` field is an arbitrary string where users can keep any reminders of what the item will be used for or other useful notes.
+Allowed fields are:
 
-A successful response will return a JSON array of two items. The first item is the item from the user's aggregate list that has been added or updated as a result of the request. The second item is the item created or updated from the client's request.
+* `description` (string, required): A name or description of the item on the list
+* `quantity` (integer, required): The quantity of the item
+* `notes` (string, optional): Any notes about the item or what it is for
+* `unit_weight` (decimal, optional): The unit weight of the item as given in the game, precise to one decimal place
+
+A successful response will return a JSON array of any items created or updated while handling the request. These may come in any order and will include the item requested, the aggregate list item, and, if `unit_weight` is given in the request, any other items with the same description belonging to the same game that have had their `unit_weight` changed.
 
 ### Example Request
 

--- a/docs/api/resources/shopping-list-items.md
+++ b/docs/api/resources/shopping-list-items.md
@@ -60,7 +60,7 @@ Creates a shopping list item on the given list if the shopping list with the giv
 3. Is not an aggregate list AND
 4. Does not have an existing shopping list item with the same description
 
-If the first three conditions are met but the list does have an existing inventory list item with a matching description, `quantity` and `notes` are updated on the existing item to aggregate the values. If the value of `unit_weight` differs from the value on the existing item and is not `nil`, the existing item and any other items with the same description belonging to the same game will have their `unit_weight` updated.
+If the first three conditions are met but the list does have an existing shopping list item with a matching description, `quantity` and `notes` are updated on the existing item to aggregate the values. If the value of `unit_weight` differs from the value on the existing item and is not `nil`, the existing item and any other items with the same description belonging to the same game will have their `unit_weight` updated.
 
 In both cases, the aggregate list for the same game is also updated to reflect the new `quantity`, `notes`, and `unit_weight`.
 

--- a/spec/controller_services/inventory_list_items_controller/create_service_spec.rb
+++ b/spec/controller_services/inventory_list_items_controller/create_service_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'service/created_result'
+
+RSpec.describe InventoryListItemsController::CreateService do
+  describe '#perform' do
+    subject(:perform) { described_class.new(user, inventory_list.id, params).perform }
+
+    let(:user) { create(:user) }
+    let(:game) { create(:game, user: user) }
+
+    context 'when all goes well' do
+      let!(:aggregate_list) { create(:aggregate_inventory_list, game: game) }
+      let!(:inventory_list) { create(:inventory_list, game: game, aggregate_list: aggregate_list) }
+      let(:params)          { { description: 'Necklace', quantity: 2, notes: 'Hello world' } }
+
+      context 'when there is no existing matching item on the same list' do
+        context 'when there is no existing matching item on any list' do
+          it 'creates a new item on the list' do
+            expect { perform }
+              .to change(inventory_list.list_items, :count).from(0).to(1)
+          end
+
+          it 'creates a new item on the aggregate list' do
+            expect { perform }
+              .to change(aggregate_list.list_items, :count).from(0).to(1)
+          end
+
+          it 'returns a Service::CreatedResult' do
+            expect(perform).to be_a(Service::CreatedResult)
+          end
+
+          it 'sets the new and aggregate list items as the resource' do
+            expect(perform.resource).to eq [aggregate_list.list_items.last, inventory_list.list_items.last]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/controller_services/inventory_list_items_controller/create_service_spec.rb
+++ b/spec/controller_services/inventory_list_items_controller/create_service_spec.rb
@@ -184,5 +184,19 @@ RSpec.describe InventoryListItemsController::CreateService do
         expect(perform.errors).to be_blank
       end
     end
+
+    context "when the list doesn't belong to the given user" do
+      let(:params)         { { description: 'Necklace', quantity: 4, unit_weight: 0.5 } }
+      let(:inventory_list) { create(:inventory_list) }
+
+      it 'returns a Service::NotFoundResult' do
+        expect(perform).to be_a(Service::NotFoundResult)
+      end
+
+      it "doesn't return any data", :aggregate_failures do
+        expect(perform.resource).to be_blank
+        expect(perform.errors).to be_blank
+      end
+    end
   end
 end

--- a/spec/controller_services/inventory_list_items_controller/create_service_spec.rb
+++ b/spec/controller_services/inventory_list_items_controller/create_service_spec.rb
@@ -231,5 +231,21 @@ RSpec.describe InventoryListItemsController::CreateService do
         expect(perform.errors).to eq ['Cannot manually manage items on an aggregate inventory list']
       end
     end
+
+    context 'when something unexpected goes wrong' do
+      let!(:params) { { description: 'Necklace', quantity: 2 } }
+
+      before do
+        allow(InventoryList).to receive(:find).and_raise(StandardError.new('Something went horribly wrong'))
+      end
+
+      it 'returns a Service::InternalServerErrorResponse' do
+        expect(perform).to be_a(Service::InternalServerErrorResult)
+      end
+
+      it 'sets the errors' do
+        expect(perform.errors).to eq ['Something went horribly wrong']
+      end
+    end
   end
 end

--- a/spec/controller_services/inventory_list_items_controller/create_service_spec.rb
+++ b/spec/controller_services/inventory_list_items_controller/create_service_spec.rb
@@ -5,6 +5,7 @@ require 'service/created_result'
 require 'service/ok_result'
 require 'service/not_found_result'
 require 'service/method_not_allowed_result'
+require 'service/internal_server_error_result'
 
 RSpec.describe InventoryListItemsController::CreateService do
   describe '#perform' do

--- a/spec/controller_services/inventory_list_items_controller/create_service_spec.rb
+++ b/spec/controller_services/inventory_list_items_controller/create_service_spec.rb
@@ -198,5 +198,17 @@ RSpec.describe InventoryListItemsController::CreateService do
         expect(perform.errors).to be_blank
       end
     end
+
+    context 'when the params are invalid' do
+      let(:params) { { description: 'Necklace', quantity: -2 } }
+
+      it 'returns a Service::UnprocessableEntityResult' do
+        expect(perform).to be_a(Service::UnprocessableEntityResult)
+      end
+
+      it 'returns the error array' do
+        expect(perform.errors).to eq(['Quantity must be greater than 0'])
+      end
+    end
   end
 end

--- a/spec/controller_services/shopping_list_items_controller/create_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/create_service_spec.rb
@@ -2,325 +2,249 @@
 
 require 'rails_helper'
 require 'service/created_result'
-require 'service/not_found_result'
-require 'service/unprocessable_entity_result'
-require 'service/method_not_allowed_result'
-require 'service/internal_server_error_result'
 require 'service/ok_result'
+require 'service/not_found_result'
+require 'service/method_not_allowed_result'
 
 RSpec.describe ShoppingListItemsController::CreateService do
   describe '#perform' do
     subject(:perform) { described_class.new(user, shopping_list.id, params).perform }
 
-    let(:user) { create(:user) }
-    let(:game) { create(:game, user: user) }
+    let(:user)            { create(:user) }
+    let(:game)            { create(:game, user: user) }
+    let!(:aggregate_list) { create(:aggregate_shopping_list, game: game) }
+    let!(:shopping_list)  { create(:shopping_list, game: game, aggregate_list: aggregate_list) }
 
     context 'when all goes well' do
-      let!(:aggregate_list) { create(:aggregate_shopping_list, game: game) }
-      let!(:shopping_list)  { create(:shopping_list, game: game, aggregate_list: aggregate_list) }
-      let(:params)          { { description: 'Necklace', quantity: 2, notes: 'Hello world' } }
+      let(:params) { { description: 'Necklace', quantity: 2, notes: 'Hello world' } }
 
-      before do
-        user_lists = user.shopping_lists
-        allow(user).to receive(:shopping_lists).and_return(user_lists)
-        allow(user_lists).to receive(:find).and_return(shopping_list)
-        allow(shopping_list).to receive(:aggregate_list).and_return(aggregate_list)
-      end
+      context 'when there is no existing matching item on the same list' do
+        context 'when there is no existing matching item on any list' do
+          it 'creates a new item on the list' do
+            expect { perform }
+              .to change(shopping_list.list_items, :count).from(0).to(1)
+          end
 
-      context 'when there is no matching item on the regular list' do
-        before do
-          allow(aggregate_list).to receive(:add_item_from_child_list).and_call_original
-        end
+          it 'creates a new item on the aggregate list' do
+            expect { perform }
+              .to change(aggregate_list.list_items, :count).from(0).to(1)
+          end
 
-        it 'adds a list item to the given list' do
-          expect { perform }
-            .to change(shopping_list.list_items, :count).from(0).to(1)
-        end
+          it 'returns a Service::CreatedResult' do
+            expect(perform).to be_a(Service::CreatedResult)
+          end
 
-        it 'assigns the correct values' do
-          params_with_string_keys = {}
-
-          params.each {|key, value| params_with_string_keys[key.to_s] = value }
-
-          perform
-          expect(shopping_list.list_items.last.attributes).to include(**params_with_string_keys)
-        end
-
-        it 'updates the aggregate list' do
-          perform
-          expect(aggregate_list).to have_received(:add_item_from_child_list).with(shopping_list.list_items.last)
-        end
-
-        it 'updates the list model itself' do
-          t = Time.zone.now + 3.days
-          Timecop.freeze(t) do
-            perform
-            expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+          it 'sets the new and aggregate list items as the resource' do
+            expect(perform.resource).to eq [aggregate_list.list_items.last, shopping_list.list_items.last]
           end
         end
 
-        it 'updates the game' do
-          t = Time.zone.now + 3.days
-          Timecop.freeze(t) do
-            perform
-            expect(game.reload.updated_at).to be_within(0.005.seconds).of(t)
+        context 'when there is an existing matching item on another list' do
+          let(:other_list)  { create(:shopping_list, game: aggregate_list.game, aggregate_list: aggregate_list) }
+          let!(:other_item) { create(:shopping_list_item, list: other_list, description: 'Necklace', quantity: 1) }
+
+          before do
+            aggregate_list.add_item_from_child_list(other_item)
           end
-        end
 
-        it 'returns a Service::CreatedResult' do
-          expect(perform).to be_a(Service::CreatedResult)
-        end
-
-        it 'returns both the created list item and aggregate list item' do
-          expect(perform.resource).to eq([aggregate_list.list_items.last, shopping_list.list_items.last])
-        end
-
-        context 'when there is a matching item on the aggregate list' do
-          context 'when unit weight is specified' do
-            let(:params) { { description: 'Necklace', quantity: 2, unit_weight: 1, notes: 'Hello world' } }
-
-            let(:other_list)              { create(:shopping_list, game: aggregate_list.game, aggregate_list: aggregate_list) }
-            let!(:item_on_other_list)     { create(:shopping_list_item, list: other_list, unit_weight: 2, description: 'Necklace', quantity: 1) }
-            let!(:item_on_aggregate_list) { create(:shopping_list_item, list: aggregate_list, unit_weight: 2, description: 'Necklace', quantity: 1) }
-
-            before do
-              # Make sure that the response only returns matching list items belonging to
-              # the same game
-              other_list.list_items.create!(description: 'Dwarven metal ingot', quantity: 1)
-              create(:shopping_list_item, description: 'Necklace', quantity: 1)
+          context 'when the unit_weight is not set' do
+            it 'creates a new item on the list' do
+              expect { perform }
+                .to change(shopping_list.list_items, :count).from(0).to(1)
             end
 
-            it 'updates the unit weight on existing matching list items', :aggregate_failures do
+            it 'updates the item on the aggregate list', :aggregate_failures do
               perform
-              expect(item_on_other_list.reload.unit_weight).to eq 1
-              expect(item_on_aggregate_list.reload.unit_weight).to eq 1
+              expect(aggregate_list.list_items.first.quantity).to eq 3
+              expect(aggregate_list.list_items.first.notes).to eq 'Hello world'
             end
 
-            it 'returns all the list items that were updated' do
-              expect(perform.resource.sort).to eq [item_on_aggregate_list, item_on_other_list, shopping_list.list_items.last].sort
+            it 'returns a Service::CreatedResult' do
+              expect(perform).to be_a(Service::CreatedResult)
+            end
+
+            it 'sets the resource as the aggregate list item and the regular list item' do
+              expect(perform.resource).to eq([aggregate_list.list_items.first, shopping_list.list_items.first])
             end
           end
 
-          context 'when unit weight is not specified' do
-            let(:other_list)              { create(:shopping_list, game: aggregate_list.game, aggregate_list: aggregate_list) }
-            let!(:item_on_other_list)     { create(:shopping_list_item, list: other_list, unit_weight: 2, description: 'Necklace', quantity: 1) }
-            let!(:item_on_aggregate_list) { create(:shopping_list_item, list: aggregate_list, unit_weight: 2, description: 'Necklace', quantity: 1) }
+          context 'when the unit_weight is set' do
+            let(:params) { { description: 'Necklace', quantity: 2, unit_weight: 0.5, notes: 'Hello world' } }
 
-            it 'returns the regular list item and the aggregate list item' do
-              expect(perform.resource).to eq [item_on_aggregate_list, shopping_list.list_items.last]
-            end
-          end
-        end
-      end
-
-      context 'when there is a matching item on the regular list' do
-        let!(:existing_item) { create(:shopping_list_item, list: shopping_list, description: 'Necklace', quantity: 2, unit_weight: 0.5, notes: 'to enchant') }
-
-        before do
-          aggregate_list.add_item_from_child_list(existing_item)
-          allow(aggregate_list).to receive(:update_item_from_child_list).and_call_original
-        end
-
-        it "doesn't create a new item on the regular list" do
-          expect { perform }
-            .not_to change(shopping_list.list_items, :count)
-        end
-
-        it "doesn't create a new item on the aggregate list" do
-          expect { perform }
-            .not_to change(aggregate_list.list_items, :count)
-        end
-
-        it 'updates the list itself' do
-          t = Time.zone.now + 3.days
-          Timecop.freeze(t) do
-            perform
-            expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
-          end
-        end
-
-        it 'updates the game' do
-          t = Time.zone.now + 3.days
-          Timecop.freeze(t) do
-            perform
-            expect(game.reload.updated_at).to be_within(0.005.seconds).of(t)
-          end
-        end
-
-        it 'updates the aggregate list correctly' do
-          perform
-          expect(aggregate_list).to have_received(:update_item_from_child_list).with('Necklace', 2, nil, nil, 'Hello world')
-        end
-
-        context 'when no unit weight is specified' do
-          it 'leaves unit weight as-is for the existing item' do
-            perform
-            expect(existing_item.reload.unit_weight).to eq 0.5
-          end
-
-          context 'when there is a matching item on another list' do
-            let(:other_list)          { create(:shopping_list, game: aggregate_list.game, aggregate_list: aggregate_list) }
-            let!(:other_item)         { create(:shopping_list_item, list: other_list, description: 'Necklace', quantity: 1, unit_weight: 0.5) }
-            let(:aggregate_list_item) { aggregate_list.list_items.find_by(description: 'Necklace') }
-
-            before do
-              aggregate_list.add_item_from_child_list(other_item)
+            it 'creates a new item on the list' do
+              expect { perform }
+                .to change(shopping_list.list_items, :count).from(0).to(1)
             end
 
-            it 'leaves unit weight as-is for the item on the other list' do
+            it 'updates the item on the aggregate list', :aggregate_failures do
               perform
+              expect(aggregate_list.list_items.first.quantity).to eq 3
+              expect(aggregate_list.list_items.first.notes).to eq 'Hello world'
+              expect(aggregate_list.list_items.first.unit_weight).to eq 0.5
+            end
+
+            it "updates the other item's unit_weight", :aggregate_failures do
+              perform
+              expect(other_item.reload.quantity).to eq 1
               expect(other_item.reload.unit_weight).to eq 0.5
             end
 
-            it 'returns the regular list item and the aggregate list item' do
-              perform
-              expect(perform.resource).to eq [aggregate_list_item, shopping_list.list_items.last]
+            it 'returns a Service::CreatedResult' do
+              expect(perform).to be_a(Service::CreatedResult)
+            end
+
+            it 'sets the resource as the all created or changed list items' do
+              expect(perform.resource).to eq([aggregate_list.list_items.first, other_item, shopping_list.list_items.first])
             end
           end
         end
+      end
 
-        context 'when a unit weight is specified' do
-          let(:params) { { description: 'Necklace', quantity: 2, unit_weight: 1, notes: 'Hello world' } }
+      context 'when there is an existing matching item on the same list' do
+        let(:other_list)  { create(:shopping_list, game: game) }
+        let!(:other_item) { create(:shopping_list_item, list: other_list, description: 'Necklace', quantity: 2) }
+        let!(:list_item)  { create(:shopping_list_item, list: shopping_list, description: 'Necklace', quantity: 1) }
 
-          it 'updates the unit weight on the list item' do
-            perform
-            expect(existing_item.reload.unit_weight).to eq 1
+        before do
+          aggregate_list.add_item_from_child_list(other_item)
+          aggregate_list.add_item_from_child_list(list_item)
+        end
+
+        context "when unit weight isn't updated" do
+          let(:params) { { description: 'Necklace', quantity: 2 } }
+
+          it "doesn't create a new item" do
+            expect { perform }
+              .not_to change(ShoppingListItem, :count)
           end
 
-          it 'updates the unit weight on the aggregate list item' do
+          it 'combines with the existing item' do
             perform
-            expect(aggregate_list.list_items.last.unit_weight).to eq 1
+            expect(list_item.reload.quantity).to eq 3
           end
 
-          context 'when there is a matching item on another list as well' do
-            let(:other_list)  { create(:shopping_list, game: aggregate_list.game, aggregate_list: aggregate_list) }
-            let!(:other_item) { create(:shopping_list_item, unit_weight: 0.5, quantity: 1, description: 'Necklace', list: other_list) }
+          it 'updates the item on the aggregate list' do
+            perform
+            expect(aggregate_list.list_items.first.quantity).to eq 5
+          end
 
-            before do
-              aggregate_list.add_item_from_child_list(other_item)
-            end
+          it 'returns a Service::OKResult' do
+            expect(perform).to be_a(Service::OKResult)
+          end
 
-            it 'updates the unit weight on the other list item' do
-              perform
-              expect(other_item.reload.unit_weight).to eq 1
-            end
+          it 'returns the requested item and the aggregate list item' do
+            expect(perform.resource).to eq([aggregate_list.list_items.first, list_item.reload])
+          end
+        end
 
-            it 'returns all the items that were updated' do
-              expect(perform.resource.sort).to eq [aggregate_list.list_items.last, existing_item, other_item].sort
-            end
+        context 'when unit weight is updated' do
+          let(:params) { { description: 'Necklace', quantity: 2, unit_weight: 0.5 } }
+
+          it "doesn't create a new list item" do
+            expect { perform }
+              .not_to change(ShoppingListItem, :count)
+          end
+
+          it 'combines the items', :aggregate_failures do
+            perform
+            expect(list_item.reload.quantity).to eq 3
+            expect(list_item.unit_weight).to eq 0.5
+          end
+
+          it 'updates the item on the aggregate list', :aggregate_failures do
+            perform
+            expect(aggregate_list.list_items.first.quantity).to eq 5
+            expect(aggregate_list.list_items.first.unit_weight).to eq 0.5
+          end
+
+          it 'updates only the unit_weight on the other item', :aggregate_failures do
+            perform
+            expect(other_item.reload.unit_weight).to eq 0.5
+            expect(other_item.quantity).to eq 2
+          end
+
+          it 'returns a Service::OKResult' do
+            expect(perform).to be_a(Service::OKResult)
+          end
+
+          it 'returns all the items that have been updated' do
+            expect(perform.resource).to eq [aggregate_list.list_items.first, other_item.reload, list_item.reload]
           end
         end
       end
     end
 
-    context 'when the list does not exist' do
-      let(:shopping_list) { double(id: 348) }
-      let(:params)        { { 'description' => 'Necklace', 'quantity' => 2, 'notes' => 'Hello world' } }
+    context "when the list doesn't exist" do
+      let(:params)         { { description: 'Necklace', quantity: 4, unit_weight: 0.5 } }
+      let(:shopping_list) { double(id: 234_980) }
 
       it 'returns a Service::NotFoundResult' do
         expect(perform).to be_a(Service::NotFoundResult)
       end
 
       it "doesn't return any data", :aggregate_failures do
-        expect(perform.errors).to be_blank
         expect(perform.resource).to be_blank
+        expect(perform.errors).to be_blank
       end
     end
 
-    context 'when the list does not belong to the user' do
-      let!(:shopping_list) { create(:shopping_list) }
-      let(:params)         { { description: 'Necklace', quantity: 2, notes: 'Hello world' } }
+    context "when the list doesn't belong to the given user" do
+      let(:params)         { { description: 'Necklace', quantity: 4, unit_weight: 0.5 } }
+      let(:shopping_list) { create(:shopping_list) }
 
       it 'returns a Service::NotFoundResult' do
         expect(perform).to be_a(Service::NotFoundResult)
       end
 
       it "doesn't return any data", :aggregate_failures do
-        expect(perform.errors).to be_blank
         expect(perform.resource).to be_blank
-      end
-    end
-
-    context 'when there is a duplicate description' do
-      let!(:aggregate_list) { create(:aggregate_shopping_list, game: game) }
-      let!(:shopping_list)  { create(:shopping_list, game: game, aggregate_list: aggregate_list) }
-      let(:params)          { { description: 'Necklace', quantity: 2, notes: 'Hello world' } }
-
-      before do
-        shopping_list.list_items.create!(description: 'Necklace', quantity: 1, notes: 'To enchant')
-        aggregate_list.add_item_from_child_list(shopping_list.list_items.last)
-      end
-
-      it 'combines the item with an existing one' do
-        expect { perform }
-          .not_to change(shopping_list.list_items, :count)
-      end
-
-      it 'updates the shopping list' do
-        t = Time.zone.now + 3.days
-        Timecop.freeze(t) do
-          perform
-          expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
-        end
-      end
-
-      it 'updates the game' do
-        t = Time.zone.now + 3.days
-        Timecop.freeze(t) do
-          perform
-          expect(game.reload.updated_at).to be_within(0.005.seconds).of(t)
-        end
-      end
-
-      it 'returns a Service::OKResult' do
-        expect(perform).to be_a(Service::OKResult)
-      end
-
-      it 'sets the list items' do
-        expect(perform.resource).to eq([aggregate_list.list_items.last, shopping_list.list_items.last])
+        expect(perform.errors).to be_blank
       end
     end
 
     context 'when the params are invalid' do
-      let!(:shopping_list) { create(:shopping_list, game: game) }
-      let(:params)         { { description: 'Necklace', quantity: -1, notes: 'invalid quantity' } }
+      let(:params) { { description: 'Necklace', quantity: -2 } }
 
       it 'returns a Service::UnprocessableEntityResult' do
         expect(perform).to be_a(Service::UnprocessableEntityResult)
       end
 
-      it 'sets the errors' do
+      it 'returns the error array' do
         expect(perform.errors).to eq(['Quantity must be greater than 0'])
       end
     end
 
     context 'when the list is an aggregate list' do
-      let!(:shopping_list) { create(:aggregate_shopping_list, game: game) }
-      let(:params)         { { description: 'Necklace', quantity: 1, notes: 'this should not work' } }
+      let(:shopping_list)   { aggregate_list }
+      let!(:params)         { { description: 'Necklace', quantity: 2 } }
+
+      it "doesn't create an item" do
+        expect { perform }
+          .not_to change(ShoppingListItem, :count)
+      end
 
       it 'returns a Service::MethodNotAllowedResult' do
         expect(perform).to be_a(Service::MethodNotAllowedResult)
       end
 
       it 'sets the errors' do
-        expect(perform.errors).to eq(['Cannot manually manage items on an aggregate shopping list'])
+        expect(perform.errors).to eq ['Cannot manually manage items on an aggregate shopping list']
       end
     end
 
     context 'when something unexpected goes wrong' do
-      let!(:shopping_list) { create(:shopping_list, game: game) }
-      let(:params)         { { description: 'Necklace', quantity: 1, notes: 'hello world' } }
+      let!(:params) { { description: 'Necklace', quantity: 2 } }
 
       before do
-        allow_any_instance_of(ShoppingListItem).to receive(:save!).and_raise(StandardError, 'Something went horribly wrong')
+        allow(ShoppingList).to receive(:find).and_raise(StandardError.new('Something went horribly wrong'))
       end
 
-      it 'returns a 500 response' do
+      it 'returns a Service::InternalServerErrorResponse' do
         expect(perform).to be_a(Service::InternalServerErrorResult)
       end
 
-      it 'sets the error message' do
-        expect(perform.errors).to eq(['Something went horribly wrong'])
+      it 'sets the errors' do
+        expect(perform.errors).to eq ['Something went horribly wrong']
       end
     end
   end

--- a/spec/controller_services/shopping_list_items_controller/create_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/create_service_spec.rb
@@ -5,6 +5,7 @@ require 'service/created_result'
 require 'service/ok_result'
 require 'service/not_found_result'
 require 'service/method_not_allowed_result'
+require 'service/internal_server_error_result'
 
 RSpec.describe ShoppingListItemsController::CreateService do
   describe '#perform' do

--- a/spec/requests/inventory_list_items_spec.rb
+++ b/spec/requests/inventory_list_items_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'InventoryListItems', type: :request do
+  let(:headers) do
+    {
+      'Content-Type'  => 'application/json',
+      'Authorization' => 'Bearer xxxxxxxx',
+    }
+  end
+
+  describe 'POST /inventory_lists/:inventory_list_id/inventory_list_items' do
+    subject(:create_item) do
+      post "/inventory_lists/#{inventory_list.id}/inventory_list_items",
+           params:  params.to_json,
+           headers: headers
+    end
+
+    let!(:aggregate_list) { create(:aggregate_inventory_list) }
+    let!(:inventory_list) { create(:inventory_list, aggregate_list: aggregate_list, game: aggregate_list.game) }
+
+    context 'when authenticated' do
+      let!(:user)     { aggregate_list.user }
+      let(:validator) { instance_double(GoogleIDToken::Validator, check: validation_data) }
+
+      let(:validation_data) do
+        {
+          'exp'   => (Time.zone.now + 1.year).to_i,
+          'email' => user.email,
+          'name'  => user.name,
+        }
+      end
+
+      before do
+        allow(GoogleIDToken::Validator).to receive(:new).and_return(validator)
+      end
+
+      context 'when all goes well' do
+        let(:params) { { inventory_list_item: { description: 'Corundum ingot', quantity: 5, notes: 'To make locks' } } }
+
+        context 'when there is no existing matching item on the same list' do
+          context 'when there is no existing matching item on any list' do
+            it 'creates a new item on the requested list' do
+              expect { create_item }
+                .to change(inventory_list.list_items, :count).from(0).to(1)
+            end
+
+            it 'creates a new item on the aggregate list' do
+              expect { create_item }
+                .to change(aggregate_list.list_items, :count).from(0).to(1)
+            end
+
+            it 'returns status 201' do
+              create_item
+              expect(response.status).to eq 201
+            end
+
+            it 'returns the regular list item and the aggregate list item' do
+              create_item
+              expect(JSON.parse(response.body)).to eq(JSON.parse([aggregate_list.list_items.last, inventory_list.list_items.last].to_json))
+            end
+          end
+
+          context 'when there is an existing matching item on another list' do
+            context "when unit weight isn't set" do
+              it 'creates a new item on the requested list'
+
+              it 'updates the item on the aggregate list'
+
+              it 'returns status 201'
+
+              it 'returns the aggregate list item and the regular list item'
+            end
+
+            context 'when unit weight is set' do
+              it 'creates a new item on the requested list'
+
+              it 'updates the item on the aggregate list'
+
+              it 'updates the unit weight of the other regular-list item'
+
+              it 'returns status 201'
+
+              it 'returns all items that were created or updated'
+            end
+          end
+        end
+
+        context 'when there is an existing matching item on the same list' do
+          context "when unit weight isn't updated" do
+            it 'combines the requested item with the existing item'
+
+            it 'updates the item on the aggregate list'
+
+            it "doesn't change matching items on other regular lists"
+
+            it 'returns status 200'
+
+            it 'returns the requested item and the aggregate list item'
+          end
+
+          context 'when unit weight is updated' do
+            it 'combines the requested item with the existing item'
+
+            it 'updates the item on the aggregate list'
+
+            it 'updates matching items on other regular lists'
+
+            it 'returns status 200'
+
+            it 'returns all items that have been updated'
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/inventory_list_items_spec.rb
+++ b/spec/requests/inventory_list_items_spec.rb
@@ -202,6 +202,21 @@ RSpec.describe 'InventoryListItems', type: :request do
           end
         end
       end
+
+      context "when the list doesn't exist" do
+        let(:params)         { { description: 'Necklace', quantity: 2, unit_weight: 0.5 } }
+        let(:inventory_list) { double(id: 23_498) }
+
+        it 'returns status 404' do
+          create_item
+          expect(response.status).to eq 404
+        end
+
+        it "doesn't return any data" do
+          create_item
+          expect(response.body).to be_blank
+        end
+      end
     end
   end
 end

--- a/spec/requests/inventory_list_items_spec.rb
+++ b/spec/requests/inventory_list_items_spec.rb
@@ -237,6 +237,25 @@ RSpec.describe 'InventoryListItems', type: :request do
           expect(response.body).to be_blank
         end
       end
+
+      context 'when the params are invalid' do
+        let(:params) { { inventory_list_item: { description: 'Corundum ingot', quantity: -2 } } }
+
+        it "doesn't create the item" do
+          expect { create_item }
+            .not_to change(InventoryListItem, :count)
+        end
+
+        it 'returns status 422' do
+          create_item
+          expect(response.status).to eq 422
+        end
+
+        it 'returns the error array' do
+          create_item
+          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Quantity must be greater than 0'] })
+        end
+      end
     end
   end
 end

--- a/spec/requests/inventory_list_items_spec.rb
+++ b/spec/requests/inventory_list_items_spec.rb
@@ -256,6 +256,27 @@ RSpec.describe 'InventoryListItems', type: :request do
           expect(JSON.parse(response.body)).to eq({ 'errors' => ['Quantity must be greater than 0'] })
         end
       end
+
+      context 'when the list is an aggregate list' do
+        let(:inventory_list) { aggregate_list }
+        let(:params)         { { inventory_list_item: { description: 'Corundum ingot', quantity: 4 } } }
+
+        it "doesn't create an item" do
+          expect { create_item }
+            .not_to change(InventoryListItem, :count)
+        end
+
+        it 'returns status 405' do
+          create_item
+          expect(response.status).to eq 405
+        end
+
+        it 'returns the error' do
+          create_item
+          expect(JSON.parse(response.body))
+            .to eq({ 'errors' => ['Cannot manually manage items on an aggregate inventory list'] })
+        end
+      end
     end
   end
 end

--- a/spec/requests/inventory_list_items_spec.rb
+++ b/spec/requests/inventory_list_items_spec.rb
@@ -277,6 +277,24 @@ RSpec.describe 'InventoryListItems', type: :request do
             .to eq({ 'errors' => ['Cannot manually manage items on an aggregate inventory list'] })
         end
       end
+
+      context 'when something unexpected goes wrong' do
+        let(:params) { { inventory_list_item: { description: 'Corundum ingot', quantity: 4 } } }
+
+        before do
+          allow(InventoryList).to receive(:find).and_raise(StandardError.new('Something went horribly wrong'))
+        end
+
+        it 'returns status 500' do
+          create_item
+          expect(response.status).to eq 500
+        end
+
+        it 'returns the error' do
+          create_item
+          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Something went horribly wrong'] })
+        end
+      end
     end
   end
 end

--- a/spec/requests/inventory_list_items_spec.rb
+++ b/spec/requests/inventory_list_items_spec.rb
@@ -217,6 +217,26 @@ RSpec.describe 'InventoryListItems', type: :request do
           expect(response.body).to be_blank
         end
       end
+
+      context "when the list doesn't belong to the authenticated user" do
+        let(:inventory_list) { create(:inventory_list) }
+        let(:params)         { { inventory_list_item: { description: 'Corundum ingot', quantity: 5 } } }
+
+        it "doesn't create the list item" do
+          expect { create_item }
+            .not_to change(InventoryListItem, :count)
+        end
+
+        it 'returns status 404' do
+          create_item
+          expect(response.status).to eq 404
+        end
+
+        it "doesn't return any data" do
+          create_item
+          expect(response.body).to be_blank
+        end
+      end
     end
   end
 end

--- a/spec/requests/shopping_list_items_spec.rb
+++ b/spec/requests/shopping_list_items_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
   let(:headers) do
     {
       'Content-Type'  => 'application/json',
-      'Authorization' => 'Bearer xxxxxxxx',
+      'Authorization' => 'Bearer xxxxxxx',
     }
   end
 
@@ -294,6 +294,536 @@ RSpec.describe 'ShoppingListItems', type: :request do
           create_item
           expect(JSON.parse(response.body)).to eq({ 'errors' => ['Something went horribly wrong'] })
         end
+      end
+    end
+  end
+
+  describe 'PATCH /shopping_list_items/:id' do
+    subject(:update_item) do
+      patch "/shopping_list_items/#{list_item.id}", params: params.to_json, headers: headers
+    end
+
+    let!(:aggregate_list) { create(:aggregate_shopping_list) }
+    let!(:shopping_list)  { create(:shopping_list_with_list_items, game: aggregate_list.game) }
+
+    context 'when authenticated' do
+      let!(:user) { aggregate_list.user }
+
+      let(:validation_data) do
+        {
+          'exp'   => (Time.zone.now + 1.year).to_i,
+          'email' => user.email,
+          'name'  => user.name,
+        }
+      end
+
+      let(:validator) { instance_double(GoogleIDToken::Validator, check: validation_data) }
+
+      before do
+        allow(GoogleIDToken::Validator).to receive(:new).and_return(validator)
+      end
+
+      context 'when all goes well' do
+        let(:params)    { { shopping_list_item: { quantity: 5, notes: 'To make locks' } } }
+        let(:game)      { aggregate_list.game }
+        let(:list_item) { shopping_list.list_items.first }
+
+        before do
+          second_list = create(:shopping_list, game: game, aggregate_list: aggregate_list)
+          second_list.list_items.create!(description: list_item.description, quantity: 2)
+          aggregate_list.add_item_from_child_list(shopping_list.list_items.first)
+          aggregate_list.add_item_from_child_list(shopping_list.list_items.last) # for the sake of realism
+          aggregate_list.add_item_from_child_list(second_list.list_items.first)
+        end
+
+        it 'updates the regular list item' do
+          update_item
+          expect(list_item.reload.attributes).to include(
+                                                   'quantity' => 5,
+                                                   'notes'    => 'To make locks',
+                                                 )
+        end
+
+        it 'updates the item on the aggregate list' do
+          update_item
+          expect(aggregate_list.list_items.first.attributes).to include(
+                                                                  'description' => list_item.description,
+                                                                  'quantity'    => 7,
+                                                                  'notes'       => 'To make locks',
+                                                                )
+        end
+
+        it 'updates the regular list' do
+          t = Time.zone.now + 3.days
+          Timecop.freeze(t) do
+            update_item
+            # use `be_within` even though the time will be set to the time Timecop
+            # has frozen because Rails (Postgres?) sets the last three digits of
+            # the timestamp to 0, which was breaking stuff in CI (but somehow not
+            # in dev).
+            expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+          end
+        end
+
+        it 'returns the aggregate list item and the regular list item', :aggregate_failures do
+          update_item
+
+          # The serialization isn't as simple as .to_json and it makes it hard to determine if the JSON
+          # string is correct as some attributes are out of order and the timestamps are serialized
+          # differently. Here we grab the individual items and then we'll filter out the timestamps to
+          # verify them.
+          aggregate_list_item_actual, regular_list_item_actual = JSON.parse(response.body).map do |item_attrs|
+            item_attrs.except('created_at', 'updated_at')
+          end
+
+          aggregate_list_item_expected = aggregate_list.list_items.first.attributes.except('created_at', 'updated_at')
+          regular_list_item_expected   = shopping_list.list_items.first.attributes.except('created_at', 'updated_at')
+
+          expect(aggregate_list_item_actual).to eq(aggregate_list_item_expected)
+          expect(regular_list_item_actual).to eq(regular_list_item_expected)
+        end
+
+        it 'returns status 200' do
+          update_item
+          expect(response.status).to eq 200
+        end
+      end
+
+      context 'when the shopping list belongs to a different user' do
+        let(:user)      { create(:user) }
+        let(:params)    { { shopping_list_item: { description: 'Corundum ingot', quantity: 5, notes: 'To make locks' } } }
+        let(:list_item) { create(:shopping_list_item, description: 'Corundum ingot', notes: nil) }
+
+        it 'does not updatte the list item' do
+          update_item
+          expect(list_item.quantity).to eq 1
+          expect(list_item.notes).to be nil
+        end
+
+        it 'returns 404' do
+          update_item
+          expect(response.status).to eq 404
+        end
+
+        it 'does not return content' do
+          update_item
+          expect(response.body).to be_empty
+        end
+      end
+
+      context 'when the shopping list does not exist' do
+        let(:game)      { create(:game_with_shopping_lists) }
+        let(:user)      { game.user }
+        let(:list_item) { double("this item doesn't exist", id: 8942) }
+        let(:params)    { { shopping_list_item: { description: 'Corundum ingot', quantity: 5, notes: 'To make locks' } } }
+
+        it 'returns 404' do
+          update_item
+          expect(response.status).to eq 404
+        end
+
+        it 'returns no body' do
+          update_item
+          expect(response.body).to be_empty
+        end
+      end
+
+      context 'when the shopping list is an aggregate list' do
+        let(:game)          { create(:game_with_shopping_lists, user: user) }
+        let(:shopping_list) { game.aggregate_shopping_list }
+        let(:list_item)     { shopping_list.list_items.create!(description: 'Corundum Ingot', list: shopping_list) }
+        let(:params)        { { shopping_list_item: { 'quantity': 5, notes: 'To make locks' } } }
+
+        it 'does not update the list', :aggregate_failures do
+          update_item
+          expect(list_item.quantity).to eq 1
+          expect(list_item.notes).to be nil
+        end
+
+        it 'returns status 405' do
+          update_item
+          expect(response.status).to eq 405
+        end
+
+        it 'returns a helpful error' do
+          update_item
+          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Cannot manually update list items on an aggregate shopping list'] })
+        end
+      end
+
+      context 'when the params are invalid' do
+        let(:list_item) { shopping_list.list_items.create!(description: 'Corundum ingot') }
+        let(:params)    { { shopping_list_item: { description: 'Corundum ingot', quantity: 'foooo', notes: 'To make locks' } } }
+
+        before do
+          aggregate_list.add_item_from_child_list(list_item)
+        end
+
+        it 'does not update the aggregate list', :aggregate_failures do
+          update_item
+          expect(aggregate_list.list_items.first.quantity).to eq 1
+          expect(aggregate_list.list_items.first.notes).to be nil
+        end
+
+        it 'returns 422' do
+          update_item
+          expect(response.status).to eq 422
+        end
+
+        it 'returns the validation errors' do
+          update_item
+          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Quantity is not a number'] })
+        end
+      end
+    end
+
+    context 'when unauthenticated' do
+      let(:user)      { create(:user) }
+      let(:params)    { { shopping_list_item: { description: 'Corundum ingot', quantity: 4, notes: 'To make locks' } } }
+      let(:list_item) { create(:shopping_list_item, list: shopping_list) }
+
+      it 'returns 401' do
+        update_item
+        expect(response.status).to eq 401
+      end
+
+      it 'returns a helpful error' do
+        update_item
+        expect(JSON.parse(response.body)).to eq({ 'errors' => ['Google OAuth token validation failed'] })
+      end
+    end
+  end
+
+  describe 'PUT /shopping_list_items/:id' do
+    subject(:update_item) do
+      put "/shopping_list_items/#{list_item.id}", params: params.to_json, headers: headers
+    end
+
+    let!(:aggregate_list) { create(:aggregate_shopping_list) }
+    let!(:shopping_list) { create(:shopping_list_with_list_items, game: aggregate_list.game) }
+
+    context 'when authenticated' do
+      let!(:user) { aggregate_list.user }
+
+      let(:validation_data) do
+        {
+          'exp'   => (Time.zone.now + 1.year).to_i,
+          'email' => user.email,
+          'name'  => user.name,
+        }
+      end
+
+      let(:validator) { instance_double(GoogleIDToken::Validator, check: validation_data) }
+
+      before do
+        allow(GoogleIDToken::Validator).to receive(:new).and_return(validator)
+      end
+
+      context 'when all goes well' do
+        let(:params)    { { shopping_list_item: { quantity: 5, notes: 'To make locks' } } }
+        let(:game)      { aggregate_list.game }
+        let(:list_item) { shopping_list.list_items.first }
+
+        before do
+          second_list = create(:shopping_list, game: game, aggregate_list: aggregate_list)
+          second_list.list_items.create!(description: list_item.description, quantity: 2)
+          aggregate_list.add_item_from_child_list(shopping_list.list_items.first)
+          aggregate_list.add_item_from_child_list(shopping_list.list_items.last) # for the sake of realism
+          aggregate_list.add_item_from_child_list(second_list.list_items.first)
+        end
+
+        it 'updates the regular list item' do
+          update_item
+          expect(list_item.reload.attributes).to include(
+                                                   'quantity' => 5,
+                                                   'notes'    => 'To make locks',
+                                                 )
+        end
+
+        it 'updates the item on the aggregate list' do
+          update_item
+          expect(aggregate_list.list_items.first.attributes).to include(
+                                                                  'description' => list_item.description,
+                                                                  'quantity'    => 7,
+                                                                  'notes'       => 'To make locks',
+                                                                )
+        end
+
+        it 'updates the regular list' do
+          t = Time.zone.now + 3.days
+          Timecop.freeze(t) do
+            update_item
+            # use `be_within` even though the time will be set to the time Timecop
+            # has frozen because Rails (Postgres?) sets the last three digits of
+            # the timestamp to 0, which was breaking stuff in CI (but somehow not
+            # in dev).
+            expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+          end
+        end
+
+        it 'returns the aggregate list item and the regular list item', :aggregate_failures do
+          update_item
+
+          # The serialization isn't as simple as .to_json and it makes it hard to determine if the JSON
+          # string is correct as some attributes are out of order and the timestamps are serialized
+          # differently. Here we grab the individual items and then we'll filter out the timestamps to
+          # verify them.
+          aggregate_list_item_actual, regular_list_item_actual = JSON.parse(response.body).map do |item_attrs|
+            item_attrs.except('created_at', 'updated_at')
+          end
+
+          aggregate_list_item_expected = aggregate_list.list_items.first.attributes.except('created_at', 'updated_at')
+          regular_list_item_expected   = shopping_list.list_items.first.attributes.except('created_at', 'updated_at')
+
+          expect(aggregate_list_item_actual).to eq(aggregate_list_item_expected)
+          expect(regular_list_item_actual).to eq(regular_list_item_expected)
+        end
+
+        it 'returns status 200' do
+          update_item
+          expect(response.status).to eq 200
+        end
+      end
+
+      context 'when the shopping list belongs to a different user' do
+        let(:user)      { create(:user) }
+        let(:params)    { { shopping_list_item: { description: 'Corundum ingot', quantity: 5, notes: 'To make locks' } } }
+        let(:list_item) { create(:shopping_list_item, description: 'Corundum ingot', notes: nil) }
+
+        it 'does not updatte the list item' do
+          update_item
+          expect(list_item.quantity).to eq 1
+          expect(list_item.notes).to be nil
+        end
+
+        it 'returns 404' do
+          update_item
+          expect(response.status).to eq 404
+        end
+
+        it 'does not return content' do
+          update_item
+          expect(response.body).to be_empty
+        end
+      end
+
+      context 'when the shopping list does not exist' do
+        let(:game)      { create(:game_with_shopping_lists) }
+        let(:user)      { game.user }
+        let(:list_item) { double("this item doesn't exist", id: 8942) }
+        let(:params)    { { shopping_list_item: { description: 'Corundum ingot', quantity: 5, notes: 'To make locks' } } }
+
+        it 'returns 404' do
+          update_item
+          expect(response.status).to eq 404
+        end
+
+        it 'returns no body' do
+          update_item
+          expect(response.body).to be_empty
+        end
+      end
+
+      context 'when the shopping list is an aggregate list' do
+        let(:game)          { create(:game_with_shopping_lists, user: user) }
+        let(:shopping_list) { game.aggregate_shopping_list }
+        let(:list_item)     { shopping_list.list_items.create!(description: 'Corundum Ingot', list: shopping_list) }
+
+        let(:params) { { shopping_list_item: { 'quantity': 5, notes: 'To make locks' } } }
+
+        it 'does not update the list', :aggregate_failures do
+          update_item
+          expect(list_item.quantity).to eq 1
+          expect(list_item.notes).to be nil
+        end
+
+        it 'returns status 405' do
+          update_item
+          expect(response.status).to eq 405
+        end
+
+        it 'returns a helpful error' do
+          update_item
+          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Cannot manually update list items on an aggregate shopping list'] })
+        end
+      end
+
+      context 'when the params are invalid' do
+        let(:list_item) { shopping_list.list_items.create!(description: 'Corundum ingot') }
+        let(:params)    { { shopping_list_item: { description: 'Corundum ingot', quantity: 'foooo', notes: 'To make locks' } } }
+
+        before do
+          aggregate_list.add_item_from_child_list(list_item)
+        end
+
+        it 'does not update the aggregate list', :aggregate_failures do
+          update_item
+          expect(aggregate_list.list_items.first.quantity).to eq 1
+          expect(aggregate_list.list_items.first.notes).to be nil
+        end
+
+        it 'returns 422' do
+          update_item
+          expect(response.status).to eq 422
+        end
+
+        it 'returns the validation errors' do
+          update_item
+          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Quantity is not a number'] })
+        end
+      end
+    end
+
+    context 'when unauthenticated' do
+      let(:user)      { create(:user) }
+      let(:params)    { { shopping_list_item: { description: 'Corundum ingot', quantity: 4, notes: 'To make locks' } } }
+      let(:list_item) { create(:shopping_list_item, list: shopping_list) }
+
+      it 'returns 401' do
+        update_item
+        expect(response.status).to eq 401
+      end
+
+      it 'returns a helpful error' do
+        update_item
+        expect(JSON.parse(response.body)).to eq({ 'errors' => ['Google OAuth token validation failed'] })
+      end
+    end
+  end
+
+  describe 'DELETE /shopping_list_items/:id' do
+    subject(:destroy_item) { delete "/shopping_list_items/#{list_item.id}", headers: headers }
+
+    context 'when authenticated' do
+      let!(:aggregate_list) { create(:aggregate_shopping_list, game: game) }
+      let!(:shopping_list)  { create(:shopping_list, game: game, aggregate_list: aggregate_list) }
+
+      let(:game)      { create(:game) }
+      let(:validator) { instance_double(GoogleIDToken::Validator, check: validation_data) }
+      let(:validation_data) do
+        {
+          'exp'   => (Time.zone.now + 1.year).to_i,
+          'email' => game.user.email,
+          'name'  => game.user.name,
+        }
+      end
+
+      before do
+        allow(GoogleIDToken::Validator).to receive(:new).and_return(validator)
+      end
+
+      context 'when all goes well' do
+        let(:user)      { list_item.user }
+        let(:list_item) { create(:shopping_list_item, list: shopping_list, quantity: 3, notes: 'foo') }
+
+        before do
+          aggregate_list.add_item_from_child_list(list_item)
+        end
+
+        context 'when the quantity on the regular list equals that on the aggregate list' do
+          it 'destroys the item on the regular list' do
+            destroy_item
+            expect { ShoppingListItem.find(list_item.id) }
+              .to raise_error ActiveRecord::RecordNotFound
+          end
+
+          it 'destroys the item on the aggregate list' do
+            destroy_item
+            expect(aggregate_list.list_items).to be_empty
+          end
+
+          it 'returns an empty response' do
+            destroy_item
+            expect(response.body).to be_empty
+          end
+
+          it 'returns status 204' do
+            destroy_item
+            expect(response.status).to eq 204
+          end
+        end
+
+        context 'when the quantity on the aggregate list exceeds that on the regular list' do
+          let(:second_list) { create(:shopping_list, game: game) }
+          let(:second_item) { create(:shopping_list_item, list: second_list, description: list_item.description, quantity: 2, notes: 'bar') }
+
+          before do
+            aggregate_list.add_item_from_child_list(second_item)
+          end
+
+          it 'destroys the item on the regular list' do
+            destroy_item
+            expect { ShoppingListItem.find(list_item.id) }
+              .to raise_error ActiveRecord::RecordNotFound
+          end
+
+          it 'updates the quantity of the item on the aggregate list' do
+            destroy_item
+            expect(aggregate_list.list_items.first.quantity).to eq 2
+          end
+
+          it 'updates the notes of the item on the aggregate list', :aggregate_failures do
+            destroy_item
+            expect(aggregate_list.list_items.first.notes).to match /bar/
+            expect(aggregate_list.list_items.first.notes).not_to match /foo/
+          end
+        end
+      end
+
+      context "when the specified list item doesn't exist" do
+        let(:list_item) { double("this doesn't exist", id: 772) }
+
+        it 'returns status 404' do
+          destroy_item
+          expect(response.status).to eq 404
+        end
+
+        it "doesn't return any error messages" do
+          destroy_item
+          expect(response.body).to be_empty
+        end
+      end
+
+      context "when the specified list item doesn't belong to the authenticated user" do
+        let(:list_item) { create(:shopping_list_item) }
+
+        it 'returns status 404' do
+          destroy_item
+          expect(response.status).to eq 404
+        end
+
+        it 'returns an empty response body' do
+          destroy_item
+          expect(response.body).to be_empty
+        end
+      end
+
+      context 'when the specified list item is on an aggregate list' do
+        let(:list_item) { create(:shopping_list_item, list: aggregate_list) }
+
+        it 'returns status 405' do
+          destroy_item
+          expect(response.status).to eq 405
+        end
+
+        it 'returns a helpful error message' do
+          destroy_item
+          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Cannot manually delete list item from aggregate shopping list'] })
+        end
+      end
+    end
+
+    context 'when unauthenticated' do
+      let(:list_item) { create(:shopping_list_item) }
+
+      it 'returns a 401' do
+        destroy_item
+        expect(response.status).to eq 401
+      end
+
+      it 'indicates the request was unauthenticated' do
+        destroy_item
+        expect(JSON.parse(response.body)).to eq({ 'errors' => ['Google OAuth token validation failed'] })
       end
     end
   end

--- a/spec/requests/shopping_list_items_spec.rb
+++ b/spec/requests/shopping_list_items_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
   let(:headers) do
     {
       'Content-Type'  => 'application/json',
-      'Authorization' => 'Bearer xxxxxxx',
+      'Authorization' => 'Bearer xxxxxxxx',
     }
   end
 
@@ -18,10 +18,11 @@ RSpec.describe 'ShoppingListItems', type: :request do
     end
 
     let!(:aggregate_list) { create(:aggregate_shopping_list) }
-    let!(:shopping_list)  { create(:shopping_list, game: aggregate_list.game) }
+    let!(:shopping_list)  { create(:shopping_list, aggregate_list: aggregate_list, game: aggregate_list.game) }
 
     context 'when authenticated' do
-      let!(:user) { aggregate_list.user }
+      let!(:user)     { aggregate_list.user }
+      let(:validator) { instance_double(GoogleIDToken::Validator, check: validation_data) }
 
       let(:validation_data) do
         {
@@ -31,8 +32,6 @@ RSpec.describe 'ShoppingListItems', type: :request do
         }
       end
 
-      let(:validator) { instance_double(GoogleIDToken::Validator, check: validation_data) }
-
       before do
         allow(GoogleIDToken::Validator).to receive(:new).and_return(validator)
       end
@@ -40,815 +39,261 @@ RSpec.describe 'ShoppingListItems', type: :request do
       context 'when all goes well' do
         let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 5, notes: 'To make locks' } } }
 
-        it 'creates a new shopping list item on the shopping list' do
+        context 'when there is no existing matching item on the same list' do
+          context 'when there is no existing matching item on any list' do
+            it 'creates a new item on the requested list' do
+              expect { create_item }
+                .to change(shopping_list.list_items, :count).from(0).to(1)
+            end
+
+            it 'creates a new item on the aggregate list' do
+              expect { create_item }
+                .to change(aggregate_list.list_items, :count).from(0).to(1)
+            end
+
+            it 'returns status 201' do
+              create_item
+              expect(response.status).to eq 201
+            end
+
+            it 'returns the regular list item and the aggregate list item' do
+              create_item
+              expect(JSON.parse(response.body)).to eq(JSON.parse([aggregate_list.list_items.last, shopping_list.list_items.last].to_json))
+            end
+          end
+
+          context 'when there is an existing matching item on another list' do
+            let(:other_list)  { create(:shopping_list, game: aggregate_list.game) }
+            let!(:other_item) { create(:shopping_list_item, list: other_list, description: 'Corundum ingot', quantity: 2) }
+
+            before do
+              aggregate_list.add_item_from_child_list(other_item)
+            end
+
+            context "when unit weight isn't set" do
+              let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 5 } } }
+
+              it 'creates a new item on the requested list' do
+                expect { create_item }
+                  .to change(shopping_list.list_items, :count).from(0).to(1)
+              end
+
+              it 'updates the item on the aggregate list' do
+                create_item
+                expect(aggregate_list.list_items.first.quantity).to eq 7
+              end
+
+              it 'returns status 201' do
+                create_item
+                expect(response.status).to eq 201
+              end
+
+              it 'returns the aggregate list item and the regular list item' do
+                create_item
+                expect(JSON.parse(response.body)).to eq(JSON.parse([aggregate_list.list_items.first, shopping_list.list_items.first].to_json))
+              end
+            end
+
+            context 'when unit weight is set' do
+              let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 5, unit_weight: 1 } } }
+
+              it 'creates a new item on the requested list' do
+                expect { create_item }
+                  .to change(shopping_list.list_items, :count).from(0).to(1)
+              end
+
+              it 'updates the item on the aggregate list', :aggregate_failures do
+                create_item
+                expect(aggregate_list.list_items.first.quantity).to eq 7
+                expect(aggregate_list.list_items.first.unit_weight).to eq 1
+              end
+
+              it 'updates the unit weight of the other regular-list item', :aggregate_failures do
+                create_item
+                expect(other_item.reload.unit_weight).to eq 1
+                expect(other_item.reload.quantity).to eq 2
+              end
+
+              it 'returns status 201' do
+                create_item
+                expect(response.status).to eq 201
+              end
+
+              it 'returns all items that were created or updated' do
+                create_item
+                expect(JSON.parse(response.body)).to eq(JSON.parse([aggregate_list.list_items.first, other_item.reload, shopping_list.list_items.first].to_json))
+              end
+            end
+          end
+        end
+
+        context 'when there is an existing matching item on the same list' do
+          let(:other_list) { create(:shopping_list, game: aggregate_list.game, aggregate_list: aggregate_list) }
+          let!(:other_item) { create(:shopping_list_item, list: other_list, description: 'Corundum ingot', quantity: 2) }
+          let!(:list_item)  { create(:shopping_list_item, list: shopping_list, description: 'Corundum ingot', quantity: 3) }
+
+          before do
+            aggregate_list.add_item_from_child_list(other_item)
+            aggregate_list.add_item_from_child_list(list_item)
+          end
+
+          context "when unit weight isn't updated" do
+            it "doesn't create a new item" do
+              expect { create_item }
+                .not_to change(ShoppingListItem, :count)
+            end
+
+            it 'combines with the existing item' do
+              create_item
+              expect(list_item.reload.quantity).to eq 8
+            end
+
+            it 'updates the item on the aggregate list' do
+              create_item
+              expect(aggregate_list.list_items.first.quantity).to eq 10
+            end
+
+            it 'returns status 200' do
+              create_item
+              expect(response.status).to eq 200
+            end
+
+            it 'returns the requested item and the aggregate list item' do
+              create_item
+              expect(JSON.parse(response.body)).to eq(JSON.parse([aggregate_list.list_items.first, list_item.reload].to_json))
+            end
+          end
+
+          context 'when unit weight is updated' do
+            let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 2, unit_weight: 1 } } }
+
+            it "doesn't create a new list item" do
+              expect { create_item }
+                .not_to change(ShoppingListItem, :count)
+            end
+
+            it 'combines it with the existing item', :aggregate_failures do
+              create_item
+              expect(list_item.reload.quantity).to eq 5
+              expect(list_item.unit_weight).to eq 1
+            end
+
+            it 'updates the item on the aggregate list', :aggregate_failures do
+              create_item
+              expect(aggregate_list.list_items.first.quantity).to eq 7
+              expect(aggregate_list.list_items.first.unit_weight).to eq 1
+            end
+
+            it 'updates only the unit_weight on the other item', :aggregate_failures do
+              create_item
+              expect(other_item.reload.unit_weight).to eq 1
+              expect(other_item.quantity).to eq 2
+            end
+
+            it 'returns status 200' do
+              create_item
+              expect(response.status).to eq 200
+            end
+
+            it 'returns all items that have been updated' do
+              create_item
+              expect(JSON.parse(response.body)).to eq(JSON.parse([aggregate_list.list_items.first, other_item.reload, list_item.reload].to_json))
+            end
+          end
+        end
+      end
+
+      context "when the list doesn't exist" do
+        let(:params)         { { description: 'Necklace', quantity: 2, unit_weight: 0.5 } }
+        let(:shopping_list)  { double(id: 23_498) }
+
+        it 'returns status 404' do
+          create_item
+          expect(response.status).to eq 404
+        end
+
+        it "doesn't return any data" do
+          create_item
+          expect(response.body).to be_blank
+        end
+      end
+
+      context "when the list doesn't belong to the authenticated user" do
+        let(:shopping_list) { create(:shopping_list) }
+        let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 5 } } }
+
+        it "doesn't create the list item" do
           expect { create_item }
-            .to change(shopping_list.list_items, :count).from(0).to(1)
+            .not_to change(ShoppingListItem, :count)
         end
 
-        context 'when the aggregate list has no items on it' do
-          it 'adds the item to the aggregate list' do
-            expect { create_item }
-              .to change(ShoppingListItem, :count).from(0).to(2)
-          end
-
-          it 'assigns the right attributes' do
-            create_item
-            item = shopping_list.list_items.last
-            expect(aggregate_list.list_items.last.attributes).to include(
-                                                                   'description' => item.description,
-                                                                   'quantity'    => item.quantity,
-                                                                   'notes'       => item.notes,
-                                                                 )
-          end
-
-          it 'updates the regular list' do
-            t = Time.zone.now + 3.days
-            Timecop.freeze(t) do
-              create_item
-              # use `be_within` even though the time will be set to the time Timecop
-              # has frozen because Rails (Postgres?) sets the last three digits of
-              # the timestamp to 0, which was breaking stuff in CI (but somehow not
-              # in dev).
-              expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
-            end
-          end
-
-          it 'updates the game' do
-            t = Time.zone.now + 3.days
-            Timecop.freeze(t) do
-              create_item
-              # use `be_within` even though the time will be set to the time Timecop
-              # has frozen because Rails (Postgres?) sets the last three digits of
-              # the timestamp to 0, which was breaking stuff in CI (but somehow not
-              # in dev).
-              expect(aggregate_list.game.reload.updated_at).to be_within(0.005.seconds).of(t)
-            end
-          end
-
-          it 'returns the aggregate list item and the regular list item' do
-            create_item
-            expect(response.body).to eq([aggregate_list.list_items.last, shopping_list.list_items.last].to_json)
-          end
-
-          it 'returns status 201' do
-            create_item
-            expect(response.status).to eq 201
-          end
-        end
-
-        context 'when the aggregate list has a matching item from a different list' do
-          before do
-            second_list = aggregate_list.game.shopping_lists.create!(title: 'Proudspire Manor', aggregate_list: aggregate_list)
-            second_list.list_items.create!(
-              description: 'Corundum ingot',
-              quantity:    1,
-              notes:       'some other notes',
-            )
-            aggregate_list.add_item_from_child_list(second_list.list_items.last)
-          end
-
-          it 'updates the item on the aggregate list', :aggregate_failures do
-            create_item
-            expect(aggregate_list.list_items.count).to eq 1
-            expect(aggregate_list.list_items.last.attributes).to include(
-                                                                   'description' => 'Corundum ingot',
-                                                                   'quantity'    => 6,
-                                                                   'notes'       => 'some other notes -- To make locks',
-                                                                 )
-          end
-
-          it 'returns the aggregate list item and the regular list item', :aggregate_failures do
-            create_item
-
-            # The serialization isn't as simple as .to_json and it makes it hard to determine if the JSON
-            # string is correct as some attributes are out of order and the timestamps are serialized
-            # differently. Here we grab the individual items and then we'll filter out the timestamps to
-            # verify them.
-            aggregate_list_item_actual, regular_list_item_actual = JSON.parse(response.body).map do |item_attrs|
-              item_attrs.except('created_at', 'updated_at')
-            end
-
-            aggregate_list_item_expected = aggregate_list.list_items.last.attributes.except('created_at', 'updated_at')
-            regular_list_item_expected   = shopping_list.list_items.last.attributes.except('created_at', 'updated_at')
-
-            expect(aggregate_list_item_actual).to eq(aggregate_list_item_expected)
-            expect(regular_list_item_actual).to eq(regular_list_item_expected)
-          end
-
-          it 'returns status 201' do
-            create_item
-            expect(response.status).to eq 201
-          end
-
-          # Rubocop swears up and down this is a duplicate example within the same
-          # example group but I'd say it depends on what it considers an example group
-          # to be. This is definitely not testing the same thing as the other similar
-          # specs.
-
-          # rubocop:disable RSpec/RepeatedExample
-          it 'updates the regular list' do
-            t = Time.zone.now + 3.days
-            Timecop.freeze(t) do
-              create_item
-              # use `be_within` even though the time will be set to the time Timecop
-              # has frozen because Rails (Postgres?) sets the last three digits of
-              # the timestamp to 0, which was breaking stuff in CI (but somehow not
-              # in dev).
-              expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
-            end
-          end
-
-          it 'updates the game' do
-            t = Time.zone.now + 3.days
-            Timecop.freeze(t) do
-              create_item
-              # use `be_within` even though the time will be set to the time Timecop
-              # has frozen because Rails (Postgres?) sets the last three digits of
-              # the timestamp to 0, which was breaking stuff in CI (but somehow not
-              # in dev).
-              expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
-            end
-          end
-          # rubocop:enable RSpec/RepeatedExample
-        end
-
-        context 'when the new item matches an existing item on the same list' do
-          before do
-            item = shopping_list.list_items.create!(description: 'Corundum ingot', quantity: 2, notes: 'To make locks')
-            aggregate_list.add_item_from_child_list(item)
-          end
-
-          it "doesn't create a new item" do
-            expect { create_item }
-              .not_to change(shopping_list.list_items, :count)
-          end
-
-          it "doesn't create a new item on the aggregate list" do
-            expect { create_item }
-              .not_to change(aggregate_list.list_items, :count)
-          end
-
-          it 'updates the existing item' do
-            create_item
-            expect(shopping_list.list_items.first.attributes).to include(
-                                                                   'description' => 'Corundum ingot',
-                                                                   'quantity'    => 7,
-                                                                   'notes'       => 'To make locks -- To make locks',
-                                                                 )
-          end
-
-          it 'updates the aggregate list', :aggregate_failures do
-            create_item
-            expect(aggregate_list.list_items.first.quantity).to eq 7
-            expect(aggregate_list.list_items.first.notes).to eq 'To make locks -- To make locks'
-          end
-
-          it 'updates the regular list' do
-            t = Time.zone.now + 3.days
-            Timecop.freeze(t) do
-              create_item
-              # use `be_within` even though the time will be set to the time Timecop
-              # has frozen because Rails (Postgres?) sets the last three digits of
-              # the timestamp to 0, which was breaking stuff in CI (but somehow not
-              # in dev).
-              expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
-            end
-          end
-
-          it 'returns the aggregate list item and the regular list item' do
-            create_item
-
-            # We have to go through this whole rigamarole because the timestamps are being serialised/deserialised
-            # wrong and if I check equality between JSON.parse(response.body) and [agg_list_item, reg_list_item] it
-            # fails wrongly. Likewise, response.body != [agg_list_item, reg_list_item].to_json because the JSON ends
-            # up being in a different order.
-            agg_list_item, reg_list_item = JSON.parse(response.body).map {|attrs| attrs.except('created_at', 'updated_at') }
-            agg_list_item_attributes     = aggregate_list.list_items.last.attributes.except('created_at', 'updated_at')
-            reg_list_item_attributes     = shopping_list.list_items.last.attributes.except('created_at', 'updated_at')
-
-            expect([agg_list_item, reg_list_item]).to eq([agg_list_item_attributes, reg_list_item_attributes])
-          end
-
-          it 'updates the game' do
-            t = Time.zone.now + 3.days
-            Timecop.freeze(t) do
-              create_item
-              # use `be_within` even though the time will be set to the time Timecop
-              # has frozen because Rails (Postgres?) sets the last three digits of
-              # the timestamp to 0, which was breaking stuff in CI (but somehow not
-              # in dev).
-              expect(aggregate_list.game.reload.updated_at).to be_within(0.005.seconds).of(t)
-            end
-          end
-        end
-      end
-
-      context 'when the shopping list belongs to a different user' do
-        let(:user)   { create(:user) }
-        let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 5, notes: 'To make locks' } } }
-
-        it 'returns 404' do
+        it 'returns status 404' do
           create_item
           expect(response.status).to eq 404
         end
 
-        it 'does not return content' do
+        it "doesn't return any data" do
           create_item
           expect(response.body).to be_blank
         end
       end
 
-      context 'when the shopping list does not exist' do
-        subject(:create_item) do
-          post '/shopping_lists/838934/shopping_list_items',
-               params:  params.to_json,
-               headers: headers
+      context 'when the params are invalid' do
+        let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: -2 } } }
+
+        it "doesn't create the item" do
+          expect { create_item }
+            .not_to change(ShoppingListItem, :count)
         end
 
-        let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 5, notes: 'To make locks' } } }
-
-        it 'returns 404' do
+        it 'returns status 422' do
           create_item
-          expect(response.status).to eq 404
+          expect(response.status).to eq 422
         end
 
-        it 'does not return content' do
+        it 'returns the error array' do
           create_item
-          expect(response.body).to be_blank
+          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Quantity must be greater than 0'] })
         end
       end
 
-      context 'when the shopping list is an aggregate list' do
+      context 'when the list is an aggregate list' do
         let(:shopping_list) { aggregate_list }
-        let(:params)        { { shopping_list_item: { description: 'Corundum ingot', quantity: 5, notes: 'To make locks' } } }
+        let(:params)        { { shopping_list_item: { description: 'Corundum ingot', quantity: 4 } } }
+
+        it "doesn't create an item" do
+          expect { create_item }
+            .not_to change(ShoppingListItem, :count)
+        end
 
         it 'returns status 405' do
           create_item
           expect(response.status).to eq 405
         end
 
-        it 'returns an error message' do
+        it 'returns the error' do
           create_item
-          expect(response.body).to eq({ errors: ['Cannot manually manage items on an aggregate shopping list'] }.to_json)
+          expect(JSON.parse(response.body))
+            .to eq({ 'errors' => ['Cannot manually manage items on an aggregate shopping list'] })
         end
       end
 
-      context 'when the params are invalid' do
-        let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 'fooooo', notes: 'To make locks' } } }
+      context 'when something unexpected goes wrong' do
+        let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 4 } } }
 
-        it 'returns 422' do
+        before do
+          allow(ShoppingList).to receive(:find).and_raise(StandardError.new('Something went horribly wrong'))
+        end
+
+        it 'returns status 500' do
           create_item
-          expect(response.status).to eq 422
+          expect(response.status).to eq 500
         end
 
-        it 'returns the validation errors' do
+        it 'returns the error' do
           create_item
-          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Quantity is not a number'] })
+          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Something went horribly wrong'] })
         end
-      end
-    end
-
-    context 'when unauthenticated' do
-      let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 5, notes: 'To make locks' } } }
-
-      it 'returns 401' do
-        create_item
-        expect(response.status).to eq 401
-      end
-
-      it 'returns a helpful error' do
-        create_item
-        expect(JSON.parse(response.body)).to eq({ 'errors' => ['Google OAuth token validation failed'] })
-      end
-    end
-  end
-
-  describe 'PATCH /shopping_list_items/:id' do
-    subject(:update_item) do
-      patch "/shopping_list_items/#{list_item.id}", params: params.to_json, headers: headers
-    end
-
-    let!(:aggregate_list) { create(:aggregate_shopping_list) }
-    let!(:shopping_list)  { create(:shopping_list_with_list_items, game: aggregate_list.game) }
-
-    context 'when authenticated' do
-      let!(:user) { aggregate_list.user }
-
-      let(:validation_data) do
-        {
-          'exp'   => (Time.zone.now + 1.year).to_i,
-          'email' => user.email,
-          'name'  => user.name,
-        }
-      end
-
-      let(:validator) { instance_double(GoogleIDToken::Validator, check: validation_data) }
-
-      before do
-        allow(GoogleIDToken::Validator).to receive(:new).and_return(validator)
-      end
-
-      context 'when all goes well' do
-        let(:params)    { { shopping_list_item: { quantity: 5, notes: 'To make locks' } } }
-        let(:game)      { aggregate_list.game }
-        let(:list_item) { shopping_list.list_items.first }
-
-        before do
-          second_list = create(:shopping_list, game: game, aggregate_list: aggregate_list)
-          second_list.list_items.create!(description: list_item.description, quantity: 2)
-          aggregate_list.add_item_from_child_list(shopping_list.list_items.first)
-          aggregate_list.add_item_from_child_list(shopping_list.list_items.last) # for the sake of realism
-          aggregate_list.add_item_from_child_list(second_list.list_items.first)
-        end
-
-        it 'updates the regular list item' do
-          update_item
-          expect(list_item.reload.attributes).to include(
-                                                   'quantity' => 5,
-                                                   'notes'    => 'To make locks',
-                                                 )
-        end
-
-        it 'updates the item on the aggregate list' do
-          update_item
-          expect(aggregate_list.list_items.first.attributes).to include(
-                                                                  'description' => list_item.description,
-                                                                  'quantity'    => 7,
-                                                                  'notes'       => 'To make locks',
-                                                                )
-        end
-
-        it 'updates the regular list' do
-          t = Time.zone.now + 3.days
-          Timecop.freeze(t) do
-            update_item
-            # use `be_within` even though the time will be set to the time Timecop
-            # has frozen because Rails (Postgres?) sets the last three digits of
-            # the timestamp to 0, which was breaking stuff in CI (but somehow not
-            # in dev).
-            expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
-          end
-        end
-
-        it 'returns the aggregate list item and the regular list item', :aggregate_failures do
-          update_item
-
-          # The serialization isn't as simple as .to_json and it makes it hard to determine if the JSON
-          # string is correct as some attributes are out of order and the timestamps are serialized
-          # differently. Here we grab the individual items and then we'll filter out the timestamps to
-          # verify them.
-          aggregate_list_item_actual, regular_list_item_actual = JSON.parse(response.body).map do |item_attrs|
-            item_attrs.except('created_at', 'updated_at')
-          end
-
-          aggregate_list_item_expected = aggregate_list.list_items.first.attributes.except('created_at', 'updated_at')
-          regular_list_item_expected   = shopping_list.list_items.first.attributes.except('created_at', 'updated_at')
-
-          expect(aggregate_list_item_actual).to eq(aggregate_list_item_expected)
-          expect(regular_list_item_actual).to eq(regular_list_item_expected)
-        end
-
-        it 'returns status 200' do
-          update_item
-          expect(response.status).to eq 200
-        end
-      end
-
-      context 'when the shopping list belongs to a different user' do
-        let(:user)      { create(:user) }
-        let(:params)    { { shopping_list_item: { description: 'Corundum ingot', quantity: 5, notes: 'To make locks' } } }
-        let(:list_item) { create(:shopping_list_item, description: 'Corundum ingot', notes: nil) }
-
-        it 'does not updatte the list item' do
-          update_item
-          expect(list_item.quantity).to eq 1
-          expect(list_item.notes).to be nil
-        end
-
-        it 'returns 404' do
-          update_item
-          expect(response.status).to eq 404
-        end
-
-        it 'does not return content' do
-          update_item
-          expect(response.body).to be_empty
-        end
-      end
-
-      context 'when the shopping list does not exist' do
-        let(:game)      { create(:game_with_shopping_lists) }
-        let(:user)      { game.user }
-        let(:list_item) { double("this item doesn't exist", id: 8942) }
-        let(:params)    { { shopping_list_item: { description: 'Corundum ingot', quantity: 5, notes: 'To make locks' } } }
-
-        it 'returns 404' do
-          update_item
-          expect(response.status).to eq 404
-        end
-
-        it 'returns no body' do
-          update_item
-          expect(response.body).to be_empty
-        end
-      end
-
-      context 'when the shopping list is an aggregate list' do
-        let(:game)          { create(:game_with_shopping_lists, user: user) }
-        let(:shopping_list) { game.aggregate_shopping_list }
-        let(:list_item)     { shopping_list.list_items.create!(description: 'Corundum Ingot', list: shopping_list) }
-        let(:params)        { { shopping_list_item: { 'quantity': 5, notes: 'To make locks' } } }
-
-        it 'does not update the list', :aggregate_failures do
-          update_item
-          expect(list_item.quantity).to eq 1
-          expect(list_item.notes).to be nil
-        end
-
-        it 'returns status 405' do
-          update_item
-          expect(response.status).to eq 405
-        end
-
-        it 'returns a helpful error' do
-          update_item
-          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Cannot manually update list items on an aggregate shopping list'] })
-        end
-      end
-
-      context 'when the params are invalid' do
-        let(:list_item) { shopping_list.list_items.create!(description: 'Corundum ingot') }
-        let(:params)    { { shopping_list_item: { description: 'Corundum ingot', quantity: 'foooo', notes: 'To make locks' } } }
-
-        before do
-          aggregate_list.add_item_from_child_list(list_item)
-        end
-
-        it 'does not update the aggregate list', :aggregate_failures do
-          update_item
-          expect(aggregate_list.list_items.first.quantity).to eq 1
-          expect(aggregate_list.list_items.first.notes).to be nil
-        end
-
-        it 'returns 422' do
-          update_item
-          expect(response.status).to eq 422
-        end
-
-        it 'returns the validation errors' do
-          update_item
-          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Quantity is not a number'] })
-        end
-      end
-    end
-
-    context 'when unauthenticated' do
-      let(:user)      { create(:user) }
-      let(:params)    { { shopping_list_item: { description: 'Corundum ingot', quantity: 4, notes: 'To make locks' } } }
-      let(:list_item) { create(:shopping_list_item, list: shopping_list) }
-
-      it 'returns 401' do
-        update_item
-        expect(response.status).to eq 401
-      end
-
-      it 'returns a helpful error' do
-        update_item
-        expect(JSON.parse(response.body)).to eq({ 'errors' => ['Google OAuth token validation failed'] })
-      end
-    end
-  end
-
-  describe 'PUT /shopping_list_items/:id' do
-    subject(:update_item) do
-      put "/shopping_list_items/#{list_item.id}", params: params.to_json, headers: headers
-    end
-
-    let!(:aggregate_list) { create(:aggregate_shopping_list) }
-    let!(:shopping_list) { create(:shopping_list_with_list_items, game: aggregate_list.game) }
-
-    context 'when authenticated' do
-      let!(:user) { aggregate_list.user }
-
-      let(:validation_data) do
-        {
-          'exp'   => (Time.zone.now + 1.year).to_i,
-          'email' => user.email,
-          'name'  => user.name,
-        }
-      end
-
-      let(:validator) { instance_double(GoogleIDToken::Validator, check: validation_data) }
-
-      before do
-        allow(GoogleIDToken::Validator).to receive(:new).and_return(validator)
-      end
-
-      context 'when all goes well' do
-        let(:params)    { { shopping_list_item: { quantity: 5, notes: 'To make locks' } } }
-        let(:game)      { aggregate_list.game }
-        let(:list_item) { shopping_list.list_items.first }
-
-        before do
-          second_list = create(:shopping_list, game: game, aggregate_list: aggregate_list)
-          second_list.list_items.create!(description: list_item.description, quantity: 2)
-          aggregate_list.add_item_from_child_list(shopping_list.list_items.first)
-          aggregate_list.add_item_from_child_list(shopping_list.list_items.last) # for the sake of realism
-          aggregate_list.add_item_from_child_list(second_list.list_items.first)
-        end
-
-        it 'updates the regular list item' do
-          update_item
-          expect(list_item.reload.attributes).to include(
-                                                   'quantity' => 5,
-                                                   'notes'    => 'To make locks',
-                                                 )
-        end
-
-        it 'updates the item on the aggregate list' do
-          update_item
-          expect(aggregate_list.list_items.first.attributes).to include(
-                                                                  'description' => list_item.description,
-                                                                  'quantity'    => 7,
-                                                                  'notes'       => 'To make locks',
-                                                                )
-        end
-
-        it 'updates the regular list' do
-          t = Time.zone.now + 3.days
-          Timecop.freeze(t) do
-            update_item
-            # use `be_within` even though the time will be set to the time Timecop
-            # has frozen because Rails (Postgres?) sets the last three digits of
-            # the timestamp to 0, which was breaking stuff in CI (but somehow not
-            # in dev).
-            expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
-          end
-        end
-
-        it 'returns the aggregate list item and the regular list item', :aggregate_failures do
-          update_item
-
-          # The serialization isn't as simple as .to_json and it makes it hard to determine if the JSON
-          # string is correct as some attributes are out of order and the timestamps are serialized
-          # differently. Here we grab the individual items and then we'll filter out the timestamps to
-          # verify them.
-          aggregate_list_item_actual, regular_list_item_actual = JSON.parse(response.body).map do |item_attrs|
-            item_attrs.except('created_at', 'updated_at')
-          end
-
-          aggregate_list_item_expected = aggregate_list.list_items.first.attributes.except('created_at', 'updated_at')
-          regular_list_item_expected   = shopping_list.list_items.first.attributes.except('created_at', 'updated_at')
-
-          expect(aggregate_list_item_actual).to eq(aggregate_list_item_expected)
-          expect(regular_list_item_actual).to eq(regular_list_item_expected)
-        end
-
-        it 'returns status 200' do
-          update_item
-          expect(response.status).to eq 200
-        end
-      end
-
-      context 'when the shopping list belongs to a different user' do
-        let(:user)      { create(:user) }
-        let(:params)    { { shopping_list_item: { description: 'Corundum ingot', quantity: 5, notes: 'To make locks' } } }
-        let(:list_item) { create(:shopping_list_item, description: 'Corundum ingot', notes: nil) }
-
-        it 'does not updatte the list item' do
-          update_item
-          expect(list_item.quantity).to eq 1
-          expect(list_item.notes).to be nil
-        end
-
-        it 'returns 404' do
-          update_item
-          expect(response.status).to eq 404
-        end
-
-        it 'does not return content' do
-          update_item
-          expect(response.body).to be_empty
-        end
-      end
-
-      context 'when the shopping list does not exist' do
-        let(:game)      { create(:game_with_shopping_lists) }
-        let(:user)      { game.user }
-        let(:list_item) { double("this item doesn't exist", id: 8942) }
-        let(:params)    { { shopping_list_item: { description: 'Corundum ingot', quantity: 5, notes: 'To make locks' } } }
-
-        it 'returns 404' do
-          update_item
-          expect(response.status).to eq 404
-        end
-
-        it 'returns no body' do
-          update_item
-          expect(response.body).to be_empty
-        end
-      end
-
-      context 'when the shopping list is an aggregate list' do
-        let(:game)          { create(:game_with_shopping_lists, user: user) }
-        let(:shopping_list) { game.aggregate_shopping_list }
-        let(:list_item)     { shopping_list.list_items.create!(description: 'Corundum Ingot', list: shopping_list) }
-
-        let(:params) { { shopping_list_item: { 'quantity': 5, notes: 'To make locks' } } }
-
-        it 'does not update the list', :aggregate_failures do
-          update_item
-          expect(list_item.quantity).to eq 1
-          expect(list_item.notes).to be nil
-        end
-
-        it 'returns status 405' do
-          update_item
-          expect(response.status).to eq 405
-        end
-
-        it 'returns a helpful error' do
-          update_item
-          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Cannot manually update list items on an aggregate shopping list'] })
-        end
-      end
-
-      context 'when the params are invalid' do
-        let(:list_item) { shopping_list.list_items.create!(description: 'Corundum ingot') }
-        let(:params)    { { shopping_list_item: { description: 'Corundum ingot', quantity: 'foooo', notes: 'To make locks' } } }
-
-        before do
-          aggregate_list.add_item_from_child_list(list_item)
-        end
-
-        it 'does not update the aggregate list', :aggregate_failures do
-          update_item
-          expect(aggregate_list.list_items.first.quantity).to eq 1
-          expect(aggregate_list.list_items.first.notes).to be nil
-        end
-
-        it 'returns 422' do
-          update_item
-          expect(response.status).to eq 422
-        end
-
-        it 'returns the validation errors' do
-          update_item
-          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Quantity is not a number'] })
-        end
-      end
-    end
-
-    context 'when unauthenticated' do
-      let(:user)      { create(:user) }
-      let(:params)    { { shopping_list_item: { description: 'Corundum ingot', quantity: 4, notes: 'To make locks' } } }
-      let(:list_item) { create(:shopping_list_item, list: shopping_list) }
-
-      it 'returns 401' do
-        update_item
-        expect(response.status).to eq 401
-      end
-
-      it 'returns a helpful error' do
-        update_item
-        expect(JSON.parse(response.body)).to eq({ 'errors' => ['Google OAuth token validation failed'] })
-      end
-    end
-  end
-
-  describe 'DELETE /shopping_list_items/:id' do
-    subject(:destroy_item) { delete "/shopping_list_items/#{list_item.id}", headers: headers }
-
-    context 'when authenticated' do
-      let!(:aggregate_list) { create(:aggregate_shopping_list, game: game) }
-      let!(:shopping_list)  { create(:shopping_list, game: game, aggregate_list: aggregate_list) }
-
-      let(:game)      { create(:game) }
-      let(:validator) { instance_double(GoogleIDToken::Validator, check: validation_data) }
-      let(:validation_data) do
-        {
-          'exp'   => (Time.zone.now + 1.year).to_i,
-          'email' => game.user.email,
-          'name'  => game.user.name,
-        }
-      end
-
-      before do
-        allow(GoogleIDToken::Validator).to receive(:new).and_return(validator)
-      end
-
-      context 'when all goes well' do
-        let(:user)      { list_item.user }
-        let(:list_item) { create(:shopping_list_item, list: shopping_list, quantity: 3, notes: 'foo') }
-
-        before do
-          aggregate_list.add_item_from_child_list(list_item)
-        end
-
-        context 'when the quantity on the regular list equals that on the aggregate list' do
-          it 'destroys the item on the regular list' do
-            destroy_item
-            expect { ShoppingListItem.find(list_item.id) }
-              .to raise_error ActiveRecord::RecordNotFound
-          end
-
-          it 'destroys the item on the aggregate list' do
-            destroy_item
-            expect(aggregate_list.list_items).to be_empty
-          end
-
-          it 'returns an empty response' do
-            destroy_item
-            expect(response.body).to be_empty
-          end
-
-          it 'returns status 204' do
-            destroy_item
-            expect(response.status).to eq 204
-          end
-        end
-
-        context 'when the quantity on the aggregate list exceeds that on the regular list' do
-          let(:second_list) { create(:shopping_list, game: game) }
-          let(:second_item) { create(:shopping_list_item, list: second_list, description: list_item.description, quantity: 2, notes: 'bar') }
-
-          before do
-            aggregate_list.add_item_from_child_list(second_item)
-          end
-
-          it 'destroys the item on the regular list' do
-            destroy_item
-            expect { ShoppingListItem.find(list_item.id) }
-              .to raise_error ActiveRecord::RecordNotFound
-          end
-
-          it 'updates the quantity of the item on the aggregate list' do
-            destroy_item
-            expect(aggregate_list.list_items.first.quantity).to eq 2
-          end
-
-          it 'updates the notes of the item on the aggregate list', :aggregate_failures do
-            destroy_item
-            expect(aggregate_list.list_items.first.notes).to match /bar/
-            expect(aggregate_list.list_items.first.notes).not_to match /foo/
-          end
-        end
-      end
-
-      context "when the specified list item doesn't exist" do
-        let(:list_item) { double("this doesn't exist", id: 772) }
-
-        it 'returns status 404' do
-          destroy_item
-          expect(response.status).to eq 404
-        end
-
-        it "doesn't return any error messages" do
-          destroy_item
-          expect(response.body).to be_empty
-        end
-      end
-
-      context "when the specified list item doesn't belong to the authenticated user" do
-        let(:list_item) { create(:shopping_list_item) }
-
-        it 'returns status 404' do
-          destroy_item
-          expect(response.status).to eq 404
-        end
-
-        it 'returns an empty response body' do
-          destroy_item
-          expect(response.body).to be_empty
-        end
-      end
-
-      context 'when the specified list item is on an aggregate list' do
-        let(:list_item) { create(:shopping_list_item, list: aggregate_list) }
-
-        it 'returns status 405' do
-          destroy_item
-          expect(response.status).to eq 405
-        end
-
-        it 'returns a helpful error message' do
-          destroy_item
-          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Cannot manually delete list item from aggregate shopping list'] })
-        end
-      end
-    end
-
-    context 'when unauthenticated' do
-      let(:list_item) { create(:shopping_list_item) }
-
-      it 'returns a 401' do
-        destroy_item
-        expect(response.status).to eq 401
-      end
-
-      it 'indicates the request was unauthenticated' do
-        destroy_item
-        expect(JSON.parse(response.body)).to eq({ 'errors' => ['Google OAuth token validation failed'] })
       end
     end
   end


### PR DESCRIPTION
## Context

[**POST /inventory_lists/:list_id/inventory_list_items endpoint**](https://trello.com/c/90J6djv1/141-post-inventorylists-listid-inventorylistitems-endpoint)

We need an endpoint where a user can add an inventory list item to one of their inventory lists.

## Changes

* Create `InventoryListItemsController` and `InventoryListItemsController::CreateService` to handle create requests for inventory list items
* Wire up the controller with routes
* Add request specs and unit specs for the new controller service
* Beef up the `ShoppingListItem` request specs to cover more edge cases
* Add docs

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate
