### PR TITLE
Allow additional valid strength units on enchantments

### DIFF
--- a/app/models/enchantment.rb
+++ b/app/models/enchantment.rb
@@ -46,7 +46,12 @@ class Enchantment < ApplicationRecord
   has_many :canonical_jewelry_items, through: :canonical_jewelry_items_enchantments
 
   validates :name, presence: true, uniqueness: { message: 'must be unique' }
-  validates :strength_unit, inclusion: { in: %w[point percentage], message: 'must be "point" or "percentage"', allow_blank: true }
+  validates :strength_unit,
+            inclusion: {
+                         in:          %w[point percentage second level],
+                         message:     'must be "point", "percentage", "second", or the "level" of affected characters',
+                         allow_blank: true,
+                       }
   validates :school, inclusion: { in: SCHOOLS, message: 'must be a valid school of magic', allow_blank: true }
   validate :validate_enchantable_items
 

--- a/app/models/enchantment.rb
+++ b/app/models/enchantment.rb
@@ -36,6 +36,8 @@ class Enchantment < ApplicationRecord
 
   ENCHANTABLE_ITEMS = (ENCHANTABLE_WEAPONS + ENCHANTABLE_APPAREL_ITEMS).freeze
 
+  STRENGTH_UNITS = %w[percentage point second level].freeze
+
   has_many :canonical_armors_enchantments, dependent: :destroy
   has_many :canonical_armors, through: :canonical_armors_enchantments
 
@@ -48,7 +50,7 @@ class Enchantment < ApplicationRecord
   validates :name, presence: true, uniqueness: { message: 'must be unique' }
   validates :strength_unit,
             inclusion: {
-                         in:          %w[point percentage second level],
+                         in:          STRENGTH_UNITS,
                          message:     'must be "point", "percentage", "second", or the "level" of affected characters',
                          allow_blank: true,
                        }

--- a/lib/tasks/canonical_models/enchantments.json
+++ b/lib/tasks/canonical_models/enchantments.json
@@ -69,7 +69,7 @@
       "axe",
       "pickaxe"
     ],
-    "strength_unit": null
+    "strength_unit": "level"
   },
   {
     "name": "Chaos Damage",
@@ -105,7 +105,7 @@
       "axe",
       "pickaxe"
     ],
-    "strength_unit": null
+    "strength_unit": "second"
   },
   {
     "name": "Fiery Soul Trap",
@@ -123,7 +123,7 @@
       "axe",
       "pickaxe"
     ],
-    "strength_unit": null
+    "strength_unit": "second"
   },
   {
     "name": "Fire Damage",
@@ -456,7 +456,7 @@
     "enchantable_items": [
       "feet"
     ],
-    "strength_unit": null
+    "strength_unit": "percentage"
   },
   {
     "name": "Frost Damage",
@@ -492,7 +492,7 @@
       "axe",
       "pickaxe"
     ],
-    "strength_unit": null
+    "strength_unit": "point"
   },
   {
     "name": "Magicka Damage",
@@ -513,14 +513,6 @@
     "strength_unit": "point"
   },
   {
-    "name": "Notched Pickaxe",
-    "school": null,
-    "enchantable_items": [
-      "pickaxe"
-    ],
-    "strength_unit": null
-  },
-  {
     "name": "Paralyze",
     "school": "Alteration",
     "enchantable_items": [
@@ -536,7 +528,7 @@
       "axe",
       "pickaxe"
     ],
-    "strength_unit": null
+    "strength_unit": "second"
   },
   {
     "name": "Resist Disease",
@@ -655,7 +647,7 @@
       "axe",
       "pickaxe"
     ],
-    "strength_unit": null
+    "strength_unit": "second"
   },
   {
     "name": "Stamina Damage",
@@ -691,7 +683,7 @@
       "axe",
       "pickaxe"
     ],
-    "strength_unit": null
+    "strength_unit": "level"
   },
   {
     "name": "Waterbreathing",

--- a/spec/models/enchantment_spec.rb
+++ b/spec/models/enchantment_spec.rb
@@ -32,11 +32,11 @@ RSpec.describe Enchantment, type: :model do
     end
 
     describe 'strength_unit' do
-      it 'must be one of "point" or "percentage"' do
+      it 'must be "point", "percentage", "second", or "level"' do
         enchantment = described_class.new(strength_unit: 'foobar')
 
         enchantment.validate
-        expect(enchantment.errors[:strength_unit]).to include 'must be "point" or "percentage"'
+        expect(enchantment.errors[:strength_unit]).to include 'must be "point", "percentage", "second", or the "level" of affected characters'
       end
 
       it 'can be blank' do


### PR DESCRIPTION
## Context

[**Allow additional valid strength units on enchantments**](https://trello.com/c/2D42QLfX/168-allow-additional-valid-strength-units-on-enchantments)

Currently, SIM accepts `"point"`, `"percentage"`, and `NULL` as valid values for the `strength_unit` of enchantments. However, there are a few enchantments ("Fear", "Paralyze", "Soul Trap") that measure their strength in seconds, as well as some ("Banish") that measure theirs by the level of affected targets ("summoned Daedra up to level X are sent back to Oblivion").

## Changes

* Add "second" and "level" to valid values of `strength_unit` on enchantments
* Update tests
* Update JSON data for enchantments

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

Although almost every enchantment has a `strength_unit` now, Waterbreathing does not take a unit - it is either present or not - and therefore the column still needs to allow `NULL` values.

I also removed `Notched Pickaxe` as an enchantment as I've opted to explain this as a magical effect on an object rather than an enchantment.
