### PR TITLE
Add description to alchemical properties

### DIFF
--- a/app/models/alchemical_property.rb
+++ b/app/models/alchemical_property.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AlchemicalProperty < ApplicationRecord
+  VALID_STRENGTH_UNITS = %w[point percentage level].freeze
+
   has_many :canonical_ingredients_alchemical_properties,
            dependent:  :destroy,
            class_name: 'Canonical::IngredientsAlchemicalProperty'
@@ -8,7 +10,7 @@ class AlchemicalProperty < ApplicationRecord
 
   validates :name, presence: true, uniqueness: { message: 'must be unique' }
   validates :description, presence: true
-  validates :strength_unit, inclusion: { in: %w[point percentage], message: 'must be "point" or "percentage"', allow_blank: true }
+  validates :strength_unit, inclusion: { in: VALID_STRENGTH_UNITS, message: 'must be "point", "percentage", or the "level" of affected targets', allow_blank: true }
 
   def self.unique_identifier
     :name

--- a/app/models/alchemical_property.rb
+++ b/app/models/alchemical_property.rb
@@ -7,6 +7,7 @@ class AlchemicalProperty < ApplicationRecord
   has_many :canonical_ingredients, through: :canonical_ingredients_alchemical_properties
 
   validates :name, presence: true, uniqueness: { message: 'must be unique' }
+  validates :description, presence: true
   validates :strength_unit, inclusion: { in: %w[point percentage], message: 'must be "point" or "percentage"', allow_blank: true }
 
   def self.unique_identifier

--- a/db/migrate/20220524073420_add_description_to_alchemical_properties.rb
+++ b/db/migrate/20220524073420_add_description_to_alchemical_properties.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDescriptionToAlchemicalProperties < ActiveRecord::Migration[6.1]
+  def change
+    add_column :alchemical_properties, :description, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_24_004554) do
+ActiveRecord::Schema.define(version: 2022_05_24_073420) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2022_05_24_004554) do
     t.boolean "effects_cumulative", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "description", null: false
     t.index ["name"], name: "index_alchemical_properties_on_name", unique: true
   end
 

--- a/lib/tasks/canonical_models/alchemical_properties.json
+++ b/lib/tasks/canonical_models/alchemical_properties.json
@@ -2,6 +2,7 @@
   {
     "attributes": {
       "name": "Cure Disease",
+      "description": "Cures all diseases.",
       "strength_unit": null,
       "effects_cumulative": false
     }
@@ -9,6 +10,7 @@
   {
     "attributes": {
       "name": "Damage Health",
+      "description": "Causes <strength> points of poison damage.",
       "strength_unit": "point",
       "effects_cumulative": false
     }
@@ -16,6 +18,7 @@
   {
     "attributes": {
       "name": "Damage Magicka",
+      "description": "Drains the target's Magicka by <strength> points.",
       "strength_unit": "point",
       "effects_cumulative": false
     }
@@ -23,6 +26,7 @@
   {
     "attributes": {
       "name": "Damage Magicka Regen",
+      "description": "Decreases the target's Magicka regeneration by <strength>% for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false
     }
@@ -30,6 +34,7 @@
   {
     "attributes": {
       "name": "Damage Stamina",
+      "description": "Drains the target's Stamina by <strength> points.",
       "strength_unit": "point",
       "effects_cumulative": false
     }
@@ -37,6 +42,7 @@
   {
     "attributes": {
       "name": "Damage Stamina Regen",
+      "description": "Decrease the target's Stamina regeneration by <strength>% for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false
     }
@@ -44,13 +50,15 @@
   {
     "attributes": {
       "name": "Fear",
-      "strength_unit": null,
+      "description": "Creatures and people up to level <strength> flee from combat for <duration> seconds.",
+      "strength_unit": "level",
       "effects_cumulative": false
     }
   },
   {
     "attributes": {
       "name": "Fortify Alteration",
+      "description": "Alteration spells last <strength>% longer for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false
     }
@@ -58,6 +66,7 @@
   {
     "attributes": {
       "name": "Fortify Barter",
+      "description": "You haggle for <strength>% better prices for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false
     }
@@ -65,6 +74,7 @@
   {
     "attributes": {
       "name": "Fortify Block",
+      "description": "Blocking absorbs <strength>% more damage for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false
     }
@@ -72,6 +82,7 @@
   {
     "attributes": {
       "name": "Fortify Carry Weight",
+      "description": "Carrying capacity increases by <strength> for <duration> seconds.",
       "strength_unit": "point",
       "effects_cumulative": false
     }
@@ -79,6 +90,7 @@
   {
     "attributes": {
       "name": "Fortify Conjuration",
+      "description": "Conjuration spells last <strength>% longer for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false
     }
@@ -86,6 +98,7 @@
   {
     "attributes": {
       "name": "Fortify Destruction",
+      "description": "Destruction spells are <strength>% stronger for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false
     }
@@ -93,6 +106,7 @@
   {
     "attributes": {
       "name": "Fortify Enchanting",
+      "description": "For <duration> seconds, items are enchanted <strength>% stronger.",
       "strength_unit": "percentage",
       "effects_cumulative": false
     }
@@ -100,13 +114,15 @@
   {
     "attributes": {
       "name": "Fortify Health",
-      "strength_unit": "percentage",
+      "description": "Health is increased by <strength> points for <duration> seconds.",
+      "strength_unit": "point",
       "effects_cumulative": false
     }
   },
   {
     "attributes": {
       "name": "Fortify Heavy Armor",
+      "description": "Increase Heavy Armor skill by <strength> points for <duration> seconds.",
       "strength_unit": "point",
       "effects_cumulative": false
     }
@@ -114,6 +130,7 @@
   {
     "attributes": {
       "name": "Fortify Illusion",
+      "description": "Illusion spells are <strength>% stronger for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false
     }
@@ -121,6 +138,7 @@
   {
     "attributes": {
       "name": "Fortify Light Armor",
+      "description": "Increases Light Armor skill by <strength> points for <duration> seconds.",
       "strength_unit": "point",
       "effects_cumulative": false
     }
@@ -128,6 +146,7 @@
   {
     "attributes": {
       "name": "Fortify Lockpicking",
+      "description": "Lockpicking is <strength>% easier for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false
     }
@@ -135,6 +154,7 @@
   {
     "attributes": {
       "name": "Fortify Magicka",
+      "description": "Magicka is increased by <strength> points for <duration> seconds.",
       "strength_unit": "point",
       "effects_cumulative": false
     }
@@ -142,6 +162,7 @@
   {
     "attributes": {
       "name": "Fortify Marksman",
+      "description": "Bows do <strength>% more damage for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false
     }
@@ -149,6 +170,7 @@
   {
     "attributes": {
       "name": "Fortify One-Handed",
+      "description": "One-handed weapons do <strength>% more damage for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false
     }
@@ -156,6 +178,7 @@
   {
     "attributes": {
       "name": "Fortify Pickpocket",
+      "description": "Pickpocketing is <strength>% easier for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false
     }
@@ -163,6 +186,7 @@
   {
     "attributes": {
       "name": "Fortify Restoration",
+      "description": "Restoration spells are <strength>% stronger for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false
     }
@@ -170,6 +194,7 @@
   {
     "attributes": {
       "name": "Fortify Smithing",
+      "description": "For <duration> seconds, weapon and armor improving is <strength>% better.",
       "strength_unit": "percentage",
       "effects_cumulative": false
     }
@@ -177,6 +202,7 @@
   {
     "attributes": {
       "name": "Fortify Sneak",
+      "description": "You are <strength>% harder to detect for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false
     }
@@ -184,6 +210,7 @@
   {
     "attributes": {
       "name": "Fortify Stamina",
+      "description": "Stamina is increased by <strength> points for <duration> seconds.",
       "strength_unit": "point",
       "effects_cumulative": false
     }
@@ -191,6 +218,7 @@
   {
     "attributes": {
       "name": "Fortify Two-Handed",
+      "description": "Two-handed weapons do <strength>% more damage for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false
     }
@@ -198,13 +226,15 @@
   {
     "attributes": {
       "name": "Frenzy",
-      "strength_unit": null,
+      "description": "Creatures and people up to level <strength> will attack anything nearby for <duration> seconds.",
+      "strength_unit": "level",
       "effects_cumulative": false
     }
   },
   {
     "attributes": {
       "name": "Invisibility",
+      "description": "Invisibility for <duration> seconds.",
       "strength_unit": null,
       "effects_cumulative": false
     }
@@ -212,6 +242,7 @@
   {
     "attributes": {
       "name": "Lingering Damage Health",
+      "description": "Causes <strength> points of poison damage for <duration> seconds.",
       "strength_unit": "point",
       "effects_cumulative": true
     }
@@ -219,6 +250,7 @@
   {
     "attributes": {
       "name": "Lingering Damage Magicka",
+      "description": "Drains the target's Magicka by <strength> points per second for <duration> seconds.",
       "strength_unit": "point",
       "effects_cumulative": true
     }
@@ -226,6 +258,7 @@
   {
     "attributes": {
       "name": "Lingering Damage Stamina",
+      "description": "Drain the target's Stamina by <strength> points per second for <duration> seconds.",
       "strength_unit": "point",
       "effects_cumulative": true
     }
@@ -233,6 +266,7 @@
   {
     "attributes": {
       "name": "Paralysis",
+      "description": "Target is paralyzed for <duration> seconds.",
       "strength_unit": null,
       "effects_cumulative": false
     }
@@ -240,6 +274,7 @@
   {
     "attributes": {
       "name": "Ravage Health",
+      "description": "Causes <strength> points of concentrated poison damage.",
       "strength_unit": "point",
       "effects_cumulative": false
     }
@@ -247,6 +282,7 @@
   {
     "attributes": {
       "name": "Ravage Magicka",
+      "description": "Concentrated poison damages maximum Magicka by <strength> points.",
       "strength_unit": "point",
       "effects_cumulative": false
     }
@@ -254,6 +290,7 @@
   {
     "attributes": {
       "name": "Ravage Stamina",
+      "description": "Concentrated poison damages maximum Stamina by <strength> points.",
       "strength_unit": "point",
       "effects_cumulative": false
     }
@@ -261,6 +298,7 @@
   {
     "attributes": {
       "name": "Regenerate Health",
+      "description": "Health regenerates <strength>% faster for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false
     }
@@ -268,6 +306,7 @@
   {
     "attributes": {
       "name": "Regenerate Magicka",
+      "description": "Magicka regenerates <strength>% faster for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false
     }
@@ -275,6 +314,7 @@
   {
     "attributes": {
       "name": "Regenerate Stamina",
+      "description": "Stamina regenerates <strength>% faster for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false
     }
@@ -282,6 +322,7 @@
   {
     "attributes": {
       "name": "Resist Fire",
+      "description": "Resist <strength>% of fire damage for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false
     }
@@ -289,6 +330,7 @@
   {
     "attributes": {
       "name": "Resist Frost",
+      "description": "Resist <strength>% of frost damage for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false
     }
@@ -296,6 +338,7 @@
   {
     "attributes": {
       "name": "Resist Magic",
+      "description": "Resist <strength>% of magic for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false
     }
@@ -303,6 +346,7 @@
   {
     "attributes": {
       "name": "Resist Poison",
+      "description": "Resist <strength>% of poison for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false
     }
@@ -310,6 +354,7 @@
   {
     "attributes": {
       "name": "Resist Shock",
+      "description": "Resist <strength>% of shock damage for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false
     }
@@ -317,6 +362,7 @@
   {
     "attributes": {
       "name": "Restore Health",
+      "description": "Restore <strength> points of Health.",
       "strength_unit": "point",
       "effects_cumulative": false
     }
@@ -324,6 +370,7 @@
   {
     "attributes": {
       "name": "Restore Magicka",
+      "description": "Restore <strength> points of Magicka.",
       "strength_unit": "point",
       "effects_cumulative": false
     }
@@ -331,6 +378,7 @@
   {
     "attributes": {
       "name": "Restore Stamina",
+      "description": "Restore <strength> Stamina.",
       "strength_unit": "point",
       "effects_cumulative": false
     }
@@ -338,6 +386,7 @@
   {
     "attributes": {
       "name": "Slow",
+      "description": "Target moves at 50% speed for <duration> seconds.",
       "strength_unit": null,
       "effects_cumulative": false
     }
@@ -345,6 +394,7 @@
   {
     "attributes": {
       "name": "Waterbreathing",
+      "description": "Can breathe underwater for <duration> seconds.",
       "strength_unit": null,
       "effects_cumulative": false
     }
@@ -352,6 +402,7 @@
   {
     "attributes": {
       "name": "Weakness to Fire",
+      "description": "Target is <strength>% weaker to fire damage for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false
     }
@@ -359,6 +410,7 @@
   {
     "attributes": {
       "name": "Weakness to Frost",
+      "description": "Target is <strength>% weaker to frost damage for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false
     }
@@ -366,6 +418,7 @@
   {
     "attributes": {
       "name": "Weakness to Magic",
+      "description": "Target is <strength>% weaker to magic for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false
     }
@@ -373,6 +426,7 @@
   {
     "attributes": {
       "name": "Weakness to Poison",
+      "description": "Target is <strength>% weaker to poison for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false
     }
@@ -380,6 +434,7 @@
   {
     "attributes": {
       "name": "Weakness to Shock",
+      "description": "Target is <strength>% weaker to shock damage for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false
     }

--- a/lib/tasks/export_csvs.rake
+++ b/lib/tasks/export_csvs.rake
@@ -22,7 +22,7 @@ namespace :csv do
       csv_path  = Rails.root.join('lib', 'tasks', 'canonical_models', 'alchemical_properties.csv')
       json_data = JSON.parse(File.read(json_path), symbolize_names: true)
 
-      headers = "name,strength_unit,effects_cumulative\n"
+      headers = "name,description,strength_unit,effects_cumulative\n"
 
       csv_data = CSV.generate(headers) do |csv|
         json_data.each {|property| csv << property[:attributes].values }

--- a/spec/factories/alchemical_properties.rb
+++ b/spec/factories/alchemical_properties.rb
@@ -3,5 +3,6 @@
 FactoryBot.define do
   factory :alchemical_property do
     sequence(:name) {|n| "Alchemical Property #{n}" }
+    description     { 'Something magical' }
   end
 end

--- a/spec/fixtures/canonical/sync/alchemical_properties.json
+++ b/spec/fixtures/canonical/sync/alchemical_properties.json
@@ -2,6 +2,7 @@
   {
     "attributes": {
       "name": "Cure Disease",
+      "description": "Cures all diseases.",
       "strength_unit": null,
       "effects_cumulative": false
     }
@@ -9,6 +10,7 @@
   {
     "attributes": {
       "name": "Damage Health",
+      "description": "Causes <strength> points of poison damage.",
       "strength_unit": "point",
       "effects_cumulative": false
     }
@@ -16,6 +18,7 @@
   {
     "attributes": {
       "name": "Damage Magicka",
+      "description": "Drains the target's Magicka by <strength> points.",
       "strength_unit": "point",
       "effects_cumulative": false
     }
@@ -23,6 +26,7 @@
   {
     "attributes": {
       "name": "Damage Magicka Regen",
+      "description": "Decreases the target's Magicka regeneration by <strength>% for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false
     }

--- a/spec/models/alchemical_property_spec.rb
+++ b/spec/models/alchemical_property_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe AlchemicalProperty, type: :model do
         model = build(:alchemical_property, strength_unit: 'Foobar')
         model.validate
 
-        expect(model.errors[:strength_unit]).to include 'must be "point" or "percentage"'
+        expect(model.errors[:strength_unit]).to include 'must be "point", "percentage", or the "level" of affected targets'
       end
     end
   end

--- a/spec/models/alchemical_property_spec.rb
+++ b/spec/models/alchemical_property_spec.rb
@@ -6,32 +6,43 @@ RSpec.describe AlchemicalProperty, type: :model do
   describe 'validations' do
     describe 'name' do
       it 'must be present' do
-        property = described_class.new
+        model = build(:alchemical_property, name: nil)
 
-        property.validate
-        expect(property.errors[:name]).to include "can't be blank"
+        model.validate
+        expect(model.errors[:name]).to include "can't be blank"
       end
 
       it 'must be unique' do
-        described_class.create!(name: 'Restore Health', strength_unit: 'point')
+        create(:alchemical_property, name: 'Restore Health', strength_unit: 'point')
+        model = build(:alchemical_property, name: 'Restore Health')
 
-        property = described_class.new(name: 'Restore Health')
-        property.validate
-        expect(property.errors[:name]).to include 'must be unique'
+        model.validate
+        expect(model.errors[:name]).to include 'must be unique'
+      end
+    end
+
+    describe 'description' do
+      it "can't be blank" do
+        model = build(:alchemical_property, description: nil)
+
+        model.validate
+        expect(model.errors[:description]).to include "can't be blank"
       end
     end
 
     describe 'strength_unit' do
       it "isn't required" do
-        property = described_class.new
-        property.validate
-        expect(property.errors[:strength_unit]).to be_empty
+        model = build(:alchemical_property, strength_unit: nil)
+
+        model.validate
+        expect(model.errors[:strength_unit]).to be_empty
       end
 
       it 'must be one of "point" or "percentage"' do
-        property = described_class.new(strength_unit: 'Foobar')
-        property.validate
-        expect(property.errors[:strength_unit]).to include 'must be "point" or "percentage"'
+        model = build(:alchemical_property, strength_unit: 'Foobar')
+        model.validate
+
+        expect(model.errors[:strength_unit]).to include 'must be "point" or "percentage"'
       end
     end
   end


### PR DESCRIPTION
## Context

[**Add description to canonical alchemical models**](https://trello.com/c/ELOCEVVQ/178-add-description-to-canonical-alchemical-properties)

Alchemical properties have no way to determine what their effects are from the models themselves. It makes sense to add a 'description' field to them so they know their own effects.

## Changes

* Add `description` column to alchemical_properties table
* Add validation for description to `AlchemicalProperty` model
* Add `'level'` as a possible strength unit
* Update spec file to be more consistent with other spec files in addition to testing new functionality

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [ ] ~~Added and updated API docs and developer docs as appropriate~~

## Considerations

Descriptions of potions and poisons include information about the strength and duration of their effects (measured by the strength unit of the alchemical property and seconds, respectively). For the canonical model, I've put these variables in angle brackets to enable easy regex replacement. In the models representing potions/poisons, these values will be defined specifically and interpolated. So, "Target is <strength>% weaker to magic for <duration> seconds." becomes "Target is 20% weaker to magic for 30 seconds.", for example, if that is the strength and duration of that particular poison.
