### PR TITLE
Create CanonicalJewelryItem model

### DIFF
--- a/app/models/canonical_armor.rb
+++ b/app/models/canonical_armor.rb
@@ -18,5 +18,5 @@ class CanonicalArmor < ApplicationRecord
                          in:      %w[head body hands feet shield],
                          message: 'must be "head", "body", "hands", "feet", or "shield"',
                        }
-  validates :unit_weight, numericality: { greater_than_or_equal_to: 0 }
+  validates :unit_weight, presence: true, numericality: { greater_than_or_equal_to: 0 }
 end

--- a/app/models/canonical_jewelry_item.rb
+++ b/app/models/canonical_jewelry_item.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CanonicalJewelryItem < ApplicationRecord
+  has_many :enchantments, through: :canonical_jewelry_items_enchantments
+
   validates :name, presence: true, uniqueness: true
   validates :jewelry_type,
             presence:  true,

--- a/app/models/canonical_jewelry_item.rb
+++ b/app/models/canonical_jewelry_item.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class CanonicalJewelryItem < ApplicationRecord
+  validates :name, presence: true, uniqueness: true
+  validates :jewelry_type,
+            presence:  true,
+            inclusion: { in: %w[ring circlet amulet], message: 'must be "ring", "circlet", or "amulet"' }
+  validates :unit_weight, presence: true, numericality: { greater_than_or_equal_to: 0 }
+end

--- a/app/models/canonical_jewelry_items_enchantment.rb
+++ b/app/models/canonical_jewelry_items_enchantment.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class CanonicalJewelryItemsEnchantment < ApplicationRecord
+  belongs_to :canonical_jewelry_item
+  belongs_to :enchantment
+end

--- a/app/models/canonical_material.rb
+++ b/app/models/canonical_material.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class CanonicalMaterial < ApplicationRecord
+  has_many :smithable_armors, through: :canonical_armors_smithing_materials, source: :canonical_armor
+  has_many :temperable_armors, through: :canonical_armors_tempering_materials, source: :canonical_armor
+
   validates :name, presence: true, uniqueness: true
   validates :unit_weight, presence: true, numericality: { greater_than_or_equal_to: 0 }
 end

--- a/app/models/canonical_material.rb
+++ b/app/models/canonical_material.rb
@@ -2,5 +2,5 @@
 
 class CanonicalMaterial < ApplicationRecord
   validates :name, presence: true, uniqueness: true
-  validates :unit_weight, numericality: { greater_than_or_equal_to: 0 }
+  validates :unit_weight, presence: true, numericality: { greater_than_or_equal_to: 0 }
 end

--- a/app/models/enchantment.rb
+++ b/app/models/enchantment.rb
@@ -38,6 +38,7 @@ class Enchantment < ApplicationRecord
 
   has_many :canonical_armors, through: :canonical_armors_enchantments
   has_many :canonical_clothing_items, through: :canonical_clothing_items_enchantments
+  has_many :canonical_jewelry_items, through: :canonical_jewelry_items_enchantments
 
   validates :name, presence: true, uniqueness: { message: 'must be unique' }
   validates :strength_unit, inclusion: { in: %w[point percentage], message: 'must be "point" or "percentage"', allow_blank: true }

--- a/db/migrate/20220429080952_create_canonical_clothing_items.rb
+++ b/db/migrate/20220429080952_create_canonical_clothing_items.rb
@@ -4,7 +4,7 @@ class CreateCanonicalClothingItems < ActiveRecord::Migration[6.1]
   def change
     create_table :canonical_clothing_items do |t|
       t.string :name, null: false, unique: true
-      t.decimal :unit_weight, precision: 5, scale: 1, default: 1.0
+      t.decimal :unit_weight, precision: 5, scale: 1
       t.boolean :quest_item, default: false
 
       t.index :name, unique: true

--- a/db/migrate/20220429091909_create_canonical_jewelry_items.rb
+++ b/db/migrate/20220429091909_create_canonical_jewelry_items.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateCanonicalJewelryItems < ActiveRecord::Migration[6.1]
+  def change
+    create_table :canonical_jewelry_items do |t|
+      t.string :name, null: false, unique: true
+      t.string :jewelry_type, null: false
+      t.decimal :unit_weight, scale: 1, precision: 5
+      t.boolean :quest_item
+
+      t.index :name, unique: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220429094922_create_canonical_jewelry_items_enchantments.rb
+++ b/db/migrate/20220429094922_create_canonical_jewelry_items_enchantments.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateCanonicalJewelryItemsEnchantments < ActiveRecord::Migration[6.1]
+  def change
+    create_table :canonical_jewelry_items_enchantments do |t|
+      t.references :canonical_jewelry_item,
+                   null:        false,
+                   foreign_key: true,
+                   index:       { name: :index_canonical_jewelry_items_enchantments_on_jewelry_item_id }
+      t.references :enchantment, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_29_091909) do
+ActiveRecord::Schema.define(version: 2022_04_29_094922) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -91,6 +91,15 @@ ActiveRecord::Schema.define(version: 2022_04_29_091909) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["name"], name: "index_canonical_jewelry_items_on_name", unique: true
+  end
+
+  create_table "canonical_jewelry_items_enchantments", force: :cascade do |t|
+    t.bigint "canonical_jewelry_item_id", null: false
+    t.bigint "enchantment_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["canonical_jewelry_item_id"], name: "index_canonical_jewelry_items_enchantments_on_jewelry_item_id"
+    t.index ["enchantment_id"], name: "index_canonical_jewelry_items_enchantments_on_enchantment_id"
   end
 
   create_table "canonical_materials", force: :cascade do |t|
@@ -241,6 +250,8 @@ ActiveRecord::Schema.define(version: 2022_04_29_091909) do
   add_foreign_key "canonical_armors_tempering_materials", "canonical_materials"
   add_foreign_key "canonical_clothing_items_enchantments", "canonical_clothing_items"
   add_foreign_key "canonical_clothing_items_enchantments", "enchantments"
+  add_foreign_key "canonical_jewelry_items_enchantments", "canonical_jewelry_items"
+  add_foreign_key "canonical_jewelry_items_enchantments", "enchantments"
   add_foreign_key "games", "users"
   add_foreign_key "inventory_items", "inventory_lists", column: "list_id"
   add_foreign_key "inventory_lists", "games"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_29_084831) do
+ActiveRecord::Schema.define(version: 2022_04_29_091909) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -66,7 +66,7 @@ ActiveRecord::Schema.define(version: 2022_04_29_084831) do
 
   create_table "canonical_clothing_items", force: :cascade do |t|
     t.string "name", null: false
-    t.decimal "unit_weight", precision: 5, scale: 1, default: "1.0"
+    t.decimal "unit_weight", precision: 5, scale: 1
     t.boolean "quest_item", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -81,6 +81,16 @@ ActiveRecord::Schema.define(version: 2022_04_29_084831) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["canonical_clothing_item_id"], name: "index_canonical_clothing_enchantments_on_canonical_clothing_id"
     t.index ["enchantment_id"], name: "index_canonical_clothing_items_enchantments_on_enchantment_id"
+  end
+
+  create_table "canonical_jewelry_items", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "jewelry_type", null: false
+    t.decimal "unit_weight", precision: 5, scale: 1
+    t.boolean "quest_item"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["name"], name: "index_canonical_jewelry_items_on_name", unique: true
   end
 
   create_table "canonical_materials", force: :cascade do |t|

--- a/docs/canonical-models.md
+++ b/docs/canonical-models.md
@@ -5,6 +5,7 @@ SIM knows certain things about Skyrim that it may or may not immediately reveal 
 * [`AlchemicalProperty`](/app/models/alchemical_property.rb): actual properties of ingredients or potions that exist in the game
 * [`CanonicalArmor`](/app/models/canonical_armor.rb): actual armor pieces available in the game
 * [`CanonicalClothingItem`](/app/models/canonical_clothing_item.rb): actual clothing items available in the game; includes mages' robes as well as plain clothes
+* [`CanonicalJewelryItem`](/app/models/canonical_jewelry_item.rb): actual jewelry items available in-game, including both generic and unique pieces
 * [`CanonicalMaterial`](/app/models/canonical_material.rb): actual building and smithing materials present in the game
 * [`CanonicalProperty`](/app/models/canonical_property.rb): actual properties (homes) the player character can own in the game
 * [`Enchantment`](/app/models/enchantment.rb): actual enchantments that exist in the game

--- a/spec/factories/canonical_jewelry_items.rb
+++ b/spec/factories/canonical_jewelry_items.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :canonical_jewelry_item do
+    sequence(:name) {|n| "Jewelry Item #{n}" }
+    jewelry_type    { 'ring' }
+    unit_weight     { 37.0 }
+    quest_item      { false }
+  end
+end

--- a/spec/models/alchemical_property_spec.rb
+++ b/spec/models/alchemical_property_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe AlchemicalProperty, type: :model do
         property = described_class.new
 
         property.validate
-        expect(property.errors[:name]).to eq ["can't be blank"]
+        expect(property.errors[:name]).to include "can't be blank"
       end
 
       it 'must be unique' do
@@ -17,7 +17,7 @@ RSpec.describe AlchemicalProperty, type: :model do
 
         property = described_class.new(name: 'Restore Health')
         property.validate
-        expect(property.errors[:name]).to eq ['must be unique']
+        expect(property.errors[:name]).to include 'must be unique'
       end
     end
 
@@ -31,7 +31,7 @@ RSpec.describe AlchemicalProperty, type: :model do
       it 'must be one of "point" or "percentage"' do
         property = described_class.new(strength_unit: 'Foobar')
         property.validate
-        expect(property.errors[:strength_unit]).to eq ['must be "point" or "percentage"']
+        expect(property.errors[:strength_unit]).to include 'must be "point" or "percentage"'
       end
     end
   end

--- a/spec/models/canonical_armor_spec.rb
+++ b/spec/models/canonical_armor_spec.rb
@@ -9,25 +9,45 @@ RSpec.describe CanonicalArmor, type: :model do
         armor = described_class.new(weight: 'heavy armor', unit_weight: 1.0, body_slot: 'body')
 
         armor.validate
-        expect(armor.errors[:name]).to eq ["can't be blank"]
+        expect(armor.errors[:name]).to include "can't be blank"
       end
     end
 
     describe 'weight' do
-      it 'is invalid without a valid weight' do
+      it 'is invalid without a weight' do
         armor = described_class.new(name: 'fur armor', unit_weight: 2.5, body_slot: 'head')
 
         armor.validate
-        expect(armor.errors[:weight]).to eq ["can't be blank", 'must be "light armor" or "heavy armor"']
+        expect(armor.errors[:weight]).to include "can't be blank"
+      end
+
+      it 'is invalid with an invalid weight value' do
+        armor = described_class.new(name: 'fur armor', unit_weight: 2.5, body_slot: 'head', weight: 'medium armor')
+
+        armor.validate
+        expect(armor.errors[:weight]).to include 'must be "light armor" or "heavy armor"'
       end
     end
 
     describe 'body_slot' do
-      it 'is invalid without a valid body slot' do
+      it 'is invalid without a body slot' do
         armor = described_class.new(name: 'fur armor', weight: 'light armor', unit_weight: 47.0)
 
         armor.validate
-        expect(armor.errors[:body_slot]).to eq ["can't be blank", 'must be "head", "body", "hands", "feet", or "shield"']
+        expect(armor.errors[:body_slot]).to include "can't be blank"
+      end
+
+      it 'is invalid without a valid body slot value' do
+        armor = described_class.new(name: 'fur armor', weight: 'light armor', unit_weight: 47.0, body_slot: 'foo')
+
+        armor.validate
+        expect(armor.errors[:body_slot]).to include 'must be "head", "body", "hands", "feet", or "shield"'
+      end
+
+      it 'is valid with a valid body slot' do
+        armor = described_class.new(name: 'fur armor', weight: 'light armor', unit_weight: 47.0, body_slot: 'feet')
+
+        expect(armor).to be_valid
       end
     end
 
@@ -36,21 +56,21 @@ RSpec.describe CanonicalArmor, type: :model do
         armor = described_class.new(name: 'steel helmet', weight: 'heavy armor', body_slot: 'head')
 
         armor.validate
-        expect(armor.errors[:unit_weight]).to eq ['is not a number']
+        expect(armor.errors[:unit_weight]).to include "can't be blank"
       end
 
       it 'is invalid with a non-numeric unit weight' do
         armor = described_class.new(name: 'steel helmet', weight: 'heavy armor', body_slot: 'head', unit_weight: 'foo')
 
         armor.validate
-        expect(armor.errors[:unit_weight]).to eq ['is not a number']
+        expect(armor.errors[:unit_weight]).to include 'is not a number'
       end
 
       it 'is invalid with a negative unit weight' do
         armor = described_class.new(name: 'steel helmet', weight: 'heavy armor', body_slot: 'head', unit_weight: -2.4)
 
         armor.validate
-        expect(armor.errors[:unit_weight]).to eq ['must be greater than or equal to 0']
+        expect(armor.errors[:unit_weight]).to include 'must be greater than or equal to 0'
       end
 
       it 'is valid with a valid unit weight' do

--- a/spec/models/canonical_armors_smithing_material_spec.rb
+++ b/spec/models/canonical_armors_smithing_material_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CanonicalArmorsSmithingMaterial, type: :model do
         model    = described_class.new(count: 0, canonical_armor: armor, canonical_material: material)
 
         model.validate
-        expect(model.errors[:count]).to eq ['must be greater than 0']
+        expect(model.errors[:count]).to include 'must be greater than 0'
       end
 
       it 'is invalid if count is not an integer' do
@@ -20,7 +20,7 @@ RSpec.describe CanonicalArmorsSmithingMaterial, type: :model do
         model    = described_class.new(count: 1.3, canonical_armor: armor, canonical_material: material)
 
         model.validate
-        expect(model.errors[:count]).to eq ['must be an integer']
+        expect(model.errors[:count]).to include 'must be an integer'
       end
 
       it 'is valid with a valid count' do

--- a/spec/models/canonical_armors_tempering_materials_spec.rb
+++ b/spec/models/canonical_armors_tempering_materials_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CanonicalArmorsTemperingMaterial, type: :model do
         model    = described_class.new(count: 0, canonical_material: material, canonical_armor: armor)
 
         model.validate
-        expect(model.errors[:count]).to eq ['must be greater than 0']
+        expect(model.errors[:count]).to include 'must be greater than 0'
       end
 
       it 'is invalid if count is not an integer' do
@@ -20,7 +20,7 @@ RSpec.describe CanonicalArmorsTemperingMaterial, type: :model do
         model    = described_class.new(count: 7.6, canonical_material: material, canonical_armor: armor)
 
         model.validate
-        expect(model.errors[:count]).to eq ['must be an integer']
+        expect(model.errors[:count]).to include 'must be an integer'
       end
 
       it 'is valid with a valid count' do

--- a/spec/models/canonical_clothing_item_spec.rb
+++ b/spec/models/canonical_clothing_item_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CanonicalClothingItem, type: :model do
         item = described_class.new
 
         item.validate
-        expect(item.errors[:name]).to eq ["can't be blank"]
+        expect(item.errors[:name]).to include "can't be blank"
       end
 
       it 'is invalid with a non-unique name' do
@@ -17,7 +17,7 @@ RSpec.describe CanonicalClothingItem, type: :model do
         item = described_class.new(name: 'foo')
 
         item.validate
-        expect(item.errors[:name]).to eq ['has already been taken']
+        expect(item.errors[:name]).to include 'has already been taken'
       end
 
       it 'is valid with a valid name' do
@@ -32,14 +32,14 @@ RSpec.describe CanonicalClothingItem, type: :model do
         item = described_class.new(name: 'foo', unit_weight: 'bar')
 
         item.validate
-        expect(item.errors[:unit_weight]).to eq ['is not a number']
+        expect(item.errors[:unit_weight]).to include 'is not a number'
       end
 
       it 'is invalid with a negative unit weight' do
         item = described_class.new(name: 'foo', unit_weight: -34)
 
         item.validate
-        expect(item.errors[:unit_weight]).to eq ['must be greater than or equal to 0']
+        expect(item.errors[:unit_weight]).to include 'must be greater than or equal to 0'
       end
 
       it 'is valid with a positive decimal unit weight value' do
@@ -54,14 +54,14 @@ RSpec.describe CanonicalClothingItem, type: :model do
         item = described_class.new(name: 'foo', unit_weight: 2.0)
 
         item.validate
-        expect(item.errors[:body_slot]).to eq ["can't be blank", 'must be "head", "hands", "body", "feet", or "shield"']
+        expect(item.errors[:body_slot]).to include "can't be blank"
       end
 
       it 'is invalid with an invalid body_slot value' do
         item = described_class.new(name: 'foo', unit_weight: 2.0, body_slot: 'bar')
 
         item.validate
-        expect(item.errors[:body_slot]).to eq ['must be "head", "hands", "body", "feet", or "shield"']
+        expect(item.errors[:body_slot]).to include 'must be "head", "hands", "body", "feet", or "shield"'
       end
 
       it 'is valid with a valid body_slot value' do

--- a/spec/models/canonical_jewelry_item_spec.rb
+++ b/spec/models/canonical_jewelry_item_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CanonicalJewelryItem, type: :model do
+  describe 'validations' do
+    describe 'name' do
+      it 'is invalid with no name' do
+        item = described_class.new(jewelry_type: 'amulet', unit_weight: 1.0)
+
+        item.validate
+        expect(item.errors[:name]).to include "can't be blank"
+      end
+
+      it 'is invalid with a non-unique name' do
+        create(:canonical_jewelry_item, name: 'foo')
+        item = described_class.new(name: 'foo', jewelry_type: 'amulet', unit_weight: 1.0)
+
+        item.validate
+        expect(item.errors[:name]).to include 'has already been taken'
+      end
+
+      it 'is valid with a unique name' do
+        item = described_class.new(name: 'foo', jewelry_type: 'amulet', unit_weight: 1.0)
+
+        expect(item).to be_valid
+      end
+    end
+
+    describe 'jewelry_type' do
+      it 'is invalid without a jewelry_type' do
+        item = described_class.new(name: 'foo', unit_weight: 1.0)
+
+        item.validate
+        expect(item.errors[:jewelry_type]).to include "can't be blank"
+      end
+
+      it 'is invalid with an invalid jewelry_type' do
+        item = described_class.new(name: 'foo', unit_weight: 1.0, jewelry_type: 'bar')
+
+        item.validate
+        expect(item.errors[:jewelry_type]).to include 'must be "ring", "circlet", or "amulet"'
+      end
+
+      it 'is valid with a valid jewelry_type' do
+        item = described_class.new(name: 'foo', unit_weight: 1.0, jewelry_type: 'circlet')
+
+        expect(item).to be_valid
+      end
+    end
+
+    describe 'unit_weight' do
+      it 'is invalid without a unit weight' do
+        item = described_class.new(name: 'foo', jewelry_type: 'ring')
+
+        item.validate
+        expect(item.errors[:unit_weight]).to include "can't be blank"
+      end
+
+      it 'is invalid with a non-numeric unit weight' do
+        item = described_class.new(name: 'foo', unit_weight: 'bar', jewelry_type: 'circlet')
+
+        item.validate
+        expect(item.errors[:unit_weight]).to include 'is not a number'
+      end
+
+      it 'is invalid with a negative unit weight' do
+        item = described_class.new(name: 'foo', unit_weight: -4.3, jewelry_type: 'amulet')
+
+        item.validate
+        expect(item.errors[:unit_weight]).to include 'must be greater than or equal to 0'
+      end
+    end
+  end
+end

--- a/spec/models/canonical_material_spec.rb
+++ b/spec/models/canonical_material_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe CanonicalMaterial, type: :model do
         material = described_class.new(unit_weight: 4.2)
 
         material.validate
-        expect(material.errors[:name]).to eq ["can't be blank"]
+        expect(material.errors[:name]).to include "can't be blank"
       end
 
       it 'is invalid with a duplicate name' do
@@ -23,7 +23,7 @@ RSpec.describe CanonicalMaterial, type: :model do
         material = described_class.new(name: 'foo', unit_weight: 34.0)
 
         material.validate
-        expect(material.errors[:name]).to eq ['has already been taken']
+        expect(material.errors[:name]).to include 'has already been taken'
       end
     end
 
@@ -32,21 +32,21 @@ RSpec.describe CanonicalMaterial, type: :model do
         material = described_class.new(name: 'foo')
 
         material.validate
-        expect(material.errors[:unit_weight]).to eq ['is not a number']
+        expect(material.errors[:unit_weight]).to include "can't be blank"
       end
 
       it 'is invalid with a non-numeric unit weight' do
         material = described_class.new(name: 'foo', unit_weight: 'bar')
 
         material.validate
-        expect(material.errors[:unit_weight]).to eq ['is not a number']
+        expect(material.errors[:unit_weight]).to include 'is not a number'
       end
 
       it 'is invalid without a negative unit weight' do
         material = described_class.new(name: 'foo', unit_weight: -4.0)
 
         material.validate
-        expect(material.errors[:unit_weight]).to eq ['must be greater than or equal to 0']
+        expect(material.errors[:unit_weight]).to include 'must be greater than or equal to 0'
       end
     end
   end

--- a/spec/models/canonical_property_spec.rb
+++ b/spec/models/canonical_property_spec.rb
@@ -6,46 +6,57 @@ RSpec.describe CanonicalProperty, type: :model do
   subject(:property) { described_class.new }
 
   describe 'validations' do
-    it 'must have a valid name' do
-      property.validate
-      expect(property.errors[:name]).to eq ["can't be blank", "must be an ownable property in Skyrim, or the Arch-Mage's Quarters"]
+    describe 'name' do
+      it 'must have a name' do
+        property.validate
+        expect(property.errors[:name]).to include "can't be blank"
+      end
+
+      it 'must have a valid name' do
+        property.validate
+        expect(property.errors[:name]).to include "must be an ownable property in Skyrim, or the Arch-Mage's Quarters"
+      end
+
+      it 'must have a unique name' do
+        described_class.create!(name: 'Breezehome', hold: 'Whiterun')
+        property.name = 'Breezehome'
+        property.validate
+        expect(property.errors[:name]).to include 'must be unique'
+      end
     end
 
-    it 'must have a unique name' do
-      described_class.create!(name: 'Breezehome', hold: 'Whiterun')
-      property.name = 'Breezehome'
-      property.validate
-      expect(property.errors[:name]).to eq ['must be unique']
+    describe 'hold' do
+      it 'must have a valid hold' do
+        property.validate
+        expect(property.errors[:hold]).to eq ["can't be blank", 'must be one of the nine Skyrim holds, or Solstheim']
+      end
+
+      it 'must have a unique hold' do
+        described_class.create!(name: 'Heljarchen Hall', hold: 'The Pale')
+        property.hold = 'The Pale'
+        property.validate
+        expect(property.errors[:hold]).to eq ['must be unique']
+      end
     end
 
-    it 'must have a valid hold' do
-      property.validate
-      expect(property.errors[:hold]).to eq ["can't be blank", 'must be one of the nine Skyrim holds, or Solstheim']
-    end
+    describe 'city' do
+      it 'must have a valid city' do
+        property.city = 'Tampa'
+        property.validate
+        expect(property.errors[:city]).to eq ['must be a Skyrim city in which an ownable property is located']
+      end
 
-    it 'must have a unique hold' do
-      described_class.create!(name: 'Heljarchen Hall', hold: 'The Pale')
-      property.hold = 'The Pale'
-      property.validate
-      expect(property.errors[:hold]).to eq ['must be unique']
-    end
+      it 'must have a unique city (if not null)' do
+        described_class.create!(name: 'Proudspire Manor', hold: 'Haafingar', city: 'Solitude')
+        property.city = 'Solitude'
+        property.validate
+        expect(property.errors[:city]).to eq ['must be unique if present']
+      end
 
-    it 'must have a valid city' do
-      property.city = 'Tampa'
-      property.validate
-      expect(property.errors[:city]).to eq ['must be a Skyrim city in which an ownable property is located']
-    end
-
-    it 'must have a unique city (if not null)' do
-      described_class.create!(name: 'Proudspire Manor', hold: 'Haafingar', city: 'Solitude')
-      property.city = 'Solitude'
-      property.validate
-      expect(property.errors[:city]).to eq ['must be unique if present']
-    end
-
-    it 'can have a blank city' do
-      property.validate
-      expect(property.errors[:city]).to be_blank
+      it 'can have a blank city' do
+        property.validate
+        expect(property.errors[:city]).to be_blank
+      end
     end
   end
 

--- a/spec/models/enchantment_spec.rb
+++ b/spec/models/enchantment_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Enchantment, type: :model do
         enchantment = described_class.new(strength_unit: 'percentage', enchantable_items: %w[sword mace])
 
         enchantment.validate
-        expect(enchantment.errors[:name]).to eq ["can't be blank"]
+        expect(enchantment.errors[:name]).to include "can't be blank"
       end
 
       it 'requires a unique name' do
@@ -18,7 +18,7 @@ RSpec.describe Enchantment, type: :model do
         enchantment = described_class.new(name: 'Absorb Health', strength_unit: 'percentage', enchantable_items: %w[sword mace greatsword])
 
         enchantment.validate
-        expect(enchantment.errors[:name]).to eq ['must be unique']
+        expect(enchantment.errors[:name]).to include 'must be unique'
       end
     end
 
@@ -27,7 +27,7 @@ RSpec.describe Enchantment, type: :model do
         enchantment = described_class.new(school: 'Foo')
 
         enchantment.validate
-        expect(enchantment.errors[:school]).to eq ['must be a valid school of magic']
+        expect(enchantment.errors[:school]).to include 'must be a valid school of magic'
       end
     end
 
@@ -36,7 +36,7 @@ RSpec.describe Enchantment, type: :model do
         enchantment = described_class.new(strength_unit: 'foobar')
 
         enchantment.validate
-        expect(enchantment.errors[:strength_unit]).to eq ['must be "point" or "percentage"']
+        expect(enchantment.errors[:strength_unit]).to include 'must be "point" or "percentage"'
       end
 
       it 'can be blank' do
@@ -53,7 +53,7 @@ RSpec.describe Enchantment, type: :model do
 
         enchantment.validate
 
-        expect(enchantment.errors[:enchantable_items]).to eq ['must consist of valid enchantable item types']
+        expect(enchantment.errors[:enchantable_items]).to include 'must consist of valid enchantable item types'
       end
     end
   end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Game, type: :model do
           create(:game, name: 'My Game', user: user)
 
           game.validate
-          expect(game.errors[:user]).to include 'must be unique'
+          expect(game.errors[:name]).to include 'must be unique'
         end
 
         it "doesn't have to be unique across all users" do
@@ -26,8 +26,9 @@ RSpec.describe Game, type: :model do
       describe 'format' do
         it 'only contains alphanumeric characters, spaces, commas, hyphens, and apostrophes', :aggregate_failures do
           invalid_game = build(:game, name: "#\t&\n^")
+
           invalid_game.validate
-          expect(invalid_game.errors[:format]).to eq 'foobar'
+          expect(invalid_game.errors[:name]).to include "can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')"
 
           valid_game = build(:game, name: "bA1 ,-'")
           expect(valid_game).to be_valid

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -12,7 +12,9 @@ RSpec.describe Game, type: :model do
 
         it 'is unique per user' do
           create(:game, name: 'My Game', user: user)
-          expect(game).not_to be_valid
+
+          game.validate
+          expect(game.errors[:user]).to include 'must be unique'
         end
 
         it "doesn't have to be unique across all users" do
@@ -24,7 +26,8 @@ RSpec.describe Game, type: :model do
       describe 'format' do
         it 'only contains alphanumeric characters, spaces, commas, hyphens, and apostrophes', :aggregate_failures do
           invalid_game = build(:game, name: "#\t&\n^")
-          expect(invalid_game).not_to be_valid
+          invalid_game.validate
+          expect(invalid_game.errors[:format]).to eq 'foobar'
 
           valid_game = build(:game, name: "bA1 ,-'")
           expect(valid_game).to be_valid

--- a/spec/models/inventory_list_spec.rb
+++ b/spec/models/inventory_list_spec.rb
@@ -129,13 +129,14 @@ RSpec.describe InventoryList, type: :model do
         it 'is not allowed for a regular list', :aggregate_failures do
           list = build(:inventory_list, title: 'all items')
           expect(list).not_to be_valid
-          expect(list.errors[:title]).to eq(['cannot be "All Items"'])
+          expect(list.errors[:title]).to include 'cannot be "All Items"'
         end
       end
 
       context 'when the title contains "all items" as well as other characters' do
         it 'is valid' do
           list = build(:inventory_list, title: 'aLL iTems the seQUel')
+
           expect(list).to be_valid
         end
       end
@@ -143,30 +144,35 @@ RSpec.describe InventoryList, type: :model do
       describe 'allowed characters' do
         it 'allows alphanumeric characters, spaces, commas, apostrophes, and hyphens' do
           list = build(:inventory_list, title: "aB 61 ,'-")
+
           expect(list).to be_valid
         end
 
         it "doesn't allow newlines", :aggregate_failures do
           list = build(:inventory_list, title: "My\nList 1  ")
-          expect(list).not_to be_valid
-          expect(list.errors[:title]).to eq(["can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')"])
+
+          list.validate
+          expect(list.errors[:title]).to include "can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')"
         end
 
         it "doesn't allow other non-space whitespace", :aggregate_failures do
           list = build(:inventory_list, title: "My\tList 1")
-          expect(list).not_to be_valid
-          expect(list.errors[:title]).to eq(["can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')"])
+
+          list.validate
+          expect(list.errors[:title]).to include "can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')"
         end
 
         it "doesn't allow special characters", :aggregate_failures do
           list = build(:inventory_list, title: 'My^List&1')
-          expect(list).not_to be_valid
-          expect(list.errors[:title]).to eq(["can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')"])
+
+          list.validate
+          expect(list.errors[:title]).to include "can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')"
         end
 
         # Leading and trailing whitespace characters will be stripped anyway so no need to validate
         it 'ignores leading or trailing whitespace characters' do
           list = build(:inventory_list, title: "My List 1\n\t")
+
           expect(list).to be_valid
         end
       end
@@ -873,18 +879,21 @@ RSpec.describe InventoryList, type: :model do
 
     it 'is invalid without a game' do
       list = described_class.new(aggregate_list: aggregate_list)
+
       list.validate
-      expect(list.errors[:game]).to eq ['must exist']
+      expect(list.errors[:game]).to include 'must exist'
     end
 
     it "doesn't have to have a property" do
       list = described_class.new(aggregate_list: aggregate_list)
+
       list.validate
       expect(list.errors[:property]).to be_blank
     end
 
     it 'can have a property' do
       list = described_class.new(aggregate_list: aggregate_list, property: property)
+
       expect(list.property).to eq property
     end
   end

--- a/spec/models/property_spec.rb
+++ b/spec/models/property_spec.rb
@@ -29,22 +29,32 @@ RSpec.describe Property, type: :model do
 
     it 'is invalid without a game' do
       property.validate
-      expect(property.errors[:game]).to eq ['must exist']
+      expect(property.errors[:game]).to include 'must exist'
     end
 
     it 'is invalid without a canonical property' do
       property.validate
-      expect(property.errors[:canonical_property]).to eq ['must exist']
+      expect(property.errors[:canonical_property]).to include 'must exist'
+    end
+
+    it 'must have a name' do
+      property.validate
+      expect(property.errors[:name]).to include "can't be blank"
     end
 
     it 'must have a valid name' do
       property.validate
-      expect(property.errors[:name]).to eq ["can't be blank", "must be an ownable property in Skyrim, or the Arch-Mage's Quarters"]
+      expect(property.errors[:name]).to include "must be an ownable property in Skyrim, or the Arch-Mage's Quarters"
+    end
+
+    it 'must have a hold' do
+      property.validate
+      expect(property.errors[:hold]).to include "can't be blank"
     end
 
     it 'must have a valid hold' do
       property.validate
-      expect(property.errors[:hold]).to eq ["can't be blank", 'must be one of the nine Skyrim holds, or Solstheim']
+      expect(property.errors[:hold]).to include 'must be one of the nine Skyrim holds, or Solstheim'
     end
 
     it 'only allows up to 10 per game', :aggregate_failures do
@@ -61,7 +71,7 @@ RSpec.describe Property, type: :model do
       property.name = 'Vlindrel Hall'
       property.hold = 'The Reach'
       property.validate
-      expect(property.errors[:game]).to eq ['already has max number of ownable properties']
+      expect(property.errors[:game]).to include 'already has max number of ownable properties'
       expect(Rails.logger).to have_received(:error).with('Cannot create property "Vlindrel Hall" in hold "The Reach": this game already has 10 properties')
     end
 
@@ -81,21 +91,21 @@ RSpec.describe Property, type: :model do
         property.game               = game
         property.canonical_property = canonical_property
         property.validate
-        expect(property.errors[:canonical_property]).to eq ['must be unique per game']
+        expect(property.errors[:canonical_property]).to include 'must be unique per game'
       end
 
       it 'has a unique name per game' do
         property.game = game
         property.name = canonical_property.name
         property.validate
-        expect(property.errors[:name]).to eq ['must be unique per game']
+        expect(property.errors[:name]).to include 'must be unique per game'
       end
 
       it 'has a unique hold per game' do
         property.game = game
         property.hold = canonical_property.hold
         property.validate
-        expect(property.errors[:hold]).to eq ['must be unique per game']
+        expect(property.errors[:hold]).to include 'must be unique per game'
       end
     end
 
@@ -108,7 +118,7 @@ RSpec.describe Property, type: :model do
         property.hold                  = canonical_property.hold
         property.city                  = nil
         property.validate
-        expect(property.errors[:base]).to eq ['property attributes must match attributes of a property that exists in Skyrim']
+        expect(property.errors[:base]).to include 'property attributes must match attributes of a property that exists in Skyrim'
       end
     end
 
@@ -120,7 +130,7 @@ RSpec.describe Property, type: :model do
           property.canonical_property_id = canonical_property.id
           property.has_arcane_enchanter  = true
           property.validate
-          expect(property.errors[:has_arcane_enchanter]).to eq ['cannot be true because this property cannot have an arcane enchanter in Skyrim']
+          expect(property.errors[:has_arcane_enchanter]).to include 'cannot be true because this property cannot have an arcane enchanter in Skyrim'
         end
       end
 
@@ -151,7 +161,7 @@ RSpec.describe Property, type: :model do
           property.canonical_property_id = canonical_property.id
           property.has_forge             = true
           property.validate
-          expect(property.errors[:has_forge]).to eq ['cannot be true because this property cannot have a forge in Skyrim']
+          expect(property.errors[:has_forge]).to include 'cannot be true because this property cannot have a forge in Skyrim'
         end
       end
 

--- a/spec/models/shopping_list_spec.rb
+++ b/spec/models/shopping_list_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe ShoppingList, type: :model do
 
         it 'is invalid', :aggregate_failures do
           expect(aggregate_list).not_to be_valid
-          expect(aggregate_list.errors[:aggregate]).to eq ['can only be one list per game']
+          expect(aggregate_list.errors[:aggregate]).to include 'can only be one list per game'
         end
       end
     end
@@ -129,7 +129,7 @@ RSpec.describe ShoppingList, type: :model do
         it 'is not allowed for a regular list', :aggregate_failures do
           list = build(:shopping_list, title: 'all items')
           expect(list).not_to be_valid
-          expect(list.errors[:title]).to eq(['cannot be "All Items"'])
+          expect(list.errors[:title]).to include 'cannot be "All Items"'
         end
       end
 
@@ -149,19 +149,19 @@ RSpec.describe ShoppingList, type: :model do
         it "doesn't allow newlines", :aggregate_failures do
           list = build(:shopping_list, title: "My\nList 1  ")
           expect(list).not_to be_valid
-          expect(list.errors[:title]).to eq(["can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')"])
+          expect(list.errors[:title]).to include "can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')"
         end
 
         it "doesn't allow other non-space whitespace", :aggregate_failures do
           list = build(:shopping_list, title: "My\tList 1")
           expect(list).not_to be_valid
-          expect(list.errors[:title]).to eq(["can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')"])
+          expect(list.errors[:title]).to include "can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')"
         end
 
         it "doesn't allow special characters", :aggregate_failures do
           list = build(:shopping_list, title: 'My^List&1')
           expect(list).not_to be_valid
-          expect(list.errors[:title]).to eq(["can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')"])
+          expect(list.errors[:title]).to include "can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')"
         end
 
         # Leading and trailing whitespace characters will be stripped anyway so no need to validate
@@ -871,7 +871,7 @@ RSpec.describe ShoppingList, type: :model do
 
       it 'is invalid without a game' do
         list.validate
-        expect(list.errors[:game]).to eq ['must exist']
+        expect(list.errors[:game]).to include 'must exist'
       end
 
       it "doesn't have to have a property" do

--- a/spec/models/spell_spec.rb
+++ b/spec/models/spell_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Spell, type: :model do
       end
 
       it 'must be a valid school of magic' do
-        spell = described_class.new 'Alternation'
+        spell = described_class.new(name: 'Alternation')
 
         spell.validate
         expect(spell.errors[:school]).to include 'must be a valid school of magic'

--- a/spec/models/spell_spec.rb
+++ b/spec/models/spell_spec.rb
@@ -7,70 +7,97 @@ RSpec.describe Spell, type: :model do
     describe 'name' do
       it 'must be present' do
         spell = described_class.new
+
         spell.validate
-        expect(spell.errors[:name]).to eq ["can't be blank"]
+        expect(spell.errors[:name]).to include "can't be blank"
       end
 
       it 'must be unique' do
         described_class.create!(name: 'Clairvoyance', school: 'Illusion', level: 'Novice', description: 'Something')
-
         spell = described_class.new(name: 'Clairvoyance')
+
         spell.validate
-        expect(spell.errors[:name]).to eq ['must be unique']
+        expect(spell.errors[:name]).to include 'must be unique'
       end
     end
 
     describe 'school' do
-      it 'must be a valid school of magic' do
+      it 'must be present' do
         spell = described_class.new
+
         spell.validate
-        expect(spell.errors[:school]).to eq ["can't be blank", 'must be a valid school of magic']
+        expect(spell.errors[:school]).to include "can't be blank"
+      end
+
+      it 'must be a valid school of magic' do
+        spell = described_class.new 'Alternation'
+
+        spell.validate
+        expect(spell.errors[:school]).to include 'must be a valid school of magic'
       end
     end
 
     describe 'level' do
+      it 'must be present' do
+        spell = described_class.new
+
+        spell.validate
+        expect(spell.errors[:level]).to include "can't be blank"
+      end
+
       it 'must be a valid level' do
         spell = described_class.new
+
         spell.validate
-        expect(spell.errors[:level]).to eq ["can't be blank", 'must be "Novice", "Apprentice", "Adept", "Expert", or "Master"']
+        expect(spell.errors[:level]).to include 'must be "Novice", "Apprentice", "Adept", "Expert", or "Master"'
       end
     end
 
     describe 'description' do
       it 'must be present' do
         spell = described_class.new
+
         spell.validate
-        expect(spell.errors[:description]).to eq ["can't be blank"]
+        expect(spell.errors[:description]).to include "can't be blank"
       end
     end
 
     describe 'strength and strength_unit' do
       it 'is valid with both a strength and a strength_unit' do
-        spell = described_class.new(strength: 50, strength_unit: 'point', name: 'Fire Rune', level: 'Adept', school: 'Destruction', description: 'Hello world')
+        spell = described_class.new(
+                  strength:      50,
+                  strength_unit: 'point',
+                  name:          'Fire Rune',
+                  level:         'Adept',
+                  school:        'Destruction',
+                  description:   'Hello world',
+                )
+
         expect(spell).to be_valid
       end
 
       it 'is valid with neither a strength nor a strength_unit' do
         spell = described_class.new(name: 'Clairvoyance', level: 'Novice', school: 'Illusion', description: 'Hello world')
+
         expect(spell).to be_valid
       end
 
       it 'is invalid with a strength but no strength_unit' do
         spell = described_class.new(strength: 50)
         spell.validate
-        expect(spell.errors[:strength_unit]).to eq ['must be present if strength is given']
+        expect(spell.errors[:strength_unit]).to include 'must be present if strength is given'
       end
 
       it 'is invalid with a strength_unit but no strength' do
         spell = described_class.new(strength_unit: 'percentage')
         spell.validate
-        expect(spell.errors[:strength]).to eq ['must be present if strength unit is given']
+        expect(spell.errors[:strength]).to include 'must be present if strength unit is given'
       end
 
       it 'requires a valid strength_unit value' do
         spell = described_class.new(strength: 50, strength_unit: 'foo')
         spell.validate
-        expect(spell.errors[:strength_unit]).to eq ['must be "point" or "percentage"']
+        expect(spell.errors[:strength_unit]).to include 'must be "point" or "percentage"'
       end
     end
   end


### PR DESCRIPTION
## Context

[**Create and populate canonical apparel models**](https://trello.com/c/hD3Ff0BA/152-create-and-populate-canonical-apparel-models)

The last of the canonical apparel item models we'll be creating is the CanonicalJewelryItem; the accompanying CanonicalJewelryItemsEnchantment model is a join table enabling multiple enchantments on a single piece of jewelry. (This join table is intended to add actual enchantments to special pieces of jewellery that have them - it isn't intended to associate _potential_ enchantments.

## Changes

* Migration to create the `canonical_jewelry_items` table
* `CanonicalJewelryItem` model class
* Migration to create `canonical_jewelry_items_enchantments` join table, enabling multiple enchantments to be associated to pieces of jewellery
* `CanonicalJewelryItemsEnchantment` model corresponding to the join table
* Remove default `unit_weight` value from the CanonicalClothingItem model migration since it hasn't run in production yet
* Light refactoring of tests to test that validated models' errors objects `include` an error message rather than testing the value of the total array
* Add missing associations to `CanonicalMaterial` model

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate