### PR TITLE
Add docs about populating canonical models and add Rake task to setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,12 @@ notes: string
 
 ### Local Setup
 
-The Skyrim Inventory Management API is a basic Rails API running on Rails 6 and Ruby 3.0.1. You can set it up locally by cloning the repository, `cd`ing into it, and running:
+The Skyrim Inventory Management API is a basic Rails API running on Rails 6 and Ruby 3.0.2. You can set it up locally by cloning the repository, `cd`ing into it, and running:
 ```bash
 ./script/setup.sh
 ```
+The setup script installs dependencies (including Bundler), sets up the database, and populates [canonical models](/docs/canonical-models.md), including alchemical properties, enchantments, and spells.
+
 Note that the setup script installs a Git pre-commit hook that runs [Rubocop](#rubocop). **Running the setup script will overwrite any existing precommit hooks you have in the repo.** Since these are not saved in Git, they are not recoverable if you overwrite them (unless you've committed them to Git somewhere outside this repo). 
 
 To run the server, simply run `bundle exec rails s` and your server will start on `localhost:3000`.

--- a/docs/canonical-models.md
+++ b/docs/canonical-models.md
@@ -6,4 +6,25 @@ SIM knows certain things about Skyrim that it may or may not immediately reveal 
 * [`Enchantment`](/app/models/enchantment.rb): actual enchantments that exist in the game
 * [`Spell`](/app/models/spell.rb): actual spells that exist in the game
 
-These models are not user-created and are to be stored in the database with actual data from the game. There is [planned work](https://trello.com/c/WwBkrm30/179-populate-canonical-models-in-database) to populate the models in the database and provide seeds or a Rake task to seed development and test databases.
+These models are not user-created and are to be stored in the database with actual data from the game. The data from which the database is populated live in JSON files in the `/lib/tasks/canonical_models` directory. These JSON files contain attributes for each model that should exist in the database (whether in development or production). 
+
+## Seeding Canonical Models
+
+### Rake Tasks
+
+The following idempotent Rake tasks can be used to populate the database with the canonical models from the JSON data or update existing models:
+
+* `rails canonical_models:populate:all` (populates all canonical models from JSON data)
+* `rails canonical_models:populate:alchemical_properties` (populates canonical alchemical properties from JSON data)
+* `rails canonical_models:populate:enchantments` (populates canonical enchantments from JSON data)
+* `rails canonical_models:populate:spells` (populates canonical spells from JSON data)
+
+These tasks populate the models with the attributes in the JSON files. The tasks are idempotent. If a model already exists in the database with a given name, it will be updated with the attributes given in the JSON data.
+
+### Running Rake Tasks in Production
+
+To run the Rake tasks in production, use the `heroku run` CLI command from within this repo (you will need to log in to Heroku):
+```
+heroku login
+heroku run bundle exec rails canonical_models:populate:all
+```

--- a/script/setup.sh
+++ b/script/setup.sh
@@ -16,6 +16,9 @@ bundle install
 echo "+++ Setting up development and test databases......."
 bundle exec rails db:setup
 
+echo "+++ Populating canonical models from JSON data......."
+bundle exec rails canonical_models:populate:all
+
 # Install precommit hook to run Rubocop against changed Ruby
 # files before each git commit
 echo "+++ Installing Git precommit hook......."


### PR DESCRIPTION
## Context

[**Populate canonical models in database**](https://trello.com/c/WwBkrm30/179-populate-canonical-models-in-database)

In #74 I added Rake tasks and JSON data to populate canonical `AlchemicalProperty`, `Enchantment`, and `Spell` models in the database. I forgot to update docs about populating the database or run the Rake task as part of the setup script.

## Changes

* Add docs about Rake tasks for seeding canonical models
* Populate canonical models in setup script

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [x] Added and updated API docs and developer docs as appropriate
