### PR TITLE
Ensure unit weight properly set for new list items

### DIFF
--- a/spec/models/shopping_list_item_spec.rb
+++ b/spec/models/shopping_list_item_spec.rb
@@ -3,24 +3,21 @@
 require 'rails_helper'
 
 RSpec.describe ShoppingListItem, type: :model do
-  let!(:game) { create(:game) }
+  let!(:game)          { create(:game) }
+  let(:aggregate_list) { create(:aggregate_shopping_list, game: game) }
+  let(:shopping_list)  { create(:shopping_list, game: game, aggregate_list: aggregate_list) }
 
   describe 'delegation' do
-    let(:shopping_list) { create(:shopping_list, game: game) }
-    let(:list_item)     { create(:shopping_list_item, list: shopping_list) }
-
-    before do
-      create(:aggregate_shopping_list, game: game)
-    end
+    let(:list_item) { create(:shopping_list_item, list: shopping_list) }
 
     describe '#game' do
-      it 'returns game its ShoppingList belongs to' do
-        expect(list_item.game).to eq(game)
+      it 'returns the game its ShoppingList belongs to' do
+        expect(list_item.game).to eq game
       end
     end
 
     describe '#user' do
-      it 'returns the user the game belongs to' do
+      it 'returns the user its game belongs to' do
         expect(list_item.user).to eq game.user
       end
     end
@@ -28,13 +25,11 @@ RSpec.describe ShoppingListItem, type: :model do
 
   describe 'scopes' do
     describe '::index_order' do
-      let!(:aggregate_list) { create(:aggregate_shopping_list) }
-
       let!(:list_item1) { create(:shopping_list_item, list: list) }
       let!(:list_item2) { create(:shopping_list_item, list: list) }
       let!(:list_item3) { create(:shopping_list_item, list: list) }
 
-      let(:list) { create(:shopping_list, game: aggregate_list.game) }
+      let(:list) { create(:shopping_list, game: game) }
 
       before do
         list_item2.update!(quantity: 3)
@@ -46,9 +41,15 @@ RSpec.describe ShoppingListItem, type: :model do
     end
 
     describe '::belonging_to_game' do
-      let!(:list1) { create(:shopping_list_with_list_items, game: game) }
-      let!(:list2) { create(:shopping_list_with_list_items, game: game) }
-      let!(:list3) { create(:shopping_list_with_list_items, game: game) }
+      let!(:list1) { create(:shopping_list_with_list_items, game: game, aggregate_list: aggregate_list) }
+      let!(:list2) { create(:shopping_list_with_list_items, game: game, aggregate_list: aggregate_list) }
+      let!(:list3) { create(:shopping_list_with_list_items, game: game, aggregate_list: aggregate_list) }
+
+      before do
+        # There should be some that don't belong to the game to make sure they
+        # don't also get included
+        create(:shopping_list_with_list_items)
+      end
 
       it 'returns all list items from all the lists for the given game' do
         # We don't actually care what order these are in since we currently only use this
@@ -70,7 +71,7 @@ RSpec.describe ShoppingListItem, type: :model do
       let(:user) { game.user }
 
       before do
-        create(:shopping_list_with_list_items, game: game)
+        create(:shopping_list_with_list_items, game: game, aggregate_list: aggregate_list)
         create(:game_with_shopping_lists_and_items, user: user)
         create(:game_with_shopping_lists_and_items, user: user)
         create(:shopping_list_with_list_items) # one from a different user
@@ -90,8 +91,6 @@ RSpec.describe ShoppingListItem, type: :model do
     context 'when there is an existing item on the same list with the same (case-insensitive) description' do
       subject(:combine_or_create) { described_class.combine_or_create!(description: 'existing item', quantity: 1, list: shopping_list, notes: 'notes 2') }
 
-      let(:aggregate_list) { create(:aggregate_shopping_list) }
-      let!(:shopping_list) { create(:shopping_list, game: aggregate_list.game, aggregate_list: aggregate_list) }
       let!(:existing_item) { create(:shopping_list_item, description: 'ExIsTiNg ItEm', quantity: 2, unit_weight: 0.3, list: shopping_list, notes: 'notes 1') }
 
       it "doesn't create a new list item" do
@@ -125,14 +124,27 @@ RSpec.describe ShoppingListItem, type: :model do
         end
       end
     end
+
+    context 'when there is an existing item on a different list with the same (case-insensitive) description' do
+      subject(:combine_or_create) { described_class.combine_or_create!(description: 'New Item', quantity: 1, list: shopping_list, unit_weight: nil) }
+
+      let(:other_list) { create(:shopping_list, game: game, aggregate_list: aggregate_list) }
+      let!(:other_item) { create(:shopping_list_item, description: 'New Item', list: other_list, unit_weight: 1) }
+
+      before do
+        aggregate_list.add_item_from_child_list(other_item)
+      end
+
+      it 'sets the unit weight to that of the existing item' do
+        expect(combine_or_create.unit_weight).to eq 1
+      end
+    end
   end
 
   describe '::combine_or_new' do
     context 'when there is an existing item on the same list with the same (case-insensitive) description' do
       subject(:combine_or_new) { described_class.combine_or_new(description: 'existing item', quantity: 1, list: shopping_list, notes: 'notes 2') }
 
-      let(:aggregate_list) { create(:aggregate_shopping_list) }
-      let!(:shopping_list) { create(:shopping_list, game: aggregate_list.game) }
       let!(:existing_item) { create(:shopping_list_item, description: 'ExIsTiNg ItEm', quantity: 2, unit_weight: 0.3, list: shopping_list, notes: 'notes 1') }
 
       before do
@@ -144,15 +156,13 @@ RSpec.describe ShoppingListItem, type: :model do
         expect(described_class).not_to have_received(:new)
       end
 
-      it 'returns the existing item' do
+      it 'returns the existing item with the quantity updated', :aggregate_failures do
         expect(combine_or_new).to eq existing_item
-      end
-
-      it 'updates the quantity', :aggregate_failures do
         expect(combine_or_new.quantity).to eq 3
       end
 
       it 'concatenates the notes for the two items', :aggregate_failures do
+        expect(combine_or_new).to eq existing_item
         expect(combine_or_new.notes).to eq 'notes 1 -- notes 2'
       end
 
@@ -172,22 +182,39 @@ RSpec.describe ShoppingListItem, type: :model do
     end
 
     context 'when there is not an existing item on the same list with that description' do
-      subject(:combine_or_create) { described_class.combine_or_create!(description: 'new item', quantity: 1, list: shopping_list) }
+      subject(:combine_or_new) { described_class.combine_or_new(description: 'new item', quantity: 1, list: shopping_list) }
 
-      let(:aggregate_list) { create(:aggregate_shopping_list) }
-      let!(:shopping_list) { create(:shopping_list, game: aggregate_list.game) }
+      before do
+        allow(described_class).to receive(:new).and_call_original
+      end
 
-      it 'creates a new item on the list' do
-        expect { combine_or_create }
-          .to change(shopping_list.list_items, :count).by(1)
+      it 'instantiates a new shopping list item' do
+        combine_or_new
+        expect(described_class).to have_received(:new)
+      end
+
+      it "doesn't save the shopping list item yet" do
+        expect { combine_or_new }
+          .not_to change(shopping_list.list_items, :count)
+      end
+
+      context 'when unit weight is nil and there are matching items on other lists' do
+        let!(:other_list) { create(:shopping_list, game: game, aggregate_list: aggregate_list) }
+        let!(:other_item) { create(:shopping_list_item, description: 'new item', list: other_list, unit_weight: 1) }
+
+        before do
+          aggregate_list.add_item_from_child_list(other_item)
+        end
+
+        it "sets the new item's unit weight to match the existing items" do
+          expect(combine_or_new.unit_weight).to eq 1
+        end
       end
     end
   end
 
   describe '#update!' do
-    let(:aggregate_list) { create(:aggregate_shopping_list) }
-    let(:shopping_list) { create(:shopping_list, game: aggregate_list.game) }
-    let!(:list_item)    { create(:shopping_list_item, quantity: 1, list: shopping_list) }
+    let!(:list_item) { create(:shopping_list_item, quantity: 1, list: shopping_list) }
 
     context 'when updating quantity' do
       subject(:update_item) { list_item.update!(quantity: 4) }


### PR DESCRIPTION
## Context

[**Set unit weight properly on newly created list items**](https://trello.com/c/7WWqkEzS/161-set-unit-weight-properly-on-newly-created-list-items)

When a new shopping or inventory list item is created, if the unit weight is `nil`, the new item is either combined with an existing item and takes on its unit weight (if any) or created with a `nil` unit weight. The catch with this is that it doesn't check if there is a matching item on one of the same game's other lists that has a different weight. So that could mean that there are existing items with the same description that have a unit weight while the new item is created with a `nil` unit weight and is out of sync with the others.

## Changes

* Ensure that new items with `nil` unit weights take on the unit weight of matching items on other lists (if they exist)
* Add tests for new behaviour

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [ ] ~~Added and updated API docs and developer docs as appropriate~~
