### PR TITLE
Create Canonical::MiscItem model

### DIFF
--- a/app/models/canonical/misc_item.rb
+++ b/app/models/canonical/misc_item.rb
@@ -26,7 +26,7 @@ module Canonical
     validates :unit_weight, presence: true, numericality: { greater_than_or_equal_to: 0 }
     validates :item_types, presence: true
 
-    validate :validate_item_type
+    validate :validate_item_types
     validate :validate_boolean_values
     validate :verify_unique_item_also_rare
 
@@ -36,7 +36,7 @@ module Canonical
 
     private
 
-    def validate_item_type
+    def validate_item_types
       errors.add(:item_types, 'must include at least one item type') if item_types.blank?
       errors.add(:item_types, 'can only include valid item types') if item_types&.any? {|type| VALID_ITEM_TYPES.exclude?(type) }
     end

--- a/app/models/canonical/misc_item.rb
+++ b/app/models/canonical/misc_item.rb
@@ -38,7 +38,7 @@ module Canonical
 
     def validate_item_types
       errors.add(:item_types, 'must include at least one item type') if item_types.blank?
-      errors.add(:item_types, 'can only include valid item types') if item_types&.any? {|type| VALID_ITEM_TYPES.exclude?(type) }
+      errors.add(:item_types, 'can only include valid item types') unless item_types&.all? {|type| VALID_ITEM_TYPES.include?(type) }
     end
 
     def validate_boolean_values

--- a/app/models/canonical/misc_item.rb
+++ b/app/models/canonical/misc_item.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Canonical
+  class MiscItem < ApplicationRecord
+    self.table_name = 'canonical_misc_items'
+
+    BOOLEAN_VALUES = [true, false].freeze
+
+    VALID_ITEM_TYPES = [
+                         'animal part',
+                         'book',
+                         'daedric artifact',
+                         'dragon claw',
+                         'Dwemer artifact',
+                         'gemstone',
+                         'key',
+                         'larceny trophy',
+                         'map',
+                         'miscellaneous',
+                         'paragon',
+                         'pelt',
+                       ].freeze
+
+    validates :name, presence: true
+    validates :item_code, presence: true, uniqueness: { message: 'must be unique' }
+    validates :unit_weight, presence: true, numericality: { greater_than_or_equal_to: 0 }
+    validates :item_types, presence: true
+
+    validate :validate_item_type
+    validate :validate_boolean_values
+    validate :verify_unique_item_also_rare
+
+    private
+
+    def validate_item_type
+      errors.add(:item_types, 'must include at least one item type') if item_types.blank?
+      errors.add(:item_types, 'can only include valid item types') if item_types&.any? {|type| VALID_ITEM_TYPES.exclude?(type) }
+    end
+
+    def validate_boolean_values
+      errors.add(:purchasable, 'boolean value must be present') unless BOOLEAN_VALUES.include?(purchasable)
+      errors.add(:unique_item, 'boolean value must be present') unless BOOLEAN_VALUES.include?(unique_item)
+      errors.add(:rare_item, 'boolean value must be present') unless BOOLEAN_VALUES.include?(rare_item)
+      errors.add(:quest_item, 'boolean value must be present') unless BOOLEAN_VALUES.include?(quest_item)
+    end
+
+    def verify_unique_item_also_rare
+      errors.add(:rare_item, 'must be true if item is unique') if unique_item && !rare_item
+    end
+  end
+end

--- a/app/models/canonical/misc_item.rb
+++ b/app/models/canonical/misc_item.rb
@@ -30,6 +30,10 @@ module Canonical
     validate :validate_boolean_values
     validate :verify_unique_item_also_rare
 
+    def self.unique_identifier
+      :item_code
+    end
+
     private
 
     def validate_item_type

--- a/app/models/canonical/sync.rb
+++ b/app/models/canonical/sync.rb
@@ -16,6 +16,7 @@ module Canonical
                 book:                Canonical::Sync::Books,
                 clothing:            Canonical::Sync::ClothingItems,
                 jewelry:             Canonical::Sync::JewelryItems,
+                misc_item:           Canonical::Sync::MiscItems,
                 property:            Canonical::Sync::Properties,
                 spell:               Canonical::Sync::Spells,
                 staff:               Canonical::Sync::Staves,

--- a/app/models/canonical/sync/misc_items.rb
+++ b/app/models/canonical/sync/misc_items.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Canonical
+  module Sync
+    class MiscItems < Syncer
+      private
+
+      def model_class
+        Canonical::MiscItem
+      end
+
+      def json_file_path
+        Rails.root.join('lib', 'tasks', 'canonical_models', 'canonical_misc_items.json')
+      end
+    end
+  end
+end

--- a/db/migrate/20220524004554_create_canonical_misc_items.rb
+++ b/db/migrate/20220524004554_create_canonical_misc_items.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class CreateCanonicalMiscItems < ActiveRecord::Migration[6.1]
+  def change
+    create_table :canonical_misc_items do |t|
+      t.string :name, null: false
+      t.string :item_code, null: false, unique: true
+      t.decimal :unit_weight, null: false
+      t.string :item_types, array: true, null: false, default: []
+      t.string :description
+      t.boolean :purchasable, null: false
+      t.boolean :unique_item, null: false
+      t.boolean :rare_item, null: false
+      t.boolean :quest_item, null: false, default: false
+
+      t.index :item_code, unique: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_21_032400) do
+ActiveRecord::Schema.define(version: 2022_05_24_004554) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -142,6 +142,21 @@ ActiveRecord::Schema.define(version: 2022_05_21_032400) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["item_code"], name: "index_canonical_materials_on_item_code", unique: true
+  end
+
+  create_table "canonical_misc_items", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "item_code", null: false
+    t.decimal "unit_weight", null: false
+    t.string "item_types", default: [], null: false, array: true
+    t.string "description"
+    t.boolean "purchasable", null: false
+    t.boolean "unique_item", null: false
+    t.boolean "rare_item", null: false
+    t.boolean "quest_item", default: false, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["item_code"], name: "index_canonical_misc_items_on_item_code", unique: true
   end
 
   create_table "canonical_powerables_powers", force: :cascade do |t|

--- a/docs/canonical_models/canonical-models.md
+++ b/docs/canonical_models/canonical-models.md
@@ -8,6 +8,7 @@ The following canonical models exist in the SIM database:
 * [`Canonical::Ingredient`](/app/models/canonical/ingredient.rb): actual ingredients available in the game; has many-to-many association to `AlchemicalProperty`, which it can have no more than 4 of without causing a validation error
 * [`Canonical::JewelryItem`](/app/models/canonical/jewelry_item.rb): actual jewelry items available in-game, including both generic and unique pieces
 * [`Canonical::Material`](/app/models/canonical/material.rb): actual building and smithing materials present in the game
+* [`Canonical::MiscItem`](/app/models/canonical/misc_item.rb): miscellaneous items occurring in the game that may be either useful or decorative
 * [`Canonical::Property`](/app/models/canonical/property.rb): actual properties (homes) the player character can own in the game
 * [`Canonical::Weapon`](/app/models/canonical/weapon.rb): actual weapons the player character can acquire in the game
 * [`Canonical::Staff`](/app/models/canonical/staff.rb): actual staves the player character can acquire in the game

--- a/docs/canonical_models/syncing-canonical-models.md
+++ b/docs/canonical_models/syncing-canonical-models.md
@@ -19,18 +19,19 @@ The following idempotent Rake tasks can be used to sync the database with the ca
 
 * `rails canonical_models:sync:all` (syncs all canonical models with JSON data)
 * `rails canonical_models:sync:alchemical_properties` (syncs canonical alchemical properties with JSON data)
+* `rails canonical_models:sync:armor` (syncs canonical armours with JSON data)
+* `rails canonical_models:sync:books` (sync canonical books with JSON data)
+* `rails canonical_models:sync:clothing` (syncs canonical clothing items with JSON data)
+* `rails canonical_models:sync:enchantments` (syncs canonical enchantments with JSON data)
+* `rails canonical_models:sync:ingredients` (sync canonical ingredients with JSON data)
+* `rails canonical_models:sync:jewelry` (syncs canonical jewellery with JSON data)
+* `rails canonical_models:sync:materials` (syncs canonical materials with JSON data)
+* `rails canonical_models:sync:misc_items` (syncs misc items with JSON data)
 * `rails canonical_models:sync:powers` (syncs powers and abilities with JSON data)
 * `rails canonical_models:sync:properties` (syncs canonical properties with JSON data)
-* `rails canonical_models:sync:enchantments` (syncs canonical enchantments with JSON data)
 * `rails canonical_models:sync:spells` (syncs canonical spells with JSON data)
-* `rails canonical_models:sync:ingredients` (sync canonical ingredients with JSON data)
-* `rails canonical_models:sync:materials` (syncs canonical materials with JSON data)
-* `rails canonical_models:sync:armor` (syncs canonical armours with JSON data)
-* `rails canonical_models:sync:jewelry` (syncs canonical jewellery with JSON data)
-* `rails canonical_models:sync:clothing` (syncs canonical clothing items with JSON data)
-* `rails canonical_models:sync:weapons` (sync canonical weapons with JSON data)
-* `rails canonical_models:sync:books` (sync canonical books with JSON data)
 * `rails canonical_models:sync:staves` (sync canonical staves with JSON data)
+* `rails canonical_models:sync:weapons` (sync canonical weapons with JSON data)
 
 These tasks sync the models with the attributes in the JSON files. The tasks are idempotent. If a model already exists in the database with a given name, it will be updated with the attributes given in the JSON data. This is also true of associations: if an association is found in the database then the corresponding model (or join model) will be updated with data from the JSON files. **The Rake tasks will also remove models and associations that exist in the database but are not present in the JSON data.** This behaviour can be disabled by setting the `preserve_existing_records` argument on the Rake tasks to `true` (or any value other than `false`):
 

--- a/lib/tasks/canonical_models/canonical_misc_items.json
+++ b/lib/tasks/canonical_models/canonical_misc_items.json
@@ -1,0 +1,2089 @@
+[
+  {
+    "attributes": {
+      "name": "Aetherium Crest",
+      "item_code": "XX00575B",
+      "unit_weight": 1.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Aetherium Shard (Bottom)",
+      "item_code": "XX01433C",
+      "unit_weight": 0.3,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Aetherium Shard (Left)",
+      "item_code": "XX00575C",
+      "unit_weight": 0.3,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Aetherium Shard (Right)",
+      "item_code": "XX01433E",
+      "unit_weight": 0.3,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Aetherium Shard (Top)",
+      "item_code": "XX01433D",
+      "unit_weight": 0.3,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Albino Spider Pod",
+      "item_code": "XX017719",
+      "unit_weight": 1.0,
+      "item_types": [
+        "animal part"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    }
+  },
+  {
+    "attributes": {
+      "name": "Amethyst Claw, Left Half",
+      "item_code": "XX01CAC0",
+      "unit_weight": 0.5,
+      "item_types": [
+        "dragon claw"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Amethyst Claw, Right Half",
+      "item_code": "XX01CAC1",
+      "unit_weight": 0.5,
+      "item_types": [
+        "dragon claw"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Amethyst Paragon",
+      "item_code": "XX012F97",
+      "unit_weight": 0.3,
+      "item_types": [
+        "paragon"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Ancient Traveler's Skull",
+      "item_code": "000F6767",
+      "unit_weight": 5.0,
+      "item_types": [
+        "animal part"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": false
+    }
+  },
+  {
+    "attributes": {
+      "name": "Aretino Family Heirloom",
+      "item_code": "0001F6D4",
+      "unit_weight": 0.5,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Attunement Sphere",
+      "item_code": "0003532C",
+      "unit_weight": 0.0,
+      "item_types": [
+        "Dwemer artifact"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Azura's Star",
+      "item_code": "00063B27",
+      "unit_weight": 0.0,
+      "item_types": [
+        "daedric artifact"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Bee in a Jar",
+      "item_code": "000B08C7",
+      "unit_weight": 1.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": "Live bee in a jar",
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": false
+    }
+  },
+  {
+    "attributes": {
+      "name": "Blank Lexicon",
+      "item_code": "0003A3D2",
+      "unit_weight": 0.0,
+      "item_types": [
+        "Dwemer artifact"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Bone Hawk Claw",
+      "item_code": "XX011CF7",
+      "unit_weight": 1.0,
+      "item_types": [
+        "animal part"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    }
+  },
+  {
+    "attributes": {
+      "name": "Broken Azura's Star",
+      "item_code": "00028AD7",
+      "unit_weight": 0.5,
+      "item_types": [
+        "daedric artifact"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Bust of the Gray Fox",
+      "item_code": "00019954",
+      "unit_weight": 0.0,
+      "item_types": [
+        "larceny trophy"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Butterfly in a Jar",
+      "item_code": "000FBC3C",
+      "unit_weight": 1.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": "Live monarch butterfly in a jar",
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": false
+    }
+  },
+  {
+    "attributes": {
+      "name": "Calcelmo's Stone Rubbing",
+      "item_code": "00033764",
+      "unit_weight": 0.5,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Centurion Dynamo Core",
+      "item_code": "000F4983",
+      "unit_weight": 4.0,
+      "item_types": [
+        "Dwemer artifact"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Charcoal (Chunk)",
+      "item_code": "000BFB09",
+      "unit_weight": 0.5,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    }
+  },
+  {
+    "attributes": {
+      "name": "Charcoal (Stick)",
+      "item_code": "00033760",
+      "unit_weight": 0.5,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Child's Doll",
+      "item_code": "XX00C1DE",
+      "unit_weight": 2.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    }
+  },
+  {
+    "attributes": {
+      "name": "Coral Dragon Claw",
+      "item_code": "000B634C",
+      "unit_weight": 0.5,
+      "item_types": [
+        "dragon claw"
+      ],
+      "description": null,
+      "purchasable": true,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Crown of Barenziah",
+      "item_code": "0009DFF5",
+      "unit_weight": 0.0,
+      "item_types": [
+        "larceny trophy"
+      ],
+      "description": "Crown of Barenziah (no stones)",
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Crown of Barenziah",
+      "item_code": "000DA74D",
+      "unit_weight": 0.0,
+      "item_types": [
+        "larceny trophy"
+      ],
+      "description": "Crown of Barenziah (with stones)",
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Curious Silver Mold",
+      "item_code": "00044E12",
+      "unit_weight": 1.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Damaged Albino Spider Pod",
+      "item_code": "XX01771F",
+      "unit_weight": 1.0,
+      "item_types": [
+        "animal part"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    }
+  },
+  {
+    "attributes": {
+      "name": "Diamond Dragon Claw",
+      "item_code": "000AB375",
+      "unit_weight": 0.5,
+      "item_types": [
+        "dragon claw"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Diamond Paragon",
+      "item_code": "XX012FC3",
+      "unit_weight": 0.3,
+      "item_types": [
+        "paragon"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Dibella Statue",
+      "item_code": "0008F997",
+      "unit_weight": 2.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    }
+  },
+  {
+    "attributes": {
+      "name": "Do Not Delete",
+      "item_code": "C7316",
+      "unit_weight": 0.5,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    }
+  },
+  {
+    "attributes": {
+      "name": "Dragon Heartscales",
+      "item_code": "000D0756",
+      "unit_weight": 10.0,
+      "item_types": [
+        "animal part"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Dragonfly in a Jar",
+      "item_code": "000FBC3B",
+      "unit_weight": 1.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": "Live orange dartwing in a jar",
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": false
+    }
+  },
+  {
+    "attributes": {
+      "name": "Dragonstone",
+      "item_code": "000DF202",
+      "unit_weight": 25.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Dwarven Crossbow Schematic",
+      "item_code": "XX00F1C8",
+      "unit_weight": 0.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Dwemer Cog",
+      "item_code": "000AEBF1",
+      "unit_weight": 10.0,
+      "item_types": [
+        "Dwemer artifact"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Dwemer Exploding Fire Bolt Schematic",
+      "item_code": "XX006BAD",
+      "unit_weight": 0.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Dwemer Exploding Ice Bolt Schematic",
+      "item_code": "XX00F1C4",
+      "unit_weight": 0.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Dwemer Exploding Shock Bolt Schematic",
+      "item_code": "XX00F1C5",
+      "unit_weight": 0.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Dwemer Gyro",
+      "item_code": "000C8868",
+      "unit_weight": 2.0,
+      "item_types": [
+        "Dwemer artifact"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Dwemer Puzzle Cube",
+      "item_code": "0005598C",
+      "unit_weight": 0.0,
+      "item_types": [
+        "larceny trophy",
+        "Dwemer artifact"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "East Empire Shipping Map",
+      "item_code": "00060CC2",
+      "unit_weight": 0.0,
+      "item_types": [
+        "larceny trophy",
+        "map"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Ebony Dragon Claw",
+      "item_code": "0005AF48",
+      "unit_weight": 0.5,
+      "item_types": [
+        "dragon claw"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Eldergleam Sapling",
+      "item_code": "0001CB81",
+      "unit_weight": 0.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Emerald Dragon Claw",
+      "item_code": "000ed417",
+      "unit_weight": 0.5,
+      "item_types": [
+        "dragon claw"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Emerald Paragon",
+      "item_code": "XX019ABC",
+      "unit_weight": 0.3,
+      "item_types": [
+        "paragon"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Empty Wine Bottle",
+      "item_code": "000F2012",
+      "unit_weight": 0.5,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    }
+  },
+  {
+    "attributes": {
+      "name": "Enhanced Crossbow Schematic",
+      "item_code": "XX00F1C7",
+      "unit_weight": 0.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Enhanced Dwarven Crossbow Schematic",
+      "item_code": "XX00F1C9",
+      "unit_weight": 0.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Essence Extractor",
+      "item_code": "0001A31C",
+      "unit_weight": 1.0,
+      "item_types": [
+        "Dwemer artifact"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Exquisite Sapphire",
+      "item_code": "XX039E4E",
+      "unit_weight": 0.2,
+      "item_types": [
+        "gemstone"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": false
+    }
+  },
+  {
+    "attributes": {
+      "name": "Finn's Lute",
+      "item_code": "000DABAB",
+      "unit_weight": 4.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Focusing Crystal",
+      "item_code": "0009F7A6",
+      "unit_weight": 1.0,
+      "item_types": [
+        "Dwemer artifact"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Gildergreen Sapling",
+      "item_code": "0005C09E",
+      "unit_weight": 8.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Glass Dragon Claw",
+      "item_code": "0007C260",
+      "unit_weight": 0.5,
+      "item_types": [
+        "dragon claw"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Glenmoril Witch Head",
+      "item_code": "0002996F",
+      "unit_weight": 5.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Golden Claw",
+      "item_code": "00039647",
+      "unit_weight": 0.5,
+      "item_types": [
+        "dragon claw"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Golden Ship Model",
+      "item_code": "00044E8B",
+      "unit_weight": 0.0,
+      "item_types": [
+        "larceny trophy"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Golden Urn",
+      "item_code": "00044E63",
+      "unit_weight": 0.0,
+      "item_types": [
+        "larceny trophy"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Haelga's Statue of Dibella",
+      "item_code": "00021EA3",
+      "unit_weight": 2.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Heart Stone",
+      "item_code": "XX017749",
+      "unit_weight": 1.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Honningbrew Decanter",
+      "item_code": "00019952",
+      "unit_weight": 0.0,
+      "item_types": [
+        "larceny trophy"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": false
+    }
+  },
+  {
+    "attributes": {
+      "name": "Horn of Jurgen Windcaller",
+      "item_code": "0003292F",
+      "unit_weight": 4.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Imperial War Horn",
+      "item_code": "000200BA",
+      "unit_weight": 5.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    }
+  },
+  {
+    "attributes": {
+      "name": "Iron Dragon Claw",
+      "item_code": "0008CDFA",
+      "unit_weight": 0.5,
+      "item_types": [
+        "dragon claw"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Ivory Dragon Claw",
+      "item_code": "000AB7BB",
+      "unit_weight": 0.5,
+      "item_types": [
+        "dragon claw"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Jeweled Candlestick",
+      "item_code": "00044E6A",
+      "unit_weight": 0.0,
+      "item_types": [
+        "larceny trophy"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Jeweled Flagon",
+      "item_code": "00044E67",
+      "unit_weight": 0.0,
+      "item_types": [
+        "larceny trophy"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Jeweled Goblet",
+      "item_code": "00044E6C",
+      "unit_weight": 0.0,
+      "item_types": [
+        "larceny trophy"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Jeweled Pitcher",
+      "item_code": "00044E6E",
+      "unit_weight": 0.0,
+      "item_types": [
+        "larceny trophy"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Kagrumez Resonance Gem",
+      "item_code": "XX02145A",
+      "unit_weight": 0.2,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Klimmek's Supplies",
+      "item_code": "000DAB04",
+      "unit_weight": 0.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Left Eye of the Falmer",
+      "item_code": "0001994F",
+      "unit_weight": 5.0,
+      "item_types": [
+        "larceny trophy"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Lisbet's Dibella Statue",
+      "item_code": "0008F997",
+      "unit_weight": 2.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Lockpick",
+      "item_code": "0000000A",
+      "unit_weight": 0.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    }
+  },
+  {
+    "attributes": {
+      "name": "Mammoth Tusk",
+      "item_code": "0003AD6C",
+      "unit_weight": 5.0,
+      "item_types": [
+        "animal part"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Mammoth Tusk Powder",
+      "item_code": "0002C25E",
+      "unit_weight": 0.5,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Map of Dragon Burials",
+      "item_code": "000BBCD5",
+      "unit_weight": 0.0,
+      "item_types": [
+        "book"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": false
+    }
+  },
+  {
+    "attributes": {
+      "name": "Mercer's Plans",
+      "item_code": "00037CE9",
+      "unit_weight": 0.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Meridia's Beacon",
+      "item_code": "0004E4E6",
+      "unit_weight": 0.5,
+      "item_types": [
+        "daedric artifact"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Michaela's Flagon",
+      "item_code": "000F257D",
+      "unit_weight": 0.5,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": false
+    }
+  },
+  {
+    "attributes": {
+      "name": "Model Ship",
+      "item_code": "0006F266",
+      "unit_weight": 0.0,
+      "item_types": [
+        "larceny trophy"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": false
+    }
+  },
+  {
+    "attributes": {
+      "name": "Moth in a Jar",
+      "item_code": "000FBC3D",
+      "unit_weight": 1.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": "Live luna moth in a jar",
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": false
+    }
+  },
+  {
+    "attributes": {
+      "name": "Nurelion's Mixture",
+      "item_code": "000C4F2E",
+      "unit_weight": 0.5,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Olava's Token",
+      "item_code": "00059654",
+      "unit_weight": 0.5,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Opaque Vessel",
+      "item_code": "0003E6BC",
+      "unit_weight": 0.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Opaque Vessel",
+      "item_code": "0003E6BB",
+      "unit_weight": 0.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Opaque Vessel",
+      "item_code": "0008D770",
+      "unit_weight": 0.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Ornate Drinking Horn",
+      "item_code": "00044E65",
+      "unit_weight": 0.0,
+      "item_types": [
+        "larceny trophy"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Pantea's Flute",
+      "item_code": "000DABA7",
+      "unit_weight": 2.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Pelagius' Hip Bone",
+      "item_code": "0004286C",
+      "unit_weight": 1.0,
+      "item_types": [
+        "animal part"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Pest Poison",
+      "item_code": "0002BAAB",
+      "unit_weight": 0.5,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Potema's Skull",
+      "item_code": "0009E01F",
+      "unit_weight": 0.0,
+      "item_types": [
+        "animal part"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Queen Bee Statue",
+      "item_code": "00019958",
+      "unit_weight": 0.0,
+      "item_types": [
+        "larceny trophy"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Quill of Gemination",
+      "item_code": "000C04BB",
+      "unit_weight": 0.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Reaper Gem Fragment",
+      "item_code": "XX0066F3",
+      "unit_weight": 0.1,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Reaper Gem Fragment",
+      "item_code": "XX0066F5",
+      "unit_weight": 0.1,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Reaper Gem Fragment",
+      "item_code": "XX0066F6",
+      "unit_weight": 0.1,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Right Eye of the Falmer",
+      "item_code": "001092B8",
+      "unit_weight": 5.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Rjorn's Drum",
+      "item_code": "000DABA9",
+      "unit_weight": 4.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Roll of Paper",
+      "item_code": "00033761",
+      "unit_weight": 1.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    }
+  },
+  {
+    "attributes": {
+      "name": "Ruby Dragon Claw",
+      "item_code": "0004b56c",
+      "unit_weight": 0.5,
+      "item_types": [
+        "dragon claw"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Ruby Paragon",
+      "item_code": "XX019ABD",
+      "unit_weight": 0.3,
+      "item_types": [
+        "paragon"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Ruined Book",
+      "item_code": "000CE70B",
+      "unit_weight": 2.0,
+      "item_types": [
+        "book"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    }
+  },
+  {
+    "attributes": {
+      "name": "Runed Lexicon",
+      "item_code": "0003A3DD",
+      "unit_weight": 0.0,
+      "item_types": [
+        "Dwemer artifact"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Saerek's Skull Key",
+      "item_code": "000AADB6",
+      "unit_weight": 0.3,
+      "item_types": [
+        "key"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Sapphire Dragon Claw",
+      "item_code": "00663d7",
+      "unit_weight": 0.5,
+      "item_types": [
+        "dragon claw"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Sapphire Paragon",
+      "item_code": "XX019ABB",
+      "unit_weight": 0.3,
+      "item_types": [
+        "paragon"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Satchel of Moon Sugar",
+      "item_code": "000D8E43",
+      "unit_weight": 0.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Sealed Scroll",
+      "item_code": "000457AB",
+      "unit_weight": 0.5,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Sigil Stone",
+      "item_code": "000D363B",
+      "unit_weight": 0.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Silver Hand Strategem",
+      "item_code": "000F1491",
+      "unit_weight": 0.0,
+      "item_types": [
+        "book"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Sinding's Skin",
+      "item_code": "0002AC62",
+      "unit_weight": 0.0,
+      "item_types": [
+        "animal part"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Skull",
+      "item_code": "000AF5FD",
+      "unit_weight": 2.0,
+      "item_types": [
+        "animal part"
+      ],
+      "description": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    }
+  },
+  {
+    "attributes": {
+      "name": "Skull",
+      "item_code": "XX020DCF",
+      "unit_weight": 2.0,
+      "item_types": [
+        "animal part"
+      ],
+      "description": "Skull covered in carvings",
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Soaked Taproot",
+      "item_code": "XX01AAD6",
+      "unit_weight": 2.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Soul Essence Gem",
+      "item_code": "XX00EA6A",
+      "unit_weight": 0.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Stone of Barenziah",
+      "item_code": "0009DFBB",
+      "unit_weight": 0.5,
+      "item_types": [
+        "gemstone"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Sylgja's Satchel",
+      "item_code": "000E49F7",
+      "unit_weight": 0.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "The Black Star",
+      "item_code": "00063B29",
+      "unit_weight": 0.0,
+      "item_types": [
+        "daedric artifact"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "The Dancer's Flute",
+      "item_code": "00105109",
+      "unit_weight": 2.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": false
+    }
+  },
+  {
+    "attributes": {
+      "name": "Tolfdir's Alembic",
+      "item_code": "00026C31",
+      "unit_weight": 2.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Torc of Labyrinthian",
+      "item_code": "000A34F8",
+      "unit_weight": 1.0,
+      "item_types": [
+        "key"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Torch",
+      "item_code": "0001D4EC",
+      "unit_weight": 0.5,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    }
+  },
+  {
+    "attributes": {
+      "name": "Torchbug in a Jar",
+      "item_code": "000FBC3A",
+      "unit_weight": 1.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": "Live torchbug in a jar",
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": false
+    }
+  },
+  {
+    "attributes": {
+      "name": "Torsten's Skull Key",
+      "item_code": "000AADB7",
+      "unit_weight": 0.3,
+      "item_types": [
+        "key"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Torygg's War Horn",
+      "item_code": "000E77BB",
+      "unit_weight": 5.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Verner's Satchel",
+      "item_code": "000E49F8",
+      "unit_weight": 0.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Warped Soul Gem",
+      "item_code": "0006A106",
+      "unit_weight": 0.5,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Wedding Ring",
+      "item_code": "0001CB34",
+      "unit_weight": 0.5,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Werewolf Pelt",
+      "item_code": "000FE6A9",
+      "unit_weight": 5.0,
+      "item_types": [
+        "pelt"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Werewolf Totem",
+      "item_code": "000E3146",
+      "unit_weight": 0.5,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Werewolf Totem",
+      "item_code": "000E3147",
+      "unit_weight": 0.5,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Werewolf Totem",
+      "item_code": "000E3148",
+      "unit_weight": 0.5,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Wylandriah's Soul Gem",
+      "item_code": "00043E26",
+      "unit_weight": 0.0,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Wylandriah's Spoon",
+      "item_code": "00043E28",
+      "unit_weight": 0.5,
+      "item_types": [
+        "Dwemer artifact"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Ysgramor's Soup Spoon",
+      "item_code": "00105A4E",
+      "unit_weight": 0.5,
+      "item_types": [
+        "Dwemer artifact"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": false
+    }
+  }
+]

--- a/lib/tasks/canonical_models/canonical_misc_items.json
+++ b/lib/tasks/canonical_models/canonical_misc_items.json
@@ -1128,21 +1128,6 @@
   },
   {
     "attributes": {
-      "name": "Lisbet's Dibella Statue",
-      "item_code": "0008F997",
-      "unit_weight": 2.0,
-      "item_types": [
-        "miscellaneous"
-      ],
-      "description": null,
-      "purchasable": false,
-      "unique_item": true,
-      "rare_item": true,
-      "quest_item": true
-    }
-  },
-  {
-    "attributes": {
       "name": "Lockpick",
       "item_code": "0000000A",
       "unit_weight": 0.0,

--- a/lib/tasks/export_csvs.rake
+++ b/lib/tasks/export_csvs.rake
@@ -263,5 +263,24 @@ namespace :csv do
 
       File.write(csv_path, csv_data)
     end
+
+    desc 'Export a CSV of misc items from JSON data'
+    task misc_items: :environment do
+      json_path = Rails.root.join('lib', 'tasks', 'canonical_models', 'canonical_misc_items.json')
+      csv_path  = Rails.root.join('lib', 'tasks', 'canonical_models', 'canonical_misc_items.csv')
+      json_data = JSON.parse(File.read(json_path), symbolize_names: true)
+
+      headers = "#{json_data.first[:attributes].keys.map(&:to_s).join(',')}\n"
+
+      csv_data = CSV.generate(headers) do |csv|
+        json_data.each do |item|
+          item[:attributes][:item_types] = item.dig(:attributes, :item_types).join(',')
+
+          csv << item[:attributes].values
+        end
+      end
+
+      File.write(csv_path, csv_data)
+    end
   end
 end

--- a/lib/tasks/sync_canonical_models.rake
+++ b/lib/tasks/sync_canonical_models.rake
@@ -132,6 +132,13 @@ namespace :canonical_models do
     end
     # rubocop:enable Layout/BlockAlignment
 
+    desc 'Sync canonical misc items in the database with JSON data'
+    task :misc_items, %i[preserve_existing_records] => :environment do |_t, args|
+      args.with_defaults(preserve_existing_records: false)
+
+      Canonical::Sync.perform(:misc_item, FALSEY_VALUES.exclude?(args[:preserve_existing_records]))
+    end
+
     desc 'Sync all canonical models with JSON files'
     task :all, %i[preserve_existing_records] => :environment do |_t, args|
       args.with_defaults(preserve_existing_records: false)

--- a/spec/factories/canonical/misc_items.rb
+++ b/spec/factories/canonical/misc_items.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :canonical_misc_item, class: Canonical::MiscItem do
+    name                 { 'My Misc Item' }
+    sequence(:item_code) {|n| "xx123x#{n}" }
+    unit_weight          { 1.0 }
+    item_types           { %w[miscellaneous] }
+    purchasable          { true }
+    unique_item          { false }
+    rare_item            { false }
+    quest_item           { false }
+  end
+end

--- a/spec/fixtures/canonical/sync/misc_items.json
+++ b/spec/fixtures/canonical/sync/misc_items.json
@@ -1,0 +1,62 @@
+[
+  {
+    "attributes": {
+      "name": "Amethyst Paragon",
+      "item_code": "XX012F97",
+      "unit_weight": 0.3,
+      "item_types": [
+        "paragon"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Ancient Traveler's Skull",
+      "item_code": "000F6767",
+      "unit_weight": 5.0,
+      "item_types": [
+        "animal part"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": false
+    }
+  },
+  {
+    "attributes": {
+      "name": "Aretino Family Heirloom",
+      "item_code": "0001F6D4",
+      "unit_weight": 0.5,
+      "item_types": [
+        "miscellaneous"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  },
+  {
+    "attributes": {
+      "name": "Attunement Sphere",
+      "item_code": "0003532C",
+      "unit_weight": 0.0,
+      "item_types": [
+        "Dwemer artifact"
+      ],
+      "description": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    }
+  }
+]

--- a/spec/models/canonical/misc_item_spec.rb
+++ b/spec/models/canonical/misc_item_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Canonical::MiscItem, type: :model do
+  describe 'validations' do
+    describe 'name' do
+      it "can't be blank" do
+        model = build(:canonical_misc_item, name: nil)
+
+        model.validate
+        expect(model.errors[:name]).to include "can't be blank"
+      end
+    end
+
+    describe 'item_code' do
+      it "can't be blank" do
+        model = build(:canonical_misc_item, item_code: nil)
+
+        model.validate
+        expect(model.errors[:item_code]).to include "can't be blank"
+      end
+
+      it 'must be unique' do
+        create(:canonical_misc_item, item_code: 'foo')
+        model = build(:canonical_misc_item, item_code: 'foo')
+
+        model.validate
+        expect(model.errors[:item_code]).to include 'must be unique'
+      end
+    end
+
+    describe 'unit_weight' do
+      it "can't be blank" do
+        model = build(:canonical_misc_item, unit_weight: nil)
+
+        model.validate
+        expect(model.errors[:unit_weight]).to include "can't be blank"
+      end
+
+      it 'must be a number' do
+        model = build(:canonical_misc_item, unit_weight: 'foo')
+
+        model.validate
+        expect(model.errors[:unit_weight]).to include 'is not a number'
+      end
+
+      it 'must be at least zero' do
+        model = build(:canonical_misc_item, unit_weight: -2)
+
+        model.validate
+        expect(model.errors[:unit_weight]).to include 'must be greater than or equal to 0'
+      end
+    end
+
+    describe 'item_types' do
+      it "can't be blank" do
+        model = build(:canonical_misc_item, item_types: nil)
+
+        model.validate
+        expect(model.errors[:item_types]).to include "can't be blank"
+      end
+
+      it 'must include at least one valid type' do
+        model = build(:canonical_misc_item, item_types: [])
+
+        model.validate
+        expect(model.errors[:item_types]).to include 'must include at least one item type'
+      end
+
+      it 'must include only valid types' do
+        model = build(:canonical_misc_item, item_types: ['Dwemer artifact', 'industrial equipment'])
+
+        model.validate
+        expect(model.errors[:item_types]).to include 'can only include valid item types'
+      end
+    end
+
+    describe 'purchasable' do
+      it "can't be blank" do
+        model = build(:canonical_misc_item, purchasable: nil)
+
+        model.validate
+        expect(model.errors[:purchasable]).to include 'boolean value must be present'
+      end
+    end
+
+    describe 'unique_item' do
+      it "can't be blank" do
+        model = build(:canonical_misc_item, unique_item: nil)
+
+        model.validate
+        expect(model.errors[:unique_item]).to include 'boolean value must be present'
+      end
+    end
+
+    describe 'rare_item' do
+      it "can't be blank" do
+        model = build(:canonical_misc_item, rare_item: nil)
+
+        model.validate
+        expect(model.errors[:rare_item]).to include 'boolean value must be present'
+      end
+
+      it 'must be true if unique_item is true' do
+        model = build(:canonical_misc_item, unique_item: true, rare_item: false)
+
+        model.validate
+        expect(model.errors[:rare_item]).to include 'must be true if item is unique'
+      end
+    end
+
+    describe 'quest_item' do
+      it "can't be blank" do
+        model = build(:canonical_misc_item, quest_item: nil)
+
+        model.validate
+        expect(model.errors[:quest_item]).to include 'boolean value must be present'
+      end
+    end
+  end
+end

--- a/spec/models/canonical/sync_spec.rb
+++ b/spec/models/canonical/sync_spec.rb
@@ -189,5 +189,18 @@ RSpec.describe Canonical::Sync do
         expect(Canonical::Sync::Books).to have_received(:perform).with(false)
       end
     end
+
+    context 'when the model is ":misc_item"' do
+      subject(:perform) { described_class.perform(:misc_item, true) }
+
+      before do
+        allow(Canonical::Sync::MiscItems).to receive(:perform)
+      end
+
+      it 'calls #perform on the correct syncer' do
+        perform
+        expect(Canonical::Sync::MiscItems).to have_received(:perform).with(true)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

[**Create Canonical::MiscItem model**](167-create-canonicalmiscitem-model)

As part of our work creating canonical models, we need to create a category of miscellaneous items that occur in Skyrim.

## Changes

* Migration to create `canonical_misc_items` table
* `Canonical::MiscItem` model
* Syncer for canonical misc items
* JSON data for canonical misc items
* Tests for all of the above
* Doc updates
* Rake task to export misc item JSON data to CSV format

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

Keeping in mind the scope and purposes of SIM, it didn't make sense to include every possible miscellaneous item in the game in the collected data. Instead, I added only items that were useful, quest items, or unique/rare and collectible. This will mean that SIM will sometimes misidentify extant items, such as cups and plates, as nonexistent should a user attempt to add them to their inventory. We don't anticipate this happening enough to justify the time needed to add the items to the database now, however.

It's worth noting that, because of the subset of misc items selected for inclusion in SIM, the proportion of rare and unique items is much higher than for the other canonical models, with over 70% of misc items being identified as unique and over 90% as rare.
