### PR TITLE
Endpoint to delete inventory list items

### DIFF
--- a/app/controller_services/inventory_list_items_controller/destroy_service.rb
+++ b/app/controller_services/inventory_list_items_controller/destroy_service.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'service/no_content_result'
+
+class InventoryListItemsController < ApplicationController
+  class DestroyService
+    def initialize(user, item_id)
+      @user    = user
+      @item_id = item_id
+    end
+
+    def perform
+      aggregate_list_item = nil
+
+      ActiveRecord::Base.transaction do
+        list_item.destroy!
+        aggregate_list_item = aggregate_list.remove_item_from_child_list(list_item.attributes)
+      end
+
+      Service::NoContentResult.new
+    end
+
+    private
+
+    attr_reader :user, :item_id
+
+    def aggregate_list
+      @aggregate_list ||= inventory_list.aggregate_list
+    end
+
+    def inventory_list
+      @inventory_list ||= list_item.list
+    end
+
+    def list_item
+      @list_item ||= user.inventory_list_items.find(item_id)
+    end
+  end
+end

--- a/app/controller_services/inventory_list_items_controller/destroy_service.rb
+++ b/app/controller_services/inventory_list_items_controller/destroy_service.rb
@@ -3,15 +3,20 @@
 require 'service/no_content_result'
 require 'service/ok_result'
 require 'service/not_found_result'
+require 'service/method_not_allowed_result'
 
 class InventoryListItemsController < ApplicationController
   class DestroyService
+    AGGREGATE_LIST_ERROR = 'Cannot manually delete list item from aggregate inventory list'
+
     def initialize(user, item_id)
       @user    = user
       @item_id = item_id
     end
 
     def perform
+      return Service::MethodNotAllowedResult.new(errors: [AGGREGATE_LIST_ERROR]) if inventory_list.aggregate == true
+
       aggregate_list_item = nil
 
       ActiveRecord::Base.transaction do

--- a/app/controller_services/inventory_list_items_controller/destroy_service.rb
+++ b/app/controller_services/inventory_list_items_controller/destroy_service.rb
@@ -4,6 +4,7 @@ require 'service/no_content_result'
 require 'service/ok_result'
 require 'service/not_found_result'
 require 'service/method_not_allowed_result'
+require 'service/internal_server_error_result'
 
 class InventoryListItemsController < ApplicationController
   class DestroyService
@@ -27,6 +28,8 @@ class InventoryListItemsController < ApplicationController
       aggregate_list_item.nil? ? Service::NoContentResult.new : Service::OKResult.new(resource: aggregate_list_item)
     rescue ActiveRecord::RecordNotFound
       Service::NotFoundResult.new
+    rescue StandardError => e
+      Service::InternalServerErrorResult.new(errors: [e.message])
     end
 
     private

--- a/app/controller_services/inventory_list_items_controller/destroy_service.rb
+++ b/app/controller_services/inventory_list_items_controller/destroy_service.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'service/no_content_result'
+require 'service/ok_result'
 
 class InventoryListItemsController < ApplicationController
   class DestroyService
@@ -17,7 +18,7 @@ class InventoryListItemsController < ApplicationController
         aggregate_list_item = aggregate_list.remove_item_from_child_list(list_item.attributes)
       end
 
-      Service::NoContentResult.new
+      aggregate_list_item.nil? ? Service::NoContentResult.new : Service::OKResult.new(resource: aggregate_list_item)
     end
 
     private

--- a/app/controller_services/inventory_list_items_controller/destroy_service.rb
+++ b/app/controller_services/inventory_list_items_controller/destroy_service.rb
@@ -2,6 +2,7 @@
 
 require 'service/no_content_result'
 require 'service/ok_result'
+require 'service/not_found_result'
 
 class InventoryListItemsController < ApplicationController
   class DestroyService
@@ -19,6 +20,8 @@ class InventoryListItemsController < ApplicationController
       end
 
       aggregate_list_item.nil? ? Service::NoContentResult.new : Service::OKResult.new(resource: aggregate_list_item)
+    rescue ActiveRecord::RecordNotFound
+      Service::NotFoundResult.new
     end
 
     private

--- a/app/controllers/inventory_list_items_controller.rb
+++ b/app/controllers/inventory_list_items_controller.rb
@@ -15,6 +15,12 @@ class InventoryListItemsController < ApplicationController
     ::Controller::Response.new(self, result).execute
   end
 
+  def destroy
+    result = DestroyService.new(current_user, params[:id]).perform
+
+    ::Controller::Response.new(self, result).execute
+  end
+
   private
 
   def list_item_params

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
     end
 
     resources :inventory_lists, shallow: true, except: %i[show] do
-      resources :inventory_list_items, shallow: true, only: %i[create update]
+      resources :inventory_list_items, shallow: true, except: %i[index show]
     end
   end
 

--- a/docs/api/resources/shopping-list-items.md
+++ b/docs/api/resources/shopping-list-items.md
@@ -329,7 +329,7 @@ Authorization: Bearer xxxxxxxxxxx
 
 #### Example Body
 
-The API will return a 204 response if the list item has been destroyed along with the corresponding item on the aggregate list. This responsee does not include a body. On the other hand, if the aggregate list item has been updated, it will be returned and the status code will be 200.
+The API will return a 204 response if the list item has been destroyed along with the corresponding item on the aggregate list. This response does not include a body. On the other hand, if the aggregate list item has been updated rather than destroyed, it will be returned and the status code will be 200.
 
 Example 200 response body containing the updated aggregate list item:
 ```json
@@ -363,17 +363,7 @@ A 405 error, which is returned if the specified shopping list item is on an aggr
 ```json
 {
   "errors": [
-    "Cannot manually delete an aggregate shopping list"
-  ]
-}
-```
-
-A 422 error, returned as a result of a validation error, includes whichever errors prevented the list item from being created:
-```json
-{
-  "errors": [
-    "Quantity must be a number",
-    "Quantity must be greater than zero"
+    "Cannot manually delete an item from an aggregate shopping list"
   ]
 }
 ```

--- a/spec/controller_services/inventory_list_items_controller/destroy_service_spec.rb
+++ b/spec/controller_services/inventory_list_items_controller/destroy_service_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 require 'service/no_content_result'
 require 'service/ok_result'
+require 'service/not_found_result'
 
 RSpec.describe InventoryListItemsController::DestroyService do
   describe '#perform' do
@@ -59,6 +60,19 @@ RSpec.describe InventoryListItemsController::DestroyService do
         it 'returns the aggregate list item', :aggregate_failures do
           expect(perform.resource).to eq aggregate_list.list_items.first
         end
+      end
+    end
+
+    context 'when the list item is not found' do
+      let(:list_item) { double(id: 4568) }
+
+      it 'returns a Service::NotFoundResult' do
+        expect(perform).to be_a(Service::NotFoundResult)
+      end
+
+      it "doesn't set a resource or errors array", :aggregate_failures do
+        expect(perform.resource).to be_blank
+        expect(perform.errors).to be_blank
       end
     end
   end

--- a/spec/controller_services/inventory_list_items_controller/destroy_service_spec.rb
+++ b/spec/controller_services/inventory_list_items_controller/destroy_service_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'service/no_content_result'
+
+RSpec.describe InventoryListItemsController::DestroyService do
+  describe '#perform' do
+    subject(:perform) { described_class.new(user, list_item.id).perform }
+
+    let(:user) { create(:user) }
+    let(:game) { create(:game, user: user) }
+
+    let!(:aggregate_list) { create(:aggregate_inventory_list, game: game) }
+    let!(:inventory_list) { create(:inventory_list, game: game, aggregate_list: aggregate_list) }
+
+    context 'when all goes well' do
+      context 'when there is no matching item on another list' do
+        let!(:list_item) { create(:inventory_list_item, list: inventory_list) }
+
+        before do
+          aggregate_list.add_item_from_child_list(list_item)
+        end
+
+        it 'destroys the list item and aggregate list item' do
+          expect { perform }
+            .to change(game.inventory_list_items, :count).from(2).to(0)
+        end
+
+        it 'returns a Service::NoContentResult' do
+          expect(perform).to be_a(Service::NoContentResult)
+        end
+
+        it "doesn't return any data", :aggregate_failures do
+          expect(perform.resource).to be_blank
+          expect(perform.errors).to be_blank
+        end
+      end
+    end
+  end
+end

--- a/spec/controller_services/inventory_list_items_controller/destroy_service_spec.rb
+++ b/spec/controller_services/inventory_list_items_controller/destroy_service_spec.rb
@@ -75,5 +75,18 @@ RSpec.describe InventoryListItemsController::DestroyService do
         expect(perform.errors).to be_blank
       end
     end
+
+    context 'when the list item belongs to another user' do
+      let(:list_item) { create(:inventory_list_item) }
+
+      it 'returns a Service::NotFoundResult' do
+        expect(perform).to be_a(Service::NotFoundResult)
+      end
+
+      it "doesn't set a resource or errors array", :aggregate_failures do
+        expect(perform.resource).to be_blank
+        expect(perform.errors).to be_blank
+      end
+    end
   end
 end

--- a/spec/controller_services/inventory_list_items_controller/destroy_service_spec.rb
+++ b/spec/controller_services/inventory_list_items_controller/destroy_service_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 require 'service/no_content_result'
 require 'service/ok_result'
 require 'service/not_found_result'
+require 'service/method_not_allowed_result'
 
 RSpec.describe InventoryListItemsController::DestroyService do
   describe '#perform' do
@@ -86,6 +87,23 @@ RSpec.describe InventoryListItemsController::DestroyService do
       it "doesn't set a resource or errors array", :aggregate_failures do
         expect(perform.resource).to be_blank
         expect(perform.errors).to be_blank
+      end
+    end
+
+    context 'when the list item is on an aggregate list' do
+      let!(:list_item) { create(:inventory_list_item, list: aggregate_list) }
+
+      it "doesn't destroy the item" do
+        expect { perform }
+          .not_to change(InventoryListItem, :count)
+      end
+
+      it 'returns a Service::MethodNotAllowedResult' do
+        expect(perform).to be_a(Service::MethodNotAllowedResult)
+      end
+
+      it 'sets the errors' do
+        expect(perform.errors).to eq(['Cannot manually delete list item from aggregate inventory list'])
       end
     end
   end

--- a/spec/controller_services/inventory_list_items_controller/destroy_service_spec.rb
+++ b/spec/controller_services/inventory_list_items_controller/destroy_service_spec.rb
@@ -5,6 +5,7 @@ require 'service/no_content_result'
 require 'service/ok_result'
 require 'service/not_found_result'
 require 'service/method_not_allowed_result'
+require 'service/internal_server_error_result'
 
 RSpec.describe InventoryListItemsController::DestroyService do
   describe '#perform' do
@@ -104,6 +105,22 @@ RSpec.describe InventoryListItemsController::DestroyService do
 
       it 'sets the errors' do
         expect(perform.errors).to eq(['Cannot manually delete list item from aggregate inventory list'])
+      end
+    end
+
+    context 'when something unexpected goes wrong' do
+      let!(:list_item) { create(:inventory_list_item, list: inventory_list) }
+
+      before do
+        allow_any_instance_of(InventoryList).to receive(:aggregate).and_raise(StandardError.new('Something went horribly wrong'))
+      end
+
+      it 'returns a Service::InternalServerErrorResult' do
+        expect(perform).to be_a(Service::InternalServerErrorResult)
+      end
+
+      it 'sets the errors' do
+        expect(perform.errors).to eq ['Something went horribly wrong']
       end
     end
   end

--- a/spec/requests/inventory_list_items_spec.rb
+++ b/spec/requests/inventory_list_items_spec.rb
@@ -966,7 +966,23 @@ RSpec.describe 'InventoryListItems', type: :request do
         end
       end
 
-      context 'when something unexpected goes wrong'
+      context 'when something unexpected goes wrong' do
+        let!(:list_item) { create(:inventory_list_item, list: inventory_list) }
+
+        before do
+          allow_any_instance_of(InventoryList).to receive(:aggregate).and_raise(StandardError.new('Something went horribly wrong'))
+        end
+
+        it 'returns status 500' do
+          destroy_item
+          expect(response.status).to eq 500
+        end
+
+        it 'returns the error' do
+          destroy_item
+          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Something went horribly wrong'] })
+        end
+      end
     end
 
     context 'when not authenticated' do

--- a/spec/requests/inventory_list_items_spec.rb
+++ b/spec/requests/inventory_list_items_spec.rb
@@ -296,6 +296,20 @@ RSpec.describe 'InventoryListItems', type: :request do
         end
       end
     end
+
+    context 'when not authenticated' do
+      let(:params) { { quantity: 4 } }
+
+      it 'returns status 401' do
+        create_item
+        expect(response.status).to eq 401
+      end
+
+      it 'returns the error' do
+        create_item
+        expect(JSON.parse(response.body)).to eq({ 'errors' => ['Google OAuth token validation failed'] })
+      end
+    end
   end
 
   describe 'PATCH /inventory_list_items/:id' do
@@ -578,6 +592,21 @@ RSpec.describe 'InventoryListItems', type: :request do
         end
       end
     end
+
+    context 'when not authenticated' do
+      let!(:list_item) { create(:inventory_list_item, list: inventory_list) }
+      let(:params)     { { quantity: 4 } }
+
+      it 'returns status 401' do
+        update_item
+        expect(response.status).to eq 401
+      end
+
+      it 'returns the errors' do
+        update_item
+        expect(JSON.parse(response.body)).to eq({ 'errors' => ['Google OAuth token validation failed'] })
+      end
+    end
   end
 
   describe 'PUT /inventory_list_items/:id' do
@@ -804,5 +833,24 @@ RSpec.describe 'InventoryListItems', type: :request do
         end
       end
     end
+
+    context 'when not authenticated' do
+      let!(:list_item) { create(:inventory_list_item, list: inventory_list) }
+      let(:params)     { { notes: 'Hello world' } }
+
+      it 'returns status 401' do
+        update_item
+        expect(response.status).to eq 401
+      end
+
+      it 'returns the errors' do
+        update_item
+        expect(JSON.parse(response.body)).to eq({ 'errors' => ['Google OAuth token validation failed'] })
+      end
+    end
+  end
+
+  describe 'DELETE /inventory_list_items/:id' do
+    #
   end
 end

--- a/spec/requests/inventory_list_items_spec.rb
+++ b/spec/requests/inventory_list_items_spec.rb
@@ -918,6 +918,26 @@ RSpec.describe 'InventoryListItems', type: :request do
           end
         end
       end
+
+      context 'when the list item is not found' do
+        let(:list_item) { double(id: 428_943) }
+
+        it 'returns status 404' do
+          destroy_item
+          expect(response.status).to eq 404
+        end
+
+        it "doesn't return any data" do
+          destroy_item
+          expect(response.body).to be_blank
+        end
+      end
+
+      context "when the list item doesn't belong to the authenticated user"
+
+      context 'when the list item is on an aggregate list'
+
+      context 'when something unexpected goes wrong'
     end
 
     context 'when not authenticated' do

--- a/spec/requests/inventory_list_items_spec.rb
+++ b/spec/requests/inventory_list_items_spec.rb
@@ -933,7 +933,7 @@ RSpec.describe 'InventoryListItems', type: :request do
         end
       end
 
-      context 'when the list item belongs to a different user' do
+      context "when the list item doesn't belong to the authenticated user" do
         let(:list_item) { create(:inventory_list_item) }
 
         it 'returns status 404' do
@@ -947,9 +947,24 @@ RSpec.describe 'InventoryListItems', type: :request do
         end
       end
 
-      context "when the list item doesn't belong to the authenticated user"
+      context 'when the list item is on an aggregate list' do
+        let!(:list_item) { create(:inventory_list_item, list: aggregate_list) }
 
-      context 'when the list item is on an aggregate list'
+        it "doesn't destroy the list item" do
+          expect { destroy_item }
+            .not_to change(InventoryListItem, :count)
+        end
+
+        it 'returns status 405' do
+          destroy_item
+          expect(response.status).to eq 405
+        end
+
+        it 'returns an error message' do
+          destroy_item
+          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Cannot manually delete list item from aggregate inventory list'] })
+        end
+      end
 
       context 'when something unexpected goes wrong'
     end

--- a/spec/requests/inventory_list_items_spec.rb
+++ b/spec/requests/inventory_list_items_spec.rb
@@ -891,6 +891,32 @@ RSpec.describe 'InventoryListItems', type: :request do
             expect(response.status).to eq 204
           end
         end
+
+        context 'when there is a matching list item on another list' do
+          let!(:list_item)  { create(:inventory_list_item, list: inventory_list) }
+          let(:other_list)  { create(:inventory_list, game: game) }
+          let!(:other_item) { create(:inventory_list_item, description: list_item.description, list: other_list) }
+
+          before do
+            aggregate_list.add_item_from_child_list(list_item)
+            aggregate_list.add_item_from_child_list(other_item)
+          end
+
+          it 'removes only the list item requested' do
+            expect { destroy_item }
+              .to change(InventoryListItem, :count).from(3).to(2)
+          end
+
+          it 'returns status 200' do
+            destroy_item
+            expect(response.status).to eq 200
+          end
+
+          it 'returns the updated aggregate list item' do
+            destroy_item
+            expect(JSON.parse(response.body)).to eq(JSON.parse(aggregate_list.list_items.first.to_json))
+          end
+        end
       end
     end
 

--- a/spec/requests/inventory_list_items_spec.rb
+++ b/spec/requests/inventory_list_items_spec.rb
@@ -886,6 +886,30 @@ RSpec.describe 'InventoryListItems', type: :request do
               .to change(game.inventory_list_items, :count).from(2).to(0)
           end
 
+          it 'updates the regular list' do
+            t = Time.zone.now + 3.days
+            Timecop.freeze(t) do
+              destroy_item
+              expect(inventory_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+            end
+          end
+
+          it 'updates the aggregate list' do
+            t = Time.zone.now + 3.days
+            Timecop.freeze(t) do
+              destroy_item
+              expect(aggregate_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+            end
+          end
+
+          it 'updates the game' do
+            t = Time.zone.now + 3.days
+            Timecop.freeze(t) do
+              destroy_item
+              expect(game.reload.updated_at).to be_within(0.005.seconds).of(t)
+            end
+          end
+
           it 'returns status 204' do
             destroy_item
             expect(response.status).to eq 204
@@ -905,6 +929,30 @@ RSpec.describe 'InventoryListItems', type: :request do
           it 'removes only the list item requested' do
             expect { destroy_item }
               .to change(InventoryListItem, :count).from(3).to(2)
+          end
+
+          it 'updates the regular list' do
+            t = Time.zone.now + 3.days
+            Timecop.freeze(t) do
+              destroy_item
+              expect(inventory_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+            end
+          end
+
+          it 'updates the aggregate list' do
+            t = Time.zone.now + 3.days
+            Timecop.freeze(t) do
+              destroy_item
+              expect(aggregate_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+            end
+          end
+
+          it 'updates the game' do
+            t = Time.zone.now + 3.days
+            Timecop.freeze(t) do
+              destroy_item
+              expect(game.reload.updated_at).to be_within(0.005.seconds).of(t)
+            end
           end
 
           it 'returns status 200' do

--- a/spec/requests/inventory_list_items_spec.rb
+++ b/spec/requests/inventory_list_items_spec.rb
@@ -933,6 +933,20 @@ RSpec.describe 'InventoryListItems', type: :request do
         end
       end
 
+      context 'when the list item belongs to a different user' do
+        let(:list_item) { create(:inventory_list_item) }
+
+        it 'returns status 404' do
+          destroy_item
+          expect(response.status).to eq 404
+        end
+
+        it "doesn't return any data" do
+          destroy_item
+          expect(response.body).to be_blank
+        end
+      end
+
       context "when the list item doesn't belong to the authenticated user"
 
       context 'when the list item is on an aggregate list'

--- a/spec/requests/shopping_list_items_spec.rb
+++ b/spec/requests/shopping_list_items_spec.rb
@@ -296,6 +296,20 @@ RSpec.describe 'ShoppingListItems', type: :request do
         end
       end
     end
+
+    context 'when not authenticated' do
+      let(:params) { { description: 'Corundum ingot', quantity: 4 } }
+
+      it 'returns status 401' do
+        create_item
+        expect(response.status).to eq 401
+      end
+
+      it 'returns the error' do
+        create_item
+        expect(JSON.parse(response.body)).to eq({ 'errors' => ['Google OAuth token validation failed'] })
+      end
+    end
   end
 
   describe 'PATCH /shopping_list_items/:id' do
@@ -602,6 +616,21 @@ RSpec.describe 'ShoppingListItems', type: :request do
         end
       end
     end
+
+    context 'when not authenticated' do
+      let!(:list_item) { create(:shopping_list_item, list: shopping_list) }
+      let(:params)     { { quantity: 6 } }
+
+      it 'returns status 401' do
+        update_item
+        expect(response.status).to eq 401
+      end
+
+      it 'returns the errors' do
+        update_item
+        expect(JSON.parse(response.body)).to eq({ 'errors' => ['Google OAuth token validation failed'] })
+      end
+    end
   end
 
   describe 'PUT /shopping_list_items/:id' do
@@ -826,6 +855,21 @@ RSpec.describe 'ShoppingListItems', type: :request do
           update_item
           expect(JSON.parse(response.body)).to eq({ 'errors' => ['Something went horribly wrong'] })
         end
+      end
+    end
+
+    context 'when not authenticated' do
+      let!(:list_item) { create(:shopping_list_item, list: shopping_list) }
+      let(:params)     { { quantity: 12 } }
+
+      it 'returns status 401' do
+        update_item
+        expect(response.status).to eq 401
+      end
+
+      it 'returns the errors' do
+        update_item
+        expect(JSON.parse(response.body)).to eq({ 'errors' => ['Google OAuth token validation failed'] })
       end
     end
   end


### PR DESCRIPTION
## Context

[**DELETE /inventory_list_items/:id endpoint**](https://trello.com/c/t4KU1uqK/143-delete-inventorylistitems-id-endpoint)

The final REST endpoint we need for inventory lists is the endpoint to destroy an inventory list item.

## Changes

* `InventoryListItemsController::DestroyService` class to handle `DELETE` requests for inventory list items
* Wire up the `DestroyService` to the controller
* Add `DELETE /inventory_list_items/:id` route
* Add request specs and unit specs for the new controller service
* Update docs

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

I decided not to test the `Aggregatable#remove_item_from_child_list` logic in these tests because that functionality is already tested in tests for both the `InventoryList` class and the `ShoppingList` class.
