### PR TITLE
Add body_slot field to CanonicalClothingItems

### DIFF
--- a/app/models/canonical_clothing_item.rb
+++ b/app/models/canonical_clothing_item.rb
@@ -5,4 +5,7 @@ class CanonicalClothingItem < ApplicationRecord
 
   validates :name, presence: true, uniqueness: true
   validates :unit_weight, numericality: { greater_than_or_equal_to: 0 }
+  validates :body_slot,
+            presence:  true,
+            inclusion: { in: %w[head hands body feet shield], message: 'must be "head", "hands", "body", "feet", or "shield"' }
 end

--- a/db/migrate/20220429084831_add_body_slot_to_canonical_clothing_items.rb
+++ b/db/migrate/20220429084831_add_body_slot_to_canonical_clothing_items.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddBodySlotToCanonicalClothingItems < ActiveRecord::Migration[6.1]
+  def change
+    add_column :canonical_clothing_items, :body_slot, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_29_082157) do
+ActiveRecord::Schema.define(version: 2022_04_29_084831) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -70,6 +70,7 @@ ActiveRecord::Schema.define(version: 2022_04_29_082157) do
     t.boolean "quest_item", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "body_slot", null: false
     t.index ["name"], name: "index_canonical_clothing_items_on_name", unique: true
   end
 

--- a/spec/factories/canonical_clothing_items.rb
+++ b/spec/factories/canonical_clothing_items.rb
@@ -3,7 +3,8 @@
 FactoryBot.define do
   factory :canonical_clothing_item do
     sequence(:name) {|n| "Clothing Item #{n}" }
-    unit_weight { 9.9 }
-    quest_item { false }
+    unit_weight     { 9.9 }
+    body_slot       { 'body' }
+    quest_item      { false }
   end
 end

--- a/spec/models/canonical_clothing_item_spec.rb
+++ b/spec/models/canonical_clothing_item_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe CanonicalClothingItem, type: :model do
       end
 
       it 'is valid with a valid name' do
-        item = described_class.new(name: 'foo')
+        item = described_class.new(name: 'foo', unit_weight: 2.0, body_slot: 'feet')
 
         expect(item).to be_valid
       end
@@ -43,7 +43,29 @@ RSpec.describe CanonicalClothingItem, type: :model do
       end
 
       it 'is valid with a positive decimal unit weight value' do
-        item = described_class.new(name: 'foo', unit_weight: 7.0)
+        item = described_class.new(name: 'foo', unit_weight: 7.0, body_slot: 'hands')
+
+        expect(item).to be_valid
+      end
+    end
+
+    describe 'body_slot' do
+      it 'is invalid without a body_slot' do
+        item = described_class.new(name: 'foo', unit_weight: 2.0)
+
+        item.validate
+        expect(item.errors[:body_slot]).to eq ["can't be blank", 'must be "head", "hands", "body", "feet", or "shield"']
+      end
+
+      it 'is invalid with an invalid body_slot value' do
+        item = described_class.new(name: 'foo', unit_weight: 2.0, body_slot: 'bar')
+
+        item.validate
+        expect(item.errors[:body_slot]).to eq ['must be "head", "hands", "body", "feet", or "shield"']
+      end
+
+      it 'is valid with a valid body_slot value' do
+        item = described_class.new(name: 'foo', unit_weight: 14.2, body_slot: 'shield')
 
         expect(item).to be_valid
       end


### PR DESCRIPTION
## Context

[**Create and populate canonical apparel models**](https://trello.com/c/hD3Ff0BA/152-create-and-populate-canonical-apparel-models)

Clothing items' available enchantments depend on their "body slot" - Bethesda's term for the part of the body they cover. While a number of possible body slots exist, in Skyrim, the only relevant ones are "head", "hands", "body", "feet", and "shield". Unfortunately, in #83, I forgot to include a `body_slot` column on the `canonical_clothing_items` table.

## Changes

* Migration to add body slot column to `canonical_clothing_items` table
* Validations and tests for body slot column on the `CanonicalClothingItem` model

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate