### PR TITLE
Accommodate arm64 architecture in dev environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 !/tmp/pids/.keep
 
 .byebug_history
+.tool-versions
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,8 @@ GEM
     msgpack (1.4.2)
     multi_xml (0.6.0)
     nio4r (2.5.7)
+    nokogiri (1.11.7-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.11.7-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.11.7-x86_64-linux)
@@ -215,6 +217,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-19
   x86_64-linux
 
@@ -242,4 +245,4 @@ RUBY VERSION
    ruby 3.0.2p107
 
 BUNDLED WITH
-   2.2.24
+   2.2.31


### PR DESCRIPTION
## Context

I got myself the M1 Max MacBook Pro for my personal projects 🎉 However, the pg gem needed some massaging to get it to install properly for the new architecture.

## Changes

* Use correct native extensions for dev environments with the pg gem

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~
