### PR TITLE
Create CanonicalArmor model

### DIFF
--- a/app/models/canonical_armor.rb
+++ b/app/models/canonical_armor.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CanonicalArmor < ApplicationRecord
+  validates :name, presence: true
+  validates :weight,
+            presence:  true,
+            inclusion: {
+                         in:      ['light armor', 'heavy armor'],
+                         message: 'must be "light armor" or "heavy armor"',
+                       }
+  validates :body_slot,
+            presence:  true,
+            inclusion: {
+                         in:      %w[head body hands feet shield],
+                         message: 'must be "head", "body", "hands", "feet", or "shield"',
+                       }
+end

--- a/db/migrate/20220429031113_create_canonical_armors.rb
+++ b/db/migrate/20220429031113_create_canonical_armors.rb
@@ -7,6 +7,7 @@ class CreateCanonicalArmors < ActiveRecord::Migration[6.1]
       t.string :weight, null: false
       t.string :body_slot, null: false
       t.boolean :dragon_priest_mask, default: false
+      t.boolean :quest_item, default: false
 
       t.timestamps
     end

--- a/db/migrate/20220429031113_create_canonical_armors.rb
+++ b/db/migrate/20220429031113_create_canonical_armors.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateCanonicalArmors < ActiveRecord::Migration[6.1]
+  def change
+    create_table :canonical_armors do |t|
+      t.string :name, null: false
+      t.string :weight, null: false
+      t.string :body_slot, null: false
+      t.boolean :dragon_priest_mask, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -24,6 +24,16 @@ ActiveRecord::Schema.define(version: 2022_04_29_031113) do
     t.index ["name"], name: "index_alchemical_properties_on_name", unique: true
   end
 
+  create_table "canonical_armors", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "weight", null: false
+    t.string "body_slot", null: false
+    t.boolean "dragon_priest_mask", default: false
+    t.boolean "quest_item", default: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "canonical_properties", force: :cascade do |t|
     t.string "name", null: false
     t.string "hold", null: false
@@ -36,15 +46,6 @@ ActiveRecord::Schema.define(version: 2022_04_29_031113) do
     t.index ["city"], name: "index_canonical_properties_on_city", unique: true
     t.index ["hold"], name: "index_canonical_properties_on_hold", unique: true
     t.index ["name"], name: "index_canonical_properties_on_name", unique: true
-  end
-
-  create_table "canonical_armors", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "weight", null: false
-    t.string "body_slot", null: false
-    t.boolean "dragon_priest_mask", default: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "enchantments", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_29_021120) do
+ActiveRecord::Schema.define(version: 2022_04_29_031113) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,6 +36,15 @@ ActiveRecord::Schema.define(version: 2021_08_29_021120) do
     t.index ["city"], name: "index_canonical_properties_on_city", unique: true
     t.index ["hold"], name: "index_canonical_properties_on_hold", unique: true
     t.index ["name"], name: "index_canonical_properties_on_name", unique: true
+  end
+
+  create_table "canonical_armors", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "weight", null: false
+    t.string "body_slot", null: false
+    t.boolean "dragon_priest_mask", default: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "enchantments", force: :cascade do |t|

--- a/spec/models/canonical_armor_spec.rb
+++ b/spec/models/canonical_armor_spec.rb
@@ -6,21 +6,21 @@ RSpec.describe CanonicalArmor, type: :model do
   describe 'validations' do
     describe 'name' do
       it 'is invalid without a name' do
-        armor = described_class.new(weight: 'heavy armor', body_slot: 'body', dragon_priest_mask: false)
+        armor = described_class.new(weight: 'heavy armor', body_slot: 'body')
 
         armor.validate
         expect(armor.errors[:name]).to eq ["can't be blank"]
       end
 
       it 'is invalid without a valid weight' do
-        armor = described_class.new(name: 'fur armor', body_slot: 'head', dragon_priest_mask: false)
+        armor = described_class.new(name: 'fur armor', body_slot: 'head')
 
         armor.validate
         expect(armor.errors[:weight]).to eq ["can't be blank", 'must be "light armor" or "heavy armor"']
       end
 
       it 'is invalid without a valid body slot' do
-        armor = described_class.new(name: 'fur armor', weight: 'light armor', dragon_priest_mask: false)
+        armor = described_class.new(name: 'fur armor', weight: 'light armor')
 
         armor.validate
         expect(armor.errors[:body_slot]).to eq ["can't be blank", 'must be "head", "body", "hands", "feet", or "shield"']

--- a/spec/models/canonical_armor_spec.rb
+++ b/spec/models/canonical_armor_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CanonicalArmor, type: :model do
+  describe 'validations' do
+    describe 'name' do
+      it 'is invalid without a name' do
+        armor = described_class.new(weight: 'heavy armor', body_slot: 'body', dragon_priest_mask: false)
+
+        armor.validate
+        expect(armor.errors[:name]).to eq ["can't be blank"]
+      end
+
+      it 'is invalid without a valid weight' do
+        armor = described_class.new(name: 'fur armor', body_slot: 'head', dragon_priest_mask: false)
+
+        armor.validate
+        expect(armor.errors[:weight]).to eq ["can't be blank", 'must be "light armor" or "heavy armor"']
+      end
+
+      it 'is invalid without a valid body slot' do
+        armor = described_class.new(name: 'fur armor', weight: 'light armor', dragon_priest_mask: false)
+
+        armor.validate
+        expect(armor.errors[:body_slot]).to eq ["can't be blank", 'must be "head", "body", "hands", "feet", or "shield"']
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

[**Create and populate canonical apparel models**](https://trello.com/c/hD3Ff0BA/152-create-and-populate-canonical-apparel-models)

In the process of developing canonical models, we forgot that apparel items should also be checked against canonical models for validity. Because apparel can be clothing, armour, or jewellery, I'm creating three different canonical models, of which CanonicalArmor is the first.

## Changes

* Migration for `canonical_armors` table
* `CanonicalArmor` model class with appropriate validations
* Spec for validations

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

We will want to add a new table that enables us to associate enchantments to canonical armour pieces. These will be limited to actual enchantments on quest items and will not include all available enchantments for standard armour.