### PR TITLE
Create CanonicalMaterial model and join tables with CanonicalArmor

### DIFF
--- a/app/models/canonical_armor.rb
+++ b/app/models/canonical_armor.rb
@@ -3,6 +3,7 @@
 class CanonicalArmor < ApplicationRecord
   has_many :enchantments, through: :canonical_armors_enchantments
   has_many :smithing_materials, through: :canonical_armors_smithing_materials, source: :canonical_materials
+  has_many :tempering_materials, through: :canonical_armors_tempering_materials, source: :canonical_materials
 
   validates :name, presence: true
   validates :weight,

--- a/app/models/canonical_armor.rb
+++ b/app/models/canonical_armor.rb
@@ -2,6 +2,7 @@
 
 class CanonicalArmor < ApplicationRecord
   has_many :enchantments, through: :canonical_armors_enchantments
+  has_many :smithing_materials, through: :canonical_armors_smithing_materials, source: :canonical_materials
 
   validates :name, presence: true
   validates :weight,

--- a/app/models/canonical_armor.rb
+++ b/app/models/canonical_armor.rb
@@ -18,4 +18,5 @@ class CanonicalArmor < ApplicationRecord
                          in:      %w[head body hands feet shield],
                          message: 'must be "head", "body", "hands", "feet", or "shield"',
                        }
+  validates :unit_weight, numericality: { greater_than_or_equal_to: 0 }
 end

--- a/app/models/canonical_armors_smithing_material.rb
+++ b/app/models/canonical_armors_smithing_material.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class CanonicalArmorsSmithingMaterial < ApplicationRecord
+  belongs_to :canonical_armor
+  belongs_to :canonical_materials
+end

--- a/app/models/canonical_armors_smithing_material.rb
+++ b/app/models/canonical_armors_smithing_material.rb
@@ -4,5 +4,5 @@ class CanonicalArmorsSmithingMaterial < ApplicationRecord
   belongs_to :canonical_armor
   belongs_to :canonical_material
 
-  validates :count, presence: true, numericality: { only_integer: true, greater_than: 0 }
+  validates :count, numericality: { only_integer: true, greater_than: 0 }
 end

--- a/app/models/canonical_armors_smithing_material.rb
+++ b/app/models/canonical_armors_smithing_material.rb
@@ -2,5 +2,7 @@
 
 class CanonicalArmorsSmithingMaterial < ApplicationRecord
   belongs_to :canonical_armor
-  belongs_to :canonical_materials
+  belongs_to :canonical_material
+
+  validates :count, presence: true, numericality: { only_integer: true, greater_than: 0 }
 end

--- a/app/models/canonical_armors_tempering_material.rb
+++ b/app/models/canonical_armors_tempering_material.rb
@@ -4,5 +4,5 @@ class CanonicalArmorsTemperingMaterial < ApplicationRecord
   belongs_to :canonical_armor
   belongs_to :canonical_material
 
-  validates :count, presence: true, numericality: { greater_than: 0, only_integer: true }
+  validates :count, numericality: { greater_than: 0, only_integer: true }
 end

--- a/app/models/canonical_armors_tempering_material.rb
+++ b/app/models/canonical_armors_tempering_material.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class CanonicalArmorsTemperingMaterial < ApplicationRecord
+  belongs_to :canonical_armor
+  belongs_to :canonical_material
+
+  validates :count, presence: true, numericality: { greater_than: 0, only_integer: true }
+end

--- a/app/models/canonical_material.rb
+++ b/app/models/canonical_material.rb
@@ -2,4 +2,5 @@
 
 class CanonicalMaterial < ApplicationRecord
   validates :name, presence: true, uniqueness: true
+  validates :unit_weight, numericality: { greater_than_or_equal_to: 0 }
 end

--- a/app/models/canonical_material.rb
+++ b/app/models/canonical_material.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class CanonicalMaterial < ApplicationRecord
+  validates :name, presence: true, uniqueness: true
+end

--- a/db/migrate/20220429031113_create_canonical_armors.rb
+++ b/db/migrate/20220429031113_create_canonical_armors.rb
@@ -6,6 +6,7 @@ class CreateCanonicalArmors < ActiveRecord::Migration[6.1]
       t.string :name, null: false
       t.string :weight, null: false
       t.string :body_slot, null: false
+      t.decimal :unit_weight, precision: 5, scale: 1
       t.boolean :dragon_priest_mask, default: false
       t.boolean :quest_item, default: false
 

--- a/db/migrate/20220429042245_create_canonical_materials.rb
+++ b/db/migrate/20220429042245_create_canonical_materials.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateCanonicalMaterials < ActiveRecord::Migration[6.1]
+  def change
+    create_table :canonical_materials do |t|
+      t.string :name, null: false, unique: true
+      t.boolean :building_material, default: false
+      t.boolean :smithing_material, default: false
+      t.index :name, unique: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220429042245_create_canonical_materials.rb
+++ b/db/migrate/20220429042245_create_canonical_materials.rb
@@ -6,6 +6,7 @@ class CreateCanonicalMaterials < ActiveRecord::Migration[6.1]
       t.string :name, null: false, unique: true
       t.boolean :building_material, default: false
       t.boolean :smithing_material, default: false
+      t.decimal :unit_weight, precision: 5, scale: 1
       t.index :name, unique: true
 
       t.timestamps

--- a/db/migrate/20220429060600_create_canonical_armors_smithing_materials.rb
+++ b/db/migrate/20220429060600_create_canonical_armors_smithing_materials.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CreateCanonicalArmorsSmithingMaterials < ActiveRecord::Migration[6.1]
+  def change
+    create_table :canonical_armors_smithing_materials do |t|
+      t.references :canonical_armor,
+                   null:        false,
+                   foreign_key: true,
+                   index:       { name: :index_canonical_armors_smithing_mats_on_canonical_armor_id }
+      t.references :canonical_materials,
+                   null:        false,
+                   foreign_key: true,
+                   index:       { name: :index_canonical_armors_smithing_mats_on_canonical_mat_id }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220429061411_create_canonical_armors_tempering_materials.rb
+++ b/db/migrate/20220429061411_create_canonical_armors_tempering_materials.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
-class CreateCanonicalArmorsSmithingMaterials < ActiveRecord::Migration[6.1]
+class CreateCanonicalArmorsTemperingMaterials < ActiveRecord::Migration[6.1]
   def change
-    create_table :canonical_armors_smithing_materials do |t|
+    create_table :canonical_armors_tempering_materials do |t|
       t.references :canonical_armor,
                    null:        false,
                    foreign_key: true,
-                   index:       { name: :index_canonical_armors_smithing_mats_on_canonical_armor_id }
+                   index:       { name: :index_canonical_armors_tempering_mats_on_canonical_armor_id }
       t.references :canonical_material,
                    null:        false,
                    foreign_key: true,
-                   index:       { name: :index_canonical_armors_smithing_mats_on_canonical_mat_id }
+                   index:       { name: :index_canonical_armors_tempering_mats_on_canonical_material_id }
       t.integer    :count,
                    default: 1,
                    null:    false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_29_042245) do
+ActiveRecord::Schema.define(version: 2022_04_29_060600) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,6 +41,15 @@ ActiveRecord::Schema.define(version: 2022_04_29_042245) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["canonical_armor_id"], name: "index_canonical_armors_enchantments_on_canonical_armor_id"
     t.index ["enchantment_id"], name: "index_canonical_armors_enchantments_on_enchantment_id"
+  end
+
+  create_table "canonical_armors_smithing_materials", force: :cascade do |t|
+    t.bigint "canonical_armor_id", null: false
+    t.bigint "canonical_materials_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["canonical_armor_id"], name: "index_canonical_armors_smithing_mats_on_canonical_armor_id"
+    t.index ["canonical_materials_id"], name: "index_canonical_armors_smithing_mats_on_canonical_mat_id"
   end
 
   create_table "canonical_materials", force: :cascade do |t|
@@ -184,6 +193,8 @@ ActiveRecord::Schema.define(version: 2022_04_29_042245) do
 
   add_foreign_key "canonical_armors_enchantments", "canonical_armors"
   add_foreign_key "canonical_armors_enchantments", "enchantments"
+  add_foreign_key "canonical_armors_smithing_materials", "canonical_armors"
+  add_foreign_key "canonical_armors_smithing_materials", "canonical_materials", column: "canonical_materials_id"
   add_foreign_key "games", "users"
   add_foreign_key "inventory_items", "inventory_lists", column: "list_id"
   add_foreign_key "inventory_lists", "games"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_29_040232) do
+ActiveRecord::Schema.define(version: 2022_04_29_042245) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,6 +41,15 @@ ActiveRecord::Schema.define(version: 2022_04_29_040232) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["canonical_armor_id"], name: "index_canonical_armors_enchantments_on_canonical_armor_id"
     t.index ["enchantment_id"], name: "index_canonical_armors_enchantments_on_enchantment_id"
+  end
+
+  create_table "canonical_materials", force: :cascade do |t|
+    t.string "name", null: false
+    t.boolean "building_material", default: false
+    t.boolean "smithing_material", default: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["name"], name: "index_canonical_materials_on_name", unique: true
   end
 
   create_table "canonical_properties", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 2022_04_29_061411) do
     t.string "name", null: false
     t.string "weight", null: false
     t.string "body_slot", null: false
+    t.decimal "unit_weight", precision: 5, scale: 1
     t.boolean "dragon_priest_mask", default: false
     t.boolean "quest_item", default: false
     t.datetime "created_at", precision: 6, null: false
@@ -67,6 +68,7 @@ ActiveRecord::Schema.define(version: 2022_04_29_061411) do
     t.string "name", null: false
     t.boolean "building_material", default: false
     t.boolean "smithing_material", default: false
+    t.decimal "unit_weight", precision: 5, scale: 1
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["name"], name: "index_canonical_materials_on_name", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_29_060600) do
+ActiveRecord::Schema.define(version: 2022_04_29_061411) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,11 +45,22 @@ ActiveRecord::Schema.define(version: 2022_04_29_060600) do
 
   create_table "canonical_armors_smithing_materials", force: :cascade do |t|
     t.bigint "canonical_armor_id", null: false
-    t.bigint "canonical_materials_id", null: false
+    t.bigint "canonical_material_id", null: false
+    t.integer "count", default: 1, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["canonical_armor_id"], name: "index_canonical_armors_smithing_mats_on_canonical_armor_id"
-    t.index ["canonical_materials_id"], name: "index_canonical_armors_smithing_mats_on_canonical_mat_id"
+    t.index ["canonical_material_id"], name: "index_canonical_armors_smithing_mats_on_canonical_mat_id"
+  end
+
+  create_table "canonical_armors_tempering_materials", force: :cascade do |t|
+    t.bigint "canonical_armor_id", null: false
+    t.bigint "canonical_material_id", null: false
+    t.integer "count", default: 1, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["canonical_armor_id"], name: "index_canonical_armors_tempering_mats_on_canonical_armor_id"
+    t.index ["canonical_material_id"], name: "index_canonical_armors_tempering_mats_on_canonical_material_id"
   end
 
   create_table "canonical_materials", force: :cascade do |t|
@@ -194,7 +205,9 @@ ActiveRecord::Schema.define(version: 2022_04_29_060600) do
   add_foreign_key "canonical_armors_enchantments", "canonical_armors"
   add_foreign_key "canonical_armors_enchantments", "enchantments"
   add_foreign_key "canonical_armors_smithing_materials", "canonical_armors"
-  add_foreign_key "canonical_armors_smithing_materials", "canonical_materials", column: "canonical_materials_id"
+  add_foreign_key "canonical_armors_smithing_materials", "canonical_materials"
+  add_foreign_key "canonical_armors_tempering_materials", "canonical_armors"
+  add_foreign_key "canonical_armors_tempering_materials", "canonical_materials"
   add_foreign_key "games", "users"
   add_foreign_key "inventory_items", "inventory_lists", column: "list_id"
   add_foreign_key "inventory_lists", "games"

--- a/docs/canonical-models.md
+++ b/docs/canonical-models.md
@@ -3,11 +3,13 @@
 SIM knows certain things about Skyrim that it may or may not immediately reveal to users. Canonical models are models representing things in Skyrim the user may not know yet. Currently there are three canonical models:
 
 * [`AlchemicalProperty`](/app/models/alchemical_property.rb): actual properties of ingredients or potions that exist in the game
+* [`CanonicalArmor`](/app/models/canonical_armor.rb): actual armor pieces available in the game
+* [`CanonicalMaterial`](/app/models/canonical_material.rb): actual building and smithing materials present in the game
 * [`CanonicalProperty`](/app/models/canonical_property.rb): actual properties (homes) the player character can own in the game
 * [`Enchantment`](/app/models/enchantment.rb): actual enchantments that exist in the game
 * [`Spell`](/app/models/spell.rb): actual spells that exist in the game
 
-These models are not user-created and are to be stored in the database with actual data from the game. The data from which the database is populated live in JSON files in the `/lib/tasks/canonical_models` directory. These JSON files contain attributes for each model that should exist in the database (whether in development or production). 
+These models are not user-created and are to be stored in the database with actual data from the game. The data from which the database is populated live in JSON files in the `/lib/tasks/canonical_models` directory. These JSON files contain attributes for each model that should exist in the database (whether in development or production).
 
 ## Seeding Canonical Models
 

--- a/spec/factories/canonical_armors.rb
+++ b/spec/factories/canonical_armors.rb
@@ -2,8 +2,9 @@
 
 FactoryBot.define do
   factory :canonical_armor do
-    name      { 'fur armor' }
-    weight    { 'light armor' }
-    body_slot { 'body' }
+    name        { 'fur armor' }
+    weight      { 'light armor' }
+    body_slot   { 'body' }
+    unit_weight { 1.0 }
   end
 end

--- a/spec/factories/canonical_armors.rb
+++ b/spec/factories/canonical_armors.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :canonical_armor do
+    name      { 'fur armor' }
+    weight    { 'light armor' }
+    body_slot { 'body' }
+  end
+end

--- a/spec/factories/canonical_materials.rb
+++ b/spec/factories/canonical_materials.rb
@@ -2,6 +2,7 @@
 
 FactoryBot.define do
   factory :canonical_material do
-    name { 'iron ingot' }
+    name        { 'iron ingot' }
+    unit_weight { 2.4 }
   end
 end

--- a/spec/factories/canonical_materials.rb
+++ b/spec/factories/canonical_materials.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :canonical_material do
+    name { 'iron ingot' }
+  end
+end

--- a/spec/models/canonical_armor_spec.rb
+++ b/spec/models/canonical_armor_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe CanonicalArmor, type: :model do
         armor.validate
         expect(armor.errors[:name]).to eq ["can't be blank"]
       end
+    end
 
     describe 'weight' do
       it 'is invalid without a valid weight' do

--- a/spec/models/canonical_armor_spec.rb
+++ b/spec/models/canonical_armor_spec.rb
@@ -12,13 +12,16 @@ RSpec.describe CanonicalArmor, type: :model do
         expect(armor.errors[:name]).to eq ["can't be blank"]
       end
 
+    describe 'weight' do
       it 'is invalid without a valid weight' do
         armor = described_class.new(name: 'fur armor', body_slot: 'head')
 
         armor.validate
         expect(armor.errors[:weight]).to eq ["can't be blank", 'must be "light armor" or "heavy armor"']
       end
+    end
 
+    describe 'body_slot' do
       it 'is invalid without a valid body slot' do
         armor = described_class.new(name: 'fur armor', weight: 'light armor')
 

--- a/spec/models/canonical_armor_spec.rb
+++ b/spec/models/canonical_armor_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CanonicalArmor, type: :model do
   describe 'validations' do
     describe 'name' do
       it 'is invalid without a name' do
-        armor = described_class.new(weight: 'heavy armor', body_slot: 'body')
+        armor = described_class.new(weight: 'heavy armor', unit_weight: 1.0, body_slot: 'body')
 
         armor.validate
         expect(armor.errors[:name]).to eq ["can't be blank"]
@@ -15,7 +15,7 @@ RSpec.describe CanonicalArmor, type: :model do
 
     describe 'weight' do
       it 'is invalid without a valid weight' do
-        armor = described_class.new(name: 'fur armor', body_slot: 'head')
+        armor = described_class.new(name: 'fur armor', unit_weight: 2.5, body_slot: 'head')
 
         armor.validate
         expect(armor.errors[:weight]).to eq ["can't be blank", 'must be "light armor" or "heavy armor"']
@@ -24,10 +24,39 @@ RSpec.describe CanonicalArmor, type: :model do
 
     describe 'body_slot' do
       it 'is invalid without a valid body slot' do
-        armor = described_class.new(name: 'fur armor', weight: 'light armor')
+        armor = described_class.new(name: 'fur armor', weight: 'light armor', unit_weight: 47.0)
 
         armor.validate
         expect(armor.errors[:body_slot]).to eq ["can't be blank", 'must be "head", "body", "hands", "feet", or "shield"']
+      end
+    end
+
+    describe 'unit_weight' do
+      it 'is invalid without a unit weight' do
+        armor = described_class.new(name: 'steel helmet', weight: 'heavy armor', body_slot: 'head')
+
+        armor.validate
+        expect(armor.errors[:unit_weight]).to eq ['is not a number']
+      end
+
+      it 'is invalid with a non-numeric unit weight' do
+        armor = described_class.new(name: 'steel helmet', weight: 'heavy armor', body_slot: 'head', unit_weight: 'foo')
+
+        armor.validate
+        expect(armor.errors[:unit_weight]).to eq ['is not a number']
+      end
+
+      it 'is invalid with a negative unit weight' do
+        armor = described_class.new(name: 'steel helmet', weight: 'heavy armor', body_slot: 'head', unit_weight: -2.4)
+
+        armor.validate
+        expect(armor.errors[:unit_weight]).to eq ['must be greater than or equal to 0']
+      end
+
+      it 'is valid with a valid unit weight' do
+        armor = described_class.new(name: 'steel helmet', weight: 'heavy armor', body_slot: 'head', unit_weight: 2.4)
+
+        expect(armor).to be_valid
       end
     end
   end

--- a/spec/models/canonical_armors_smithing_material_spec.rb
+++ b/spec/models/canonical_armors_smithing_material_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe CanonicalArmorsSmithingMaterial, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/canonical_armors_tempering_materials_spec.rb
+++ b/spec/models/canonical_armors_tempering_materials_spec.rb
@@ -2,31 +2,31 @@
 
 require 'rails_helper'
 
-RSpec.describe CanonicalArmorsSmithingMaterial, type: :model do
+RSpec.describe CanonicalArmorsTemperingMaterial, type: :model do
   describe 'validations' do
     describe 'count' do
-      it 'is invalid if count is zero or less' do
-        armor    = create(:canonical_armor)
+      it 'is invalid if count is 0 or less' do
         material = create(:canonical_material)
-        model    = described_class.new(count: 0, canonical_armor: armor, canonical_material: material)
+        armor    = create(:canonical_armor)
+        model    = described_class.new(count: 0, canonical_material: material, canonical_armor: armor)
 
         model.validate
         expect(model.errors[:count]).to eq ['must be greater than 0']
       end
 
       it 'is invalid if count is not an integer' do
-        armor    = create(:canonical_armor)
         material = create(:canonical_material)
-        model    = described_class.new(count: 1.3, canonical_armor: armor, canonical_material: material)
+        armor    = create(:canonical_armor)
+        model    = described_class.new(count: 7.6, canonical_material: material, canonical_armor: armor)
 
         model.validate
         expect(model.errors[:count]).to eq ['must be an integer']
       end
 
       it 'is valid with a valid count' do
-        armor    = create(:canonical_armor)
         material = create(:canonical_material)
-        model    = described_class.new(count: 2, canonical_armor: armor, canonical_material: material)
+        armor    = create(:canonical_armor)
+        model    = described_class.new(count: 3, canonical_material: material, canonical_armor: armor)
 
         expect(model).to be_valid
       end

--- a/spec/models/canonical_material_spec.rb
+++ b/spec/models/canonical_material_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CanonicalMaterial, type: :model do
+  describe 'validations' do
+    describe 'name' do
+      it 'is invalid without a name' do
+        material = described_class.new
+
+        material.validate
+        expect(material.errors[:name]).to eq ["can't be blank"]
+      end
+
+      it 'is invalid with a duplicate name' do
+        material1 = described_class.create!(name: 'foo')
+        material2 = described_class.new(name: 'foo')
+
+        material2.validate
+        expect(material2.errors[:name]).to eq ['has already been taken']
+      end
+    end
+  end
+end

--- a/spec/models/canonical_material_spec.rb
+++ b/spec/models/canonical_material_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe CanonicalMaterial, type: :model do
       end
 
       it 'is invalid with a duplicate name' do
-        material1 = described_class.create!(name: 'foo')
-        material2 = described_class.new(name: 'foo')
+        described_class.create!(name: 'foo')
+        material = described_class.new(name: 'foo')
 
-        material2.validate
-        expect(material2.errors[:name]).to eq ['has already been taken']
+        material.validate
+        expect(material.errors[:name]).to eq ['has already been taken']
       end
     end
   end

--- a/spec/models/canonical_material_spec.rb
+++ b/spec/models/canonical_material_spec.rb
@@ -4,20 +4,49 @@ require 'rails_helper'
 
 RSpec.describe CanonicalMaterial, type: :model do
   describe 'validations' do
+    it 'is valid with a valid name and unit weight' do
+      material = described_class.new(unit_weight: 7.0, name: 'bear pelt')
+
+      expect(material).to be_valid
+    end
+
     describe 'name' do
       it 'is invalid without a name' do
-        material = described_class.new
+        material = described_class.new(unit_weight: 4.2)
 
         material.validate
         expect(material.errors[:name]).to eq ["can't be blank"]
       end
 
       it 'is invalid with a duplicate name' do
-        described_class.create!(name: 'foo')
-        material = described_class.new(name: 'foo')
+        described_class.create!(name: 'foo', unit_weight: 34.0)
+        material = described_class.new(name: 'foo', unit_weight: 34.0)
 
         material.validate
         expect(material.errors[:name]).to eq ['has already been taken']
+      end
+    end
+
+    describe 'unit_weight' do
+      it 'is invalid without a unit weight' do
+        material = described_class.new(name: 'foo')
+
+        material.validate
+        expect(material.errors[:unit_weight]).to eq ['is not a number']
+      end
+
+      it 'is invalid with a non-numeric unit weight' do
+        material = described_class.new(name: 'foo', unit_weight: 'bar')
+
+        material.validate
+        expect(material.errors[:unit_weight]).to eq ['is not a number']
+      end
+
+      it 'is invalid without a negative unit weight' do
+        material = described_class.new(name: 'foo', unit_weight: -4.0)
+
+        material.validate
+        expect(material.errors[:unit_weight]).to eq ['must be greater than or equal to 0']
       end
     end
   end


### PR DESCRIPTION
## Context

[**Create and populate canonical apparel models**](https://trello.com/c/hD3Ff0BA/152-create-and-populate-canonical-apparel-models)

In the course of building out canonical armour functionality, we determined we'd like to indicate what materials are required to forge the armour or to improve it. It made sense to make a `CanonicalMaterial` model for building and smithing materials.

## Changes

* Migration to create `canonical_materials` table
* `CanonicalMaterial` model
* Migration to create `canonical_armors_smithing_materials` join table
* `CanonicalArmorsSmithingMaterial` model
* Migration to create `canonical_armors_tempering_materials` join table
* `CanonicalArmorsTemperingMaterial` model
* Factories and tests for the above

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

The `CanonicalMaterial` model was not originally a part of this card, but I added it here because I wanted to be able to include the materials used to forge or improve armours with those models.

It didn't make sense to differentiate between `SmithingMaterial` and `BuildingMaterial` models because some items are both. So we added two boolean fields to the `CanonicalMaterial` model. Some `CanonicalMaterial`s - building materials like antlers - are also ingredients. This will be annoying when it comes time to keep inventory, however, I generally collect these items for one particular purpose and it should be easy enough to classify them by that purpose.

It made sense to make two join tables for the `canonical_armors` table and the `canonical_materials` table since the same armour could make use of the same materials for two different purposes - forging and improvement.