### PR TITLE
Create CanonicalClothingItem model

### DIFF
--- a/app/models/canonical_clothing_item.rb
+++ b/app/models/canonical_clothing_item.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class CanonicalClothingItem < ApplicationRecord
+  validates :name, presence: true, uniqueness: true
+  validates :unit_weight, numericality: { greater_than_or_equal_to: 0 }
+end

--- a/app/models/canonical_clothing_item.rb
+++ b/app/models/canonical_clothing_item.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CanonicalClothingItem < ApplicationRecord
+  has_many :enchantments, through: :canonical_clothing_items_enchantments
+
   validates :name, presence: true, uniqueness: true
   validates :unit_weight, numericality: { greater_than_or_equal_to: 0 }
 end

--- a/app/models/canonical_clothing_items_enchantment.rb
+++ b/app/models/canonical_clothing_items_enchantment.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class CanonicalClothingItemsEnchantment < ApplicationRecord
+  belongs_to :canonical_clothing_item
+  belongs_to :enchantment
+end

--- a/app/models/enchantment.rb
+++ b/app/models/enchantment.rb
@@ -37,6 +37,7 @@ class Enchantment < ApplicationRecord
   ENCHANTABLE_ITEMS = (ENCHANTABLE_WEAPONS + ENCHANTABLE_APPAREL_ITEMS).freeze
 
   has_many :canonical_armors, through: :canonical_armors_enchantments
+  has_many :canonical_clothing_items, through: :canonical_clothing_items_enchantments
 
   validates :name, presence: true, uniqueness: { message: 'must be unique' }
   validates :strength_unit, inclusion: { in: %w[point percentage], message: 'must be "point" or "percentage"', allow_blank: true }

--- a/db/migrate/20220429080952_create_canonical_clothing_items.rb
+++ b/db/migrate/20220429080952_create_canonical_clothing_items.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateCanonicalClothingItems < ActiveRecord::Migration[6.1]
+  def change
+    create_table :canonical_clothing_items do |t|
+      t.string :name, null: false, unique: true
+      t.decimal :unit_weight, default: 1.0
+      t.boolean :quest_item, default: false
+
+      t.index :name, unique: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220429080952_create_canonical_clothing_items.rb
+++ b/db/migrate/20220429080952_create_canonical_clothing_items.rb
@@ -4,7 +4,7 @@ class CreateCanonicalClothingItems < ActiveRecord::Migration[6.1]
   def change
     create_table :canonical_clothing_items do |t|
       t.string :name, null: false, unique: true
-      t.decimal :unit_weight, default: 1.0
+      t.decimal :unit_weight, precision: 5, scale: 1, default: 1.0
       t.boolean :quest_item, default: false
 
       t.index :name, unique: true

--- a/db/migrate/20220429082157_create_canonical_clothing_items_enchantments.rb
+++ b/db/migrate/20220429082157_create_canonical_clothing_items_enchantments.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateCanonicalClothingItemsEnchantments < ActiveRecord::Migration[6.1]
+  def change
+    create_table :canonical_clothing_items_enchantments do |t|
+      t.references :canonical_clothing_item,
+                   null:        false,
+                   foreign_key: true,
+                   index:       { name: :index_canonical_clothing_enchantments_on_canonical_clothing_id }
+      t.references :enchantment, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_29_061411) do
+ActiveRecord::Schema.define(version: 2022_04_29_080952) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -62,6 +62,15 @@ ActiveRecord::Schema.define(version: 2022_04_29_061411) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["canonical_armor_id"], name: "index_canonical_armors_tempering_mats_on_canonical_armor_id"
     t.index ["canonical_material_id"], name: "index_canonical_armors_tempering_mats_on_canonical_material_id"
+  end
+
+  create_table "canonical_clothing_items", force: :cascade do |t|
+    t.string "name", null: false
+    t.decimal "unit_weight", default: "1.0"
+    t.boolean "quest_item", default: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["name"], name: "index_canonical_clothing_items_on_name", unique: true
   end
 
   create_table "canonical_materials", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -66,7 +66,7 @@ ActiveRecord::Schema.define(version: 2022_04_29_082157) do
 
   create_table "canonical_clothing_items", force: :cascade do |t|
     t.string "name", null: false
-    t.decimal "unit_weight", default: "1.0"
+    t.decimal "unit_weight", precision: 5, scale: 1, default: "1.0"
     t.boolean "quest_item", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_29_080952) do
+ActiveRecord::Schema.define(version: 2022_04_29_082157) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -71,6 +71,15 @@ ActiveRecord::Schema.define(version: 2022_04_29_080952) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["name"], name: "index_canonical_clothing_items_on_name", unique: true
+  end
+
+  create_table "canonical_clothing_items_enchantments", force: :cascade do |t|
+    t.bigint "canonical_clothing_item_id", null: false
+    t.bigint "enchantment_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["canonical_clothing_item_id"], name: "index_canonical_clothing_enchantments_on_canonical_clothing_id"
+    t.index ["enchantment_id"], name: "index_canonical_clothing_items_enchantments_on_enchantment_id"
   end
 
   create_table "canonical_materials", force: :cascade do |t|
@@ -219,6 +228,8 @@ ActiveRecord::Schema.define(version: 2022_04_29_080952) do
   add_foreign_key "canonical_armors_smithing_materials", "canonical_materials"
   add_foreign_key "canonical_armors_tempering_materials", "canonical_armors"
   add_foreign_key "canonical_armors_tempering_materials", "canonical_materials"
+  add_foreign_key "canonical_clothing_items_enchantments", "canonical_clothing_items"
+  add_foreign_key "canonical_clothing_items_enchantments", "enchantments"
   add_foreign_key "games", "users"
   add_foreign_key "inventory_items", "inventory_lists", column: "list_id"
   add_foreign_key "inventory_lists", "games"

--- a/docs/canonical-models.md
+++ b/docs/canonical-models.md
@@ -4,6 +4,7 @@ SIM knows certain things about Skyrim that it may or may not immediately reveal 
 
 * [`AlchemicalProperty`](/app/models/alchemical_property.rb): actual properties of ingredients or potions that exist in the game
 * [`CanonicalArmor`](/app/models/canonical_armor.rb): actual armor pieces available in the game
+* [`CanonicalClothingItem`](/app/models/canonical_clothing_item.rb): actual clothing items available in the game; includes mages' robes as well as plain clothes
 * [`CanonicalMaterial`](/app/models/canonical_material.rb): actual building and smithing materials present in the game
 * [`CanonicalProperty`](/app/models/canonical_property.rb): actual properties (homes) the player character can own in the game
 * [`Enchantment`](/app/models/enchantment.rb): actual enchantments that exist in the game

--- a/spec/factories/canonical_clothing_items.rb
+++ b/spec/factories/canonical_clothing_items.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :canonical_clothing_item do
+    sequence(:name) {|n| "Clothing Item #{n}"  }
+    unit_weight { 9.9 }
+    quest_item { false }
+  end
+end

--- a/spec/factories/canonical_clothing_items.rb
+++ b/spec/factories/canonical_clothing_items.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :canonical_clothing_item do
-    sequence(:name) {|n| "Clothing Item #{n}"  }
+    sequence(:name) {|n| "Clothing Item #{n}" }
     unit_weight { 9.9 }
     quest_item { false }
   end

--- a/spec/models/canonical_clothing_item_spec.rb
+++ b/spec/models/canonical_clothing_item_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CanonicalClothingItem, type: :model do
+  describe 'validations' do
+    describe 'name' do
+      it 'is invalid without a name' do
+        item = described_class.new
+
+        item.validate
+        expect(item.errors[:name]).to eq ["can't be blank"]
+      end
+
+      it 'is invalid with a non-unique name' do
+        create(:canonical_clothing_item, name: 'foo')
+        item = described_class.new(name: 'foo')
+
+        item.validate
+        expect(item.errors[:name]).to eq ['has already been taken']
+      end
+
+      it 'is valid with a valid name' do
+        item = described_class.new(name: 'foo')
+
+        expect(item).to be_valid
+      end
+    end
+
+    describe 'unit_weight' do
+      it 'is invalid with a non-numeric unit weight' do
+        item = described_class.new(name: 'foo', unit_weight: 'bar')
+
+        item.validate
+        expect(item.errors[:unit_weight]).to eq ['is not a number']
+      end
+
+      it 'is invalid with a negative unit weight' do
+        item = described_class.new(name: 'foo', unit_weight: -34)
+
+        item.validate
+        expect(item.errors[:unit_weight]).to eq ['must be greater than or equal to 0']
+      end
+    end
+  end
+end

--- a/spec/models/canonical_clothing_item_spec.rb
+++ b/spec/models/canonical_clothing_item_spec.rb
@@ -41,6 +41,12 @@ RSpec.describe CanonicalClothingItem, type: :model do
         item.validate
         expect(item.errors[:unit_weight]).to eq ['must be greater than or equal to 0']
       end
+
+      it 'is valid with a positive decimal unit weight value' do
+        item = described_class.new(name: 'foo', unit_weight: 7.0)
+
+        expect(item).to be_valid
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

[**Create and populate canonical apparel models**](https://trello.com/c/hD3Ff0BA/152-create-and-populate-canonical-apparel-models)

We're creating canonical apparel models, with separate models for armour, clothing, and jewellery. The CanonicalClothingItem model encompasses both plain clothes and mages' robes - anything that isn't armour.

## Changes

* Migration to create the `canonical_clothing_items` table
* `CanonicalClothingItem` model
* Migration to create the `canonical_clothing_items_enchantments` join table to enable clothing to have multiple enchantments
* `CanonicalClothingItemsEnchantment` model
* Add many-to-many relationship between CanonicalClothingItems and Enchantments
* Add tests
* Update docs

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate