### PR TITLE
Create many-to-many association between canonical armor and enchantments

### DIFF
--- a/app/models/canonical_armor.rb
+++ b/app/models/canonical_armor.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CanonicalArmor < ApplicationRecord
+  has_many :enchantments, through: :canonical_armors_enchantments
+
   validates :name, presence: true
   validates :weight,
             presence:  true,

--- a/app/models/canonical_armors_enchantment.rb
+++ b/app/models/canonical_armors_enchantment.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class CanonicalArmorsEnchantment < ApplicationRecord
+  belongs_to :canonical_armor
+  belongs_to :enchantment
+end

--- a/app/models/enchantment.rb
+++ b/app/models/enchantment.rb
@@ -36,6 +36,8 @@ class Enchantment < ApplicationRecord
 
   ENCHANTABLE_ITEMS = (ENCHANTABLE_WEAPONS + ENCHANTABLE_APPAREL_ITEMS).freeze
 
+  has_many :canonical_armors, through: :canonical_armors_enchantments
+
   validates :name, presence: true, uniqueness: { message: 'must be unique' }
   validates :strength_unit, inclusion: { in: %w[point percentage], message: 'must be "point" or "percentage"', allow_blank: true }
   validates :school, inclusion: { in: SCHOOLS, message: 'must be a valid school of magic', allow_blank: true }

--- a/db/migrate/20220429040232_create_canonical_armors_enchantments.rb
+++ b/db/migrate/20220429040232_create_canonical_armors_enchantments.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateCanonicalArmorsEnchantments < ActiveRecord::Migration[6.1]
+  def change
+    create_table :canonical_armors_enchantments do |t|
+      t.references :canonical_armor, null: false, foreign_key: true
+      t.references :enchantment, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_29_031113) do
+ActiveRecord::Schema.define(version: 2022_04_29_040232) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,6 +32,15 @@ ActiveRecord::Schema.define(version: 2022_04_29_031113) do
     t.boolean "quest_item", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "canonical_armors_enchantments", force: :cascade do |t|
+    t.bigint "canonical_armor_id", null: false
+    t.bigint "enchantment_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["canonical_armor_id"], name: "index_canonical_armors_enchantments_on_canonical_armor_id"
+    t.index ["enchantment_id"], name: "index_canonical_armors_enchantments_on_enchantment_id"
   end
 
   create_table "canonical_properties", force: :cascade do |t|
@@ -164,6 +173,8 @@ ActiveRecord::Schema.define(version: 2022_04_29_031113) do
     t.index ["uid"], name: "index_users_on_uid", unique: true
   end
 
+  add_foreign_key "canonical_armors_enchantments", "canonical_armors"
+  add_foreign_key "canonical_armors_enchantments", "enchantments"
   add_foreign_key "games", "users"
   add_foreign_key "inventory_items", "inventory_lists", column: "list_id"
   add_foreign_key "inventory_lists", "games"


### PR DESCRIPTION
## Context

[**Create and populate canonical apparel models**](https://trello.com/c/hD3Ff0BA/152-create-and-populate-canonical-apparel-models)

One characteristic of apparel is that a lot of it can be enchanted. For quest items and other unique armours that are canonically enchanted, we want to enable any existing enchantments to be associated with the canonical armour items. Note that the purpose of this change is not to associate any enchantments that _may_ be applied to the canonical armour items - that is achieved through checking whether any element the "enchantable_items" array of the enchantment matches the "body_slot" of a piece of armour. This change is only to associate items that are strictly enchanted with specific enchantments in the game - such as Nightingale Armour - to be associated to those enchantments.

## Changes

* Migration creating `canonical_armors_enchantments` join table
* CanonicalArmorsEnchantment model with relationships to CanonicalArmor and Enchantment models
* `has_many :through` relationship between CanonicalArmor and Enchantment models
* Documentation update

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

This join table will not actually be used until after we've added the `CanonicalMaterial` model representing building and smithing materials, which also need to be associated to CanonicalArmor to indicate required materials to make or improve a piece of armour. This model will be added in an upcoming PR.
