### PR TITLE
Create Canonical::Book model

### DIFF
--- a/app/models/canonical/book.rb
+++ b/app/models/canonical/book.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module Canonical
+  class Book < ApplicationRecord
+    self.table_name = 'canonical_books'
+
+    BOOLEAN_VALUES = [true, false].freeze
+
+    BOOK_TYPES = [
+                   'black book',
+                   'document',
+                   'elder scroll',
+                   'journal',
+                   'letter',
+                   'lore book',
+                   'quest book',
+                   'recipe',
+                   'skill book',
+                   'treasure map',
+                 ].freeze
+
+    SKILLS = [
+               'Alchemy',
+               'Alteration',
+               'Archery',
+               'Block',
+               'Conjuration',
+               'Destruction',
+               'Enchanting',
+               'Heavy Armor',
+               'Illusion',
+               'Light Armor',
+               'Lockpicking',
+               'One-Handed',
+               'Pickpocket',
+               'Restoration',
+               'Smithing',
+               'Sneak',
+               'Speech',
+               'Two-Handed',
+             ].freeze
+
+    has_many :canonical_recipes_ingredients,
+             dependent:   :destroy,
+             class_name:  'Canonical::RecipesIngredient',
+             inverse_of:  :recipe,
+             foreign_key: :recipe_id
+    has_many :canonical_ingredients, through: :canonical_recipes_ingredients, class_name: 'Canonical::Ingredient', source: :ingredient
+
+    validates :title, presence: true
+    validates :item_code, presence: true, uniqueness: { message: 'must be unique' }
+    validates :unit_weight, presence: true, numericality: { greater_than_or_equal_to: 0 }
+    validates :book_type, inclusion: { in: BOOK_TYPES, message: 'must be a book type that exists in Skyrim' }
+    validates :skill_name, inclusion: { in: SKILLS, message: 'must be a skill that exists in Skyrim', allow_blank: true }
+    validates :purchasable, inclusion: { in: BOOLEAN_VALUES, message: 'must be true or false' }
+    validates :unique_item, inclusion: { in: BOOLEAN_VALUES, message: 'must be true or false' }
+    validates :rare_item, inclusion: { in: BOOLEAN_VALUES, message: 'must be true or false' }
+    validates :solstheim_only, inclusion: { in: BOOLEAN_VALUES, message: 'must be true or false' }
+    validates :quest_item, inclusion: { in: BOOLEAN_VALUES, message: 'must be true or false' }
+
+    validate :validate_skill_name_presence
+    validate :verify_unique_item_rare
+
+    def self.unique_identifier
+      :item_code
+    end
+
+    private
+
+    def validate_skill_name_presence
+      if book_type == 'skill book'
+        errors.add(:skill_name, "can't be blank for skill books") if skill_name.blank?
+      elsif skill_name.present?
+        errors.add(:skill_name, 'can only be defined for skill books')
+      end
+    end
+
+    def verify_unique_item_rare
+      errors.add(:rare_item, 'must be true if item is unique') if unique_item && !rare_item
+    end
+  end
+end

--- a/app/models/canonical/ingredient.rb
+++ b/app/models/canonical/ingredient.rb
@@ -9,6 +9,12 @@ module Canonical
              class_name: 'Canonical::IngredientsAlchemicalProperty'
     has_many :alchemical_properties, through: :canonical_ingredients_alchemical_properties
 
+    has_many :canonical_recipes_ingredients,
+             dependent:  :destroy,
+             class_name: 'Canonical::RecipesIngredient',
+             inverse_of: :ingredient
+    has_many :recipes, through: :canonical_recipes_ingredients, class_name: 'Canonical::Book', source: :recipe
+
     validates :name, presence: true
     validates :item_code, presence: true, uniqueness: { message: 'must be unique' }
     validates :unit_weight, presence: true, numericality: { greater_than_or_equal_to: 0 }

--- a/app/models/canonical/recipes_ingredient.rb
+++ b/app/models/canonical/recipes_ingredient.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Canonical
+  class RecipesIngredient < ApplicationRecord
+    self.table_name = 'canonical_recipes_ingredients'
+
+    belongs_to :recipe, class_name: 'Canonical::Book'
+    belongs_to :ingredient, class_name: 'Canonical::Ingredient'
+
+    validate :verify_recipe_is_recipe
+
+    private
+
+    def verify_recipe_is_recipe
+      errors.add(:recipe, 'must be a recipe') unless recipe.book_type == 'recipe'
+    end
+  end
+end

--- a/app/models/canonical/sync.rb
+++ b/app/models/canonical/sync.rb
@@ -10,10 +10,11 @@ module Canonical
                 enchantment:         Canonical::Sync::Enchantments,
                 material:            Canonical::Sync::Materials,
                 power:               Canonical::Sync::Powers,
+                ingredient:          Canonical::Sync::Ingredients,
                 # Syncers that are not prerequisites for other syncers
                 armor:               Canonical::Sync::Armor,
+                book:                Canonical::Sync::Books,
                 clothing:            Canonical::Sync::ClothingItems,
-                ingredient:          Canonical::Sync::Ingredients,
                 jewelry:             Canonical::Sync::JewelryItems,
                 property:            Canonical::Sync::Properties,
                 spell:               Canonical::Sync::Spells,

--- a/app/models/canonical/sync/books.rb
+++ b/app/models/canonical/sync/books.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Canonical
+  module Sync
+    class Books < AssociationSyncer
+      private
+
+      def model_class
+        Canonical::Book
+      end
+
+      def json_file_path
+        Rails.root.join('lib', 'tasks', 'canonical_models', 'canonical_books.json')
+      end
+
+      def prerequisites
+        [Canonical::Ingredient]
+      end
+    end
+  end
+end

--- a/db/migrate/20220521021219_create_canonical_books.rb
+++ b/db/migrate/20220521021219_create_canonical_books.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class CreateCanonicalBooks < ActiveRecord::Migration[6.1]
+  def change
+    create_table :canonical_books do |t|
+      t.string :title, null: false
+      t.string :title_variants, array: true, default: []
+      t.string :item_code, null: false, unique: true
+      t.decimal :unit_weight, precision: 5, scale: 2, null: false
+      t.string :book_type, null: false
+      t.string :authors, array: true, default: []
+      t.string :skill_name
+      t.boolean :purchasable, null: false
+      t.boolean :unique_item, null: false, default: false
+      t.boolean :rare_item, null: false, default: false
+      t.boolean :solstheim_only, null: false, default: false
+      t.boolean :quest_item, null: false, default: false
+
+      t.index :item_code, unique: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220521032400_create_canonical_recipes_ingredients.rb
+++ b/db/migrate/20220521032400_create_canonical_recipes_ingredients.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateCanonicalRecipesIngredients < ActiveRecord::Migration[6.1]
+  def change
+    create_table :canonical_recipes_ingredients do |t|
+      t.references :recipe, null: false, foreign_key: { to_table: 'canonical_books' }
+      t.references :ingredient, null: false, foreign_key: { to_table: 'canonical_ingredients' }
+
+      t.index %i[recipe_id ingredient_id], unique: true, name: 'index_can_books_ingredients_on_recipe_and_ingredient'
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_16_043808) do
+ActiveRecord::Schema.define(version: 2022_05_21_032400) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,6 +38,24 @@ ActiveRecord::Schema.define(version: 2022_05_16_043808) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["item_code"], name: "index_canonical_armors_on_item_code", unique: true
+  end
+
+  create_table "canonical_books", force: :cascade do |t|
+    t.string "title", null: false
+    t.string "title_variants", default: [], array: true
+    t.string "item_code", null: false
+    t.decimal "unit_weight", precision: 5, scale: 2, null: false
+    t.string "book_type", null: false
+    t.string "authors", default: [], array: true
+    t.string "skill_name"
+    t.boolean "purchasable", null: false
+    t.boolean "unique_item", default: false, null: false
+    t.boolean "rare_item", default: false, null: false
+    t.boolean "solstheim_only", default: false, null: false
+    t.boolean "quest_item", default: false, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["item_code"], name: "index_canonical_books_on_item_code", unique: true
   end
 
   create_table "canonical_clothing_items", force: :cascade do |t|
@@ -148,6 +166,16 @@ ActiveRecord::Schema.define(version: 2022_05_16_043808) do
     t.index ["city"], name: "index_canonical_properties_on_city", unique: true
     t.index ["hold"], name: "index_canonical_properties_on_hold", unique: true
     t.index ["name"], name: "index_canonical_properties_on_name", unique: true
+  end
+
+  create_table "canonical_recipes_ingredients", force: :cascade do |t|
+    t.bigint "recipe_id", null: false
+    t.bigint "ingredient_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["ingredient_id"], name: "index_canonical_recipes_ingredients_on_ingredient_id"
+    t.index ["recipe_id", "ingredient_id"], name: "index_can_books_ingredients_on_recipe_and_ingredient", unique: true
+    t.index ["recipe_id"], name: "index_canonical_recipes_ingredients_on_recipe_id"
   end
 
   create_table "canonical_staves", force: :cascade do |t|
@@ -338,6 +366,8 @@ ActiveRecord::Schema.define(version: 2022_05_16_043808) do
   add_foreign_key "canonical_ingredients_alchemical_properties", "alchemical_properties"
   add_foreign_key "canonical_ingredients_alchemical_properties", "canonical_ingredients", column: "ingredient_id"
   add_foreign_key "canonical_powerables_powers", "powers"
+  add_foreign_key "canonical_recipes_ingredients", "canonical_books", column: "recipe_id"
+  add_foreign_key "canonical_recipes_ingredients", "canonical_ingredients", column: "ingredient_id"
   add_foreign_key "canonical_staves_spells", "canonical_staves", column: "staff_id"
   add_foreign_key "canonical_staves_spells", "spells"
   add_foreign_key "canonical_temperables_tempering_materials", "canonical_materials", column: "material_id"

--- a/docs/canonical-models.md
+++ b/docs/canonical-models.md
@@ -3,12 +3,12 @@
 SIM knows certain things about Skyrim that it may or may not immediately reveal to users. However, it will prevent users from creating impossible objects for UX reasons. Which objects are impossible is a hard question to answer without canonical data: the actual set of objects that exist in Skyrim. The purpose of canonical models is to store the data used to validate user input. The following canonical models exist in the SIM database:
 
 * [`Canonical::Armor`](/app/models/canonical/armor.rb): actual armor pieces available in the game
+* [`Canonical::Book`](/app/models/canonical/book.rb): actual books, letters, recipes, and journals available in the game; includes Elder Scrolls; additional information about this model is available [here](/docs/models/canonical-book.md)
 * [`Canonical::ClothingItem`](/app/models/canonical/clothing_item.rb): actual clothing items available in the game; includes mages' robes as well as plain clothes
 * [`Canonical::Ingredient`](/app/models/canonical/ingredient.rb): actual ingredients available in the game; has many-to-many association to `AlchemicalProperty`, which it can have no more than 4 of without causing a validation error
 * [`Canonical::JewelryItem`](/app/models/canonical/jewelry_item.rb): actual jewelry items available in-game, including both generic and unique pieces
 * [`Canonical::Material`](/app/models/canonical/material.rb): actual building and smithing materials present in the game
 * [`Canonical::Property`](/app/models/canonical/property.rb): actual properties (homes) the player character can own in the game
-* [`Canonical::Staff`](/app/models/canonical/staff.rb)
 * [`Canonical::Weapon`](/app/models/canonical/weapon.rb): actual weapons the player character can acquire in the game
 * [`Canonical::Staff`](/app/models/canonical/staff.rb): actual staves the player character can acquire in the game
 
@@ -26,6 +26,7 @@ Note that the lists above do not include join tables for the `has_many, :through
 * [`Canonical::EnchantablesEnchantment`](/app/models/canonical/enchantables_enchantment.rb): This polymorphic join table associates enchantments with any enchantable items, including armours, jewellery, clothing items, and weapons, adding a field called `strength` for the strength of the enchantment on that particular item
 * [`Canonical::CraftablesCraftingMaterial`](/app/models/canonical/craftables_crafting_material.rb): This polymorphic join table associates canonical materials with any items that are able to be crafted using those materials, including armours, jewellery, and weapons, adding a field called `quantity` for the quantity of a given material needed to craft that particular item
 * [`Canonical::PowerablesPower](/app/models/canonical/powerables_power.rb): This polymorphic join table associates powers with any objects enchanted with them, including weapons and staves, adding no additional fields to the join table
+* [`Canonical::RecipesIngredient`](/app/models/canonical/recipes_ingredient.rb): This join table links canonical books that are recipes with the ingredients specified in the recipe; there are no fields on this table other than foreign keys and timestamps
 * [`Canonical::StavesSpell](/app/models/canonical/staves_spell.rb): This join table links enchanted staves to the spells they are enchanted with, adding a `strength` field in case the strength of the spell on the staff differs from the base strength of the spell
 * [`Canonical::TemperablesTemperingMaterial`](/app/models/canonical/temperables_tempering_material.rb): This polymorphic join table associates canonical materials with any items that are able to be tempered using those materials, including armours and weapons, adding a field called `quantity` for the quantity of a given material needed to temper that particular item
 * [`Canonical::IngredientsAlchemicalProperty](/app/models/canonical/ingredients_alchemical_property.rb): Associates canonical ingredients with the `AlchemicalProperty` model; no more than 4 can be created for each ingredient before a validation error is raised; additional docs available [here](/docs/models/canonical-ingredients-alchemical-property.md)
@@ -46,12 +47,13 @@ The following idempotent Rake tasks can be used to sync the database with the ca
 * `rails canonical_models:sync:properties` (syncs canonical properties with JSON data)
 * `rails canonical_models:sync:enchantments` (syncs canonical enchantments with JSON data)
 * `rails canonical_models:sync:spells` (syncs canonical spells with JSON data)
+* `rails canonical_models:sync:ingredients` (sync canonical ingredients with JSON data)
 * `rails canonical_models:sync:materials` (syncs canonical materials with JSON data)
 * `rails canonical_models:sync:armor` (syncs canonical armours with JSON data)
 * `rails canonical_models:sync:jewelry` (syncs canonical jewellery with JSON data)
 * `rails canonical_models:sync:clothing` (syncs canonical clothing items with JSON data)
-* `rails canonical_models:sync:ingredients` (sync canonical ingredients with JSON data)
 * `rails canonical_models:sync:weapons` (sync canonical weapons with JSON data)
+* `rails canonical_models:sync:books` (sync canonical books with JSON data)
 * `rails canonical_models:sync:staves` (sync canonical staves with JSON data)
 
 These tasks sync the models with the attributes in the JSON files. The tasks are idempotent. If a model already exists in the database with a given name, it will be updated with the attributes given in the JSON data. This is also true of associations: if an association is found in the database then the corresponding model (or join model) will be updated with data from the JSON files. **The Rake tasks will also remove models and associations that exist in the database but are not present in the JSON data.** This behaviour can be disabled by setting the `preserve_existing_records` argument on the Rake tasks to `true` (or any value other than `false`):

--- a/docs/models/canonical-book.md
+++ b/docs/models/canonical-book.md
@@ -1,0 +1,48 @@
+# Canonical::Book
+
+The `Canonical::Book` model has some special characteristics, mainly pertaining to attributes of the model.
+
+## Title Variants
+
+The `title_variants` array includes alternative spellings of the title, full titles if different from the title that appears in inventory, and other variations on a book's title that may occur in game. Since the purpose of canonical models is validation of user-generated input, title variants can be used to ensure that whichever version of the title the user inputs will be associated to the correct model.
+
+## Book Type
+
+There are numerous items classed as "books" in Skyrim. These include letters, documents, journals, recipes, lore books, skill books, quest books, black books, treasure maps, and elder scrolls.
+
+### Recipes
+
+Recipes are special in that they have associated ingredients. This is to distinguish between multiple recipes for the same potions. There are other books that are called recipes or contain lists of components - such as "recipes" for spider scrolls found in Solstheim - that are nonetheless not classified as recipes in SIM because they cannot have associated ingredients. If you attempt to associate ingredients to a book that is not a recipe, a validation error will occur.
+
+### Skill Books
+
+Skill books have to have to have a `skill_name` defined. A validation error will be raised if a book is designated a skill book but does not include the `skill_name` field, or if the skill is not a recognised skill in Skyrim. On the other hand, a book that _isn't_ a skill book is not allowed to have this field defined. In this case, a validation error will be raised indicating that only skill books can have skill names.
+
+## Purchasable, Rare and Unique Items
+
+There are three boolean fields on the `Canonical::Book` model that interact with one another: `purchasable`, `rare_item`, and `unique_item`.
+
+### Purchasable
+
+Books that can be purchased through Urag Gro-Shub or another source are designated as `purchasable`.
+
+### Unique Items
+
+Books and other items classed as books that are unique in the game will have `unique_item` set to `true`. Items whose content varies by interpolated variables (e.g., letters with equivalent text signed by different NPCs, bounties pointing to radiant locations or items, etc.), are not considered unique.
+
+### Rare Items
+
+Books can also be designated as `rare_item`s. The logic determining whether a book should be considered rare is as follows:
+
+* Unique items are always rare
+* Books that are purchasable are rare if there are less than three other locations in the game where the book can be found
+* Books that are not purchasable are rare if the book is found in fewer than 10 locations in the game
+* Non-unique books are never classed as rare if they are found in one of the canonical ownable properties.
+
+## Solstheim Only
+
+Books that are only found in Solstheim, whether rare or not, have the `solstheim_only` attribute set to `true`. This column is a little extraneous since all books will ultimately be associated with locations where they are found, but I had already collected this data so I opted to include it and drop the column later if it turns out not to be needed.
+
+## Quest Items
+
+Like with other canonical models, SIM defines a quest item differently than Skyrim does. A quest item is any item that can only be obtained in the course of a quest, whether that item is required for the quest or not. Quest rewards are considered quest items if completing a quest is the only way to obtain them.

--- a/docs/models/canonical-ingredients-alchemical-property.md
+++ b/docs/models/canonical-ingredients-alchemical-property.md
@@ -1,6 +1,6 @@
-# CanonicalIngredientsAlchemicalProperty
+# Canonical::IngredientsAlchemicalProperty
 
-The `CanonicalIngredientsAlchemicalProperty` model is a join model between `Canonical::Ingredient` and `AlchemicalProperty`. It has a couple noteworthy characteristics.
+The `Canonical::IngredientsAlchemicalProperty` model is a join model between `Canonical::Ingredient` and `AlchemicalProperty`. It has a couple noteworthy characteristics.
 
 ## Count Limit
 
@@ -10,9 +10,9 @@ Each ingredient has four and only four alchemical properties. Therefore, a valid
 
 In Skyrim, each ingredient's properties have a priority that affects which potions are produced, how strong they are, and how long the effects last when they are combined with other ingredients. ([This wiki page](https://en.uesp.net/wiki/Skyrim:Alchemy_Effects) offers detailed information about how priority affects potions produced.) In SIM, the `priority` field is used to track this. Because each canonical ingredient has exactly four alchemical properties, the integer priority values for each model will range from 1 to 4.
 
-There is a uniqueness constraint in place on the `CanonicalIngredientsAlchemicalProperty` model to ensure that each ingredient only has one property with each valid value. Because of this, changing priority values after four models with priorities exist in the database for a single ingredient requires an additional step. Before you can change the priority on any model, you will need to clear any that conflict.
+There is a uniqueness constraint in place on the `Canonical::IngredientsAlchemicalProperty` model to ensure that each ingredient only has one property with each valid value. Because of this, changing priority values after four models with priorities exist in the database for a single ingredient requires an additional step. Before you can change the priority on any model, you will need to clear any that conflict.
 
-Say you have four `CanonicalIngredientsAlchemicalProperty` models:
+Say you have four `Canonical::IngredientsAlchemicalProperty` models:
 ```ruby
 [
   {

--- a/lib/tasks/canonical_models/canonical_books.json
+++ b/lib/tasks/canonical_models/canonical_books.json
@@ -15731,7 +15731,7 @@
       "authors": [
         "Brarilu Theran"
       ],
-      "skill_name": null,
+      "skill_name": "Enchanting",
       "purchasable": false,
       "unique_item": false,
       "rare_item": true,

--- a/lib/tasks/canonical_models/canonical_books.json
+++ b/lib/tasks/canonical_models/canonical_books.json
@@ -1,0 +1,16684 @@
+[
+  {
+    "attributes": {
+      "title": "2920, vol 01 - Morning Star",
+      "title_variants": [
+        "2920, Morning Star, v1",
+        "Morning Star Book One of 2920 The Last Year of the First Era"
+      ],
+      "item_code": "0001AFD9",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Carlovac Townway"
+      ],
+      "skill_name": "One-Handed",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "2920, vol 02 - Sun's Dawn",
+      "title_variants": [
+        "Sun's Dawn, Book Two of 2920"
+      ],
+      "item_code": "0001B010",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Carlovac Townway"
+      ],
+      "skill_name": "Illusion",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "2920, vol 03 - First Seed",
+      "title_variants": [
+        "2920, First Seed, v3",
+        "First Seed, Book Three of 2920"
+      ],
+      "item_code": "0001ACE5",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Carlovac Townway"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "2920, vol 04 - Rain's Hand",
+      "title_variants": [
+        "Rain's Hand Book Four of 2920, the Last Year of the First Era"
+      ],
+      "item_code": "0001B017",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Carlovac Townway"
+      ],
+      "skill_name": "Restoration",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "2920, vol 05 - Second Seed",
+      "title_variants": [
+        "Second Seed, Book Five of 2920"
+      ],
+      "item_code": "0001B025",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Carlovac Townway"
+      ],
+      "skill_name": "Speech",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "2920, vol 06 - Mid Year",
+      "title_variants": [
+        "Mid Year, Book Six of 2920"
+      ],
+      "item_code": "0001AFF7",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Carlovac Townway"
+      ],
+      "skill_name": "Heavy Armor",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "2920, vol 07 - Sun's Height",
+      "title_variants": [
+        "2920, Sun's Height, v7",
+        "Sun's Height, Book Seven of 2920"
+      ],
+      "item_code": "0001B00C",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Carlovac Townway"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "2920, vol 08 - Last Seed",
+      "title_variants": [
+        "Last Seed, Book Eight of 2920"
+      ],
+      "item_code": "0001B01F",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Carlovac Townway"
+      ],
+      "skill_name": "Sneak",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "2920, vol 09 - Hearth Fire",
+      "title_variants": [
+        "Hearth Fire, Book Nine of 2920"
+      ],
+      "item_code": "0001AFE9",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Carlovac Townway"
+      ],
+      "skill_name": "Conjuration",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "2920, vol 10 - Frostfall",
+      "title_variants": [
+        "Frostfall, Book Ten of 2920"
+      ],
+      "item_code": "0001AFEA",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Carlovac Townway"
+      ],
+      "skill_name": "Conjuration",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "2920, vol 11 - Sun's Dusk",
+      "title_variants": [
+        "Sun's Dusk, Book Eleven of 2920"
+      ],
+      "item_code": "0001ACE3",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Carlovac Townway"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "2920, vol 12 - Evening Star",
+      "title_variants": [
+        "Evening Star, Book Twelve of 2920"
+      ],
+      "item_code": "0001ACE4",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Carlovac Townway"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "A Children's Anuad",
+      "title_variants": [
+        "A Children's Anuad: The Anuad Paraphrased"
+      ],
+      "item_code": "0001ACDF",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "A Dance in Fire, Book I",
+      "title_variants": [
+        "A Dance in Fire, v1"
+      ],
+      "item_code": "0001AFC0",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Waughin Jarth"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "A Dance in Fire, Book II",
+      "title_variants": [
+        "A Dance in Fire, v2"
+      ],
+      "item_code": "0001AFDF",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Waughin Jarth"
+      ],
+      "skill_name": "Block",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "A Dance in Fire, Book III",
+      "title_variants": [
+        "A Dance in Fire, v3"
+      ],
+      "item_code": "0001AFD4",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Waughin Jarth"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "A Dance in Fire, Book IV",
+      "title_variants": [
+        "A Dance in Fire, v4"
+      ],
+      "item_code": "0001AFC1",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Waughin Jarth"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "A Dance in Fire, Book V",
+      "title_variants": [
+        "A Dance in Fire, v5"
+      ],
+      "item_code": "0001B006",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Waughin Jarth"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "A Dance in Fire, Book VI",
+      "title_variants": [
+        "A Dance in Fire, v6"
+      ],
+      "item_code": "0001B00D",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Waughin Jarth"
+      ],
+      "skill_name": "Speech",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "A Dance in Fire, Book VII",
+      "title_variants": [
+        "A Dance in Fire, v7"
+      ],
+      "item_code": "0001B00E",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Waughin Jarth"
+      ],
+      "skill_name": "Speech",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "A Dream of Sovngarde",
+      "title_variants": null,
+      "item_code": "000ED02F",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Skardan Free-Winter"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "A Game at Dinner",
+      "title_variants": null,
+      "item_code": "0001AFC4",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": "Alchemy",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "A Gentleman's Guide to Whiterun",
+      "title_variants": null,
+      "item_code": "000ED02E",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Mikael the Bard"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "A Hypothetical Treachery",
+      "title_variants": [
+        "A Hypothetical Treachery A One Act Play"
+      ],
+      "item_code": "0001AFEE",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Anthil Morvir"
+      ],
+      "skill_name": "Destruction",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "A Kiss, Sweet Mother",
+      "title_variants": null,
+      "item_code": "000A0322",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "A Letter to Selina I",
+      "title_variants": null,
+      "item_code": "XX030C9A",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Maximian Axius"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "A Letter to Selina II",
+      "title_variants": null,
+      "item_code": "XX030C9B",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Maximian Axius"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "A Letter to Selina III",
+      "title_variants": null,
+      "item_code": "XX030C9C",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Maximian Axius"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "A Letter to Selina IV",
+      "title_variants": null,
+      "item_code": "XX030C9D",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Maximian Axius"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "A Life of Uriel Septim VII",
+      "title_variants": [
+        "A Short Life of Uriel Septim VII"
+      ],
+      "item_code": "0001ACDC",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Rufus Hayn"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "A Minor Maze",
+      "title_variants": [
+        "A Minor Maze: Shalidor \u0026 Labyrinthian"
+      ],
+      "item_code": "000F1AB3",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "A Note",
+      "title_variants": null,
+      "item_code": "XX033C7D",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Falas Selvayn"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "A Scrawled Note",
+      "title_variants": null,
+      "item_code": "000B1260",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "A Short History of Morrowind",
+      "title_variants": null,
+      "item_code": "0001B22B",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Jeanette Sitte"
+      ],
+      "skill_name": "Conjuration",
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "A Tragedy in Black",
+      "title_variants": [
+        "A Tragedy in Black: A folk tale from the time of the Oblivion Crisis"
+      ],
+      "item_code": "0002F838",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": "Enchanting",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "A Warning",
+      "title_variants": null,
+      "item_code": "000F6928",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Vex"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Admonition Against Ebony",
+      "title_variants": null,
+      "item_code": "000F6843",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Adonato's Book",
+      "title_variants": [
+        "Olaf and the Dragon"
+      ],
+      "item_code": "000403AF",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Adonato Leonetti"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Adril's Survey Results",
+      "title_variants": null,
+      "item_code": "XX03A4DD",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Adril Arano"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Advances in Lockpicking",
+      "title_variants": null,
+      "item_code": "0001B01C",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": "Lockpicking",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Adventurer's Journal",
+      "title_variants": null,
+      "item_code": "000D95E3",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Adventurer"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Aedra and Daedra",
+      "title_variants": null,
+      "item_code": "0001B22C",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Aeri's Note",
+      "title_variants": null,
+      "item_code": "00090E52",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Aeri"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Aevar Stone-Singer",
+      "title_variants": null,
+      "item_code": "0001ACE6",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": "Pickpocket",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Afflicted's Note",
+      "title_variants": null,
+      "item_code": "00045F94",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Agrius's Journal",
+      "title_variants": null,
+      "item_code": "00083AE8",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Agrius"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Ahzidal's Descent",
+      "title_variants": null,
+      "item_code": "XX033BD8",
+      "unit_weight": 1.0,
+      "book_type": "quest book",
+      "authors": [
+        "Halund Greycloak"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Ahzirr Traajijazeri",
+      "title_variants": null,
+      "item_code": "0001AFF3",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Aicantar's Lab Journal",
+      "title_variants": null,
+      "item_code": "00065C35",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Aicantar"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Alchemist's Journal",
+      "title_variants": null,
+      "item_code": "0003A523",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Anonymous Alchemist"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Alchemist's Journal",
+      "title_variants": null,
+      "item_code": "000CE5BD",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Anonymous Alchemist"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Alchemist's Note",
+      "title_variants": null,
+      "item_code": "0006DF90",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Head Alchemist Froda"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Alduin is Real",
+      "title_variants": [
+        "Alduin is Real, and he ent Akatosh!"
+      ],
+      "item_code": "000EA5B0",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Thromgar Iron-Head"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Alethius's Notes",
+      "title_variants": null,
+      "item_code": "000C370E",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Alethius"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "All Employees Must Read!",
+      "title_variants": null,
+      "item_code": "000F68A2",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Indaryn"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Alva's Journal",
+      "title_variants": null,
+      "item_code": "0002A96D",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Alva"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Amaund Motierre's Sealed Letter",
+      "title_variants": null,
+      "item_code": "0005BF2E",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Amaund Motierre"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Amongst the Draugr",
+      "title_variants": null,
+      "item_code": "000ED03F",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Bernadette Bantien"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "An Accounting of the Scrolls",
+      "title_variants": null,
+      "item_code": "000ED03A",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Quintus Nerevelus"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "An Apology",
+      "title_variants": null,
+      "item_code": "000F68A4",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Wilhelm"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "An Explorer's Guide to Skyrim",
+      "title_variants": null,
+      "item_code": "00083B38",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Marcius Carvain"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "An Overview of Gods and Worship in Tamriel",
+      "title_variants": [
+        "Gods and Worship"
+      ],
+      "item_code": "0001ACD5",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Brother Hetchfeld"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Ancestors and the Dunmer",
+      "title_variants": null,
+      "item_code": "0001B22D",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Ancient Edict",
+      "title_variants": null,
+      "item_code": "000ED441",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Anders's Message",
+      "title_variants": null,
+      "item_code": "000FF223",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anders"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Anise's Letter",
+      "title_variants": null,
+      "item_code": "000DDFB6",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anise"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Annals of the Dragonguard",
+      "title_variants": null,
+      "item_code": "0003636A",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Brother Annulus"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Anonymous Letter",
+      "title_variants": null,
+      "item_code": "000504EE",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Anonymous Letter",
+      "title_variants": null,
+      "item_code": "000504EF",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Antecedents of Dwemer Law",
+      "title_variants": null,
+      "item_code": "0001B22F",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Arcana Restored",
+      "title_variants": [
+        "Arcana Restored: A Handbook"
+      ],
+      "item_code": "0001ACFE",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Wapna Neustra"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Argonian Ceremony",
+      "title_variants": null,
+      "item_code": "000F68A8",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Talen-Jei"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Arondil's Journal, Part 1",
+      "title_variants": null,
+      "item_code": "00080D63",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Arondil"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Arondil's Journal, Part 2",
+      "title_variants": null,
+      "item_code": "00080D64",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Arondil"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Arondil's Journal, Part 3",
+      "title_variants": null,
+      "item_code": "00080D65",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Arondil"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Arondil's Journal, Part 4",
+      "title_variants": null,
+      "item_code": "00080D66",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Arondil"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Arvel's Journal",
+      "title_variants": null,
+      "item_code": "00039654",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Arvel the Swift"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Assassin's Writ",
+      "title_variants": null,
+      "item_code": "XX01AA22",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Atlas of Dragons",
+      "title_variants": [
+        "Atlas of Dragons, 2E 373"
+      ],
+      "item_code": "000FF227",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Brother Mathnan"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Atronach Forge Manual",
+      "title_variants": null,
+      "item_code": "0006CE1C",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Attention Employees!",
+      "title_variants": null,
+      "item_code": "000F68A0",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Indaryn"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Azura and the Box",
+      "title_variants": [
+        "Ancient Tales of the Dwemer, Part IX: Azura and the Box"
+      ],
+      "item_code": "0001ACE9",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Marobar Sul"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Balmora Blue Note",
+      "title_variants": null,
+      "item_code": "000DC176",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Dyryn"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Bandit Leader's Journal",
+      "title_variants": null,
+      "item_code": "00078DD2",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Bandit Leader"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Bandit's Journal",
+      "title_variants": null,
+      "item_code": "00083AFB",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Bandit's Journal",
+      "title_variants": null,
+      "item_code": "00083B01",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Battle of Sancre Tor",
+      "title_variants": [
+        "The Battle of Sancre Tor"
+      ],
+      "item_code": "0001AFDC",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": "Two-Handed",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Before the Ages of Man",
+      "title_variants": [
+        "Timeline Series - Vol 1: Before the Ages of Man"
+      ],
+      "item_code": "0001B012",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Aicantar of Shimerene"
+      ],
+      "skill_name": "Illusion",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Beggar",
+      "title_variants": null,
+      "item_code": "0001AFD6",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Reven"
+      ],
+      "skill_name": "Pickpocket",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Beggar Prince",
+      "title_variants": [
+        "Beggar Prince: The Story of Wheedle and his gifts from the Daedric Lord Namira"
+      ],
+      "item_code": "0001ACC7",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Beware the Butcher!",
+      "title_variants": null,
+      "item_code": "00021683",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Viola Giordano"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Biography of Barenziah, v1",
+      "title_variants": [
+        "Biography of Queen Barenziah, Vol 1"
+      ],
+      "item_code": "0001ACB5",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Stern Gamboge"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Biography of Barenziah, v2",
+      "title_variants": [
+        "Biography of Queen Barenziah, Vol 2"
+      ],
+      "item_code": "0001ACB6",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Stern Gamboge"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Biography of Barenziah, v3",
+      "title_variants": [
+        "Biography of Queen Barenziah, Vol 1"
+      ],
+      "item_code": "0001ACB7",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Stern Gamboge"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Biography of the Wolf Queen",
+      "title_variants": null,
+      "item_code": "0001B023",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Katar Eriphanes"
+      ],
+      "skill_name": "Speech",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Black Book: Epistolary Acumen",
+      "title_variants": null,
+      "item_code": "XX016E2C",
+      "unit_weight": 1.0,
+      "book_type": "black book",
+      "authors": [
+        "The Transparent One"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Black Book: Filament and Filigree",
+      "title_variants": null,
+      "item_code": "XX01E99E",
+      "unit_weight": 1.0,
+      "book_type": "black book",
+      "authors": [
+        "Jelketheris"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Black Book: The Hidden Twilight",
+      "title_variants": null,
+      "item_code": "XX01E99F",
+      "unit_weight": 1.0,
+      "book_type": "black book",
+      "authors": [
+        "Carillius Melfus"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Black Book: The Sallow Regent",
+      "title_variants": null,
+      "item_code": "XX01E99D",
+      "unit_weight": 1.0,
+      "book_type": "black book",
+      "authors": [
+        "Hawfip the Crafter"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Black Book: The Winds of Change",
+      "title_variants": null,
+      "item_code": "XX01E99C",
+      "unit_weight": 1.0,
+      "book_type": "black book",
+      "authors": [
+        "Liesl Grey-Heart"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Black Book: Untold Legends",
+      "title_variants": [
+        "Black Book: Untold Legends: The Other Lives of Ysgramor"
+      ],
+      "item_code": "XX016E2D",
+      "unit_weight": 1.0,
+      "book_type": "black book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Black Book: Waking Dreams",
+      "title_variants": [
+        "Black Book: Waking Dreams of a Starless Sky"
+      ],
+      "item_code": "XX016E22",
+      "unit_weight": 1.0,
+      "book_type": "black book",
+      "authors": [
+        "Bilius Felcrex"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Blood Horker Orders",
+      "title_variants": null,
+      "item_code": "000C58A6",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Haldyn"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Bloodstained Letter",
+      "title_variants": null,
+      "item_code": "XX02B23A",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "H"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Bloodstained Note",
+      "title_variants": null,
+      "item_code": "000D397A",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Sudi"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Boethiah's Glory",
+      "title_variants": null,
+      "item_code": "0001B233",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Boethiah's Proving",
+      "title_variants": null,
+      "item_code": "00032E72",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Bolar's Writ",
+      "title_variants": null,
+      "item_code": "00083AF6",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Acilius Bolar"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Bone, Book I",
+      "title_variants": [
+        "Bone, Book One"
+      ],
+      "item_code": "XX028261",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Tavi Dromio"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Bone, Book II",
+      "title_variants": [
+        "Bone, Book Two"
+      ],
+      "item_code": "XX028262",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Tavi Dromio"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Bonemold Formula",
+      "title_variants": null,
+      "item_code": "XX02AD3C",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Glover Mallory"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Bounty",
+      "title_variants": null,
+      "item_code": "00095129",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Various"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Bravil: Daughter of the Niben",
+      "title_variants": [
+        "Daughter of the Niben"
+      ],
+      "item_code": "0001AFC9",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Sathyr Longleat"
+      ],
+      "skill_name": "Alteration",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Breathing Water",
+      "title_variants": null,
+      "item_code": "0001B236",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Haliel Myrm"
+      ],
+      "skill_name": "Alteration",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Brief History of the Empire, Book I",
+      "title_variants": [
+        "Brief History of the Empire, V1",
+        "A Brief History of the Empire, Part One"
+      ],
+      "item_code": "0001ACB9",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Stronach k'Thojj III"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Brief History of the Empire, Book II",
+      "title_variants": [
+        "Brief History of the Empire, V2",
+        "A Brief History of the Empire, Part Two"
+      ],
+      "item_code": "0001ACBA",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Stronach k'Thojj III"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Brief History of the Empire, Book III",
+      "title_variants": [
+        "Brief History of the Empire, V3",
+        "A Brief History of the Empire, Part Three"
+      ],
+      "item_code": "0001ACBB",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Stronach k'Thojj III"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Brief History of the Empire, Book IV",
+      "title_variants": [
+        "Brief History of the Empire, v4",
+        "A Brief History of the Empire, Part Four"
+      ],
+      "item_code": "0001ACBC",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Stronach k'Thojj III"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Butcher Journal #1",
+      "title_variants": null,
+      "item_code": "00024737",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "The Butcher"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Butcher Journal #2",
+      "title_variants": null,
+      "item_code": "00066182",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "The Butcher"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Butcher Journal #3",
+      "title_variants": null,
+      "item_code": "00024763",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "The Butcher"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Catalogue of Armor Enchantments",
+      "title_variants": [
+        "Complete Catalogue of Enchantments for Armor"
+      ],
+      "item_code": "0002F83B",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Yvonne Bienne"
+      ],
+      "skill_name": "Enchanting",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Catalogue of Weapon Enchantments",
+      "title_variants": [
+        "Complete Catalogue of Weapon Enchantments"
+      ],
+      "item_code": "0002F83A",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Yvonne Bienne"
+      ],
+      "skill_name": "Enchanting",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Cats of Skyrim",
+      "title_variants": null,
+      "item_code": "000ED605",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Aldetuile"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Chance's Folly",
+      "title_variants": null,
+      "item_code": "0001B237",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Zylmoc Golge"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Charwich-Koniinge Letters, v1",
+      "title_variants": [
+        "The Charwich-Koniinge Letters, v1",
+        "The Charwich-Koniinge Letters, Book I"
+      ],
+      "item_code": "0001B238",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Charwich"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Charwich-Koniinge Letters, v2",
+      "title_variants": [
+        "The Charwich-Koniinge Letters, v2",
+        "The Charwich-Koniinge Letters, Book II"
+      ],
+      "item_code": "0001B239",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Koniinge"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Charwich-Koniinge Letters, v3",
+      "title_variants": [
+        "The Charwich-Koniinge Letters, v3",
+        "The Charwich-Koniinge Letters, Book III"
+      ],
+      "item_code": "0001B23A",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Charwich"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Charwich-Koniinge Letters, v4",
+      "title_variants": [
+        "The Charwich-Koniinge Letters, v4",
+        "The Charwich-Koniinge Letters, Book IV"
+      ],
+      "item_code": "0001B23B",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Syrix Goinithi"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Chaurus Pie: A Recipe",
+      "title_variants": null,
+      "item_code": "000ED032",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Nils"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Cherim's Heart",
+      "title_variants": [
+        "Cherim's Heart of Anequina",
+        "Interviews with Tapestrists Volume Eighteen: Cherim's Heart"
+      ],
+      "item_code": "0001AFD1",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Livillus Perus"
+      ],
+      "skill_name": "Smithing",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Children of the All-Maker",
+      "title_variants": null,
+      "item_code": "XX03ABCC",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Tharstan of Solitude"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Children of the Sky",
+      "title_variants": null,
+      "item_code": "0001AD03",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Chimarvamidium",
+      "title_variants": [
+        "Ancient Tales of the Dwemer, Part VI: Chimarvamidium"
+      ],
+      "item_code": "0001AFF8",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Marobar Sul"
+      ],
+      "skill_name": "Heavy Armor",
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Chronicles of Nchuleft",
+      "title_variants": [
+        "The Chronicles of Nchuleft"
+      ],
+      "item_code": "0001B23C",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Cicero's Journal - Final Volume",
+      "title_variants": null,
+      "item_code": "00019514",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Cicero"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Cicero's Journal - Volume 1",
+      "title_variants": null,
+      "item_code": "0009DABE",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Cicero"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Cicero's Journal - Volume 2",
+      "title_variants": null,
+      "item_code": "0009DAC1",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Cicero"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Cicero's Journal - Volume 3",
+      "title_variants": null,
+      "item_code": "0009DAC4",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Cicero"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Cicero's Journal - Volume 4",
+      "title_variants": null,
+      "item_code": "0009DAC5",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Cicero"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Commander's Note",
+      "title_variants": null,
+      "item_code": "00083B05",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Complaint Letter",
+      "title_variants": null,
+      "item_code": "0008AA46",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Agnis"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Confessions of a Dunmer Skooma Eater",
+      "title_variants": null,
+      "item_code": "XX028264",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Tilse Sendas"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Confessions of a Khajiit Fur Trader",
+      "title_variants": null,
+      "item_code": "XX016692",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "The Fur Trader"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Consider Adoption",
+      "title_variants": null,
+      "item_code": "XX003F7C",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Constance Michel"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Contract",
+      "title_variants": null,
+      "item_code": "00035B65",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Various"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Contract",
+      "title_variants": null,
+      "item_code": "0004EF00",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Various"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Cook's Journal",
+      "title_variants": null,
+      "item_code": "000951AE",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Corpse Note",
+      "title_variants": null,
+      "item_code": "000BA300",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Breton Woman"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Courier's Letter",
+      "title_variants": null,
+      "item_code": "001065F5",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Cultist's Orders",
+      "title_variants": null,
+      "item_code": "XX0331C2",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Cure Disease Potion Recipe",
+      "title_variants": null,
+      "item_code": "000F5CB8",
+      "unit_weight": 0.0,
+      "book_type": "recipe",
+      "authors": null,
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": [
+      {
+        "item_code": "00052695"
+      },
+      {
+        "item_code": "0006BC00"
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "title": "Cure Disease Potion Recipe",
+      "title_variants": null,
+      "item_code": "000F5CB9",
+      "unit_weight": 0.0,
+      "book_type": "recipe",
+      "authors": null,
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": [
+      {
+        "item_code": "0006BC00"
+      },
+      {
+        "item_code": "0003AD76"
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "title": "Damage Health Poison Recipe",
+      "title_variants": null,
+      "item_code": "000F5CB5",
+      "unit_weight": 0.0,
+      "book_type": "recipe",
+      "authors": null,
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": [
+      {
+        "item_code": "0003AD6F"
+      },
+      {
+        "item_code": "0003AD60"
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "title": "Damage Health Poison Recipe",
+      "title_variants": null,
+      "item_code": "000F5CB7",
+      "unit_weight": 0.0,
+      "book_type": "recipe",
+      "authors": null,
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": [
+      {
+        "item_code": "0003AD63"
+      },
+      {
+        "item_code": "0003AD72"
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "title": "Damage Health Poison Recipe",
+      "title_variants": null,
+      "item_code": "000F5CB6",
+      "unit_weight": 0.0,
+      "book_type": "recipe",
+      "authors": null,
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": [
+      {
+        "item_code": "0003AD6F"
+      },
+      {
+        "item_code": "0006BC0B"
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "title": "Dark Brotherhood Assassin's Note",
+      "title_variants": null,
+      "item_code": "0010596A",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Astrid"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Darkest Darkness",
+      "title_variants": null,
+      "item_code": "0001ACC9",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Darkfall Cave Note",
+      "title_variants": null,
+      "item_code": "XX00A83B",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Darkfall Passage Note I",
+      "title_variants": null,
+      "item_code": "XX01860D",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Darkfall Passage Note II",
+      "title_variants": null,
+      "item_code": "XX018645",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Dawnguard Orders - Hakar",
+      "title_variants": null,
+      "item_code": "XX003517",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Dawnguard"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Dawnguard Orders - Lynoit",
+      "title_variants": null,
+      "item_code": "XX003521",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Dawnguard"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Dawnguard Orders - Saliah",
+      "title_variants": null,
+      "item_code": "XX00350B",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Dawnguard"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Daynas Valen's Journal",
+      "title_variants": null,
+      "item_code": "00085FE2",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Daynas Valen"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Daynas Valen's Notes",
+      "title_variants": null,
+      "item_code": "00085FE3",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Daynas Valen"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "De Rerum Dirennis",
+      "title_variants": null,
+      "item_code": "0001AFC7",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Vorian Direnni"
+      ],
+      "skill_name": "Alchemy",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Dearest Dinya",
+      "title_variants": null,
+      "item_code": "XX03A4B2",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Captain Veleth"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Death of a Wanderer",
+      "title_variants": [
+        "The Death of a Wanderer"
+      ],
+      "item_code": "000ED040",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Deathbrand",
+      "title_variants": null,
+      "item_code": "XX03661A",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Artise Dralen"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Deathbrand Treasure Map",
+      "title_variants": null,
+      "item_code": "XX02BAAE",
+      "unit_weight": 0.0,
+      "book_type": "treasure map",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Declaration of War",
+      "title_variants": null,
+      "item_code": "XX01BFE5",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "General Falx Carius"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Decree of Monument",
+      "title_variants": null,
+      "item_code": "000D55D9",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Diary of Faire Agarwen",
+      "title_variants": null,
+      "item_code": "XX01A3E7",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Faire Agarwen"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Discovering Ruunvald, Vol I",
+      "title_variants": null,
+      "item_code": "XX0192F0",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Moric Sidrey"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Discovering Ruunvald, Vol II",
+      "title_variants": null,
+      "item_code": "XX019578",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Moric Sidrey"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Discovering Ruunvald, Vol III",
+      "title_variants": null,
+      "item_code": "XX01957A",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Moric Sidrey"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Discovering Ruunvald, Vol IV",
+      "title_variants": null,
+      "item_code": "XX01957C",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Moric Sidrey"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Dragon Investigation: Current Status",
+      "title_variants": null,
+      "item_code": "00039F2A",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Rulindil"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Dragon Language: Myth no More",
+      "title_variants": null,
+      "item_code": "000EF2C0",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Hela Thrice-Versed"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Dryston's Note",
+      "title_variants": null,
+      "item_code": "000D672A",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Dryston"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Dunmer of Skyrim",
+      "title_variants": [
+        "The Dunmer of Skyrim"
+      ],
+      "item_code": "000E2FC5",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Athal Sarys"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Dwarven Haul",
+      "title_variants": null,
+      "item_code": "XX006BB3",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Dwarves, v1",
+      "title_variants": [
+        "Dwarves, the Lost Race of Tamriel, Volume 1: Architecture and Designs"
+      ],
+      "item_code": "00083168",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Calcelmo"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Dwarves, v2",
+      "title_variants": [
+        "Dwarves, the Lost Race of Tamriel, Volume II: Weapons, Armor and Machines"
+      ],
+      "item_code": "00083169",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Calcelmo"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Dwarves, v3",
+      "title_variants": [
+        "Dwarves, the Lost Race of Tamriel, Volume III: Culture and History"
+      ],
+      "item_code": "0008316A",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Calcelmo"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Dwemer History and Culture",
+      "title_variants": [
+        "Collected Essays on Dwemer History and Culture Chapter 1"
+      ],
+      "item_code": "0001ACEA",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Hasphat Antabolis"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Dwemer Inquiries Vol I",
+      "title_variants": null,
+      "item_code": "000E7F31",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Thelwe Ghelein"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Dwemer Inquiries Vol II",
+      "title_variants": null,
+      "item_code": "000E7F33",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Thelwe Ghelein"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Dwemer Inquiries Vol III",
+      "title_variants": null,
+      "item_code": "000E7F34",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Thelwe Ghelein"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "East Empire Connection",
+      "title_variants": null,
+      "item_code": "000F6932",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Effects of the Elder Scrolls",
+      "title_variants": null,
+      "item_code": "0003010B",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Justinius Poluhnius"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Elder Scroll (Blood)",
+      "title_variants": null,
+      "item_code": "XX0118F9",
+      "unit_weight": 20.0,
+      "book_type": "elder scroll",
+      "authors": null,
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Elder Scroll (Dragon)",
+      "title_variants": null,
+      "item_code": "0002D513",
+      "unit_weight": 20.0,
+      "book_type": "elder scroll",
+      "authors": null,
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Elder Scroll (Sun)",
+      "title_variants": null,
+      "item_code": "XX011A13",
+      "unit_weight": 20.0,
+      "book_type": "elder scroll",
+      "authors": null,
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Elsa's Journal",
+      "title_variants": null,
+      "item_code": "000D0BF6",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Elsa Blackthorn"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Eltrys' Note",
+      "title_variants": null,
+      "item_code": "000D1955",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Eltrys"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Enchanter's Primer",
+      "title_variants": [
+        "A Primer on Enchanting"
+      ],
+      "item_code": "0002F837",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Sergius Turrianus"
+      ],
+      "skill_name": "Enchanting",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Endrast's Journal",
+      "title_variants": null,
+      "item_code": "0008ACD0",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Endrast"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Erj's Notes",
+      "title_variants": null,
+      "item_code": "000C084B",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Erj"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Expedition Manifest",
+      "title_variants": null,
+      "item_code": "0008ACD1",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Sulla Trebatius"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Eydis's Journal",
+      "title_variants": null,
+      "item_code": "XX03B53E",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Eydis"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Eyes Open",
+      "title_variants": null,
+      "item_code": "000F692F",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Faded Diary",
+      "title_variants": null,
+      "item_code": "000F0422",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Faendal's Fake Letter from Sven",
+      "title_variants": null,
+      "item_code": "0005C846",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Faendal"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Faleen's Letter to Calcelmo",
+      "title_variants": null,
+      "item_code": "00026EFE",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Faleen"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Fall from Glory",
+      "title_variants": null,
+      "item_code": "000ED033",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Nithilis Lidari"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Fall of the Snow Prince",
+      "title_variants": null,
+      "item_code": "0001ACF7",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Lokheim"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Faralda's Notes",
+      "title_variants": null,
+      "item_code": "0005D2EA",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Faralda"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Father of the Niben",
+      "title_variants": null,
+      "item_code": "0001B008",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Florin Jaliil"
+      ],
+      "skill_name": "Archery",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Father's Missive",
+      "title_variants": null,
+      "item_code": "00037F89",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Da"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Fear Poison Recipe",
+      "title_variants": null,
+      "item_code": "000F5CC2",
+      "unit_weight": 0.0,
+      "book_type": "recipe",
+      "authors": null,
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": [
+      {
+        "item_code": "0006BC10"
+      },
+      {
+        "item_code": "0003AD5B"
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "title": "Fear Poison Recipe",
+      "title_variants": null,
+      "item_code": "000F5CC1",
+      "unit_weight": 0.0,
+      "book_type": "recipe",
+      "authors": null,
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": [
+      {
+        "item_code": "0004DA24"
+      },
+      {
+        "item_code": "000E4F0C"
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "title": "Feyfolken, Book I",
+      "title_variants": [
+        "Feyfolken I",
+        "Feyfolken Book One"
+      ],
+      "item_code": "0001ACEB",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Waughin Jarth"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Feyfolken, Book II",
+      "title_variants": [
+        "Feyfolken II",
+        "Feyfolken Book II"
+      ],
+      "item_code": "0001ACEC",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Waughin Jarth"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Feyfolken, Book III",
+      "title_variants": [
+        "Feyfolken III",
+        "Feyfolken Book Three"
+      ],
+      "item_code": "0001ACED",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Waughin Jarth"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Fire and Darkness",
+      "title_variants": [
+        "Fire and Darkness: The Brotherhoods of Death"
+      ],
+      "item_code": "0001AFDA",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Ynir Gorming"
+      ],
+      "skill_name": "One-Handed",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "First Letter from EEC",
+      "title_variants": null,
+      "item_code": "XX03A2A0",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Vittoria Vici"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "First Letter from Linwe",
+      "title_variants": null,
+      "item_code": "000D7773",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Linwe"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Fisherman's Journal",
+      "title_variants": null,
+      "item_code": "0007F667",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Fisherman's Journal",
+      "title_variants": null,
+      "item_code": "00088FE2",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Five Songs of King Wulfharth",
+      "title_variants": null,
+      "item_code": "0001AD05",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Flight from the Thalmor",
+      "title_variants": null,
+      "item_code": "000ED04E",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Hadrik Oaken-Heart",
+        "Ashad Ibn Khaled"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "For Shelly",
+      "title_variants": null,
+      "item_code": "000BB3D3",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Trius"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Forge, Hammer, and Anvil",
+      "title_variants": null,
+      "item_code": "000E3E69",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Adolphus Eritius"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Forsworn Missive",
+      "title_variants": null,
+      "item_code": "000A4CE2",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Forsworn Note",
+      "title_variants": null,
+      "item_code": "00083AE3",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Forsworn Note",
+      "title_variants": null,
+      "item_code": "00083B0B",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Fort Neugrad Treasure Map",
+      "title_variants": null,
+      "item_code": "000F33D2",
+      "unit_weight": 0.0,
+      "book_type": "treasure map",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Fortify Carry Weight Potion Recipe",
+      "title_variants": null,
+      "item_code": "000F5CC7",
+      "unit_weight": 0.0,
+      "book_type": "recipe",
+      "authors": null,
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": [
+      {
+        "item_code": "0006BC0E"
+      },
+      {
+        "item_code": "0006F950"
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "title": "Fortify Carry Weight Potion Recipe",
+      "title_variants": null,
+      "item_code": "000F5CC6",
+      "unit_weight": 0.0,
+      "book_type": "recipe",
+      "authors": null,
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": [
+      {
+        "item_code": "000B2183"
+      },
+      {
+        "item_code": "0003AD64"
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "title": "Fragment: On Artaeum",
+      "title_variants": null,
+      "item_code": "0001AD06",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Taurce il-Anselma"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Frenzy Poison Recipe",
+      "title_variants": null,
+      "item_code": "XX00F39C",
+      "unit_weight": 0.0,
+      "book_type": "recipe",
+      "authors": null,
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": [
+      {
+        "item_code": "0004DA25"
+      },
+      {
+        "item_code": "0003AD5D"
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "title": "Frontier, Conquest",
+      "title_variants": [
+        "Frontier, Conquest and Accommodation: A Social History of Cyrodiil"
+      ],
+      "item_code": "0001ACCB",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "University of Gwilym Press"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Frost's Identity Papers",
+      "title_variants": null,
+      "item_code": "000E8BDB",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Gaius Maro's Schedule",
+      "title_variants": null,
+      "item_code": "00015475",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Commander Maro"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Galerion the Mystic",
+      "title_variants": null,
+      "item_code": "0001ACCD",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Asgrim Kolsgreg"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Gallus's Encoded Journal",
+      "title_variants": null,
+      "item_code": "000CEDA6",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Gallus Desidenius"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Geirmund's Epitaph",
+      "title_variants": null,
+      "item_code": "000E7A33",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Ghosts in the Storm",
+      "title_variants": null,
+      "item_code": "000ED031",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Adonato Leotelli"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Gissur's Note",
+      "title_variants": null,
+      "item_code": "0006DEB6",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Gissur"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Give Me A Chance",
+      "title_variants": null,
+      "item_code": "000F692A",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Delvin Mallory"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Glories and Laments",
+      "title_variants": [
+        "Glories and Laments Among the Ayleid Ruins"
+      ],
+      "item_code": "0001AD07",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Alexandre Hetrard"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Glover's Letter",
+      "title_variants": null,
+      "item_code": "XX02AD41",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Glover Mallory"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Goldenglow",
+      "title_variants": null,
+      "item_code": "000F692E",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Mercer Frey"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Goldenglow Bill of Sale",
+      "title_variants": null,
+      "item_code": "0007A508",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Goldenglow Bill of Sale",
+      "title_variants": null,
+      "item_code": "0004C6C8",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Gorm's Letter",
+      "title_variants": null,
+      "item_code": "000AD8DE",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Gorm"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Gourmet's Writ of Passage",
+      "title_variants": null,
+      "item_code": "0003BEB6",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Clerk of Titus Mede II"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Gratian's Journal",
+      "title_variants": null,
+      "item_code": "XX020A2F",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Gratian Caerellius"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Gratian's Letter",
+      "title_variants": null,
+      "item_code": "XX020A44",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Rendellus Thandarian"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Great Harbingers",
+      "title_variants": [
+        "Great Harbingers of the Companions"
+      ],
+      "item_code": "000ED047",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Swyk the Long-Sighted"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Guard's Orders",
+      "title_variants": null,
+      "item_code": "000E94DF",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Guide to Better Thieving",
+      "title_variants": [
+        "Wulfmare's Guide to Better Thieving"
+      ],
+      "item_code": "0002F836",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Wulfmare Shadow-Cloak"
+      ],
+      "skill_name": "Pickpocket",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Gulum-Ei's Confession",
+      "title_variants": null,
+      "item_code": "000EF579",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Gulum-Ei"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Habd's Journal",
+      "title_variants": null,
+      "item_code": "00048160",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Habd"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Hajvarr's Journal",
+      "title_variants": null,
+      "item_code": "000E1647",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Hajvarr Iron-Hand"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Hallgerd's Tale",
+      "title_variants": null,
+      "item_code": "0001AFF6",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Tavi Dromio"
+      ],
+      "skill_name": "Heavy Armor",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Hamelyn's Journal",
+      "title_variants": null,
+      "item_code": "0010B2CD",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Hamelyn"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Hand-written note",
+      "title_variants": [
+        "On Apocrypha: Delving Pincers"
+      ],
+      "item_code": "XX033154",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "A"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Hanging Gardens",
+      "title_variants": [
+        "Hanging Gardens of Wasten Coridale"
+      ],
+      "item_code": "0001AD08",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Hargar's Journal",
+      "title_variants": null,
+      "item_code": "000BABB4",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Captain Hargar"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Harvesting Frostbite Spider Venom",
+      "title_variants": null,
+      "item_code": "000ED603",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Hastily Scribbled Note",
+      "title_variants": null,
+      "item_code": "000F23BA",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Gaston Bellefort"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Have Need of Cynric",
+      "title_variants": null,
+      "item_code": "000F6933",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Maven Black-Briar"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Have Need of Cynric",
+      "title_variants": null,
+      "item_code": "000F6931",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Heavy Armor Forging",
+      "title_variants": null,
+      "item_code": "0001AFD2",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Sven Two-Hammers"
+      ],
+      "skill_name": "Smithing",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Heddic's Volunruud Notes",
+      "title_variants": null,
+      "item_code": "0008AD99",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Heddic"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Heljarchen Hall Charter",
+      "title_variants": null,
+      "item_code": "XX0157A1",
+      "unit_weight": 0.0,
+      "book_type": "document",
+      "authors": null,
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Herbalist's Guide to Skyrim",
+      "title_variants": null,
+      "item_code": "0001AFC8",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Agneta Falia"
+      ],
+      "skill_name": "Alchemy",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Herbane's Bestiary: Automatons",
+      "title_variants": null,
+      "item_code": "000ED60C",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Herbane"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Herbane's Bestiary: Hagravens",
+      "title_variants": null,
+      "item_code": "000ED60B",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Herbane"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Herbane's Bestiary: Ice Wraiths",
+      "title_variants": null,
+      "item_code": "000D6F0B",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Herbane"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Hired Thug's Missive",
+      "title_variants": null,
+      "item_code": "000F98B4",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "History of Raven Rock, Vol. I",
+      "title_variants": [
+        "The History of Raven Rock Volume I"
+      ],
+      "item_code": "XX03AF1B",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Lyrin Telleno"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "History of Raven Rock, Vol. II",
+      "title_variants": [
+        "The History of Raven Rock Volume II"
+      ],
+      "item_code": "XX03AF1C",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Lyrin Telleno"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "History of Raven Rock, Vol. III",
+      "title_variants": [
+        "The History of Raven Rock Volume III"
+      ],
+      "item_code": "XX03AF1D",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Lyrin Telleno"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Holdings of Jarl Gjalund",
+      "title_variants": [
+        "Survey of the Holdings of Jarl Gjalund"
+      ],
+      "item_code": "000FBA57",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Slafknir the Scribe"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Horker Attacks",
+      "title_variants": [
+        "Surviving a Horker Attack"
+      ],
+      "item_code": "000ED604",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Heidmir Starkad"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "House Redoran's Reply",
+      "title_variants": null,
+      "item_code": "XX03A4DC",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Drails Rorlen"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Hrodulf's Journal",
+      "title_variants": null,
+      "item_code": "XX028FAF",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Hrodulf"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Hunter's Journal",
+      "title_variants": null,
+      "item_code": "000993FC",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Hunter's Journal",
+      "title_variants": null,
+      "item_code": "000F54D4",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Ice and Chitin",
+      "title_variants": null,
+      "item_code": "0001B001",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Pletius Spatec"
+      ],
+      "skill_name": "Light Armor",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Idgrod's Note",
+      "title_variants": null,
+      "item_code": "000940DD",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Idgrod the Younger"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Ildari's Journal",
+      "title_variants": null,
+      "item_code": "XX026AE7",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Ildari Sarothril"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Ildari's Journal, vol. I",
+      "title_variants": null,
+      "item_code": "XX027E4D",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Ildari Sarothril"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Ildari's Journal, vol. II",
+      "title_variants": null,
+      "item_code": "XX027E4E",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Ildari Sarothril"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Ildari's Journal, vol. III",
+      "title_variants": null,
+      "item_code": "XX027E4F",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Ildari Sarothril"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Immortal Blood",
+      "title_variants": null,
+      "item_code": "0001AFF1",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Imperial Condolences",
+      "title_variants": null,
+      "item_code": "0009020C",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Pius Bruccius"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Imperial Letter",
+      "title_variants": null,
+      "item_code": "00083AED",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Imperial Missive",
+      "title_variants": null,
+      "item_code": "00083AFD",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Fort Neugrad's Fort Commander"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Imperial Missive",
+      "title_variants": null,
+      "item_code": "00039C8E",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "General Tullius"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Imperial Report on Saarthal",
+      "title_variants": [
+        "The Fall of Saarthal"
+      ],
+      "item_code": "000EDA90",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Heseph Chirirnis"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Incident at Necrom",
+      "title_variants": [
+        "Incident in Necrom"
+      ],
+      "item_code": "0001B00F",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Jonquilla Bothe"
+      ],
+      "skill_name": "Illusion",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Incriminating Letter",
+      "title_variants": null,
+      "item_code": "000E0BA1",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Maven Black-Briar"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Incriminating Letter",
+      "title_variants": null,
+      "item_code": "XX0050CA",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Feran Sadri"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Incriminating Letter",
+      "title_variants": null,
+      "item_code": "00050502",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "D.M."
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Incriminating Letter",
+      "title_variants": null,
+      "item_code": "000749B5",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Commander Maro"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Invisibility Potion Recipe",
+      "title_variants": null,
+      "item_code": "000F5CB4",
+      "unit_weight": 0.0,
+      "book_type": "recipe",
+      "authors": null,
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": [
+      {
+        "item_code": "0003AD6A"
+      },
+      {
+        "item_code": "0003AD56"
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "title": "Invisibility Potion Recipe",
+      "title_variants": null,
+      "item_code": "000F5CB3",
+      "unit_weight": 0.0,
+      "book_type": "recipe",
+      "authors": null,
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": [
+      {
+        "item_code": "000727DF"
+      },
+      {
+        "item_code": "0003AD56"
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "title": "Invitation to Elenwen's Reception",
+      "title_variants": null,
+      "item_code": "00042396",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Elenwen"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Invocation of Azura",
+      "title_variants": null,
+      "item_code": "0001B245",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Sigillah Parate"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Isabelle's Letter",
+      "title_variants": null,
+      "item_code": "00064EB2",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Isabelle Rolaine"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "J'dathaar's Note",
+      "title_variants": null,
+      "item_code": "0005437D",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "J'datharr"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "J'zhar's Journal",
+      "title_variants": null,
+      "item_code": "000F03E5",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "J'zhar"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Japhet's Journal",
+      "title_variants": null,
+      "item_code": "000F6844",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Japhet"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Jornibret's Last Dance",
+      "title_variants": [
+        "Lord Jornibret's Last Dance"
+      ],
+      "item_code": "0001B002",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": "Light Armor",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Journal",
+      "title_variants": null,
+      "item_code": "00077536",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Journal",
+      "title_variants": null,
+      "item_code": "0008E5DF",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Kornalus Frey"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Journal",
+      "title_variants": null,
+      "item_code": "000DC198",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Journal Fragment",
+      "title_variants": null,
+      "item_code": "XX0188C8",
+      "unit_weight": 0.0,
+      "book_type": "journal",
+      "authors": [
+        "Feral Vampire"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Journal of Drokt",
+      "title_variants": null,
+      "item_code": "00026D85",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Drokt"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Journal of Mirtil Angoth",
+      "title_variants": null,
+      "item_code": "XX01A3E6",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Mirtil Angoth"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Journal of a Madman",
+      "title_variants": null,
+      "item_code": "XX027A13",
+      "unit_weight": 0.0,
+      "book_type": "journal",
+      "authors": [
+        "Wizard"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Justiciar Execution Order",
+      "title_variants": null,
+      "item_code": "000BA0BE",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Karan's Journal",
+      "title_variants": null,
+      "item_code": "0003A06F",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Breton"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Katria's Journal",
+      "title_variants": null,
+      "item_code": "XX0146DB",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Katria"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Killing - Before You're Killed",
+      "title_variants": null,
+      "item_code": "000EDD35",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Eduardo Corvus"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "King",
+      "title_variants": null,
+      "item_code": "0001AFE5",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Reven"
+      ],
+      "skill_name": "Two-Handed",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "King Olaf's Verse",
+      "title_variants": null,
+      "item_code": "000AE324",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Kodlak's Journal",
+      "title_variants": null,
+      "item_code": "000F6841",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Kodlak Whitemane"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Kolb and the Dragon",
+      "title_variants": [
+        "Kolb and the Dragon: An Adventure for Nord Boys"
+      ],
+      "item_code": "000EF53E",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": null,
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Krag's Journal",
+      "title_variants": null,
+      "item_code": "000C36EF",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Krag"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Kyr's Bounty",
+      "title_variants": null,
+      "item_code": "000D07B2",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Kyr"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Kyr's Log",
+      "title_variants": null,
+      "item_code": "000D0E4E",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Kyr"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Lakeview Manor Charter",
+      "title_variants": null,
+      "item_code": "XX01579F",
+      "unit_weight": 1.0,
+      "book_type": "document",
+      "authors": null,
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Last Scabbard of Akrash",
+      "title_variants": [
+        "The Last Scabbard of Akrash",
+        "The Last Scabbard of Akrash, Story of a slaver's daughter and her Khajiit lover"
+      ],
+      "item_code": "0001AFCF",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Tabar Vunqidh"
+      ],
+      "skill_name": "Smithing",
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Legend of Krately House",
+      "title_variants": [
+        "The Legend of the Krately House"
+      ],
+      "item_code": "0001B021",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Baloth-Kul"
+      ],
+      "skill_name": "Sneak",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Letter",
+      "title_variants": null,
+      "item_code": "XX02B23B",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Bjornolfr"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Letter",
+      "title_variants": null,
+      "item_code": "0008ACCD",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Letter from \u003cNAME\u003e",
+      "title_variants": null,
+      "item_code": "00071443",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Various"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Letter from \u003cNAME\u003e",
+      "title_variants": null,
+      "item_code": "00071442",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Various"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Letter from \u003cNAME\u003e",
+      "title_variants": null,
+      "item_code": "00039FC3",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Various"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Letter from Calcemo",
+      "title_variants": null,
+      "item_code": "000A0F46",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Calcelmo"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Letter from Christophe",
+      "title_variants": null,
+      "item_code": "000F6893",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Christophe Bartlet"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Letter from Falk Firebeard",
+      "title_variants": null,
+      "item_code": "000D91D1",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Falk Firebeard"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Letter from Father",
+      "title_variants": null,
+      "item_code": "000CC86A",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Commander Maro"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Letter from Jon",
+      "title_variants": null,
+      "item_code": "00027F74",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Jon Battle-Born"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Letter from Maven",
+      "title_variants": null,
+      "item_code": "000F6894",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Maven Black-Briar"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Letter from Olfina",
+      "title_variants": null,
+      "item_code": "00027F73",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Olfina Gray-Mane"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Letter from Quintus Navale",
+      "title_variants": null,
+      "item_code": "000249AF",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Quintus Navale"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Letter from Ralis Sedarys",
+      "title_variants": null,
+      "item_code": "XX0365FF",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Ralis Sedarys"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Letter from Ralis Sedarys 2",
+      "title_variants": null,
+      "item_code": "XX036600",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Ralis Sedarys"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Letter from Ralis Sedarys 3",
+      "title_variants": null,
+      "item_code": "XX036601",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Ralis Sedarys"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Letter from Ralis Sedarys 4",
+      "title_variants": null,
+      "item_code": "XX036602",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Ralis Sedarys"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Letter from Sabjorn",
+      "title_variants": null,
+      "item_code": "000F6895",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Sabjorn"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Letter from Septimus Signus",
+      "title_variants": null,
+      "item_code": "000F6842",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Septimus Signus"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Letter from Solitude",
+      "title_variants": null,
+      "item_code": "0007D02F",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Letter from a Friend",
+      "title_variants": null,
+      "item_code": "00023EE5",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Letter from the Jarl of Falkreath",
+      "title_variants": null,
+      "item_code": "XX016130",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": null,
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Letter from the Steward",
+      "title_variants": null,
+      "item_code": "000CADEC",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Jorleif"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Letter from the Steward of Falkreath",
+      "title_variants": null,
+      "item_code": "XX0030A1",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": null,
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Letter from the Vampire",
+      "title_variants": null,
+      "item_code": "XX006956",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Letter of Credit",
+      "title_variants": null,
+      "item_code": "0005B49E",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Delvin Mallory"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Letter of Inheritance",
+      "title_variants": null,
+      "item_code": "0001BFF5",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Various"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Letter to Beem-Ja",
+      "title_variants": null,
+      "item_code": "000E7F3C",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Father of Salma"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Letter to Golldir",
+      "title_variants": null,
+      "item_code": "00019FEA",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Vals Veran"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Letter to Imperial City",
+      "title_variants": null,
+      "item_code": "XX026AE8",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "General Falx Carius"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Letter to Salma",
+      "title_variants": null,
+      "item_code": "000E7F3B",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Father of Salma"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Letter to Usha",
+      "title_variants": null,
+      "item_code": "XX03537C",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Monesa"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Light Armor Forging",
+      "title_variants": null,
+      "item_code": "0001AFD0",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Revus Sarvani"
+      ],
+      "skill_name": "Smithing",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Liminal Bridges",
+      "title_variants": [
+        "Liminal Bridges: A Discourse on the Theory and Praxis of Travelling Between Mundus and Oblivion"
+      ],
+      "item_code": "0001AFE8",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Camilonwe of Alinor"
+      ],
+      "skill_name": "Conjuration",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Lives of the Saints",
+      "title_variants": null,
+      "item_code": "XX028269",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Tribunal Temple"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Lorcalin's Orders",
+      "title_variants": null,
+      "item_code": "000DD99C",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Elenwen"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Lost Legends",
+      "title_variants": [
+        "Lost Legends of Skyrim"
+      ],
+      "item_code": "000ED608",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Talsgar the Elder"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Love Poem",
+      "title_variants": null,
+      "item_code": "000211D7",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Yngvar the Singer"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Lu'ah's Journal",
+      "title_variants": null,
+      "item_code": "00090213",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Lu'ah Al-Skaven"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Lycanthropic Legends of Skyrim",
+      "title_variants": null,
+      "item_code": "000ED042",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Lentulus Inventius"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Lymdrenn Telvanni's Journal",
+      "title_variants": null,
+      "item_code": "000E82BE",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Lymdrenn Telvanni",
+        "Hidyra Olen"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Mace Etiquette",
+      "title_variants": null,
+      "item_code": "0001AFE6",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": "One-Handed",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Madanach's Note",
+      "title_variants": null,
+      "item_code": "000E2513",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Madanach"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Magic from the Sky",
+      "title_variants": null,
+      "item_code": "0001ACF1",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Irlav Jarol"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Maluril's Journal",
+      "title_variants": null,
+      "item_code": "0006BE25",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Maluril"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Malyn Varen's Grimoire",
+      "title_variants": [
+        "The Black Star: An Achievement of Magic over Daedra"
+      ],
+      "item_code": "00028ADC",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Malyn Varen"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Mani's Letter",
+      "title_variants": null,
+      "item_code": "000D0968",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Mani"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Mannimarco, King of Worms",
+      "title_variants": null,
+      "item_code": "0001AFC5",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Horicles"
+      ],
+      "skill_name": "Alchemy",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Many Thanks",
+      "title_variants": null,
+      "item_code": "000F689B",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "R"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Mara Smiles Upon You!",
+      "title_variants": null,
+      "item_code": "000F68A7",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Drifa"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Margret's Journal",
+      "title_variants": null,
+      "item_code": "000D3E6B",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Margret"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Markarth Home Decorating Guide",
+      "title_variants": null,
+      "item_code": "000F1445",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Master Illusion Text",
+      "title_variants": null,
+      "item_code": "000B3236",
+      "unit_weight": 0.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Master Illusion Text",
+      "title_variants": null,
+      "item_code": "000B3239",
+      "unit_weight": 0.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Master Illusion Text",
+      "title_variants": null,
+      "item_code": "000B3238",
+      "unit_weight": 0.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Master Illusion Text",
+      "title_variants": null,
+      "item_code": "000B3237",
+      "unit_weight": 0.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Medresi's Notes",
+      "title_variants": [
+        "The Journal of Medresi Dran: On Angarvunde"
+      ],
+      "item_code": "000B716A",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Medresi Dran"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Merchant's Journal",
+      "title_variants": null,
+      "item_code": "000DD125",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Merilar's Journal",
+      "title_variants": null,
+      "item_code": "XX0280C2",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Merilar Rendas"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Midden Incident Report",
+      "title_variants": null,
+      "item_code": "000D30C8",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Unnamed Imperial Investigator"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Miner's Journal",
+      "title_variants": null,
+      "item_code": "00055549",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Hadrir"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Minorne",
+      "title_variants": [
+        "The Scripture of Minorne"
+      ],
+      "item_code": "XX01957E",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Moric Sidrey"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Mireli's Letter to Mother",
+      "title_variants": null,
+      "item_code": "XX0277F1",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Mireli"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Mixed Unit Tactics",
+      "title_variants": [
+        "Mixed Unit Tactics in the Five Years War Volume One"
+      ],
+      "item_code": "0001ACD1",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Codus Callonus"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Mogrul's Orders",
+      "title_variants": null,
+      "item_code": "XX037251",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Mogrul"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Museum Pamphlet",
+      "title_variants": null,
+      "item_code": "00094D8B",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Silus Vesuius"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Mysterious Akavir",
+      "title_variants": null,
+      "item_code": "0001ACD4",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Mysterious Note",
+      "title_variants": null,
+      "item_code": "0005224A",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Mysterious Note",
+      "title_variants": null,
+      "item_code": "0003031F",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Delphine"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Mystery of Talara, Book I",
+      "title_variants": [
+        "The Mystery of Princess Talara, Part I"
+      ],
+      "item_code": "0001AFC3",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Mera Llykith"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Mystery of Talara, Book II",
+      "title_variants": [
+        "The Mystery of Princess Talara, Part II"
+      ],
+      "item_code": "0001B018",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Mera Llykith"
+      ],
+      "skill_name": "Restoration",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Mystery of Talara, Book III",
+      "title_variants": [
+        "The Mystery of Princess Talara, Part III"
+      ],
+      "item_code": "0001AFF0",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Mera Llykith"
+      ],
+      "skill_name": "Destruction",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Mystery of Talara, Book IV",
+      "title_variants": [
+        "The Mystery of Princess Talara, Part IV"
+      ],
+      "item_code": "0001B013",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Mera Llykith"
+      ],
+      "skill_name": "Illusion",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Mystery of Talara, Book V",
+      "title_variants": [
+        "The Mystery of Princess Talara, Part V"
+      ],
+      "item_code": "0001ACF5",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Mera Llykith"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Mythic Dawn Commentaries 1",
+      "title_variants": [
+        "Commentaries on the Mysterium Xarxes: Book One"
+      ],
+      "item_code": "00086EF8",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Mankar Camoran"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Mythic Dawn Commentaries 2",
+      "title_variants": [
+        "Commentaries on the Mysterium Xarxes: Book One"
+      ],
+      "item_code": "00086EF9",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Mankar Camoran"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Mythic Dawn Commentaries 3",
+      "title_variants": [
+        "Commentaries on the Mysterium Xarxes: Book Three"
+      ],
+      "item_code": "00086EFA",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Mankar Camoran"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Mythic Dawn Commentaries 4",
+      "title_variants": [
+        "Commentaries on the Mysterium Xarxes: Book Four"
+      ],
+      "item_code": "00086EFB",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Mankar Camoran"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Myths of Sheogorath",
+      "title_variants": null,
+      "item_code": "0001ACB8",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Mymophonus"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Mzinchaleft Guard's Note",
+      "title_variants": null,
+      "item_code": "000DB0D7",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Mzinchaleft Work Order",
+      "title_variants": null,
+      "item_code": "00088FE8",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Maluril Ferano"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "N'Gasta! Kvata! Kvakis!",
+      "title_variants": null,
+      "item_code": "0001AD0E",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "N'Gasta"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Nchunak's Fire and Faith",
+      "title_variants": null,
+      "item_code": "XX02826A",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Nchunak"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Necromancer's Letter",
+      "title_variants": null,
+      "item_code": "00083B08",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Nepos' Journal",
+      "title_variants": null,
+      "item_code": "000D672B",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Nepos the Nose"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Nerevar Moon-and-Star",
+      "title_variants": null,
+      "item_code": "0001AD0D",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Carlovac Townway"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Nerevar at Red Mountain",
+      "title_variants": null,
+      "item_code": "XX02826B",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Tribunal Temple"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Night Falls on Sentinel",
+      "title_variants": null,
+      "item_code": "0001AFE4",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Boali"
+      ],
+      "skill_name": "One-Handed",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Night of Tears",
+      "title_variants": null,
+      "item_code": "0004D249",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Dranor Seleth"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Nightingales: Fact or Fiction?",
+      "title_variants": [
+        "The Nightingales: Fact or Fiction?"
+      ],
+      "item_code": "000ED039",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Wilmina Roth"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "No Word Yet",
+      "title_variants": null,
+      "item_code": "000F692C",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Athel Newberry"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Nords Arise!",
+      "title_variants": null,
+      "item_code": "000ED161",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Nords of Skyrim",
+      "title_variants": [
+        "Nords of Skyrim - My People, My Pride"
+      ],
+      "item_code": "000E0D66",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Hrothmund Wolf-Heart"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Note",
+      "title_variants": null,
+      "item_code": "0006DFAF",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Note",
+      "title_variants": null,
+      "item_code": "0006F63C",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Note",
+      "title_variants": null,
+      "item_code": "0008B471",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Note",
+      "title_variants": null,
+      "item_code": "000C0136",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Note",
+      "title_variants": null,
+      "item_code": "000D120C",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Note",
+      "title_variants": null,
+      "item_code": "000D1246",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Note",
+      "title_variants": null,
+      "item_code": "XX015D88",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Note from Agna",
+      "title_variants": null,
+      "item_code": "000BC6FD",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Agna"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Note from Jaree-Ra",
+      "title_variants": null,
+      "item_code": "000F23E0",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Jaree-Ra"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Note from Maven",
+      "title_variants": null,
+      "item_code": "000F68A3",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Maven Black-Briar"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Note to Rhorlak",
+      "title_variants": null,
+      "item_code": "00078621",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Rigel Strong-Arm"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Note to Rodulf",
+      "title_variants": null,
+      "item_code": "000E163F",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Hajvarr Iron-Hand"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Note to Thomas",
+      "title_variants": null,
+      "item_code": "000C3B1A",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Loraine"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Note to the Authorities",
+      "title_variants": null,
+      "item_code": "0009793A",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Notes on Dimhollow Crypt, Vol. 3",
+      "title_variants": null,
+      "item_code": "XX00D070",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Vigilant Adalvald"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Notes on Racial Phylogeny",
+      "title_variants": [
+        "Notes on Racial Phylogeny and Biology, Seventh Edition"
+      ],
+      "item_code": "0001B015",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Council of Healers"
+      ],
+      "skill_name": "Restoration",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Notes on Yngol Barrow",
+      "title_variants": null,
+      "item_code": "000B6426",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Notes on the Lunar Forge",
+      "title_variants": null,
+      "item_code": "00063A0F",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Notice",
+      "title_variants": null,
+      "item_code": "0008ACCC",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Notice of Cost Increase",
+      "title_variants": null,
+      "item_code": "000F68A6",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Maven Black-Briar"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Nystrom's Journal",
+      "title_variants": null,
+      "item_code": "000FF207",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Nystrom"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Ode to the Tundrastriders",
+      "title_variants": null,
+      "item_code": "000ED607",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Of Crossed Daggers",
+      "title_variants": [
+        "Of Crossed Daggers: The History of Riften"
+      ],
+      "item_code": "000ED035",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Dwennon Wyndell"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Of Fjori and Holgeir",
+      "title_variants": null,
+      "item_code": "000B64B1",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Official Warning",
+      "title_variants": null,
+      "item_code": "00068253",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Oghma Infinium",
+      "title_variants": null,
+      "item_code": "0001A332",
+      "unit_weight": 1.0,
+      "book_type": "quest book",
+      "authors": [
+        "Xarxes"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Olaf and the Dragon",
+      "title_variants": null,
+      "item_code": "000EB090",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Adonato Leotelli"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Old Tome",
+      "title_variants": null,
+      "item_code": "0008F741",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "On Apocrypha: Boneless Limbs",
+      "title_variants": null,
+      "item_code": "XX03A35F",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "On Apocrypha: Delving Pincers",
+      "title_variants": null,
+      "item_code": "XX03A360",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "On Apocrypha: Gnashing Blades",
+      "title_variants": null,
+      "item_code": "XX03A361",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "On Apocrypha: Prying Orbs",
+      "title_variants": null,
+      "item_code": "XX03A362",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "On Oblivion",
+      "title_variants": null,
+      "item_code": "0001ACF3",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Morian Zenas"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "On Stepping Lightly",
+      "title_variants": [
+        "On Stepping Lightly: The Nordic Ruins of Skyrim"
+      ],
+      "item_code": "000ED037",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Sigilis Justus"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "On the Great Collapse",
+      "title_variants": null,
+      "item_code": "000EDA8E",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Arch-Mage Deneth"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Opusculus Lamae Bal",
+      "title_variants": [
+        "Opusculus Lamae Bal ta Mezzamortie: A brief account of Lamae Bal and the Restless Death"
+      ],
+      "item_code": "0001AF40",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Mabei Aywenil"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Orders",
+      "title_variants": null,
+      "item_code": "0006DFAC",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Orders (Dawnguard)",
+      "title_variants": null,
+      "item_code": "XX007ECB",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Orsinium and the Orcs",
+      "title_variants": [
+        "How Orsinium Passed to the Orcs"
+      ],
+      "item_code": "0001AFF9",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Menyna Gsost"
+      ],
+      "skill_name": "Heavy Armor",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Palla, volume 1",
+      "title_variants": null,
+      "item_code": "0001AFFE",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Vojne Mierstyyd"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Palla, volume 2",
+      "title_variants": null,
+      "item_code": "0001ACF4",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Vojne Mierstyyd"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Paralysis Poison Recipe",
+      "title_variants": null,
+      "item_code": "000F5CB2",
+      "unit_weight": 0.0,
+      "book_type": "recipe",
+      "authors": null,
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": [
+      {
+        "item_code": "0006ABCB"
+      },
+      {
+        "item_code": "0007E8B7"
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "title": "Paralysis Poison Recipe",
+      "title_variants": null,
+      "item_code": "000F5CB1",
+      "unit_weight": 0.0,
+      "book_type": "recipe",
+      "authors": null,
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": [
+      {
+        "item_code": "0003AD61"
+      },
+      {
+        "item_code": "0007E8B7"
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "title": "Pension of the Ancestor Moth",
+      "title_variants": null,
+      "item_code": "0003010A",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Per Your Requests",
+      "title_variants": null,
+      "item_code": "000F68AA",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Mirabelle Ervine"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Physicalities of Werewolves",
+      "title_variants": [
+        "Experimentations in the Physicalities of Werewolves"
+      ],
+      "item_code": "000ED041",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Reman Crex"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Pirate King of the Abecean",
+      "title_variants": [
+        "Velekk Sain - Pirate King of the Abecean"
+      ],
+      "item_code": "000E7EF0",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Poison Song, Book I",
+      "title_variants": [
+        "The Poison Song, Book I"
+      ],
+      "item_code": "XX02826E",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Bristin Xel"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Poison Song, Book II",
+      "title_variants": [
+        "The Poison Song, Book II"
+      ],
+      "item_code": "XX02826F",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Bristin Xel"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Poison Song, Book III",
+      "title_variants": [
+        "The Poison Song, Book III"
+      ],
+      "item_code": "XX028270",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Bristin Xel"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Poison Song, Book IV",
+      "title_variants": [
+        "The Poison Song, Book IV"
+      ],
+      "item_code": "XX028271",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Bristin Xel"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Poison Song, Book V",
+      "title_variants": [
+        "The Poison Song, Book V"
+      ],
+      "item_code": "XX028272",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Bristin Xel"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Poison Song, Book VI",
+      "title_variants": [
+        "The Poison Song, Book VI"
+      ],
+      "item_code": "XX028273",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Bristin Xel"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Poison Song, Book VII",
+      "title_variants": [
+        "The Poison Song, Book VII"
+      ],
+      "item_code": "XX028274",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Bristin Xel"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Possible Rivals",
+      "title_variants": null,
+      "item_code": "000F692D",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Torsten Cruel-Sea"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Posted Notice",
+      "title_variants": null,
+      "item_code": "XX03A4B3",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Captain Veleth"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Power of the Elements",
+      "title_variants": null,
+      "item_code": "0009C8C2",
+      "unit_weight": 1.0,
+      "book_type": "quest book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Prisoner's Plan",
+      "title_variants": null,
+      "item_code": "000E94F1",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Private Letter",
+      "title_variants": null,
+      "item_code": "000D9399",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Lod"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Promissory Note",
+      "title_variants": null,
+      "item_code": "000813B6",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Proper Lock Design",
+      "title_variants": [
+        "Proper Lock Design and Construction"
+      ],
+      "item_code": "0001B01B",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": "Lockpicking",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Purchase Agreement",
+      "title_variants": null,
+      "item_code": "00085D4E",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Sarthis Idren"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Purchase Agreement",
+      "title_variants": null,
+      "item_code": "000557EC",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Bolli"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Purloined Shadows",
+      "title_variants": null,
+      "item_code": "0001B022",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Waughin Jarth"
+      ],
+      "skill_name": "Pickpocket",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Quite Pleased",
+      "title_variants": null,
+      "item_code": "000F689E",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Harrald"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Ra'jirr's Note",
+      "title_variants": null,
+      "item_code": "000D0032",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Ra'jirr"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Rahgot's Reply",
+      "title_variants": null,
+      "item_code": "0006DF94",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Rahgot"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Raleth Eldri's Notes on Kagrumez",
+      "title_variants": null,
+      "item_code": "XX0374D6",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Raleth Eldri"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Ramati's Journal",
+      "title_variants": null,
+      "item_code": "000D3973",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Ramati"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Reality and Other falsehoods",
+      "title_variants": [
+        "Reality \u0026 Other falsehoods"
+      ],
+      "item_code": "0001AFCC",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": "Alteration",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Recipe - Exploding Flame Spider",
+      "title_variants": null,
+      "item_code": "XX01DA0F",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Recipe - Exploding Flame Spider",
+      "title_variants": null,
+      "item_code": "XX01DA10",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Recipe - Exploding Frost Spider",
+      "title_variants": null,
+      "item_code": "XX026D3F",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Recipe - Exploding Frost Spider 2x",
+      "title_variants": null,
+      "item_code": "XX026D40",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Recipe - Exploding Poison Spider",
+      "title_variants": null,
+      "item_code": "XX01DA15",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Recipe - Exploding Poison Spider 2x",
+      "title_variants": null,
+      "item_code": "XX01DA16",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Recipe - Exploding Shock Spider",
+      "title_variants": null,
+      "item_code": "XX026D55",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Recipe - Exploding Shock Spider 2x",
+      "title_variants": null,
+      "item_code": "XX026D56",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Recipe - Flame Cloaked Spider",
+      "title_variants": null,
+      "item_code": "XX01DA11",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Recipe - Flame Cloaked Spider 2x",
+      "title_variants": null,
+      "item_code": "XX01DA12",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Recipe - Frost Cloaked Spider",
+      "title_variants": null,
+      "item_code": "XX026D41",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Recipe - Frost Cloaked Spider 2x",
+      "title_variants": null,
+      "item_code": "XX026D42",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Recipe - Jumping Flame Spider",
+      "title_variants": null,
+      "item_code": "XX01DA13",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Recipe - Jumping Flame Spider 2x",
+      "title_variants": null,
+      "item_code": "XX01DA14",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Recipe - Jumping Frost Spider",
+      "title_variants": null,
+      "item_code": "XX026D43",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Recipe - Jumping Frost Spider 2x",
+      "title_variants": null,
+      "item_code": "XX026D44",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Recipe - Jumping Poison Spider",
+      "title_variants": null,
+      "item_code": "XX01DA17",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Recipe - Jumping Poison Spider 2x",
+      "title_variants": null,
+      "item_code": "XX01DA18",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Recipe - Jumping Shock Spider",
+      "title_variants": null,
+      "item_code": "XX026D59",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Recipe - Jumping Shock Spider 2x",
+      "title_variants": null,
+      "item_code": "XX026D5A",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Recipe - Mind Control Spider",
+      "title_variants": null,
+      "item_code": "XX01DA1C",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Recipe - Oil Spider",
+      "title_variants": null,
+      "item_code": "XX027498",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Recipe - Poison Cloaked Spider",
+      "title_variants": null,
+      "item_code": "XX01DA19",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Recipe - Poison Cloaked Spider 2x",
+      "title_variants": null,
+      "item_code": "XX01DA1A",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Recipe - Shock Cloaked Spider",
+      "title_variants": null,
+      "item_code": "XX026D57",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Recipe - Shock Cloaked Spider 2x",
+      "title_variants": null,
+      "item_code": "XX026D58",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Red Eagle's Rite",
+      "title_variants": null,
+      "item_code": "000C2987",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Forsworn Briarheart"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Regarding Your Loss",
+      "title_variants": null,
+      "item_code": "000F6897",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Reginn Limilus"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Remanada",
+      "title_variants": null,
+      "item_code": "0001AD14",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Repair Supplies",
+      "title_variants": null,
+      "item_code": "000F798C",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Sam Guevenne"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Report: Disaster at Ionith",
+      "title_variants": [
+        "Report of the Imperial Commission on the Disaster at Ionith"
+      ],
+      "item_code": "0001ACC6",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Lord Pottreid"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Reports of a Disturbance",
+      "title_variants": null,
+      "item_code": "000F68A9",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anuriel"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Request for Help!",
+      "title_variants": null,
+      "item_code": "000F689C",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Madena"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Requested Report",
+      "title_variants": null,
+      "item_code": "000F6898",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Research Journal",
+      "title_variants": null,
+      "item_code": "00034CBC",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Oronel"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Research Notes",
+      "title_variants": null,
+      "item_code": "0006A80D",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Sulla Trebatius"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Resist Fire Potion Recipe",
+      "title_variants": null,
+      "item_code": "000F5CC0",
+      "unit_weight": 0.0,
+      "book_type": "recipe",
+      "authors": null,
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": [
+      {
+        "item_code": "00034D31"
+      },
+      {
+        "item_code": "0006BC00"
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "title": "Resist Fire Potion Recipe",
+      "title_variants": null,
+      "item_code": "000F5CBD",
+      "unit_weight": 0.0,
+      "book_type": "recipe",
+      "authors": null,
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": [
+      {
+        "item_code": "00034CDD"
+      },
+      {
+        "item_code": "0003AD5F"
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "title": "Resist Frost Potion Recipe",
+      "title_variants": null,
+      "item_code": "000F5CDF",
+      "unit_weight": 0.0,
+      "book_type": "recipe",
+      "authors": null,
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": [
+      {
+        "item_code": "0003AD5E"
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "title": "Resist Frost Potion Recipe",
+      "title_variants": null,
+      "item_code": "000F5CBE",
+      "unit_weight": 0.0,
+      "book_type": "recipe",
+      "authors": null,
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": [
+      {
+        "item_code": "0001B3BD"
+      },
+      {
+        "item_code": "00077E1E"
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "title": "Resist Poison Potion Recipe",
+      "title_variants": null,
+      "item_code": "000F5CC5",
+      "unit_weight": 0.0,
+      "book_type": "recipe",
+      "authors": null,
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": [
+      {
+        "item_code": "000134AA"
+      },
+      {
+        "item_code": "0003AD5D"
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "title": "Resist Shock Potion Recipe",
+      "title_variants": null,
+      "item_code": "000F5CC3",
+      "unit_weight": 0.0,
+      "book_type": "recipe",
+      "authors": null,
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": [
+      {
+        "item_code": "00023D6F"
+      },
+      {
+        "item_code": "0001B3BD"
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "title": "Resist Shock Potion Recipe",
+      "title_variants": null,
+      "item_code": "000F5CC4",
+      "unit_weight": 0.0,
+      "book_type": "recipe",
+      "authors": null,
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": [
+      {
+        "item_code": "0003AD73"
+      },
+      {
+        "item_code": "000854FE"
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "title": "Response to Bero's Speech",
+      "title_variants": null,
+      "item_code": "0001AFED",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Malviser"
+      ],
+      "skill_name": "Destruction",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Restore Health Potion Recipe",
+      "title_variants": null,
+      "item_code": "000F5CAE",
+      "unit_weight": 0.0,
+      "book_type": "recipe",
+      "authors": null,
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": [
+      {
+        "item_code": "000E4F0C"
+      },
+      {
+        "item_code": "00052695"
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "title": "Restore Health Potion Recipe",
+      "title_variants": null,
+      "item_code": "000F5CAD",
+      "unit_weight": 0.0,
+      "book_type": "recipe",
+      "authors": null,
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": [
+      {
+        "item_code": "0004DA23"
+      },
+      {
+        "item_code": "0004B0BA"
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "title": "Restore Health Potion Recipe",
+      "title_variants": null,
+      "item_code": "000F5CAC",
+      "unit_weight": 0.0,
+      "book_type": "recipe",
+      "authors": null,
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": [
+      {
+        "item_code": "00077E1C"
+      },
+      {
+        "item_code": "0006BC07"
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "title": "Restore Health Potion Recipe",
+      "title_variants": null,
+      "item_code": "000F5CAF",
+      "unit_weight": 0.0,
+      "book_type": "recipe",
+      "authors": null,
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": [
+      {
+        "item_code": "000727E0"
+      },
+      {
+        "item_code": "0004DA25"
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "title": "Restore Magicka Potion Recipe",
+      "title_variants": null,
+      "item_code": "000F5CBC",
+      "unit_weight": 0.0,
+      "book_type": "recipe",
+      "authors": null,
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": [
+      {
+        "item_code": "0007E8C1"
+      },
+      {
+        "item_code": "000854FE"
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "title": "Restore Magicka Potion Recipe",
+      "title_variants": null,
+      "item_code": "000F5CBB",
+      "unit_weight": 0.0,
+      "book_type": "recipe",
+      "authors": null,
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": [
+      {
+        "item_code": "00083E64"
+      },
+      {
+        "item_code": "00077E1D"
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "title": "Restore Magicka Potion Recipe",
+      "title_variants": null,
+      "item_code": "000F5CBA",
+      "unit_weight": 0.0,
+      "book_type": "recipe",
+      "authors": null,
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": [
+      {
+        "item_code": "0004DA22"
+      },
+      {
+        "item_code": "0003AD71"
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "title": "Riften Home Decorating Guide",
+      "title_variants": null,
+      "item_code": "000F11B7",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Rigel's Letter",
+      "title_variants": null,
+      "item_code": "00037F87",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Rigel Strong-Arm"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Rising Threat, Vol. I",
+      "title_variants": null,
+      "item_code": "000ED5F4",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Lathenil of Sunhold"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Rising Threat, Vol. II",
+      "title_variants": null,
+      "item_code": "000ED5F5",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Lathenil of Sunhold"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Rising Threat, Vol. III",
+      "title_variants": null,
+      "item_code": "000ED5F6",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Lathenil of Sunhold"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Rising Threat, Vol. IV",
+      "title_variants": null,
+      "item_code": "000ED5F7",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Lathenil of Sunhold"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Rislav the Righteous",
+      "title_variants": null,
+      "item_code": "0001B004",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Sinjin"
+      ],
+      "skill_name": "Light Armor",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Rogatus's Letter",
+      "title_variants": null,
+      "item_code": "000931C2",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Rogatus Salvius"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Roras's Letter",
+      "title_variants": null,
+      "item_code": "00037F8A",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Roras"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Ruined Trailbook",
+      "title_variants": null,
+      "item_code": "000F0424",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Ruins of Kemel-Ze",
+      "title_variants": [
+        "The Ruins of Kemel-Ze"
+      ],
+      "item_code": "0001ACDB",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Rolard Nordssen"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Rumination on the Elder Scrolls",
+      "title_variants": [
+        "Ruminations on the Elder Scrolls"
+      ],
+      "item_code": "00032785",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Septimus Signus"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Runil's Journal",
+      "title_variants": null,
+      "item_code": "000705C3",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Runil"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Sacred Witness",
+      "title_variants": [
+        "Sacred Witness: A True History of the Night Mother"
+      ],
+      "item_code": "0001B020",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Enric Milres"
+      ],
+      "skill_name": "Sneak",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Saden's Journal",
+      "title_variants": null,
+      "item_code": "XX02649C",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Saden"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Saint Jiub's Opus",
+      "title_variants": null,
+      "item_code": "XX003F79",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Jiub"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Saint Jiub's Opus (Page 1)",
+      "title_variants": [
+        "Jiub's Opus (Page 1)"
+      ],
+      "item_code": "XX014010",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Jiub"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Saint Jiub's Opus (Page 10)",
+      "title_variants": [
+        "Jiub's Opus (Page 10)"
+      ],
+      "item_code": "XX014019",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Jiub"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Saint Jiub's Opus (Page 2)",
+      "title_variants": [
+        "Jiub's Opus (Page 2)"
+      ],
+      "item_code": "XX014011",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Jiub"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Saint Jiub's Opus (Page 3)",
+      "title_variants": [
+        "Jiub's Opus (Page 3)"
+      ],
+      "item_code": "XX014012",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Jiub"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Saint Jiub's Opus (Page 4)",
+      "title_variants": [
+        "Jiub's Opus (Page 4)"
+      ],
+      "item_code": "XX014013",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Jiub"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Saint Jiub's Opus (Page 5)",
+      "title_variants": [
+        "Jiub's Opus (Page 5)"
+      ],
+      "item_code": "XX014014",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Jiub"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Saint Jiub's Opus (Page 6)",
+      "title_variants": [
+        "Jiub's Opus (Page 6)"
+      ],
+      "item_code": "XX014015",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Jiub"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Saint Jiub's Opus (Page 7)",
+      "title_variants": [
+        "Jiub's Opus (Page 7)"
+      ],
+      "item_code": "XX014016",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Jiub"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Saint Jiub's Opus (Page 8)",
+      "title_variants": [
+        "Jiub's Opus (Page 8)"
+      ],
+      "item_code": "XX014017",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Jiub"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Saint Jiub's Opus (Page 9)",
+      "title_variants": [
+        "Jiub's Opus (Page 9)"
+      ],
+      "item_code": "XX014018",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Jiub"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Scourge of the Gray Quarter",
+      "title_variants": null,
+      "item_code": "000ED03B",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Frilgeth Horse-Breaker"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Scrap of Paper",
+      "title_variants": null,
+      "item_code": "XX01A436",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Scrawled Note",
+      "title_variants": null,
+      "item_code": "XX031CC8",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Scrawled Page",
+      "title_variants": null,
+      "item_code": "000D3979",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Sudi"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Scribbles of a Madman",
+      "title_variants": null,
+      "item_code": "XX027A21",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Madman"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Second Letter from EEC",
+      "title_variants": null,
+      "item_code": "XX03A2A1",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Vittoria Vici"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Second Letter from Linwe",
+      "title_variants": null,
+      "item_code": "0007D67D",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Linwe"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Servos's Journal",
+      "title_variants": null,
+      "item_code": "XX0280C1",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Servos Rendas"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Shadowmarks",
+      "title_variants": null,
+      "item_code": "000F84A1",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Delvin Mallory"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Shalidor's Insights",
+      "title_variants": null,
+      "item_code": "000F6275",
+      "unit_weight": 0.0,
+      "book_type": "quest book",
+      "authors": [
+        "Arch-Mage Shalidor"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Shavari's Note",
+      "title_variants": null,
+      "item_code": "0006DEB5",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Elenwen"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Shezarr and the Divines",
+      "title_variants": null,
+      "item_code": "0001AF93",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Faustilius Junius"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Shipment's Arrived",
+      "title_variants": null,
+      "item_code": "000F692B",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Shipment's Ready",
+      "title_variants": null,
+      "item_code": "00065BDA",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Kilnyr"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Shopping List",
+      "title_variants": null,
+      "item_code": "000F689A",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Sibbi Black-Briar",
+      "title_variants": null,
+      "item_code": "000F68AB",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Maven Black-Briar"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Sild's Journal",
+      "title_variants": null,
+      "item_code": "000AD430",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Sild the Warlock"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Sinderion's Field Journal",
+      "title_variants": null,
+      "item_code": "000E4D6F",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Sinderion"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Sithis",
+      "title_variants": null,
+      "item_code": "0001AFCB",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": "Alteration",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Sixteen Accords of Madness, Book IX",
+      "title_variants": [
+        "16 Accords of Madness, v. IX",
+        "Sixteen Accords of Madness Volume IX"
+      ],
+      "item_code": "0001AFB3",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Sixteen Accords of Madness, Book VI",
+      "title_variants": [
+        "16 Accords of Madness, v. VI",
+        "Sixteen Accords of Madness Volume VI"
+      ],
+      "item_code": "0001AFB2",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Sixteen Accords of Madness, Book XII",
+      "title_variants": [
+        "16 Accords of Madness, v. XII",
+        "Sixteen Accords of Madness Volume XII"
+      ],
+      "item_code": "0001AFB1",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Skorm Snow-Strider",
+      "title_variants": null,
+      "item_code": "0007E5B8",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Skorm Snow-Strider"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Skyrim's Rule: An Outsider's View",
+      "title_variants": null,
+      "item_code": "000ED04C",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Abdul-Mujib Ababneh"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Small Note",
+      "title_variants": null,
+      "item_code": "000F5BC0",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Smuggler's Journal",
+      "title_variants": null,
+      "item_code": "000DC3AF",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Smuggler"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Smuggler's Note",
+      "title_variants": null,
+      "item_code": "000DD998",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Soldier's Request",
+      "title_variants": null,
+      "item_code": "0008AA45",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Solitude Home Decorating Guide",
+      "title_variants": null,
+      "item_code": "000F1447",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Sondas's Note",
+      "title_variants": null,
+      "item_code": "00069007",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Sondas Drenim"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Song of the Alchemists",
+      "title_variants": [
+        "Ancient Tales of the Dwemer, Part V: Song of the Alchemists"
+      ],
+      "item_code": "0001AFC6",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Marobar Sul"
+      ],
+      "skill_name": "Alchemy",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Song of the Askelde Men",
+      "title_variants": null,
+      "item_code": "000E7F37",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Songs of Skyrim",
+      "title_variants": null,
+      "item_code": "000ED062",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Giraud Gemane"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Songs of Skyrim (Revised Edition)",
+      "title_variants": null,
+      "item_code": "000F11D5",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Giraud Gemane"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Songs of the Return, Vol 19",
+      "title_variants": [
+        "Songs of the Return, Volume 19: The Second Tale of the Ylgermet"
+      ],
+      "item_code": "000ED03D",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Songs of the Return, Vol 2",
+      "title_variants": [
+        "Songs of the Return, Volume 2: The First Tale of the Darumzu"
+      ],
+      "item_code": "000ED046",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Songs of the Return, Vol 24",
+      "title_variants": [
+        "Songs of the Return, Volume 24 - The First Tale of the Krilot Lok"
+      ],
+      "item_code": "000ED048",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Songs of the Return, Vol 56",
+      "title_variants": [
+        "Songs of the Return, Volume 56: The Final Tale of the Chrion"
+      ],
+      "item_code": "000ED044",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Songs of the Return, Vol 7",
+      "title_variants": [
+        "Songs of the Return, Volume 7: The Tale of the Jorrvaskr"
+      ],
+      "item_code": "000ED045",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Souls, Black and White",
+      "title_variants": null,
+      "item_code": "0001AD0C",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Sovngarde, a Reexamination",
+      "title_variants": null,
+      "item_code": "000E2FC6",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Bereditte Jastal"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Spider Experiment Notes",
+      "title_variants": null,
+      "item_code": "XX017072",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Spirit of Nirn",
+      "title_variants": [
+        "Spirit of Nirn, God of Mortals"
+      ],
+      "item_code": "0001B25A",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": null,
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Spirit of the Daedra",
+      "title_variants": null,
+      "item_code": "0001AD15",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Staubin's Diary",
+      "title_variants": null,
+      "item_code": "0008E8FC",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Staubin"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Stormcloak Missive",
+      "title_variants": null,
+      "item_code": "00083B04",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Stormcloak Missive",
+      "title_variants": null,
+      "item_code": "00083AFF",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Stromm's Diary",
+      "title_variants": null,
+      "item_code": "00093846",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Stromm"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Sudi's Journal",
+      "title_variants": null,
+      "item_code": "000D0969",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Sudi"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Sulla's Journal",
+      "title_variants": null,
+      "item_code": "0008ACD2",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Sulla Trebatius"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Surfeit of Thieves",
+      "title_variants": null,
+      "item_code": "0001B01D",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Aniis Noru"
+      ],
+      "skill_name": "Lockpicking",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Suvaris Atheron's Logbook",
+      "title_variants": null,
+      "item_code": "0001DBFE",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Suvaris Atheron"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Sven's Fake Letter from Faendal",
+      "title_variants": null,
+      "item_code": "005C847",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Sven"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Tattered Journal",
+      "title_variants": null,
+      "item_code": "000B6D60",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Tattered Journal",
+      "title_variants": null,
+      "item_code": "000F0423",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Tattered Note",
+      "title_variants": null,
+      "item_code": "00108160",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Thalmor Dossier: Delphine",
+      "title_variants": null,
+      "item_code": "000F6845",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Thalmor Dossier: Esbern",
+      "title_variants": null,
+      "item_code": "0003AF29",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Thalmor Dossier: Ulfric Stormcloak",
+      "title_variants": null,
+      "item_code": "000F6846",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Thalmor Orders",
+      "title_variants": null,
+      "item_code": "00097803",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Elenwen"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The \"Madmen\" of the Reach",
+      "title_variants": [
+        "The \"Madmen\" of the Reach: A Cultural Treatise on the Forsworn"
+      ],
+      "item_code": "0007EB03",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Arrianus Arius"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Adabal-a",
+      "title_variants": null,
+      "item_code": "0001AF94",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Aetherium Wars",
+      "title_variants": null,
+      "item_code": "XX004D5B",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Taron Dreth"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Alduin/Akatosh Dichotomy",
+      "title_variants": null,
+      "item_code": "000ED04B",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Alexandre Simon"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Amulet of Kings",
+      "title_variants": null,
+      "item_code": "0001ACE1",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Wenengrus Monhona"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Anticipations",
+      "title_variants": null,
+      "item_code": "XX02826C",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Tribunal Temple"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Apprentice's Assistant",
+      "title_variants": null,
+      "item_code": "000EDA8F",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Aramril"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Arcturian Heresy",
+      "title_variants": null,
+      "item_code": "0001B25E",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Underking",
+        " Ysmir Kingmaker"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Argonian Account, Book I",
+      "title_variants": [
+        "The Argonian Account, Book 1",
+        "The Argonian Account, Book One"
+      ],
+      "item_code": "0001AFD7",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Waughin Jarth"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Argonian Account, Book II",
+      "title_variants": [
+        "The Argonian Account, Book 2",
+        "The Argonian Account, Book Two"
+      ],
+      "item_code": "0001ACE7",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Waughin Jarth"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Argonian Account, Book III",
+      "title_variants": [
+        "The Argonian Account, Book 3",
+        "The Argonian Account, Book Three"
+      ],
+      "item_code": "0001AFFC",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Waughin Jarth"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Argonian Account, Book IV",
+      "title_variants": [
+        "The Argonian Account, Book 4",
+        "The Argonian Account, Book Four"
+      ],
+      "item_code": "0001ACE8",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Waughin Jarth"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Armorer's Challenge",
+      "title_variants": null,
+      "item_code": "0001AFCE",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Mymophonus"
+      ],
+      "skill_name": "Smithing",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Art of War Magic",
+      "title_variants": null,
+      "item_code": "0001AFEF",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Zurin Arctus"
+      ],
+      "skill_name": "Destruction",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Axe Man",
+      "title_variants": null,
+      "item_code": "XX02826D",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Battle of Red Mountain",
+      "title_variants": [
+        "The Battle of Red Mountain and the Rise and Fall of the Tribunal"
+      ],
+      "item_code": "0002F83C",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Vivec"
+      ],
+      "skill_name": "Block",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Bear of Markarth",
+      "title_variants": [
+        "The Bear of Markarth: The Crimes of Ulfric Stormcloak"
+      ],
+      "item_code": "0007EB9E",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Arrianus Arius"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Beginner's Guide to Homesteading",
+      "title_variants": null,
+      "item_code": "XX015D59",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Betrayed",
+      "title_variants": null,
+      "item_code": "XX01A3E5",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Engwe Emeloth"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Black Arrow, Book I",
+      "title_variants": null,
+      "item_code": "0001AFC2",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Gorgic Guine"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Black Arrow, V2",
+      "title_variants": [
+        "The Black Arrow, Book II"
+      ],
+      "item_code": "0001B009",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Gorgic Guine"
+      ],
+      "skill_name": "Archery",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Black Arts on Trial",
+      "title_variants": null,
+      "item_code": "0001B011",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Hannibal Traven"
+      ],
+      "skill_name": "Illusion",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Book of Daedra",
+      "title_variants": null,
+      "item_code": "0001ACC8",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Book of Fate",
+      "title_variants": null,
+      "item_code": "00105A52",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Book of Life and Service",
+      "title_variants": null,
+      "item_code": "XX00FAC2",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Book of the Dragonborn",
+      "title_variants": null,
+      "item_code": "000F86FE",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Prior Emelene Madrine"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Brothers of Darkness",
+      "title_variants": null,
+      "item_code": "0001ACFF",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Pellarne Assi"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Buying Game",
+      "title_variants": null,
+      "item_code": "0001B00A",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Ababael Timsar-Dadisun"
+      ],
+      "skill_name": "Speech",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Cabin in the Woods",
+      "title_variants": [
+        "The Cabin in the Woods, Volume II"
+      ],
+      "item_code": "000EF638",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Mogen Son of Molag"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Cake and the Diamond",
+      "title_variants": null,
+      "item_code": "0001B262",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Athyn Muendil"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Changed Ones",
+      "title_variants": null,
+      "item_code": "XX028263",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The City of Stone: A Sellsword's Guide to Markarth",
+      "title_variants": null,
+      "item_code": "0007EBC2",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Amanda Alleia"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Cleansing of the Fane",
+      "title_variants": [
+        "The Chronicles of the Holy Brothers of of Marukh Volume IV"
+      ],
+      "item_code": "0001AD04",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Alessian Order"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Code of Malacath",
+      "title_variants": null,
+      "item_code": "0007EBC9",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Amanda Alleia"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Death Blow of Abernanit",
+      "title_variants": [
+        "The Death Blow of Abernanit with Explains by the sage Geocrates Varnus"
+      ],
+      "item_code": "0001AFDD",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": "Block",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Doors of Oblivion",
+      "title_variants": null,
+      "item_code": "0001AFE7",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Seif-Ij Hidja"
+      ],
+      "skill_name": "Conjuration",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Doors of the Spirit",
+      "title_variants": null,
+      "item_code": "XX028265",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Dowry",
+      "title_variants": [
+        "Ancient Tales of the Dwemer, Part X: The Dowry"
+      ],
+      "item_code": "0001ACF2",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Marobar Sul"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Dragon Break Reexamined",
+      "title_variants": [
+        "The Dragon Break Reexamined"
+      ],
+      "item_code": "0001AFCA",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Fal Droon"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Dragon War",
+      "title_variants": null,
+      "item_code": "000EDDD5",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Torhal Bjorik"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Dreamstride",
+      "title_variants": null,
+      "item_code": "0009DE3D",
+      "unit_weight": 1.0,
+      "book_type": "quest book",
+      "authors": [
+        "Alchemists of Vaermina"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Exodus",
+      "title_variants": null,
+      "item_code": "0001B016",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Waughin Jarth"
+      ],
+      "skill_name": "Restoration",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Falmer: A Study",
+      "title_variants": null,
+      "item_code": "000E0D68",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Ursa Uthrax"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Final Lesson",
+      "title_variants": [
+        "Final Lesson"
+      ],
+      "item_code": "0001B267",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Aegrothius Goth"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Firmament",
+      "title_variants": null,
+      "item_code": "0001ACD2",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Ffoulke"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Firsthold Revolt",
+      "title_variants": null,
+      "item_code": "0001ACD3",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Maveus Cie"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Five Far Stars",
+      "title_variants": null,
+      "item_code": "XX028267",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Zershishi Mus-Manul"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Four Totems of Volskygge",
+      "title_variants": null,
+      "item_code": "00068B5A",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": null,
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Gold Ribbon of Merit",
+      "title_variants": null,
+      "item_code": "0001B005",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Ampyrian Brum"
+      ],
+      "skill_name": "Archery",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Great War",
+      "title_variants": [
+        "A Concise Account of the Great War Between the Empire and the Aldmeri Dominion"
+      ],
+      "item_code": "000F456D",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Legate Justanius Quintius"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Guardian and the Traitor",
+      "title_variants": null,
+      "item_code": "XX03ABCD",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Lucius Gallus"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Holds of Skyrim",
+      "title_variants": [
+        "The Holds of Skyrim: A Field Officer's Guide for Use by Officers of the Imperial Legion"
+      ],
+      "item_code": "000ED030",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Hope of the Redoran",
+      "title_variants": null,
+      "item_code": "0001B26A",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Turiul Nirith"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Horror of Castle Xyr",
+      "title_variants": [
+        "The Horror of Castle Xyr: A One Act Play"
+      ],
+      "item_code": "0001AFEC",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Baloth-Kul"
+      ],
+      "skill_name": "Destruction",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The House of Troubles",
+      "title_variants": null,
+      "item_code": "XX028268",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Importance of Where",
+      "title_variants": [
+        "Ancient Tales of the Dwemer, Part III: The Importance of Where"
+      ],
+      "item_code": "0001AFE3",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Marobar Sul"
+      ],
+      "skill_name": "One-Handed",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Journal of Ralis Sedarys - Volume 19",
+      "title_variants": [
+        "The Journal of Ralis Sedarys, Volume 19"
+      ],
+      "item_code": "XX018108",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Ralis Sedarys"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Journal of Ralis Sedarys - Volume 20",
+      "title_variants": [
+        "The Journal of Ralis Sedarys, Volume 20"
+      ],
+      "item_code": "XX01810F",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Ralis Sedarys"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Journal of Ralis Sedarys - Volume 21",
+      "title_variants": [
+        "The Journal of Ralis Sedarys, Volume 21"
+      ],
+      "item_code": "XX018110",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Ralis Sedarys"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Journal of Ralis Sedarys - Volume 22",
+      "title_variants": [
+        "The Journal of Ralis Sedarys, Volume 22"
+      ],
+      "item_code": "XX018111",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Ralis Sedarys"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Journal of Ralis Sedarys - Volume 23",
+      "title_variants": [
+        "The Journal of Ralis Sedarys, Volume 23"
+      ],
+      "item_code": "XX0181CB",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Ralis Sedarys"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Keepers of the Razor",
+      "title_variants": [
+        "Keepers of the Razor: Current Descendents of the Inner Circle"
+      ],
+      "item_code": "000973AC",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Knights of the Nine",
+      "title_variants": null,
+      "item_code": "0001AFFA",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Karoline of Solitude"
+      ],
+      "skill_name": "Heavy Armor",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Last King of the Ayleids",
+      "title_variants": null,
+      "item_code": "0001AD09",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Herminia Cinna"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Legend of Red Eagle",
+      "title_variants": null,
+      "item_code": "000C1771",
+      "unit_weight": 1.0,
+      "book_type": "quest book",
+      "authors": [
+        "Tredayn Dren"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Legendary Sancre Tor",
+      "title_variants": null,
+      "item_code": "0001AFE2",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Matera Chapel"
+      ],
+      "skill_name": "Two-Handed",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Legendary Scourge",
+      "title_variants": null,
+      "item_code": "0001AD0A",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Marobar Sul"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Locked Room",
+      "title_variants": null,
+      "item_code": "0001B019",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Porbert Lyttumly"
+      ],
+      "skill_name": "Lockpicking",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Lunar Lorkhan",
+      "title_variants": null,
+      "item_code": "0001AFCD",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Fal Droon"
+      ],
+      "skill_name": "Alteration",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Lusty Argonian Maid, v1",
+      "title_variants": [
+        "The Lusty Argonian Maid, Vol 1",
+        "The Lusty Argonian Maid, Volume 1"
+      ],
+      "item_code": "0001ACEF",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Crassius Curio"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Lusty Argonian Maid, v2",
+      "title_variants": [
+        "The Lusty Argonian Maid, Vol 2",
+        "The Lusty Argonian Maid, Volume 2"
+      ],
+      "item_code": "000F699D",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Crassius Curio"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Madness of Pelagius",
+      "title_variants": null,
+      "item_code": "0001ACF0",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Tsathenes"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Marksmanship Lesson",
+      "title_variants": null,
+      "item_code": "0001B26D",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Alla Llaleth"
+      ],
+      "skill_name": "Archery",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Mirror",
+      "title_variants": null,
+      "item_code": "0001AFDE",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Berdier Wreans"
+      ],
+      "skill_name": "Block",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Monomyth",
+      "title_variants": null,
+      "item_code": "0001B26E",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Temple Zero Society"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Night Mother's Truth",
+      "title_variants": null,
+      "item_code": "000E0D67",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Gaston Bellefort"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Nightingales Volume I",
+      "title_variants": [
+        "The Nightingales Volume I: Who We Are"
+      ],
+      "item_code": "000F68AC",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Gallus Desidenius"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Nightingales Volume II",
+      "title_variants": [
+        "The Nightingales Volume II: What We Were"
+      ],
+      "item_code": "000F68AD",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Gallus Desidenius"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Nirnroot Missive",
+      "title_variants": [
+        "The Nirnroot Missive (Revised Edition)"
+      ],
+      "item_code": "0010BEDF",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Sinderion",
+        "Sharmirin Raythorne"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Oblivion Crisis",
+      "title_variants": null,
+      "item_code": "00037DEA",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Praxis Sarcorum"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Old Ways",
+      "title_variants": [
+        "The Old Ways: The Customs and Philosophy of Grave and Faithful Council"
+      ],
+      "item_code": "0001AD0F",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Celarus the Loremaster"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Pig Children",
+      "title_variants": null,
+      "item_code": "0001AD11",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Tyston Bane"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Posting of the Hunt",
+      "title_variants": null,
+      "item_code": "0001AD12",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Ransom of Zarek",
+      "title_variants": [
+        "Ancient Tales of the Dwemer, Part I: The Ransom of Zarek"
+      ],
+      "item_code": "0001AFD3",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Marobar Sul"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Real Barenziah, Book I",
+      "title_variants": [
+        "The Real Barenziah, Part 1"
+      ],
+      "item_code": "0001ACD6",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Plitinius Mero"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Real Barenziah, Book II",
+      "title_variants": [
+        "The Real Barenziah, Part 2"
+      ],
+      "item_code": "0001ACD7",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Plitinius Mero"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Real Barenziah, Book III",
+      "title_variants": [
+        "The Real Barenziah, Part 3"
+      ],
+      "item_code": "0001ACD8",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Real Barenziah, Book IV",
+      "title_variants": [
+        "The Real Barenziah, Part 4"
+      ],
+      "item_code": "0001ACD9",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Real Barenziah, Book V",
+      "title_variants": [
+        "The Real Barenziah, Part 5"
+      ],
+      "item_code": "0001ACDA",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Rear Guard",
+      "title_variants": null,
+      "item_code": "0001B000",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Tenace Mourl"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Reclamations",
+      "title_variants": [
+        "The Reclamations: The Fall of the Tribunal and the Rise of the New Temple"
+      ],
+      "item_code": "XX03B052",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Thara of Rihad"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Red Book of Riddles",
+      "title_variants": null,
+      "item_code": "0001AD13",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Red Kitchen Reader",
+      "title_variants": null,
+      "item_code": "0001AFD5",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Simocles Quo"
+      ],
+      "skill_name": "Sneak",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Red Year, Vol I",
+      "title_variants": [
+        "The Red Year, Vol. I",
+        "The Red Year, Volume I"
+      ],
+      "item_code": "XX03B063",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Melis Ravel"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Red Year, Vol II",
+      "title_variants": [
+        "The Red Year, Vol. II",
+        "The Red Year, Volume II"
+      ],
+      "item_code": "XX03B064",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Melis Ravel"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Refugees",
+      "title_variants": [
+        "The Refugees by Geros Albreigh, History of refugees fleeing the Camoran Usurper"
+      ],
+      "item_code": "0001B003",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Geros Albreigh"
+      ],
+      "skill_name": "Light Armor",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Rise and Fall of the Blades",
+      "title_variants": null,
+      "item_code": "000F4530",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Seed",
+      "title_variants": [
+        "Ancient Tales of the Dwemer, Part II: The Seed"
+      ],
+      "item_code": "0001ACFA",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Marobar Sul"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Song of Hrormir",
+      "title_variants": [
+        "Song of Hrormir"
+      ],
+      "item_code": "0001AFDB",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": "Two-Handed",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Song of Pelinal Volume 1",
+      "title_variants": [
+        "The Song of Pelinal, Book I",
+        "The Song of Pelinal, Volume I: On His Name"
+      ],
+      "item_code": "0001AF8A",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Song of Pelinal Volume 2",
+      "title_variants": [
+        "The Song of Pelinal, Book II",
+        "The Song of Pelinal, Volume 2: On His Coming"
+      ],
+      "item_code": "0001AF8B",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Song of Pelinal Volume 3",
+      "title_variants": [
+        "The Song of Pelinal, Book III",
+        "The Song of Pelinal, Volume 3: On His Enemy"
+      ],
+      "item_code": "0001AF8C",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Song of Pelinal Volume 4",
+      "title_variants": [
+        "The Song of Pelinal, Book IV",
+        "The Song of Pelinal Volume 4: On His Deeds"
+      ],
+      "item_code": "0001AF8D",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Song of Pelinal Volume 5",
+      "title_variants": [
+        "The Song of Pelinal, Book V",
+        "The Song of Pelinal Volume 5: On His Love of Morihaus"
+      ],
+      "item_code": "0001AF8E",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Song of Pelinal Volume 6",
+      "title_variants": [
+        "The Song of Pelinal, Book VI",
+        "The Song of Pelinal Volume 6: On His Madness"
+      ],
+      "item_code": "0001AF8F",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Song of Pelinal Volume 7",
+      "title_variants": [
+        "The Song of Pelinal, Book VII",
+        "The Song of Pelinal Volume 7: On His Battle in Umaril and His Dismemberment"
+      ],
+      "item_code": "0001AF90",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Song of Pelinal Volume 8",
+      "title_variants": [
+        "The Song of Pelinal, Book VIII",
+        "The Song of Pelinal Volume 8: On His Revelation at the Death of the Al-Esh"
+      ],
+      "item_code": "0001AF91",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Sultry Argonian Bard, v1",
+      "title_variants": [
+        "The Sultry Argonian Bard, Volume One"
+      ],
+      "item_code": "XX006925",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Ellya Erdain"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Tale of Dro'Zira",
+      "title_variants": null,
+      "item_code": "000F03E3",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Sonia Vette"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Talos Mistake",
+      "title_variants": null,
+      "item_code": "000ED04D",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Leonora Venatus"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Third Door",
+      "title_variants": null,
+      "item_code": "0001ACFB",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Annanar Orme"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Third Era Timeline",
+      "title_variants": [
+        "Third Era An Abbreviated Timeline"
+      ],
+      "item_code": "000ED04F",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Jaspus Ignateous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Totems of Hircine",
+      "title_variants": null,
+      "item_code": "000F6840",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The True Nature of Orcs",
+      "title_variants": null,
+      "item_code": "0001AD16",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The True Noble's Code",
+      "title_variants": null,
+      "item_code": "XX028275",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Athyn Sarethi"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Ulen Matter",
+      "title_variants": null,
+      "item_code": "XX01F31B",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Vendil Ulen"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Warmth of Mara",
+      "title_variants": null,
+      "item_code": "00053347",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Dinya Balu"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Warrior's Charge",
+      "title_variants": [
+        "The Warrior's Charge: An old poem of the Redguards"
+      ],
+      "item_code": "0001AFEB",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": "Conjuration",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Waters of Oblivion",
+      "title_variants": null,
+      "item_code": "0001AD17",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Wild Elves",
+      "title_variants": null,
+      "item_code": "0001AD18",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Kier-Jo Chorvak"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Windhelm Letters",
+      "title_variants": null,
+      "item_code": "000ED03C",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Wispmother",
+      "title_variants": null,
+      "item_code": "00083B3B",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Mathias Etienne"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Wolf Queen Book I",
+      "title_variants": [
+        "The Wolf Queen, Book I"
+      ],
+      "item_code": "0001B01A",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Waughin Jarth"
+      ],
+      "skill_name": "Lockpicking",
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Wolf Queen Book II",
+      "title_variants": [
+        "The Wolf Queen, Book II"
+      ],
+      "item_code": "0001AFF2",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Waughin Jarth"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Wolf Queen Book III",
+      "title_variants": [
+        "The Wolf Queen, Book 3"
+      ],
+      "item_code": "0001AFFB",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Waughin Jarth"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Wolf Queen Book IV",
+      "title_variants": [
+        "The Wolf Queen, Book IV"
+      ],
+      "item_code": "0001B00B",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Waughin Jarth"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Wolf Queen Book V",
+      "title_variants": [
+        "The Wolf Queen, Book V"
+      ],
+      "item_code": "0001B024",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Waughin Jarth"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Wolf Queen Book VI",
+      "title_variants": [
+        "The Wolf Queen, Book VI"
+      ],
+      "item_code": "0001B01E",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Waughin Jarth"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Wolf Queen Book VII",
+      "title_variants": [
+        "The Wolf Queen, Book VII"
+      ],
+      "item_code": "0001B026",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Waughin Jarth"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Wolf Queen Book VIII",
+      "title_variants": [
+        "The Wolf Queen, Book VIII"
+      ],
+      "item_code": "0001ACFD",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Waughin Jarth"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Woodcutter's Wife",
+      "title_variants": [
+        "The Woodcutter's Wife Volume I"
+      ],
+      "item_code": "000ED601",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Mogen Son of Molag"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "The Wraith's Wedding Dowry",
+      "title_variants": null,
+      "item_code": "0001B273",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Voltha gra-Yamwort"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "There Be Dragons",
+      "title_variants": null,
+      "item_code": "000ED5F8",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Torhal Bjorik"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Thief",
+      "title_variants": null,
+      "item_code": "0001AFBF",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Reven"
+      ],
+      "skill_name": "Pickpocket",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Thief of Virtue",
+      "title_variants": null,
+      "item_code": "0001ACDD",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Thief's Last Words",
+      "title_variants": null,
+      "item_code": "000F0425",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Things to Do",
+      "title_variants": null,
+      "item_code": "000F689F",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Bolli"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Third Letter from EEC",
+      "title_variants": null,
+      "item_code": "XX03A2A2",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Vittoria Vici"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Thirsk, a Revised History",
+      "title_variants": null,
+      "item_code": "XX03B3A5",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Bereditte Jastal"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Thonar's Journal",
+      "title_variants": null,
+      "item_code": "000D674A",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Thonar"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Three Thieves",
+      "title_variants": null,
+      "item_code": "0001B276",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": "Sneak",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Timely Offer",
+      "title_variants": null,
+      "item_code": "000F6929",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Tuldinwae"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "To Be Read Immediately!",
+      "title_variants": null,
+      "item_code": "000F68A1",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Indaryn"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "To Milore from Nilara",
+      "title_variants": null,
+      "item_code": "XX03A4B4",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Nilara"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "To a Concerned Citizen",
+      "title_variants": null,
+      "item_code": "000F68A5",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "The Society of Mercantile Freedom"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "To the Brotherhood",
+      "title_variants": null,
+      "item_code": "000F6896",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Maven Black-Briar"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "To the Owner",
+      "title_variants": null,
+      "item_code": "FF000B07",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Kilthinius Dandoril"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Torkild's Letter to Wulf",
+      "title_variants": null,
+      "item_code": "XX026562",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Torkild"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Torn Note",
+      "title_variants": null,
+      "item_code": "00074ADF",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Firir"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Torn Note",
+      "title_variants": null,
+      "item_code": "XX03780A",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Adventurer"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Touching the Sky",
+      "title_variants": null,
+      "item_code": "XX01A3E8",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Parnion Saldor"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Tova's Farewell",
+      "title_variants": null,
+      "item_code": "000D2B09",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Tova Shatter-Shield"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Training Chests",
+      "title_variants": null,
+      "item_code": "000F6930",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Trap",
+      "title_variants": null,
+      "item_code": "XX029102",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Treasure Hunter's Note",
+      "title_variants": null,
+      "item_code": "000A17B0",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Treasure Map I",
+      "title_variants": null,
+      "item_code": "000EF07A",
+      "unit_weight": 0.0,
+      "book_type": "treasure map",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Treasure Map II",
+      "title_variants": null,
+      "item_code": "000F33CE",
+      "unit_weight": 0.0,
+      "book_type": "treasure map",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Treasure Map III",
+      "title_variants": null,
+      "item_code": "000F33CF",
+      "unit_weight": 0.0,
+      "book_type": "treasure map",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Treasure Map IV",
+      "title_variants": null,
+      "item_code": "000F33D1",
+      "unit_weight": 0.0,
+      "book_type": "treasure map",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Treasure Map IX",
+      "title_variants": null,
+      "item_code": "000F33CD",
+      "unit_weight": 0.0,
+      "book_type": "treasure map",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Treasure Map V",
+      "title_variants": null,
+      "item_code": "000F33D4",
+      "unit_weight": 0.0,
+      "book_type": "treasure map",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Treasure Map VI",
+      "title_variants": null,
+      "item_code": "000F33D0",
+      "unit_weight": 0.0,
+      "book_type": "treasure map",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Treasure Map VII",
+      "title_variants": null,
+      "item_code": "000F33D5",
+      "unit_weight": 0.0,
+      "book_type": "treasure map",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Treasure Map VIII",
+      "title_variants": null,
+      "item_code": "000F33D3",
+      "unit_weight": 0.0,
+      "book_type": "treasure map",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Treasure Map X",
+      "title_variants": null,
+      "item_code": "000F33E0",
+      "unit_weight": 0.0,
+      "book_type": "treasure map",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Treatise on Ayleidic Cities",
+      "title_variants": [
+        "Treatise on Ayleidic Cities, Chapter Ten: Varsa Baalim and the Nefarivigum Test of Dagon"
+      ],
+      "item_code": "0001ADB4",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Trials of St. Alessia",
+      "title_variants": null,
+      "item_code": "0001ACE2",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Troll Slaying",
+      "title_variants": null,
+      "item_code": "000ED606",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Finn"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Twin Secrets",
+      "title_variants": null,
+      "item_code": "0002F839",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Brarilu Theran"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Ulfr's Book",
+      "title_variants": null,
+      "item_code": "000E1640",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Ulfr the Blind"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Ulyn's Journal",
+      "title_variants": null,
+      "item_code": "XX032CD5",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Ulyn"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Umana's Journal",
+      "title_variants": null,
+      "item_code": "000F0417",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Umana"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Uncommon Taste",
+      "title_variants": null,
+      "item_code": "00009F267",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "The Gourmet"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Uncommon Taste - Signed",
+      "title_variants": null,
+      "item_code": "0006851B",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "The Gourmet"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Unknown Book, Vol. I",
+      "title_variants": [
+        "The Betrayed"
+      ],
+      "item_code": "XX01A3E0",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Engwe Emeloth"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Unknown Book, Vol. II",
+      "title_variants": [
+        "Journal of Mirtil Angoth"
+      ],
+      "item_code": "XX01A3E1",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Mirtil Angoth"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Unknown Book, Vol. III",
+      "title_variants": [
+        "Diary of Faire Agarwen"
+      ],
+      "item_code": "XX01A3E2",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Faire Agarwen"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Unknown Book, Vol. IV",
+      "title_variants": [
+        "Touching the Sky"
+      ],
+      "item_code": "XX01A3E3",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Parnion Saldor"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Unsent Afflicted Letter",
+      "title_variants": null,
+      "item_code": "000E7F39",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Afflicted"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Until Next Time",
+      "title_variants": null,
+      "item_code": "000F689D",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Secret Lover"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Urag's Note",
+      "title_variants": null,
+      "item_code": "0003D29D",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Urag Gro-Shub"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Vald's Debt",
+      "title_variants": null,
+      "item_code": "00072B13",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Maven Black-Briar"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Valerica's Journal",
+      "title_variants": null,
+      "item_code": "XX003C4B",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Valerica"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Valmir's Orders",
+      "title_variants": null,
+      "item_code": "00093CF6",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Vampire's Note",
+      "title_variants": null,
+      "item_code": "XX006E58",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Malkus"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Varieties of Daedra",
+      "title_variants": null,
+      "item_code": "0001ACFC",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Aranea Drethan"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Varieties of Faith in the Empire",
+      "title_variants": null,
+      "item_code": "XX028276",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Mikhael Karkuxor"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Velehk Sain's Treasure Map",
+      "title_variants": null,
+      "item_code": "000DDEFB",
+      "unit_weight": 0.0,
+      "book_type": "treasure map",
+      "authors": [
+        "Velehk Sain"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Venarus Vulpin's Journal",
+      "title_variants": null,
+      "item_code": "XX0149A2",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Venarus Vulpin"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Venarus Vulpin's Research",
+      "title_variants": null,
+      "item_code": "XX0149A3",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Venarus Vulpin"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Vernaccus and Bourlor",
+      "title_variants": null,
+      "item_code": "0001B007",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Tavi Dromio"
+      ],
+      "skill_name": "Archery",
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Volk's Journal",
+      "title_variants": null,
+      "item_code": "XX0135CB",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Volk"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Wabbajack",
+      "title_variants": null,
+      "item_code": "0001AFBA",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Walking the World, Vol. XI: Solitude",
+      "title_variants": null,
+      "item_code": "000ED061",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Spatior Munius"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "War of the First Council",
+      "title_variants": [
+        "The War of the First Council"
+      ],
+      "item_code": "0001B272",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Agrippa Fundilius"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Warning",
+      "title_variants": null,
+      "item_code": "00078561",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Rigel Strong-Arm"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Warrior",
+      "title_variants": null,
+      "item_code": "0001AFE0",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Reven"
+      ],
+      "skill_name": "Block",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Watcher of Stones",
+      "title_variants": null,
+      "item_code": "000ED63F",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Gelyph Sig"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Watchtower Guard's Letter",
+      "title_variants": null,
+      "item_code": "00083AEF",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Weylin's Note",
+      "title_variants": null,
+      "item_code": "000D670F",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "N"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Where were you when the Dragon Broke?",
+      "title_variants": null,
+      "item_code": "XX028266",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Various"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Whiterun Home Decorating Guide",
+      "title_variants": null,
+      "item_code": "000F11B6",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Wind and Sand",
+      "title_variants": null,
+      "item_code": "XX01D8D0",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Afa-Saryat"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Windhelm Home Decorating Guide",
+      "title_variants": null,
+      "item_code": "000F1446",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Windstad Manor Charter",
+      "title_variants": null,
+      "item_code": "XX0157A0",
+      "unit_weight": 0.0,
+      "book_type": "document",
+      "authors": null,
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Withershins",
+      "title_variants": null,
+      "item_code": "0001B014",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Yaqut Tawashi"
+      ],
+      "skill_name": "Restoration",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Words and Philosophy",
+      "title_variants": null,
+      "item_code": "0001AFD8",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Allena Benoch"
+      ],
+      "skill_name": "Two-Handed",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Words of Clan Mother Ahnissi",
+      "title_variants": [
+        "Words of Clan Mother Ahnissi to her Favored Daughter"
+      ],
+      "item_code": "0001B27D",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Ahnissi"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Words of the Wind",
+      "title_variants": null,
+      "item_code": "XX028277",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Ahemmusa Camp"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Writ of Dawn",
+      "title_variants": null,
+      "item_code": "XX0034DC",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Writ of Execution",
+      "title_variants": null,
+      "item_code": "XX027E9F",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Writ of Sealing",
+      "title_variants": null,
+      "item_code": "000F1C17",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Writ of Sealing",
+      "title_variants": null,
+      "item_code": "000F1C18",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Writ of Sealing",
+      "title_variants": null,
+      "item_code": "000F1C19",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Wyndelius's Journal",
+      "title_variants": null,
+      "item_code": "000D9B6B",
+      "unit_weight": 1.0,
+      "book_type": "journal",
+      "authors": [
+        "Wyndelius Gatharian"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": true
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Yellow Book of Riddles",
+      "title_variants": null,
+      "item_code": "0001B274",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Yngol and the Sea-Ghosts",
+      "title_variants": null,
+      "item_code": "0002A563",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Anonymous"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Ysolda's Message",
+      "title_variants": null,
+      "item_code": "000E1A9F",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Ysolda"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  }
+]

--- a/lib/tasks/sync_canonical_models.rake
+++ b/lib/tasks/sync_canonical_models.rake
@@ -115,10 +115,21 @@ namespace :canonical_models do
                                             canonical_models:sync:spells
                                             canonical_models:sync:powers
                                           ] do |_t, args|
-        args.with_defaults(preserve_existing_records: false)
+      args.with_defaults(preserve_existing_records: false)
 
-        Canonical::Sync.perform(:staff, FALSEY_VALUES.exclude?(args[:preserve_existing_records]))
-      end
+      Canonical::Sync.perform(:staff, FALSEY_VALUES.exclude?(args[:preserve_existing_records]))
+    end
+
+    desc 'Sync canonical book models in the database with JSON data'
+    task :books,
+         %i[preserve_existing_records] => %w[
+                                            environment
+                                            canonical_models:sync:ingredients
+                                          ] do |_t, args|
+      args.with_defaults(preserve_existing_records: false)
+
+      Canonical::Sync.perform(:book, FALSEY_VALUES.exclude?(args[:preserve_existing_records]))
+    end
     # rubocop:enable Layout/BlockAlignment
 
     desc 'Sync all canonical models with JSON files'

--- a/spec/factories/canonical/books.rb
+++ b/spec/factories/canonical/books.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :canonical_book, class: Canonical::Book do
+    title                { 'My Book' }
+    sequence(:item_code) {|n| "123xxx#{n}" }
+    unit_weight          { 1.0 }
+    book_type            { 'lore book' }
+    purchasable          { true }
+    unique_item          { false }
+    rare_item            { false }
+    solstheim_only       { false }
+    quest_item           { false }
+
+    factory :canonical_recipe do
+      book_type { 'recipe' }
+    end
+  end
+end

--- a/spec/factories/canonical/recipes_ingredients.rb
+++ b/spec/factories/canonical/recipes_ingredients.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :canonical_recipes_ingredient, class: Canonical::RecipesIngredient do
+    association :recipe, factory: :canonical_recipe
+    association :ingredient, factory: :canonical_ingredient
+  end
+end

--- a/spec/fixtures/canonical/sync/books.json
+++ b/spec/fixtures/canonical/sync/books.json
@@ -1,0 +1,89 @@
+[
+  {
+    "attributes": {
+      "title": "2920, vol 01 - Morning Star",
+      "title_variants": [
+        "2920, Morning Star, v1",
+        "Morning Star Book One of 2920 The Last Year of the First Era"
+      ],
+      "item_code": "0001AFD9",
+      "unit_weight": 1.0,
+      "book_type": "skill book",
+      "authors": [
+        "Carlovac Townway"
+      ],
+      "skill_name": "One-Handed",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "2920, vol 03 - First Seed",
+      "title_variants": [
+        "2920, First Seed, v3",
+        "First Seed, Book Three of 2920"
+      ],
+      "item_code": "0001ACE5",
+      "unit_weight": 1.0,
+      "book_type": "lore book",
+      "authors": [
+        "Carlovac Townway"
+      ],
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  },
+  {
+    "attributes": {
+      "title": "Cure Disease Potion Recipe",
+      "title_variants": null,
+      "item_code": "000F5CB8",
+      "unit_weight": 0.0,
+      "book_type": "recipe",
+      "authors": null,
+      "skill_name": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "solstheim_only": false,
+      "quest_item": false
+    },
+    "canonical_ingredients": [
+      {
+        "item_code": "00052695"
+      },
+      {
+        "item_code": "0006BC00"
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "title": "A Letter to Selina I",
+      "title_variants": null,
+      "item_code": "XX030C9A",
+      "unit_weight": 0.0,
+      "book_type": "letter",
+      "authors": [
+        "Maximian Axius"
+      ],
+      "skill_name": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "solstheim_only": true,
+      "quest_item": false
+    },
+    "canonical_ingredients": []
+  }
+]

--- a/spec/models/canonical/book_spec.rb
+++ b/spec/models/canonical/book_spec.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Canonical::Book, type: :model do
+  describe 'validations' do
+    describe 'title' do
+      it "can't be blank" do
+        model = build(:canonical_book, title: nil)
+
+        model.validate
+        expect(model.errors[:title]).to include "can't be blank"
+      end
+    end
+
+    describe 'item code' do
+      it "can't be blank" do
+        model = build(:canonical_book, item_code: nil)
+
+        model.validate
+        expect(model.errors[:item_code]).to include "can't be blank"
+      end
+
+      it 'must be unique' do
+        create(:canonical_book, item_code: 'foobar')
+        model = build(:canonical_book, item_code: 'foobar')
+
+        model.validate
+        expect(model.errors[:item_code]).to include 'must be unique'
+      end
+    end
+
+    describe 'unit weight' do
+      it "can't be blank" do
+        model = build(:canonical_book, unit_weight: nil)
+
+        model.validate
+        expect(model.errors[:unit_weight]).to include "can't be blank"
+      end
+
+      it 'must be a number' do
+        model = build(:canonical_book, unit_weight: 'foo')
+
+        model.validate
+        expect(model.errors[:unit_weight]).to include 'is not a number'
+      end
+
+      it 'must be at least zero' do
+        model = build(:canonical_book, unit_weight: -4.2)
+
+        model.validate
+        expect(model.errors[:unit_weight]).to include 'must be greater than or equal to 0'
+      end
+    end
+
+    describe 'book type' do
+      it 'must be one of the allowed types' do
+        model = build(:canonical_book, book_type: 'self-help')
+
+        model.validate
+        expect(model.errors[:book_type]).to include 'must be a book type that exists in Skyrim'
+      end
+    end
+
+    describe 'skill name' do
+      context 'when the book is a skill book' do
+        it "can't be blank" do
+          model = build(:canonical_book, book_type: 'skill book', skill_name: nil)
+
+          model.validate
+          expect(model.errors[:skill_name]).to include "can't be blank for skill books"
+        end
+
+        it 'must be a valid skill' do
+          model = build(:canonical_book, book_type: 'skill book', skill_name: 'Kung-Fu Fighting')
+
+          model.validate
+          expect(model.errors[:skill_name]).to include 'must be a skill that exists in Skyrim'
+        end
+      end
+
+      context 'when the book is not a skill book' do
+        it 'cannot be defined' do
+          model = build(:canonical_book, book_type: 'lore book', skill_name: 'One-Handed')
+
+          model.validate
+          expect(model.errors[:skill_name]).to include 'can only be defined for skill books'
+        end
+
+        it 'can be blank' do
+          model = build(:canonical_book, book_type: 'recipe', skill_name: nil)
+
+          expect(model).to be_valid
+        end
+      end
+    end
+
+    describe 'purchasable' do
+      it 'is required' do
+        model = build(:canonical_book, purchasable: nil)
+
+        model.validate
+        expect(model.errors[:purchasable]).to include 'must be true or false'
+      end
+    end
+
+    describe 'unique_item' do
+      it 'is required' do
+        model = build(:canonical_book, unique_item: nil)
+
+        model.validate
+        expect(model.errors[:unique_item]).to include 'must be true or false'
+      end
+    end
+
+    describe 'rare_item' do
+      it 'is required' do
+        model = build(:canonical_book, rare_item: nil)
+
+        model.validate
+        expect(model.errors[:rare_item]).to include 'must be true or false'
+      end
+
+      it 'must be true if the item is unique' do
+        model = build(:canonical_book, unique_item: true, rare_item: false)
+
+        model.validate
+        expect(model.errors[:rare_item]).to include 'must be true if item is unique'
+      end
+    end
+
+    describe 'solstheim_only' do
+      it 'is required' do
+        model = build(:canonical_book, solstheim_only: nil)
+
+        model.validate
+        expect(model.errors[:solstheim_only]).to include 'must be true or false'
+      end
+    end
+
+    describe 'quest_item' do
+      it 'is required' do
+        model = build(:canonical_book, quest_item: nil)
+
+        model.validate
+        expect(model.errors[:quest_item]).to include 'must be true or false'
+      end
+    end
+  end
+
+  describe '::unique_identifier' do
+    it 'returns ":item_code"' do
+      expect(described_class.unique_identifier).to eq :item_code
+    end
+  end
+end

--- a/spec/models/canonical/recipes_ingredient_spec.rb
+++ b/spec/models/canonical/recipes_ingredient_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Canonical::RecipesIngredient, type: :model do
+  describe 'validations' do
+    it 'is invalid if the book is not a recipe' do
+      book  = create(:canonical_book, book_type: 'skill book', skill_name: 'Heavy Armor')
+      model = build(:canonical_recipes_ingredient, recipe: book)
+
+      model.validate
+      expect(model.errors[:recipe]).to include 'must be a recipe'
+    end
+
+    it 'is valid if the book is a recipe' do
+      book  = create(:canonical_recipe)
+      model = build(:canonical_recipes_ingredient, recipe: book)
+
+      expect(model).to be_valid
+    end
+  end
+end

--- a/spec/models/canonical/sync/books_spec.rb
+++ b/spec/models/canonical/sync/books_spec.rb
@@ -1,0 +1,224 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Canonical::Sync::Books do
+  # Use let! because if we wait to evaluate these until we've run the
+  # examples, the stub in the before block will prevent `File.read` from
+  # running.
+  let(:json_path)  { Rails.root.join('spec', 'fixtures', 'canonical', 'sync', 'books.json') }
+  let!(:json_data) { File.read(json_path) }
+
+  before do
+    allow(File).to receive(:read).and_return(json_data)
+  end
+
+  describe '::perform' do
+    subject(:perform) { described_class.perform(preserve_existing_records) }
+
+    context 'when preserve_existing_records is false' do
+      let(:preserve_existing_records) { false }
+
+      context 'when there are no existing books in the database' do
+        let(:syncer) { described_class.new(preserve_existing_records) }
+
+        before do
+          create(:canonical_ingredient, item_code: '00052695')
+          create(:canonical_ingredient, item_code: '0006BC00')
+          allow(described_class).to receive(:new).and_return(syncer)
+        end
+
+        it 'instantiates itself' do
+          perform
+          expect(described_class).to have_received(:new).with(preserve_existing_records)
+        end
+
+        it 'populates the models from the JSON file' do
+          perform
+          expect(Canonical::Book.count).to eq 4
+        end
+
+        it 'creates the associations to canonical ingredients where they exist', :aggregate_failures do
+          perform
+          expect(Canonical::Book.find_by(item_code: '0001AFD9').canonical_ingredients.length).to eq 0
+          expect(Canonical::Book.find_by(item_code: '0001ACE5').canonical_ingredients.length).to eq 0
+          expect(Canonical::Book.find_by(item_code: '000F5CB8').canonical_ingredients.length).to eq 2
+          expect(Canonical::Book.find_by(item_code: 'XX030C9A').canonical_ingredients.length).to eq 0
+        end
+      end
+
+      context 'when there are existing book records in the database' do
+        let!(:book_in_json)     { create(:canonical_book, item_code: '000F5CB8', book_type: 'recipe', title: 'The Seven Habits of Highly Successful People') }
+        let!(:book_not_in_json) { create(:canonical_book, item_code: '12345678') }
+        let(:syncer)            { described_class.new(preserve_existing_records) }
+
+        before do
+          create(:canonical_ingredient, item_code: '00052695')
+          create(:canonical_ingredient, item_code: '0006BC00')
+        end
+
+        it 'instantiates itself' do
+          allow(described_class).to receive(:new).and_return(syncer)
+          perform
+          expect(described_class).to have_received(:new).with(preserve_existing_records)
+        end
+
+        it 'updates models that were already in the database' do
+          perform
+          expect(book_in_json.reload.title).to eq 'Cure Disease Potion Recipe'
+        end
+
+        it "removes models in the database that aren't in the JSON data" do
+          perform
+          expect(Canonical::Book.find_by(item_code: '12345678')).to be_nil
+        end
+
+        it 'adds new models to the database', :aggregate_failures do
+          perform
+          expect(Canonical::Book.find_by(item_code: '0001AFD9')).to be_present
+          expect(Canonical::Book.find_by(item_code: '0001ACE5')).to be_present
+          expect(Canonical::Book.find_by(item_code: 'XX030C9A')).to be_present
+        end
+
+        it "removes canonical ingredients that don't exist in the JSON data" do
+          book_in_json.canonical_ingredients.create!(item_code: '12345678', name: 'Venus Fly Trap', unit_weight: 1)
+          perform
+          expect(book_in_json.canonical_ingredients.where(name: 'Venus Fly Trap')).to be_empty
+        end
+
+        it 'adds canonical ingredients if they exist' do
+          perform
+          expect(book_in_json.canonical_ingredients.count).to eq 2
+        end
+      end
+
+      context 'when there are no canonical ingredients in the database' do
+        before do
+          allow(Rails.logger).to receive(:error)
+        end
+
+        it "logs an error and doesn't create models", :aggregate_failures do
+          expect { perform }
+            .to raise_error(Canonical::Sync::PrerequisiteNotMetError)
+          expect(Rails.logger).to have_received(:error).with('Prerequisite(s) not met: sync Canonical::Ingredient before canonical books')
+          expect(Canonical::Book.count).to eq 0
+        end
+      end
+
+      context 'when a canonical ingredient is missing' do
+        before do
+          # prevent it from erroring out, which it will do if there are no
+          # enchantments all
+          create(:canonical_ingredient)
+          allow(Rails.logger).to receive(:error).twice
+        end
+
+        it 'logs a validation error', :aggregate_failures do
+          expect { perform }
+            .to raise_error ActiveRecord::RecordInvalid
+          expect(Rails.logger).to have_received(:error).with('Validation error saving associations for canonical book "000F5CB8": Validation failed: Ingredient must exist')
+        end
+      end
+    end
+
+    context 'when preserve_existing_records is true' do
+      let(:preserve_existing_records) { true }
+      let(:syncer)                    { described_class.new(preserve_existing_records) }
+      let!(:book_in_json)             { create(:canonical_book, item_code: '000F5CB8', title: 'Rich Dad, Poor Dad', book_type: 'recipe') }
+      let!(:book_not_in_json)         { create(:canonical_book, item_code: '12345678') }
+
+      before do
+        create(:canonical_ingredient, item_code: '00052695')
+        create(:canonical_ingredient, item_code: '0006BC00')
+        create(:canonical_recipes_ingredient, recipe: book_in_json, ingredient: create(:canonical_ingredient))
+        allow(described_class).to receive(:new).and_return(syncer)
+      end
+
+      it 'instantiates itself' do
+        perform
+        expect(described_class).to have_received(:new).with(preserve_existing_records)
+      end
+
+      it 'updates models found in the JSON data' do
+        perform
+        expect(book_in_json.reload.title).to eq 'Cure Disease Potion Recipe'
+      end
+
+      it 'adds models not already in the database', :aggregate_failures do
+        perform
+        expect(Canonical::Book.find_by(item_code: '0001AFD9')).to be_present
+        expect(Canonical::Book.find_by(item_code: '0001ACE5')).to be_present
+        expect(Canonical::Book.find_by(item_code: 'XX030C9A')).to be_present
+      end
+
+      it "doesn't destroy models that aren't in the JSON data" do
+        perform
+        expect(book_not_in_json.reload).to be_present
+      end
+
+      it "doesn't destroy associations" do
+        perform
+        expect(book_in_json.reload.canonical_ingredients.length).to eq 3
+      end
+    end
+
+    describe 'error logging' do
+      let(:preserve_existing_records) { false }
+
+      context 'when an ActiveRecord::RecordInvalid error is raised' do
+        let(:errored_model) do
+          instance_double Canonical::Book,
+                          errors: errors,
+                          class:  class_double(Canonical::Book, i18n_scope: :activerecord)
+        end
+
+        let(:errors) { double('errors', full_messages: ["Title can't be blank"]) }
+
+        before do
+          create(:canonical_ingredient)
+
+          allow_any_instance_of(Canonical::Book)
+            .to receive(:save!)
+                  .and_raise(ActiveRecord::RecordInvalid, errored_model)
+          allow(Rails.logger).to receive(:error)
+        end
+
+        it 'logs and reraises the error', :aggregate_failures do
+          expect { perform }
+            .to raise_error(ActiveRecord::RecordInvalid)
+          expect(Rails.logger).to have_received(:error).with("Error saving canonical book \"0001AFD9\": Validation failed: Title can't be blank")
+        end
+      end
+
+      context 'when another error is raised pertaining to a specific model' do
+        before do
+          create(:canonical_ingredient)
+
+          allow(Canonical::Book).to receive(:find_or_initialize_by).and_raise(StandardError, 'foobar')
+          allow(Rails.logger).to receive(:error)
+        end
+
+        it 'logs and reraises the error', :aggregate_failures do
+          expect { perform }
+            .to raise_error(StandardError)
+          expect(Rails.logger).to have_received(:error).with('Unexpected error StandardError saving canonical book "0001AFD9": foobar')
+        end
+      end
+
+      context 'when an error is raised not pertaining to a specific model' do
+        before do
+          create(:canonical_ingredient)
+
+          allow(Canonical::Book).to receive(:where).and_raise(StandardError, 'foobar')
+          allow(Rails.logger).to receive(:error)
+        end
+
+        it 'logs and reraises the error', :aggregate_failures do
+          expect { perform }
+            .to raise_error(StandardError)
+          expect(Rails.logger).to have_received(:error).with('Unexpected error StandardError while syncing canonical books: foobar')
+        end
+      end
+    end
+  end
+end

--- a/spec/models/canonical/sync/books_spec.rb
+++ b/spec/models/canonical/sync/books_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Canonical::Sync::Books do
       end
 
       context 'when there are existing book records in the database' do
-        let!(:book_in_json)     { create(:canonical_book, item_code: '000F5CB8', book_type: 'recipe', title: 'The Seven Habits of Highly Successful People') }
+        let!(:book_in_json)     { create(:canonical_recipe, item_code: '000F5CB8', title: 'The Seven Habits of Highly Successful People') }
         let!(:book_not_in_json) { create(:canonical_book, item_code: '12345678') }
         let(:syncer)            { described_class.new(preserve_existing_records) }
 
@@ -124,7 +124,7 @@ RSpec.describe Canonical::Sync::Books do
     context 'when preserve_existing_records is true' do
       let(:preserve_existing_records) { true }
       let(:syncer)                    { described_class.new(preserve_existing_records) }
-      let!(:book_in_json)             { create(:canonical_book, item_code: '000F5CB8', title: 'Rich Dad, Poor Dad', book_type: 'recipe') }
+      let!(:book_in_json)             { create(:canonical_recipe, item_code: '000F5CB8', title: 'Rich Dad, Poor Dad') }
       let!(:book_not_in_json)         { create(:canonical_book, item_code: '12345678') }
 
       before do

--- a/spec/models/canonical/sync/books_spec.rb
+++ b/spec/models/canonical/sync/books_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Canonical::Sync::Books do
       context 'when a canonical ingredient is missing' do
         before do
           # prevent it from erroring out, which it will do if there are no
-          # enchantments all
+          # ingredients at all
           create(:canonical_ingredient)
           allow(Rails.logger).to receive(:error).twice
         end

--- a/spec/models/canonical/sync_spec.rb
+++ b/spec/models/canonical/sync_spec.rb
@@ -176,5 +176,18 @@ RSpec.describe Canonical::Sync do
         expect(Canonical::Sync::Staves).to have_received(:perform).with(true)
       end
     end
+
+    context 'when the model is ":book"' do
+      subject(:perform) { described_class.perform(:book, false) }
+
+      before do
+        allow(Canonical::Sync::Books).to receive(:perform)
+      end
+
+      it 'calls #perform on the correct syncer' do
+        perform
+        expect(Canonical::Sync::Books).to have_received(:perform).with(false)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

[**Create Canonical::Book model**](https://trello.com/c/Kg89DoqA/166-create-canonicalbook-model)

One of the last canonical models we are creating as part of the Update Object Modelling epic is the `Canonical::Book` model. This includes all the various items that are grouped as "books" in Skyrim inventory. 

## Changes

* Migrations to create `canonical_books` and `canonical_recipes_ingredients` tables
* Syncer for canonical books
* JSON data for canonical books
* Specs for new models
* Docs

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

I considered creating different classes for different items, such as letters and recipes. This would've prevented the need to restrict associations to a specific `book_type`. However, in the end, I decided to keep recipes classed as books like they are in Skyrim.
