### PR TITLE
Populate canonical models in database

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1237,7 +1237,7 @@ Rails/Blank:
   NotPresent: true
   UnlessPresent: true
 Rails/BulkChangeTable:
-  Enabled: true
+  Enabled: false
 Rails/CreateTableWithTimestamps:
   Enabled: true
 Rails/Date:

--- a/app/models/alchemical_property.rb
+++ b/app/models/alchemical_property.rb
@@ -2,5 +2,5 @@
 
 class AlchemicalProperty < ApplicationRecord
   validates :name, presence: true, uniqueness: { message: 'must be unique' }
-  validates :strength_unit, presence: true, inclusion: { in: %w[point percentage], message: 'must be "point" or "percentage"' }
+  validates :strength_unit, inclusion: { in: %w[point percentage], message: 'must be "point" or "percentage"', allow_blank: true }
 end

--- a/app/models/enchantment.rb
+++ b/app/models/enchantment.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 class Enchantment < ApplicationRecord
+  SCHOOLS = %w[
+              Alteration
+              Conjuration
+              Destruction
+              Illusion
+              Restoration
+            ].freeze
+
   ENCHANTABLE_WEAPONS = [
                           'sword',
                           'mace',
@@ -13,27 +21,24 @@ class Enchantment < ApplicationRecord
                           'crossbow',
                           'staff',
                           'axe',
+                          'pickaxe',
                         ].freeze
 
   ENCHANTABLE_APPAREL_ITEMS = %w[
-                                helmet
-                                bracers
-                                gauntlets
-                                boots
+                                head
+                                chest
+                                hands
+                                feet
                                 shield
-                                armor
-                                robes
-                                shoes
-                                necklace
+                                amulet
                                 ring
-                                circlet
-                                gloves
                               ].freeze
 
   ENCHANTABLE_ITEMS = (ENCHANTABLE_WEAPONS + ENCHANTABLE_APPAREL_ITEMS).freeze
 
   validates :name, presence: true, uniqueness: { message: 'must be unique' }
   validates :strength_unit, presence: true, inclusion: { in: %w[point percentage], message: 'must be "point" or "percentage"' }
+  validates :school, inclusion: { in: SCHOOLS, message: 'must be a valid school of magic' }
   validate :validate_enchantable_items
 
   private

--- a/app/models/enchantment.rb
+++ b/app/models/enchantment.rb
@@ -37,8 +37,8 @@ class Enchantment < ApplicationRecord
   ENCHANTABLE_ITEMS = (ENCHANTABLE_WEAPONS + ENCHANTABLE_APPAREL_ITEMS).freeze
 
   validates :name, presence: true, uniqueness: { message: 'must be unique' }
-  validates :strength_unit, presence: true, inclusion: { in: %w[point percentage], message: 'must be "point" or "percentage"' }
-  validates :school, inclusion: { in: SCHOOLS, message: 'must be a valid school of magic' }
+  validates :strength_unit, inclusion: { in: %w[point percentage], message: 'must be "point" or "percentage"', allow_blank: true }
+  validates :school, inclusion: { in: SCHOOLS, message: 'must be a valid school of magic', allow_blank: true }
   validate :validate_enchantable_items
 
   private

--- a/app/models/spell.rb
+++ b/app/models/spell.rb
@@ -27,9 +27,9 @@ class Spell < ApplicationRecord
   private
 
   def strength_and_strength_unit_both_or_neither_present
-    if !strength.nil? && !strength_unit
+    if strength.present? && strength_unit.blank?
       errors.add(:strength_unit, 'must be present if strength is given')
-    elsif !strength_unit.nil? && !strength
+    elsif strength_unit.present? && strength.blank?
       errors.add(:strength, 'must be present if strength unit is given')
     end
   end

--- a/app/models/spell.rb
+++ b/app/models/spell.rb
@@ -1,6 +1,15 @@
 # frozen_string_literal: true
 
 class Spell < ApplicationRecord
+  SCHOOLS = %w[
+              Alteration
+              Conjuration
+              Destruction
+              Illusion
+              Restoration
+            ].freeze
+
   validates :name, presence: true, uniqueness: { message: 'must be unique' }
+  validates :school, presence: true, inclusion: { in: SCHOOLS, message: 'must be a valid school of magic' }
   validates :description, presence: true
 end

--- a/app/models/spell.rb
+++ b/app/models/spell.rb
@@ -9,7 +9,28 @@ class Spell < ApplicationRecord
               Restoration
             ].freeze
 
+  LEVELS = %w[
+             Novice
+             Apprentice
+             Adept
+             Expert
+             Master
+           ].freeze
+
   validates :name, presence: true, uniqueness: { message: 'must be unique' }
   validates :school, presence: true, inclusion: { in: SCHOOLS, message: 'must be a valid school of magic' }
+  validates :level, presence: true, inclusion: { in: LEVELS, message: 'must be "Novice", "Apprentice", "Adept", "Expert", or "Master"' }
+  validates :strength_unit, inclusion: { in: %w[point percentage], message: 'must be "point" or "percentage"', allow_blank: true }
   validates :description, presence: true
+  validate :strength_and_strength_unit_both_or_neither_present
+
+  private
+
+  def strength_and_strength_unit_both_or_neither_present
+    if !strength.nil? && !strength_unit
+      errors.add(:strength_unit, 'must be present if strength is given')
+    elsif !strength_unit.nil? && !strength
+      errors.add(:strength, 'must be present if strength unit is given')
+    end
+  end
 end

--- a/db/migrate/20210827104422_add_school_to_enchantments.rb
+++ b/db/migrate/20210827104422_add_school_to_enchantments.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSchoolToEnchantments < ActiveRecord::Migration[6.1]
+  def change
+    add_column :enchantments, :school, :string
+  end
+end

--- a/db/migrate/20210827104934_allow_null_for_strength_unit.rb
+++ b/db/migrate/20210827104934_allow_null_for_strength_unit.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AllowNullForStrengthUnit < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :enchantments, :strength_unit, true
+  end
+end

--- a/db/migrate/20210827225544_add_school_and_level_to_spells.rb
+++ b/db/migrate/20210827225544_add_school_and_level_to_spells.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddSchoolAndLevelToSpells < ActiveRecord::Migration[6.1]
+  def change
+    add_column :spells, :school, :string, null: false
+    add_column :spells, :level, :string, null: false
+  end
+end

--- a/db/migrate/20210827225544_add_school_to_spells.rb
+++ b/db/migrate/20210827225544_add_school_to_spells.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSchoolToSpells < ActiveRecord::Migration[6.1]
+  def change
+    add_column :spells, :school, :string, null: false
+  end
+end

--- a/db/migrate/20210827225544_add_school_to_spells.rb
+++ b/db/migrate/20210827225544_add_school_to_spells.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class AddSchoolToSpells < ActiveRecord::Migration[6.1]
-  def change
-    add_column :spells, :school, :string, null: false
-  end
-end

--- a/db/migrate/20210827234534_add_strength_unit_to_spells.rb
+++ b/db/migrate/20210827234534_add_strength_unit_to_spells.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddStrengthUnitToSpells < ActiveRecord::Migration[6.1]
+  def change
+    add_column :spells, :strength_unit, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_27_104934) do
+ActiveRecord::Schema.define(version: 2021_08_27_225544) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -100,6 +100,7 @@ ActiveRecord::Schema.define(version: 2021_08_27_104934) do
     t.boolean "effects_cumulative", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "school", null: false
     t.index ["name"], name: "index_spells_on_name", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_27_080015) do
+ActiveRecord::Schema.define(version: 2021_08_27_104934) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,9 +27,10 @@ ActiveRecord::Schema.define(version: 2021_08_27_080015) do
   create_table "enchantments", force: :cascade do |t|
     t.string "name", null: false
     t.string "enchantable_items", default: [], array: true
-    t.string "strength_unit", null: false
+    t.string "strength_unit"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "school"
     t.index ["name"], name: "index_enchantments_on_name", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_27_225544) do
+ActiveRecord::Schema.define(version: 2021_08_27_234534) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -101,6 +101,8 @@ ActiveRecord::Schema.define(version: 2021_08_27_225544) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "school", null: false
+    t.string "level", null: false
+    t.string "strength_unit"
     t.index ["name"], name: "index_spells_on_name", unique: true
   end
 

--- a/lib/tasks/canonical_models/alchemical_properties.json
+++ b/lib/tasks/canonical_models/alchemical_properties.json
@@ -1,0 +1,277 @@
+[
+  {
+    "name": "Cure Disease",
+    "strength_unit": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Damage Health",
+    "strength_unit": "point",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Damage Magicka",
+    "strength_unit": "point",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Damage Magicka Regen",
+    "strength_unit": "percentage",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Damage Stamina",
+    "strength_unit": "point",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Damage Stamina Regen",
+    "strength_unit": "percentage",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Fear",
+    "strength_unit": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Fortify Alteration",
+    "strength_unit": "percentage",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Fortify Barter",
+    "strength_unit": "percentage",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Fortify Block",
+    "strength_unit": "percentage",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Fortify Carry Weight",
+    "strength_unit": "point",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Fortify Conjuration",
+    "strength_unit": "percentage",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Fortify Destruction",
+    "strength_unit": "percentage",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Fortify Enchanting",
+    "strength_unit": "percentage",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Fortify Health",
+    "strength_unit": "percentage",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Fortify Heavy Armor",
+    "strength_unit": "point",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Fortify Illusion",
+    "strength_unit": "percentage",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Fortify Light Armor",
+    "strength_unit": "point",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Fortify Lockpicking",
+    "strength_unit": "percentage",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Fortify Magicka",
+    "strength_unit": "point",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Fortify Marksman",
+    "strength_unit": "percentage",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Fortify One-Handed",
+    "strength_unit": "percentage",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Fortify Pickpocket",
+    "strength_unit": "percentage",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Fortify Restoration",
+    "strength_unit": "percentage",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Fortify Smithing",
+    "strength_unit": "percentage",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Fortify Sneak",
+    "strength_unit": "percentage",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Fortify Stamina",
+    "strength_unit": "point",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Fortify Two-Handed",
+    "strength_unit": "percentage",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Frenzy",
+    "strength_unit": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Invisibility",
+    "strength_unit": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Lingering Damage Health",
+    "strength_unit": "point",
+    "effects_cumulative": true
+  },
+  {
+    "name": "Lingering Damage Magicka",
+    "strength_unit": "point",
+    "effects_cumulative": true
+  },
+  {
+    "name": "Lingering Damage Stamina",
+    "strength_unit": "point",
+    "effects_cumulative": true
+  },
+  {
+    "name": "Paralysis",
+    "strength_unit": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Ravage Health",
+    "strength_unit": "point",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Ravage Magicka",
+    "strength_unit": "point",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Ravage Stamina",
+    "strength_unit": "point",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Regenerate Health",
+    "strength_unit": "percentage",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Regenerate Magicka",
+    "strength_unit": "percentage",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Regenerate Stamina",
+    "strength_unit": "percentage",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Resist Fire",
+    "strength_unit": "percentage",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Resist Frost",
+    "strength_unit": "percentage",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Resist Magic",
+    "strength_unit": "percentage",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Resist Poison",
+    "strength_unit": "percentage",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Resist Shock",
+    "strength_unit": "percentage",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Restore Health",
+    "strength_unit": "point",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Restore Magicka",
+    "strength_unit": "point",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Restore Stamina",
+    "strength_unit": "point",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Slow",
+    "strength_unit": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Waterbreathing",
+    "strength_unit": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Weakness to Fire",
+    "strength_unit": "percentage",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Weakness to Frost",
+    "strength_unit": "percentage",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Weakness to Magic",
+    "strength_unit": "percentage",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Weakness to Poison",
+    "strength_unit": "percentage",
+    "effects_cumulative": false
+  },
+  {
+    "name": "Weakness to Shock",
+    "strength_unit": "percentage",
+    "effects_cumulative": false
+  }
+]

--- a/lib/tasks/canonical_models/enchantments.json
+++ b/lib/tasks/canonical_models/enchantments.json
@@ -1,0 +1,706 @@
+[
+  {
+    "name": "Absorb Health",
+    "school": "Destruction",
+    "enchantable_items": [
+      "dagger",
+      "sword",
+      "mace",
+      "war axe",
+      "greatsword",
+      "warhammer",
+      "battleaxe",
+      "bow",
+      "crossbow",
+      "axe",
+      "pickaxe"
+    ],
+    "strength_unit": "point"
+  },
+  {
+    "name": "Absorb Magicka",
+    "school": "Destruction",
+    "enchantable_items": [
+      "dagger",
+      "sword",
+      "mace",
+      "war axe",
+      "greatsword",
+      "warhammer",
+      "battleaxe",
+      "bow",
+      "crossbow",
+      "axe",
+      "pickaxe"
+    ],
+    "strength_unit": "point"
+  },
+  {
+    "name": "Absorb Stamina",
+    "school": "Destruction",
+    "enchantable_items": [
+      "dagger",
+      "sword",
+      "mace",
+      "war axe",
+      "greatsword",
+      "warhammer",
+      "battleaxe",
+      "bow",
+      "crossbow",
+      "axe",
+      "pickaxe"
+    ],
+    "strength_unit": "point"
+  },
+  {
+    "name": "Banish",
+    "school": "Conjuration",
+    "enchantable_items": [
+      "dagger",
+      "sword",
+      "mace",
+      "war axe",
+      "greatsword",
+      "warhammer",
+      "battleaxe",
+      "bow",
+      "crossbow",
+      "axe",
+      "pickaxe"
+    ],
+    "strength_unit": null
+  },
+  {
+    "name": "Chaos Damage",
+    "school": "Destruction",
+    "enchantable_items": [
+      "dagger",
+      "sword",
+      "mace",
+      "war axe",
+      "greatsword",
+      "warhammer",
+      "battleaxe",
+      "bow",
+      "crossbow",
+      "axe",
+      "pickaxe"
+    ],
+    "strength_unit": "point"
+  },
+  {
+    "name": "Fear",
+    "school": "Illusion",
+    "enchantable_items": [
+      "dagger",
+      "sword",
+      "mace",
+      "war axe",
+      "greatsword",
+      "warhammer",
+      "battleaxe",
+      "bow",
+      "crossbow",
+      "axe",
+      "pickaxe"
+    ],
+    "strength_unit": null
+  },
+  {
+    "name": "Fiery Soul Trap",
+    "school": "Conjuration",
+    "enchantable_items": [
+      "dagger",
+      "sword",
+      "mace",
+      "war axe",
+      "greatsword",
+      "warhammer",
+      "battleaxe",
+      "bow",
+      "crossbow",
+      "axe",
+      "pickaxe"
+    ],
+    "strength_unit": null
+  },
+  {
+    "name": "Fire Damage",
+    "school": "Destruction",
+    "enchantable_items": [
+      "dagger",
+      "sword",
+      "mace",
+      "war axe",
+      "greatsword",
+      "warhammer",
+      "battleaxe",
+      "bow",
+      "crossbow",
+      "axe",
+      "pickaxe"
+    ],
+    "strength_unit": "point"
+  },
+  {
+    "name": "Fortify Alchemy",
+    "school": null,
+    "enchantable_items": [
+      "head",
+      "hands",
+      "amulet",
+      "ring"
+    ],
+    "strength_unit": "percentage"
+  },
+  {
+    "name": "Fortify Alteration",
+    "school": null,
+    "enchantable_items": [
+      "head",
+      "chest",
+      "amulet",
+      "ring"
+    ],
+    "strength_unit": "percentage"
+  },
+  {
+    "name": "Fortify Alteration and Magicka Regen",
+    "school": null,
+    "enchantable_items": [
+      "chest"
+    ],
+    "strength_unit": "percentage"
+  },
+  {
+    "name": "Fortify Archery",
+    "school": null,
+    "enchantable_items": [
+      "head",
+      "hands",
+      "amulet",
+      "ring"
+    ],
+    "strength_unit": "percentage"
+  },
+  {
+    "name": "Fortify Barter",
+    "school": null,
+    "enchantable_items": [
+      "amulet"
+    ],
+    "strength_unit": "percentage"
+  },
+  {
+    "name": "Fortify Block",
+    "school": null,
+    "enchantable_items": [
+      "hands",
+      "shield",
+      "amulet",
+      "ring"
+    ],
+    "strength_unit": "percentage"
+  },
+  {
+    "name": "Fortify Carry Weight",
+    "school": null,
+    "enchantable_items": [
+      "hands",
+      "feet",
+      "amulet",
+      "ring"
+    ],
+    "strength_unit": "point"
+  },
+  {
+    "name": "Fortify Conjuration",
+    "school": null,
+    "enchantable_items": [
+      "head",
+      "chest",
+      "amulet",
+      "ring"
+    ],
+    "strength_unit": "percentage"
+  },
+  {
+    "name": "Fortify Conjuration and Magicka Regen",
+    "school": null,
+    "enchantable_items": [
+      "chest"
+    ],
+    "strength_unit": "percentage"
+  },
+  {
+    "name": "Fortify Destruction",
+    "school": null,
+    "enchantable_items": [
+      "head",
+      "chest",
+      "amulet",
+      "ring"
+    ],
+    "strength_unit": "percentage"
+  },
+  {
+    "name": "Fortify Destruction and Magicka Regen",
+    "school": null,
+    "enchantable_items": [
+      "chest"
+    ],
+    "strength_unit": "percentage"
+  },
+  {
+    "name": "Fortify Healing Rate",
+    "school": null,
+    "enchantable_items": [
+      "chest",
+      "amulet",
+      "ring"
+    ],
+    "strength_unit": "percentage"
+  },
+  {
+    "name": "Fortify Health",
+    "school": null,
+    "enchantable_items": [
+      "chest",
+      "shield",
+      "amulet",
+      "ring"
+    ],
+    "strength_unit": "point"
+  },
+  {
+    "name": "Fortify Heavy Armor",
+    "school": null,
+    "enchantable_items": [
+      "chest",
+      "hands",
+      "amulet",
+      "ring"
+    ],
+    "strength_unit": "point"
+  },
+  {
+    "name": "Fortify Illusion",
+    "school": null,
+    "enchantable_items": [
+      "head",
+      "chest",
+      "amulet",
+      "ring"
+    ],
+    "strength_unit": "percentage"
+  },
+  {
+    "name": "Fortify Illusion and Magicka Regen",
+    "school": null,
+    "enchantable_items": [
+      "chest"
+    ],
+    "strength_unit": "percentage"
+  },
+  {
+    "name": "Fortify Light Armor",
+    "school": null,
+    "enchantable_items": [
+      "chest",
+      "hands",
+      "amulet",
+      "ring"
+    ],
+    "strength_unit": "point"
+  },
+  {
+    "name": "Fortify Lockpicking",
+    "school": null,
+    "enchantable_items": [
+      "head",
+      "hands",
+      "amulet",
+      "ring"
+    ],
+    "strength_unit": "percentage"
+  },
+  {
+    "name": "Fortify Magicka",
+    "school": null,
+    "enchantable_items": [
+      "head",
+      "hands",
+      "amulet",
+      "ring"
+    ],
+    "strength_unit": "point"
+  },
+  {
+    "name": "Fortify Magicka Regen",
+    "school": null,
+    "enchantable_items": [
+      "head",
+      "chest",
+      "ring"
+    ],
+    "strength_unit": "percentage"
+  },
+  {
+    "name": "Fortify One-Handed",
+    "school": null,
+    "enchantable_items": [
+      "hands",
+      "feet",
+      "amulet",
+      "ring"
+    ],
+    "strength_unit": "percentage"
+  },
+  {
+    "name": "Fortify Pickpocket",
+    "school": null,
+    "enchantable_items": [
+      "hands",
+      "feet",
+      "amulet",
+      "ring"
+    ],
+    "strength_unit": "percentage"
+  },
+  {
+    "name": "Fortify Restoration",
+    "school": null,
+    "enchantable_items": [
+      "head",
+      "chest",
+      "amulet",
+      "ring"
+    ],
+    "strength_unit": "percentage"
+  },
+  {
+    "name": "Fortify Restoration and Magicka Regen",
+    "school": null,
+    "enchantable_items": [
+      "chest"
+    ],
+    "strength_unit": "percentage"
+  },
+  {
+    "name": "Fortify Smithing",
+    "school": null,
+    "enchantable_items": [
+      "chest",
+      "hands",
+      "amulet",
+      "ring"
+    ],
+    "strength_unit": "percentage"
+  },
+  {
+    "name": "Fortify Sneak",
+    "school": null,
+    "enchantable_items": [
+      "hands",
+      "feet",
+      "amulet",
+      "ring"
+    ],
+    "strength_unit": "percentage"
+  },
+  {
+    "name": "Fortify Stamina",
+    "school": null,
+    "enchantable_items": [
+      "chest",
+      "feet",
+      "amulet",
+      "ring"
+    ],
+    "strength_unit": "point"
+  },
+  {
+    "name": "Fortify Stamina Regen",
+    "school": null,
+    "enchantable_items": [
+      "chest",
+      "feet",
+      "amulet"
+    ],
+    "strength_unit": "percentage"
+  },
+  {
+    "name": "Fortify Two-Handed",
+    "school": null,
+    "enchantable_items": [
+      "hands",
+      "feet",
+      "amulet",
+      "ring"
+    ],
+    "strength_unit": "percentage"
+  },
+  {
+    "name": "Fortify Unarmed",
+    "school": null,
+    "enchantable_items": [
+      "hands",
+      "ring"
+    ],
+    "strength_unit": "percentage"
+  },
+  {
+    "name": "Muffle",
+    "school": null,
+    "enchantable_items": [
+      "feet"
+    ],
+    "strength_unit": null
+  },
+  {
+    "name": "Frost Damage",
+    "school": "Destruction",
+    "enchantable_items": [
+      "dagger",
+      "sword",
+      "mace",
+      "war axe",
+      "greatsword",
+      "warhammer",
+      "battleaxe",
+      "bow",
+      "crossbow",
+      "axe",
+      "pickaxe"
+    ],
+    "strength_unit": "point"
+  },
+  {
+    "name": "Huntsman's Prowess",
+    "school": null,
+    "enchantable_items": [
+      "dagger",
+      "sword",
+      "mace",
+      "war axe",
+      "greatsword",
+      "warhammer",
+      "battleaxe",
+      "bow",
+      "crossbow",
+      "axe",
+      "pickaxe"
+    ],
+    "strength_unit": null
+  },
+  {
+    "name": "Magicka Damage",
+    "school": "Destruction",
+    "enchantable_items": [
+      "dagger",
+      "sword",
+      "mace",
+      "war axe",
+      "greatsword",
+      "warhammer",
+      "battleaxe",
+      "bow",
+      "crossbow",
+      "axe",
+      "pickaxe"
+    ],
+    "strength_unit": "point"
+  },
+  {
+    "name": "Notched Pickaxe",
+    "school": null,
+    "enchantable_items": [
+      "pickaxe"
+    ],
+    "strength_unit": null
+  },
+  {
+    "name": "Paralyze",
+    "school": "Alteration",
+    "enchantable_items": [
+      "dagger",
+      "sword",
+      "mace",
+      "war axe",
+      "greatsword",
+      "warhammer",
+      "battleaxe",
+      "bow",
+      "crossbow",
+      "axe",
+      "pickaxe"
+    ],
+    "strength_unit": null
+  },
+  {
+    "name": "Resist Disease",
+    "school": null,
+    "enchantable_items": [
+      "chest",
+      "shield",
+      "amulet",
+      "ring"
+    ],
+    "strength_unit": "percentage"
+  },
+  {
+    "name": "Resist Fire",
+    "school": null,
+    "enchantable_items": [
+      "feet",
+      "shield",
+      "amulet",
+      "ring"
+    ],
+    "strength_unit": "percentage"
+  },
+  {
+    "name": "Resist Frost",
+    "school": null,
+    "enchantable_items": [
+      "feet",
+      "shield",
+      "amulet",
+      "ring"
+    ],
+    "strength_unit": "percentage"
+  },
+  {
+    "name": "Resist Magic",
+    "school": null,
+    "enchantable_items": [
+      "shield",
+      "amulet",
+      "ring"
+    ],
+    "strength_unit": "percentage"
+  },
+  {
+    "name": "Resist Poison",
+    "school": null,
+    "enchantable_items": [
+      "chest",
+      "shield",
+      "amulet",
+      "ring"
+    ],
+    "strength_unit": "percentage"
+  },
+  {
+    "name": "Resist Shock",
+    "school": null,
+    "enchantable_items": [
+      "feet",
+      "shield",
+      "amulet",
+      "ring"
+    ],
+    "strength_unit": "percentage"
+  },
+  {
+    "name": "Shock Damage",
+    "school": "Destruction",
+    "enchantable_items": [
+      "dagger",
+      "sword",
+      "mace",
+      "war axe",
+      "greatsword",
+      "warhammer",
+      "battleaxe",
+      "bow",
+      "crossbow",
+      "axe",
+      "pickaxe"
+    ],
+    "strength_unit": "point"
+  },
+  {
+    "name": "Silent Moons Enchant",
+    "school": "Destruction",
+    "enchantable_items": [
+      "dagger",
+      "sword",
+      "mace",
+      "war axe",
+      "greatsword",
+      "warhammer",
+      "battleaxe",
+      "bow",
+      "crossbow",
+      "axe",
+      "pickaxe"
+    ],
+    "strength_unit": "point"
+  },
+  {
+    "name": "Soul Trap",
+    "school": "Conjuration",
+    "enchantable_items": [
+      "dagger",
+      "sword",
+      "mace",
+      "war axe",
+      "greatsword",
+      "warhammer",
+      "battleaxe",
+      "bow",
+      "crossbow",
+      "axe",
+      "pickaxe"
+    ],
+    "strength_unit": null
+  },
+  {
+    "name": "Stamina Damage",
+    "school": "Destruction",
+    "enchantable_items": [
+      "dagger",
+      "sword",
+      "mace",
+      "war axe",
+      "greatsword",
+      "warhammer",
+      "battleaxe",
+      "bow",
+      "crossbow",
+      "axe",
+      "pickaxe"
+    ],
+    "strength_unit": "point"
+  },
+  {
+    "name": "Turn Undead",
+    "school": "Restoration",
+    "enchantable_items": [
+      "dagger",
+      "sword",
+      "mace",
+      "war axe",
+      "greatsword",
+      "warhammer",
+      "battleaxe",
+      "bow",
+      "crossbow",
+      "axe",
+      "pickaxe"
+    ],
+    "strength_unit": null
+  },
+  {
+    "name": "Waterbreathing",
+    "school": null,
+    "enchantable_items": [
+      "head",
+      "amulet",
+      "ring"
+    ],
+    "strength_unit": null
+  }
+]

--- a/lib/tasks/canonical_models/spells.json
+++ b/lib/tasks/canonical_models/spells.json
@@ -1,0 +1,1212 @@
+[
+  {
+    "name": "Arniel's Convection",
+    "school": "Destruction",
+    "level": "Novice",
+    "description": "Burns target 1 point per second. Targets on fire take extra damage.",
+    "strength": 1,
+    "strength_unit": "point",
+    "base_duration": null,
+    "effects_cumulative": true
+  },
+  {
+    "name": "Ash Rune",
+    "school": "Destruction",
+    "level": "Expert",
+    "description": "Cast on a nearby surface, explodes when enemies are nearby, immobilizing them in hardened ash for 30 seconds.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 30,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Ash Shell",
+    "school": "Alteration",
+    "level": "Adept",
+    "description": "Targets that fail to resist are immobilized in hardened ash for 30 seconds.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 30,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Bane of the Undead",
+    "school": "Restoration",
+    "level": "Master",
+    "description": "Sets undead up to level 30 on fire and makes them flee for 30 seconds.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 30,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Banish Daedra",
+    "school": "Conjuration",
+    "level": "Adept",
+    "description": "Send lesser Daedra back to Oblivion.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Blizzard",
+    "school": "Destruction",
+    "level": "Master",
+    "description": "20 Frost damage per second for 10 seconds.",
+    "strength": 20,
+    "strength_unit": "point",
+    "base_duration": 10,
+    "effects_cumulative": true
+  },
+  {
+    "name": "Bound Battleaxe",
+    "school": "Conjuration",
+    "level": "Apprentice",
+    "description": "Creates a magic battle axe for 120 seconds. Sheathe it to dispel.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 120,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Bound Bow",
+    "school": "Conjuration",
+    "level": "Adept",
+    "description": "Equips an ethereal Daedric Bow and 100 ethereal Daedric Arrows for 120 seconds.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 120,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Bound Dagger",
+    "school": "Conjuration",
+    "level": "Novice",
+    "description": "Creates a magic dagger for 120 seconds. Sheathe it to dispel.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 120,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Bound Sword",
+    "school": "Conjuration",
+    "level": "Novice",
+    "description": "Creates a magic sword for 120 seconds. Sheathe it to dispel.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 120,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Call to Arms",
+    "school": "Illusion",
+    "level": "Master",
+    "description": "Targets have improved combat skills, health, and stamina for 10 minutes.",
+    "strength": 25,
+    "strength_unit": "point",
+    "base_duration": 600,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Calm",
+    "school": "Illusion",
+    "level": "Apprentice",
+    "description": "Creatures and people up to level 9 won't fight for 30 seconds.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 30,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Candlelight",
+    "school": "Alteration",
+    "level": "Novice",
+    "description": "Creates a hovering light that lasts for 60 seconds.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 60,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Chain Lightning",
+    "school": "Destruction",
+    "level": "Adept",
+    "description": "Lightning bolt that does 40 (min) shock damage to Health and half to Magicka, then leaps to new target.",
+    "strength": 40,
+    "strength_unit": "point",
+    "base_duration": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Circle of Protection",
+    "school": "Restoration",
+    "level": "Expert",
+    "description": "Undead up to level 20 entering the circle will flee.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Clairvoyance",
+    "school": "Illusion",
+    "level": "Novice",
+    "description": "Draws a path to the next objective.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Close Wounds",
+    "school": "Restoration",
+    "level": "Adept",
+    "description": "Restores 100 points of health to the caster.",
+    "strength": 100,
+    "strength_unit": "point",
+    "base_duration": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Command Daedra",
+    "school": "Conjuration",
+    "level": "Expert",
+    "description": "Powerful summoned and raised creatures are put under the caster's control.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Conjure Ash Guardian",
+    "school": "Conjuration",
+    "level": "Expert",
+    "description": "Creates an Ash Guardian that guards that location until destroyed. Consumes a heart stone from your inventory, without which it will be hostile.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Conjure Ash Spawn",
+    "school": "Conjuration",
+    "level": "Adept",
+    "description": "Summons an Ash Spawn for 60 seconds wherever the caster is pointing.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 60,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Conjure Boneman",
+    "school": "Conjuration",
+    "level": "Apprentice",
+    "description": "Summons a Boneman Archer from the Soul Cairn for 60 seconds wherever the caster is pointing.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 60,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Conjure Dragon Priest",
+    "school": "Conjuration",
+    "level": "Expert",
+    "description": "Summons a spectral Dragon Priest.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 60,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Conjure Dremora Lord",
+    "school": "Conjuration",
+    "level": "Expert",
+    "description": "Summons a Dremora Lord for 60 seconds.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 60,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Conjure Familiar",
+    "school": "Conjuration",
+    "level": "Novice",
+    "description": "Summons a familiar for 60 seconds wherever the caster is pointing.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 60,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Conjure Flame Atronach",
+    "school": "Conjuration",
+    "level": "Apprentice",
+    "description": "Summons a Flame Atronach for 60 seconds.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 60,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Conjure Flaming Familiar",
+    "school": "Conjuration",
+    "level": "Apprentice",
+    "description": "Summons a flaming familiar which will charge into battle and explode.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Conjure Frost Atronach",
+    "school": "Conjuration",
+    "level": "Adept",
+    "description": "Summons a Frost Atronach for 60 seconds.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 60,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Conjure Mistman",
+    "school": "Conjuration",
+    "level": "Adept",
+    "description": "Summons a Mistman from the Soul Cairn for 60 seconds wherever the caster is pointing.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 60,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Conjure Seeker",
+    "school": "Conjuration",
+    "level": "Adept",
+    "description": "Summons a Seeker for 60 seconds wherever the caster is pointing.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 60,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Conjure Storm Atronach",
+    "school": "Conjuration",
+    "level": "Expert",
+    "description": "Summons a Storm Atronach for 60 seconds.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 60,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Conjure Wrathman",
+    "school": "Conjuration",
+    "level": "Expert",
+    "description": "Summons a Wrathman from the Soul Cairn for 60 seconds wherever the caster is pointing.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 60,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Courage",
+    "school": "Illusion",
+    "level": "Novice",
+    "description": "Target won't flee for 60 seconds and gets some extra health and stamina.",
+    "strength": 25,
+    "strength_unit": "point",
+    "base_duration": 60,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Dead Thrall",
+    "school": "Conjuration",
+    "level": "Master",
+    "description": "Reanimate a dead body permanently to fight for you. Only works on people.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Detect Dead",
+    "school": "Alteration",
+    "level": "Expert",
+    "description": "Nearby dead can be seen through walls.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Detect Life",
+    "school": "Alteration",
+    "level": "Adept",
+    "description": "Nearby living creatures, but not undead, machines, or daedra, can be seen through walls.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Dragonhide",
+    "school": "Alteration",
+    "level": "Master",
+    "description": "Caster ignores 80% of all physical damage.",
+    "strength": 80,
+    "strength_unit": "percentage",
+    "base_duration": 30,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Dread Zombie",
+    "school": "Conjuration",
+    "level": "Expert",
+    "description": "Reanimate a very powerful dead body to fight for you for 60 seconds.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 60,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Ebonyflesh",
+    "school": "Alteration",
+    "level": "Expert",
+    "description": "Improves the caster's armor rating by 100 points for 60 seconds.",
+    "strength": 100,
+    "strength_unit": "point",
+    "base_duration": 60,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Equilibrium",
+    "school": "Alteration",
+    "level": "Novice",
+    "description": "Convert health into magicka at 25 points per second. Caster can be killed by this effect.",
+    "strength": 25,
+    "strength_unit": "point",
+    "base_duration": null,
+    "effects_cumulative": true
+  },
+  {
+    "name": "Expel Daedra",
+    "school": "Conjuration",
+    "level": "Expert",
+    "description": "Powerful summoned daedra creatures are sent back to Oblivion.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Fade Other",
+    "school": "Illusion",
+    "level": "Expert",
+    "description": "Target is invisible for 30 seconds. Activating an object or attacking will break the spell.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 30,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Fast Healing",
+    "school": "Restoration",
+    "level": "Apprentice",
+    "description": "Heals the caster for 50 points.",
+    "strength": 50,
+    "strength_unit": "point",
+    "base_duration": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Fear",
+    "school": "Illusion",
+    "level": "Apprentice",
+    "description": "Creatures and people up to level 9 flee from combat for 30 seconds.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 30,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Fire Rune",
+    "school": "Destruction",
+    "level": "Apprentice",
+    "description": "Cast on a nearby surface, it explodes for 50 points of fire damage when enemies come near.",
+    "strength": 50,
+    "strength_unit": "point",
+    "base_duration": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Fire Storm",
+    "school": "Destruction",
+    "level": "Master",
+    "description": "Summons a fire storm that deals 100 damage.",
+    "strength": 100,
+    "strength_unit": "point",
+    "base_duration": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Fireball",
+    "school": "Destruction",
+    "level": "Adept",
+    "description": "A fiery explosion for 40 points of damage in a 15 foot radius. Targets on fire take extra damage.",
+    "strength": 40,
+    "strength_unit": "point",
+    "base_duration": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Firebolt",
+    "school": "Destruction",
+    "level": "Apprentice",
+    "description": "A blast of fire that does 25 points of damage. Targets on fire take extra damage.",
+    "strength": 25,
+    "strength_unit": "point",
+    "base_duration": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Flame Cloak",
+    "school": "Destruction",
+    "level": "Adept",
+    "description": "For 60 seconds, opponents in melee range take 8 points fire damage per second. Targets on fire take extra damage.",
+    "strength": 8,
+    "strength_unit": "point",
+    "base_duration": 60,
+    "effects_cumulative": true
+  },
+  {
+    "name": "Flame Thrall",
+    "school": "Conjuration",
+    "level": "Master",
+    "description": "Summons a Flame Atronach permanently.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Flames",
+    "school": "Destruction",
+    "level": "Novice",
+    "description": "A gout of fire that does 8 points per second. Targets on fire take extra damage.",
+    "strength": 8,
+    "strength_unit": "point",
+    "base_duration": null,
+    "effects_cumulative": true
+  },
+  {
+    "name": "Freeze",
+    "school": "Destruction",
+    "level": "Apprentice",
+    "description": "A spike of ice that does 20 points of frost damage to Health and Stamina and slows the target for 15 seconds.",
+    "strength": 20,
+    "strength_unit": "point",
+    "base_duration": 15,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Frenzy",
+    "school": "Illusion",
+    "level": "Adept",
+    "description": "Creatures and people up to level 14 will attack anyone nearby for 60 seconds.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 60,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Frenzy Rune",
+    "school": "Illusion",
+    "level": "Adept",
+    "description": "Targets up to level 20 that fail to resist are frenzied for 30 seconds.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 30,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Frost Cloak",
+    "school": "Destruction",
+    "level": "Adept",
+    "description": "For 60 seconds, opponents in melee range take 8 points frost damage and Stamina damage per second.",
+    "strength": 8,
+    "strength_unit": "point",
+    "base_duration": 60,
+    "effects_cumulative": true
+  },
+  {
+    "name": "Frost Rune",
+    "school": "Destruction",
+    "level": "Apprentice",
+    "description": "Cast on a nearby surface, it explodes for 50 points of frost damage when enemies come near.",
+    "strength": 50,
+    "strength_unit": "point",
+    "base_duration": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Frost Thrall",
+    "school": "Conjuration",
+    "level": "Master",
+    "description": "Summons a Frost Atronach permanently.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Frostbite",
+    "school": "Destruction",
+    "level": "Novice",
+    "description": "A blast of cold that does 8 points of damage per second to Health and Stamina.",
+    "strength": 8,
+    "strength_unit": "point",
+    "base_duration": null,
+    "effects_cumulative": true
+  },
+  {
+    "name": "Fury",
+    "school": "Illusion",
+    "level": "Novice",
+    "description": "Creatures and people up to level 6 will attack anything nearby for 30 seconds.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 30,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Grand Healing",
+    "school": "Restoration",
+    "level": "Expert",
+    "description": "Heals everyone close to the caster 200 points.",
+    "strength": 200,
+    "strength_unit": "point",
+    "base_duration": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Greater Ward",
+    "school": "Restoration",
+    "level": "Adept",
+    "description": "Increases armor rating by 80 points and negates up to 80 points of spell damage or effects.",
+    "strength": 80,
+    "strength_unit": "point",
+    "base_duration": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Guardian Circle",
+    "school": "Restoration",
+    "level": "Master",
+    "description": "Undead up to level 35 entering the circle will flee. Caster heals 20 health per second inside it.",
+    "strength": 20,
+    "strength_unit": "point",
+    "base_duration": 60,
+    "effects_cumulative": true
+  },
+  {
+    "name": "Harmony",
+    "school": "Illusion",
+    "level": "Master",
+    "description": "Creatures and people up to level 25 nearby won't fight for 60 seconds.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 60,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Heal Other",
+    "school": "Restoration",
+    "level": "Adept",
+    "description": "Heals the target 75 points, but not undead, atronachs or machines.",
+    "strength": 75,
+    "strength_unit": "point",
+    "base_duration": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Heal Undead",
+    "school": "Restoration",
+    "level": "Adept",
+    "description": "Heals the undead target 75 points, but not the living, atronachs or machines.",
+    "strength": 75,
+    "strength_unit": "point",
+    "base_duration": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Healing",
+    "school": "Restoration",
+    "level": "Novice",
+    "description": "Heals the caster 10 points per second.",
+    "strength": 10,
+    "strength_unit": "point",
+    "base_duration": null,
+    "effects_cumulative": true
+  },
+  {
+    "name": "Healing Hands",
+    "school": "Restoration",
+    "level": "Apprentice",
+    "description": "Heals the target 10 points per second, but not undead, atronachs, or machines.",
+    "strength": 10,
+    "strength_unit": "point",
+    "base_duration": null,
+    "effects_cumulative": true
+  },
+  {
+    "name": "Hysteria",
+    "school": "Illusion",
+    "level": "Master",
+    "description": "Creatures and people up to level 25 flee from combat.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 60,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Ice Spike",
+    "school": "Destruction",
+    "level": "Apprentice",
+    "description": "Throw a spike of ice that does 25 points of frost damage to Health and Stamina.",
+    "strength": 25,
+    "strength_unit": "point",
+    "base_duration": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Ice Storm",
+    "school": "Destruction",
+    "level": "Adept",
+    "description": "A freezing whirlwind that does 40 points of frost damage per second to Health and Stamina.",
+    "strength": 40,
+    "strength_unit": "point",
+    "base_duration": null,
+    "effects_cumulative": true
+  },
+  {
+    "name": "Icy Spear",
+    "school": "Destruction",
+    "level": "Expert",
+    "description": "A spear of ice that does 60 points of Frost Damage to Health and Stamina.",
+    "strength": 60,
+    "strength_unit": "point",
+    "base_duration": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Ignite",
+    "school": "Destruction",
+    "level": "Apprentice",
+    "description": "A blast of flame that sets targets on fire, doing 4 damage per second for 15 seconds.",
+    "strength": 4,
+    "strength_unit": "point",
+    "base_duration": 15,
+    "effects_cumulative": true
+  },
+  {
+    "name": "Incinerate",
+    "school": "Destruction",
+    "level": "Expert",
+    "description": "A blast of fire that does 60 points of damage. Targets on fire take extra damage.",
+    "strength": 60,
+    "strength_unit": "point",
+    "base_duration": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Invisibility",
+    "school": "Illusion",
+    "level": "Expert",
+    "description": "Caster is invisible for 30 seconds. Activating an object or attacking will break the spell.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 30,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Ironflesh",
+    "school": "Alteration",
+    "level": "Adept",
+    "description": "Improves caster's armor rating by 80 points for 60 seconds.",
+    "strength": 80,
+    "strength_unit": "point",
+    "base_duration": 60,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Lesser Ward",
+    "school": "Restoration",
+    "level": "Novice",
+    "description": "Increases armor rating by 40 points and negates up to 40 points of spell damage or effects.",
+    "strength": 40,
+    "strength_unit": "point",
+    "base_duration": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Lightning Bolt",
+    "school": "Destruction",
+    "level": "Apprentice",
+    "description": "A bolt of lightning that does 25 points of shock damage to health and half that to magicka.",
+    "strength": 25,
+    "strength_unit": "point",
+    "base_duration": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Lightning Cloak",
+    "school": "Destruction",
+    "level": "Adept",
+    "description": "For 60 seconds, nearby opponents take 8 points of shock damage and half magicka damage.",
+    "strength": 8,
+    "strength_unit": "point",
+    "base_duration": 60,
+    "effects_cumulative": true
+  },
+  {
+    "name": "Lightning Rune",
+    "school": "Destruction",
+    "level": "Apprentice",
+    "description": "Cast on a nearby surface, it explodes for 50 points of shock damage when enemies come near.",
+    "strength": 50,
+    "strength_unit": "point",
+    "base_duration": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Lightning Storm",
+    "school": "Destruction",
+    "level": "Master",
+    "description": "Target takes 75 points of shock damage per second to health, and half that to magicka.",
+    "strength": 75,
+    "strength_unit": "point",
+    "base_duration": null,
+    "effects_cumulative": true
+  },
+  {
+    "name": "Magelight",
+    "school": "Alteration",
+    "level": "Apprentice",
+    "description": "Cast a ball of light that lasts 60 seconds and sticks where it strikes.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 60,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Mass Paralysis",
+    "school": "Alteration",
+    "level": "Master",
+    "description": "All targets in the area that fail to resist are paralyzed for 15 seconds.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 15,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Mayhem",
+    "school": "Illusion",
+    "level": "Master",
+    "description": "Creatures and people up to level 25 will attack anyone nearby for 60 seconds.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 60,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Muffle",
+    "school": "Illusion",
+    "level": "Apprentice",
+    "description": "You move more quietly for 180 seconds.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 180,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Necromantic Healing",
+    "school": "Restoration",
+    "level": "Apprentice",
+    "description": "Heals the undead target for 10 points per second.",
+    "strength": 10,
+    "strength_unit": "point",
+    "base_duration": null,
+    "effects_cumulative": true
+  },
+  {
+    "name": "Oakflesh",
+    "school": "Alteration",
+    "level": "Novice",
+    "description": "Improves the caster's armor rating by 40 points for 60 seconds.",
+    "strength": 40,
+    "strength_unit": "point",
+    "base_duration": 60,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Pacify",
+    "school": "Illusion",
+    "level": "Expert",
+    "description": "Creatures and people up to level 20 won't fight for 60 seconds.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 60,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Paralyze",
+    "school": "Alteration",
+    "level": "Expert",
+    "description": "Targets that fail to resist are paralyzed for 10 seconds.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 10,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Poison Rune",
+    "school": "Restoration",
+    "level": "Adept",
+    "description": "Targets that fail to resist take 3 points of poison damage per second for 30 seconds.",
+    "strength": 3,
+    "strength_unit": "point",
+    "base_duration": 30,
+    "effects_cumulative": true
+  },
+  {
+    "name": "Raise Zombie",
+    "school": "Conjuration",
+    "level": "Novice",
+    "description": "Reanimate a weak dead body to fight for you for 60 seconds.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 60,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Rally",
+    "school": "Illusion",
+    "level": "Adept",
+    "description": "Targets won't flee and will get extra health and stamina.",
+    "strength": 25,
+    "strength_unit": "point",
+    "base_duration": 60,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Reanimate Corpse",
+    "school": "Conjuration",
+    "level": "Apprentice",
+    "description": "Reanimate a more powerful dead body to fight for you for 60 seconds.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 60,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Repel Lesser Undead",
+    "school": "Restoration",
+    "level": "Adept",
+    "description": "All affected undead up to level 8 flee for 30 seconds.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 30,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Repel Undead",
+    "school": "Restoration",
+    "level": "Expert",
+    "description": "All affected undead up to level 16 flee for 30 seconds.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 30,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Revenant",
+    "school": "Conjuration",
+    "level": "Adept",
+    "description": "Reanimate a powerful dead body to fight for 60 seconds.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 60,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Rout",
+    "school": "Illusion",
+    "level": "Expert",
+    "description": "Creatures and people up to level 20 flee from combat for 30 seconds.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 30,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Soul Trap",
+    "school": "Conjuration",
+    "level": "Apprentice",
+    "description": "If target dies within 60 seconds, fills a soul gem.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 60,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Sparks",
+    "school": "Destruction",
+    "level": "Novice",
+    "description": "Lightning that does 8 points of shock damage to health and magicka per second.",
+    "strength": 8,
+    "strength_unit": "point",
+    "base_duration": null,
+    "effects_cumulative": true
+  },
+  {
+    "name": "Spectral Arrow",
+    "school": "Conjuration",
+    "level": "Apprentice",
+    "description": "Causes 30 damage to health and causes target to stagger.",
+    "strength": 30,
+    "strength_unit": "point",
+    "base_duration": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Steadfast Ward",
+    "school": "Restoration",
+    "level": "Apprentice",
+    "description": "Increases armor rating by 60 points and negates up to 60 points of spell damage or effects.",
+    "strength": 60,
+    "strength_unit": "point",
+    "base_duration": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Stendarr's Aura",
+    "school": "Restoration",
+    "level": "Adept",
+    "description": "For 60 seconds, undead in melee range take 10 points of Sun damage per second.",
+    "strength": 10,
+    "strength_unit": "point",
+    "base_duration": 60,
+    "effects_cumulative": true
+  },
+  {
+    "name": "Stoneflesh",
+    "school": "Alteration",
+    "level": "Apprentice",
+    "description": "Improves the caster's armor rating by 60 points for 60 seconds.",
+    "strength": 60,
+    "strength_unit": "point",
+    "base_duration": 60,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Storm Thrall",
+    "school": "Conjuration",
+    "level": "Master",
+    "description": "Summons a Storm Atronach permanently.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Summon Arniel's Shade",
+    "school": "Conjuration",
+    "level": "Apprentice",
+    "description": "Summons Arniel's Shade wherever the caster is pointing.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 60,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Summon Arvak",
+    "school": "Conjuration",
+    "level": "Apprentice",
+    "description": "Summons Arvak in the Soul Cairn or Tamriel wilderness to act as your steed.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 60,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Summon Unbound Dremora",
+    "school": "Conjuration",
+    "level": "Novice",
+    "description": "Summons an unbound Dremora.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Sun Fire",
+    "school": "Restoration",
+    "level": "Apprentice",
+    "description": "Ball of sunlight that does 25 points of damage to undead.",
+    "strength": 25,
+    "strength_unit": "point",
+    "base_duration": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Telekinesis",
+    "school": "Alteration",
+    "level": "Adept",
+    "description": "Can pull an object from a distance. Add it to the inventory or throw it.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Thunderbolt",
+    "school": "Destruction",
+    "level": "Expert",
+    "description": "Cast a thunderbolt that does 60 points of shock damage to health and half that to magicka.",
+    "strength": 60,
+    "strength_unit": "point",
+    "base_duration": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Transmute Mineral Ore",
+    "school": "Alteration",
+    "level": "Adept",
+    "description": "Transmutes one piece of iron ore to silver ore, or silver ore to gold ore, if the caster is carrying any.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Turn Greater Undead",
+    "school": "Restoration",
+    "level": "Expert",
+    "description": "Undead up to level 21 flee for 30 seconds.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 30,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Turn Lesser Undead",
+    "school": "Restoration",
+    "level": "Apprentice",
+    "description": "Undead up to level 6 flee for 30 seconds.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 30,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Turn Undead",
+    "school": "Restoration",
+    "level": "Adept",
+    "description": "Undead up to level 13 flee for 30 seconds.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 30,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Vampire's Bane",
+    "school": "Restoration",
+    "level": "Adept",
+    "description": "Sunlight explosion that does 40 points of damage in a 15 foot radius to undead.",
+    "strength": 40,
+    "strength_unit": "point",
+    "base_duration": null,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Vampire's Seduction",
+    "school": "Illusion",
+    "level": "Apprentice",
+    "description": "Calms creatures and people up to level 10 for 30 seconds.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 30,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Vampiric Drain",
+    "school": "Destruction",
+    "level": "Novice",
+    "description": "Drains 2 health from target enemies and heals the caster simultaneously.",
+    "strength": 2,
+    "strength_unit": "point",
+    "base_duration": null,
+    "effects_cumulative": true
+  },
+  {
+    "name": "Vision of the Tenth Eye",
+    "school": "Illusion",
+    "level": "Master",
+    "description": "See what others cannot.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 30,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Wall of Flames",
+    "school": "Destruction",
+    "level": "Expert",
+    "description": "Sprayed on the ground, it creates a wall of fire that does 50 points of fire damage per second.",
+    "strength": 50,
+    "strength_unit": "point",
+    "base_duration": null,
+    "effects_cumulative": true
+  },
+  {
+    "name": "Wall of Frost",
+    "school": "Destruction",
+    "level": "Expert",
+    "description": "Sprayed on the ground, it creates a wall of frost that does 50 points of frost damage per second.",
+    "strength": 50,
+    "strength_unit": "point",
+    "base_duration": null,
+    "effects_cumulative": true
+  },
+  {
+    "name": "Wall of Storms",
+    "school": "Destruction",
+    "level": "Expert",
+    "description": "Sprayed on the ground, it creates a wall of lightning that does 50 points of shock damage per second.",
+    "strength": 50,
+    "strength_unit": "point",
+    "base_duration": null,
+    "effects_cumulative": true
+  },
+  {
+    "name": "Waterbreathing",
+    "school": "Alteration",
+    "level": "Adept",
+    "description": "Breathe underwater for 60 seconds.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 60,
+    "effects_cumulative": false
+  },
+  {
+    "name": "Whirlwind Cloak",
+    "school": "Destruction",
+    "level": "Adept",
+    "description": "For 60 seconds, opponents in melee range have a chance of being flung away.",
+    "strength": null,
+    "strength_unit": null,
+    "base_duration": 60,
+    "effects_cumulative": false
+  }
+]

--- a/lib/tasks/populate_canonical_models.rake
+++ b/lib/tasks/populate_canonical_models.rake
@@ -4,7 +4,7 @@ require 'json'
 
 namespace :canonical_models do
   namespace :populate do
-    desc 'Populate or update canonical alchemical properties'
+    desc 'Populate or update canonical alchemical properties from JSON data'
     task alchemical_properties: :environment do
       Rails.logger.info 'Populating canonical alchemical properties...'
 
@@ -22,7 +22,7 @@ namespace :canonical_models do
       end
     end
 
-    desc 'Populate or update canonical enchantments'
+    desc 'Populate or update canonical enchantments from JSON data'
     task enchantments: :environment do
       Rails.logger.info 'Populating canonical enchantments...'
 
@@ -40,7 +40,7 @@ namespace :canonical_models do
       end
     end
 
-    desc 'Populate or update canonical spells'
+    desc 'Populate or update canonical spells from JSON data'
     task spells: :environment do
       Rails.logger.info 'Populating canonical spells...'
 

--- a/lib/tasks/populate_canonical_models.rake
+++ b/lib/tasks/populate_canonical_models.rake
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'json'
+
+namespace :canonical_models do
+  namespace :populate do
+    desc 'Populate or update canonical alchemical properties'
+    task alchemical_properties: :environment do
+      Rails.logger.info 'Populating canonical alchemical properties...'
+
+      alchemical_properties = JSON.parse(File.read(Rails.root.join('lib', 'tasks', 'canonical_models', 'alchemical_properties.json')), symbolize_names: true)
+
+      ActiveRecord::Base.transaction do
+        alchemical_properties.each do |property_attributes|
+          property = AlchemicalProperty.find_or_initialize_by(name: property_attributes[:name])
+          property.assign_attributes(property_attributes)
+          property.save!
+        rescue ActiveRecord::RecordInvalid => e
+          Rails.logger.error "Error saving alchemical property \"#{property_attributes[:name]}\": #{e.message}"
+          raise e
+        end
+      end
+    end
+
+    desc 'Populate or update canonical enchantments'
+    task enchantments: :environment do
+      Rails.logger.info 'Populating canonical enchantments...'
+
+      enchantments = JSON.parse(File.read(Rails.root.join('lib', 'tasks', 'canonical_models', 'enchantments.json')), symbolize_names: true)
+
+      ActiveRecord::Base.transaction do
+        enchantments.each do |enchantment_attributes|
+          enchantment = Enchantment.find_or_initialize_by(name: enchantment_attributes[:name])
+          enchantment.assign_attributes(enchantment_attributes)
+          enchantment.save!
+        rescue ActiveRecord::RecordInvalid => e
+          Rails.logger.error("Error saving enchantment \"#{enchantment_attributes[:name]}\": #{e.message}")
+          raise e
+        end
+      end
+    end
+
+    desc 'Populate or update canonical spells'
+    task spells: :environment do
+      Rails.logger.info 'Populating canonical spells...'
+
+      spells = JSON.parse(File.read(Rails.root.join('lib', 'tasks', 'canonical_models', 'spells.json')), symbolize_names: true)
+
+      ActiveRecord::Base.transaction do
+        spells.each do |spell_attributes|
+          spell = Spell.find_or_initialize_by(name: spell_attributes[:name])
+          spell.assign_attributes(spell_attributes)
+          spell.save!
+        rescue ActiveRecord::RecordInvalid => e
+          Rails.logger.error "Error saving spell \"#{spell_attributes[:name]}\": #{e.message}"
+          raise e
+        end
+      end
+    end
+
+    desc 'Populate or update all canonical models from JSON files'
+    task all: :environment do
+      Rake::Task['canonical_models:populate:alchemical_properties'].invoke
+      Rake::Task['canonical_models:populate:enchantments'].invoke
+      Rake::Task['canonical_models:populate:spells'].invoke
+    end
+  end
+end

--- a/spec/models/alchemical_property_spec.rb
+++ b/spec/models/alchemical_property_spec.rb
@@ -22,10 +22,16 @@ RSpec.describe AlchemicalProperty, type: :model do
     end
 
     describe 'strength_unit' do
-      it 'must be one of "point" or "percentage"' do
+      it "isn't required" do
         property = described_class.new
         property.validate
-        expect(property.errors[:strength_unit]).to eq ["can't be blank", 'must be "point" or "percentage"']
+        expect(property.errors[:strength_unit]).to be_empty
+      end
+
+      it 'must be one of "point" or "percentage"' do
+        property = described_class.new(strength_unit: 'Foobar')
+        property.validate
+        expect(property.errors[:strength_unit]).to eq ['must be "point" or "percentage"']
       end
     end
   end

--- a/spec/models/enchantment_spec.rb
+++ b/spec/models/enchantment_spec.rb
@@ -22,12 +22,28 @@ RSpec.describe Enchantment, type: :model do
       end
     end
 
+    describe 'school' do
+      it 'has to be a valid school of magic' do
+        enchantment = described_class.new(school: 'Foo')
+
+        enchantment.validate
+        expect(enchantment.errors[:school]).to eq ['must be a valid school of magic']
+      end
+    end
+
     describe 'strength_unit' do
       it 'must be one of "point" or "percentage"' do
+        enchantment = described_class.new(strength_unit: 'foobar')
+
+        enchantment.validate
+        expect(enchantment.errors[:strength_unit]).to eq ['must be "point" or "percentage"']
+      end
+
+      it 'can be blank' do
         enchantment = described_class.new
 
         enchantment.validate
-        expect(enchantment.errors[:strength_unit]).to eq ["can't be blank", 'must be "point" or "percentage"']
+        expect(enchantment.errors[:strength_unit]).to be_blank
       end
     end
 

--- a/spec/models/spell_spec.rb
+++ b/spec/models/spell_spec.rb
@@ -12,11 +12,19 @@ RSpec.describe Spell, type: :model do
       end
 
       it 'must be unique' do
-        described_class.create!(name: 'Clairvoyance', description: 'Something')
+        described_class.create!(name: 'Clairvoyance', school: 'Illusion', description: 'Something')
 
         spell = described_class.new(name: 'Clairvoyance')
         spell.validate
         expect(spell.errors[:name]).to eq ['must be unique']
+      end
+    end
+
+    describe 'school' do
+      it 'must be a valid school of magic' do
+        spell = described_class.new
+        spell.validate
+        expect(spell.errors[:school]).to eq ["can't be blank", 'must be a valid school of magic']
       end
     end
 

--- a/spec/models/spell_spec.rb
+++ b/spec/models/spell_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Spell, type: :model do
       end
 
       it 'must be unique' do
-        described_class.create!(name: 'Clairvoyance', school: 'Illusion', description: 'Something')
+        described_class.create!(name: 'Clairvoyance', school: 'Illusion', level: 'Novice', description: 'Something')
 
         spell = described_class.new(name: 'Clairvoyance')
         spell.validate
@@ -28,11 +28,49 @@ RSpec.describe Spell, type: :model do
       end
     end
 
+    describe 'level' do
+      it 'must be a valid level' do
+        spell = described_class.new
+        spell.validate
+        expect(spell.errors[:level]).to eq ["can't be blank", 'must be "Novice", "Apprentice", "Adept", "Expert", or "Master"']
+      end
+    end
+
     describe 'description' do
       it 'must be present' do
         spell = described_class.new
         spell.validate
         expect(spell.errors[:description]).to eq ["can't be blank"]
+      end
+    end
+
+    describe 'strength and strength_unit' do
+      it 'is valid with both a strength and a strength_unit' do
+        spell = described_class.new(strength: 50, strength_unit: 'point', name: 'Fire Rune', level: 'Adept', school: 'Destruction', description: 'Hello world')
+        expect(spell).to be_valid
+      end
+
+      it 'is valid with neither a strength nor a strength_unit' do
+        spell = described_class.new(name: 'Clairvoyance', level: 'Novice', school: 'Illusion', description: 'Hello world')
+        expect(spell).to be_valid
+      end
+
+      it 'is invalid with a strength but no strength_unit' do
+        spell = described_class.new(strength: 50)
+        spell.validate
+        expect(spell.errors[:strength_unit]).to eq ['must be present if strength is given']
+      end
+
+      it 'is invalid with a strength_unit but no strength' do
+        spell = described_class.new(strength_unit: 'percentage')
+        spell.validate
+        expect(spell.errors[:strength]).to eq ['must be present if strength unit is given']
+      end
+
+      it 'requires a valid strength_unit value' do
+        spell = described_class.new(strength: 50, strength_unit: 'foo')
+        spell.validate
+        expect(spell.errors[:strength_unit]).to eq ['must be "point" or "percentage"']
       end
     end
   end


### PR DESCRIPTION
## Context

[**Populate canonical models in database**](https://trello.com/c/WwBkrm30/179-populate-canonical-models-in-database)

We now have three "canonical" models - i.e., those that store data on things as they exist in the game. The canonical models we have now are `AlchemicalProperty`, `Spell`, and `Enchantment`. We need to make sure every alchemical property, spell, and enchantment that exists in Skyrim is present in the database.

## Changes

* JSON files with data on all alchemical properties, enchantments, and spells in Skyrim
* Rake tasks to populate and update alchemical properties, enchantments, spells, or all of the above from JSON data
* Allow `strength_unit` to be blank for `AlchemicalProperty`, `Enchantment`, and `Spell` models
* Add `school` field for `Enchantment` model (optional) and `Spell` model (required)
* Update apparel types for enchantments to correspond to Skyrim's underlying taxonomy (head/chest/hands/feet/shield/amulet/ring)
* Add and update specs to reflect new columns and validations 

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [ ] ~~Added and updated API docs and developer docs as appropriate~~

## Considerations

I decided to use Rake tasks for this instead of database seeds but I was kind of ambivalent about which approach to use. I also decided not to seed the models for tests for now, since there currently are no tests that would require that.