### PR TITLE
Create Canonical::Potion model

### DIFF
--- a/app/models/alchemical_property.rb
+++ b/app/models/alchemical_property.rb
@@ -8,6 +8,11 @@ class AlchemicalProperty < ApplicationRecord
            class_name: 'Canonical::IngredientsAlchemicalProperty'
   has_many :canonical_ingredients, through: :canonical_ingredients_alchemical_properties
 
+  has_many :canonical_potions_alchemical_properties,
+           dependent:  :destroy,
+           class_name: 'Canonical::PotionsAlchemicalProperty'
+  has_many :canonical_potions, through: :canonical_potions_alchemical_properties, source: :potion
+
   validates :name, presence: true, uniqueness: { message: 'must be unique' }
   validates :description, presence: true
   validates :strength_unit, inclusion: { in: VALID_STRENGTH_UNITS, message: 'must be "point", "percentage", or the "level" of affected targets', allow_blank: true }

--- a/app/models/canonical/book.rb
+++ b/app/models/canonical/book.rb
@@ -4,7 +4,8 @@ module Canonical
   class Book < ApplicationRecord
     self.table_name = 'canonical_books'
 
-    BOOLEAN_VALUES = [true, false].freeze
+    BOOLEAN_VALUES             = [true, false].freeze
+    BOOLEAN_VALIDATION_MESSAGE = 'must be true or false'
 
     BOOK_TYPES = [
                    'black book',
@@ -52,14 +53,14 @@ module Canonical
     validates :unit_weight, presence: true, numericality: { greater_than_or_equal_to: 0 }
     validates :book_type, inclusion: { in: BOOK_TYPES, message: 'must be a book type that exists in Skyrim' }
     validates :skill_name, inclusion: { in: SKILLS, message: 'must be a skill that exists in Skyrim', allow_blank: true }
-    validates :purchasable, inclusion: { in: BOOLEAN_VALUES, message: 'must be true or false' }
-    validates :unique_item, inclusion: { in: BOOLEAN_VALUES, message: 'must be true or false' }
-    validates :rare_item, inclusion: { in: BOOLEAN_VALUES, message: 'must be true or false' }
-    validates :solstheim_only, inclusion: { in: BOOLEAN_VALUES, message: 'must be true or false' }
-    validates :quest_item, inclusion: { in: BOOLEAN_VALUES, message: 'must be true or false' }
+    validates :purchasable, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }
+    validates :unique_item, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }
+    validates :rare_item, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }
+    validates :solstheim_only, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }
+    validates :quest_item, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }
 
     validate :validate_skill_name_presence
-    validate :verify_unique_item_rare
+    validate :verify_unique_item_rare, if: -> { unique_item == true }
 
     def self.unique_identifier
       :item_code
@@ -76,7 +77,7 @@ module Canonical
     end
 
     def verify_unique_item_rare
-      errors.add(:rare_item, 'must be true if item is unique') if unique_item && !rare_item
+      errors.add(:rare_item, 'must be true if item is unique') unless rare_item == true
     end
   end
 end

--- a/app/models/canonical/misc_item.rb
+++ b/app/models/canonical/misc_item.rb
@@ -4,7 +4,8 @@ module Canonical
   class MiscItem < ApplicationRecord
     self.table_name = 'canonical_misc_items'
 
-    BOOLEAN_VALUES = [true, false].freeze
+    BOOLEAN_VALUES             = [true, false].freeze
+    BOOLEAN_VALIDATION_MESSAGE = 'must be true or false'
 
     VALID_ITEM_TYPES = [
                          'animal part',
@@ -28,7 +29,7 @@ module Canonical
 
     validate :validate_item_types
     validate :validate_boolean_values
-    validate :verify_unique_item_also_rare
+    validate :verify_unique_item_also_rare, if: -> { unique_item == true }
 
     def self.unique_identifier
       :item_code
@@ -42,14 +43,14 @@ module Canonical
     end
 
     def validate_boolean_values
-      errors.add(:purchasable, 'boolean value must be present') unless BOOLEAN_VALUES.include?(purchasable)
-      errors.add(:unique_item, 'boolean value must be present') unless BOOLEAN_VALUES.include?(unique_item)
-      errors.add(:rare_item, 'boolean value must be present') unless BOOLEAN_VALUES.include?(rare_item)
-      errors.add(:quest_item, 'boolean value must be present') unless BOOLEAN_VALUES.include?(quest_item)
+      errors.add(:purchasable, BOOLEAN_VALIDATION_MESSAGE) unless BOOLEAN_VALUES.include?(purchasable)
+      errors.add(:unique_item, BOOLEAN_VALIDATION_MESSAGE) unless BOOLEAN_VALUES.include?(unique_item)
+      errors.add(:rare_item, BOOLEAN_VALIDATION_MESSAGE) unless BOOLEAN_VALUES.include?(rare_item)
+      errors.add(:quest_item, BOOLEAN_VALIDATION_MESSAGE) unless BOOLEAN_VALUES.include?(quest_item)
     end
 
     def verify_unique_item_also_rare
-      errors.add(:rare_item, 'must be true if item is unique') if unique_item && !rare_item
+      errors.add(:rare_item, 'must be true if item is unique') unless rare_item == true
     end
   end
 end

--- a/app/models/canonical/potion.rb
+++ b/app/models/canonical/potion.rb
@@ -7,6 +7,12 @@ module Canonical
     BOOLEAN_VALUES             = [true, false].freeze
     BOOLEAN_VALIDATION_MESSAGE = 'must be true or false'
 
+    has_many :canonical_potions_alchemical_properties,
+             dependent:  :destroy,
+             class_name: 'Canonical::PotionsAlchemicalProperty',
+             inverse_of: :potion
+    has_many :alchemical_properties, through: :canonical_potions_alchemical_properties
+
     validates :name, presence: true
     validates :item_code, presence: true, uniqueness: { message: 'must be unique' }
     validates :unit_weight, presence: true, numericality: { greater_than_or_equal_to: 0 }

--- a/app/models/canonical/potion.rb
+++ b/app/models/canonical/potion.rb
@@ -6,6 +6,7 @@ module Canonical
 
     BOOLEAN_VALUES             = [true, false].freeze
     BOOLEAN_VALIDATION_MESSAGE = 'must be true or false'
+    VALID_POTION_TYPES         = %w[potion poison].freeze
 
     has_many :canonical_potions_alchemical_properties,
              dependent:  :destroy,
@@ -16,6 +17,7 @@ module Canonical
     validates :name, presence: true
     validates :item_code, presence: true, uniqueness: { message: 'must be unique' }
     validates :unit_weight, presence: true, numericality: { greater_than_or_equal_to: 0 }
+    validates :potion_type, presence: true, inclusion: { in: VALID_POTION_TYPES, message: 'must be "potion" or "poison"' }
 
     validate :validate_boolean_values
     validate :validate_unique_item_also_rare, if: -> { unique_item == true }

--- a/app/models/canonical/potion.rb
+++ b/app/models/canonical/potion.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Canonical
+  class Potion < ApplicationRecord
+    self.table_name = 'canonical_potions'
+
+    BOOLEAN_VALUES             = [true, false].freeze
+    BOOLEAN_VALIDATION_MESSAGE = 'must be true or false'
+
+    validates :name, presence: true
+    validates :item_code, presence: true, uniqueness: { message: 'must be unique' }
+    validates :unit_weight, presence: true, numericality: { greater_than_or_equal_to: 0 }
+
+    validate :validate_boolean_values
+    validate :validate_unique_item_also_rare, if: -> { unique_item == true }
+
+    def self.unique_identifier
+      :item_code
+    end
+
+    private
+
+    def validate_boolean_values
+      errors.add(:purchasable, BOOLEAN_VALIDATION_MESSAGE) unless BOOLEAN_VALUES.include?(purchasable)
+      errors.add(:unique_item, BOOLEAN_VALIDATION_MESSAGE) unless BOOLEAN_VALUES.include?(unique_item)
+      errors.add(:rare_item, BOOLEAN_VALIDATION_MESSAGE) unless BOOLEAN_VALUES.include?(rare_item)
+      errors.add(:quest_item, BOOLEAN_VALIDATION_MESSAGE) unless BOOLEAN_VALUES.include?(quest_item)
+    end
+
+    def validate_unique_item_also_rare
+      errors.add(:rare_item, 'must be true if item is unique') unless rare_item == true
+    end
+  end
+end

--- a/app/models/canonical/potions_alchemical_property.rb
+++ b/app/models/canonical/potions_alchemical_property.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Canonical
+  class PotionsAlchemicalProperty < ApplicationRecord
+    self.table_name = 'canonical_potions_alchemical_properties'
+
+    belongs_to :alchemical_property
+    belongs_to :potion, class_name: 'Canonical::Potion'
+
+    validates :alchemical_property_id, uniqueness: { scope: :potion_id, message: 'must form a unique combination with canonical potion' }
+    validates :strength, numericality: { greater_than: 0, only_integer: true, allow_blank: true }
+    validates :duration, numericality: { greater_than: 0, only_integer: true, allow_blank: true }
+  end
+end

--- a/app/models/canonical/staff.rb
+++ b/app/models/canonical/staff.rb
@@ -4,6 +4,9 @@ module Canonical
   class Staff < ApplicationRecord
     self.table_name = 'canonical_staves'
 
+    BOOLEAN_VALUES             = [true, false].freeze
+    BOOLEAN_VALIDATION_MESSAGE = 'must be true or false'
+
     VALID_SCHOOLS = %w[
                       Alteration
                       Conjuration
@@ -34,9 +37,9 @@ module Canonical
                               only_integer:             true,
                             }
     validates :school, inclusion: { in: VALID_SCHOOLS, message: 'must be a valid school of magic', allow_blank: true }
-    validates :daedric, inclusion: { in: [true, false], message: 'boolean value must be present' }
-    validates :unique_item, inclusion: { in: [true, false], message: 'boolean value must be present' }
-    validates :quest_item, inclusion: { in: [true, false], message: 'boolean value must be present' }
+    validates :daedric, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }
+    validates :unique_item, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }
+    validates :quest_item, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }
 
     def self.unique_identifier
       :item_code

--- a/app/models/canonical/sync.rb
+++ b/app/models/canonical/sync.rb
@@ -17,6 +17,7 @@ module Canonical
                 clothing:            Canonical::Sync::ClothingItems,
                 jewelry:             Canonical::Sync::JewelryItems,
                 misc_item:           Canonical::Sync::MiscItems,
+                potion:              Canonical::Sync::Potions,
                 property:            Canonical::Sync::Properties,
                 spell:               Canonical::Sync::Spells,
                 staff:               Canonical::Sync::Staves,

--- a/app/models/canonical/sync/potions.rb
+++ b/app/models/canonical/sync/potions.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Canonical
+  module Sync
+    class Potions < AssociationSyncer
+      private
+
+      def model_class
+        Canonical::Potion
+      end
+
+      def json_file_path
+        Rails.root.join('lib', 'tasks', 'canonical_models', 'canonical_potions.json')
+      end
+
+      def prerequisites
+        [AlchemicalProperty]
+      end
+    end
+  end
+end

--- a/db/migrate/20220525005131_create_canonical_potions.rb
+++ b/db/migrate/20220525005131_create_canonical_potions.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class CreateCanonicalPotions < ActiveRecord::Migration[6.1]
+  def change
+    create_table :canonical_potions do |t|
+      t.string :name, null: false
+      t.string :item_code, null: false, unique: true
+      t.decimal :unit_weight, null: false
+      t.string :potion_type, null: false
+      t.string :magical_effects
+      t.boolean :purchasable, null: false, default: true
+      t.boolean :unique_item, null: false, default: false
+      t.boolean :rare_item, null: false, default: false
+      t.boolean :quest_item, null: false, default: false
+
+      t.index :item_code, unique: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220525023945_create_canonical_potions_alchemical_properties.rb
+++ b/db/migrate/20220525023945_create_canonical_potions_alchemical_properties.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class CreateCanonicalPotionsAlchemicalProperties < ActiveRecord::Migration[6.1]
+  def change
+    create_table :canonical_potions_alchemical_properties do |t|
+      t.references :potion, null: false, foreign_key: { to_table: 'canonical_potions' }
+      t.references :alchemical_property,
+                   null:        false,
+                   foreign_key: true,
+                   index:       { name: 'index_can_potions_properties_on_alc_property_id' }
+      t.integer :strength
+      t.integer :duration
+
+      t.index %i[potion_id alchemical_property_id],
+              unique: true,
+              name:   'index_can_potions_properties_on_potion_and_property'
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_25_005131) do
+ActiveRecord::Schema.define(version: 2022_05_25_023945) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -173,6 +173,18 @@ ActiveRecord::Schema.define(version: 2022_05_25_005131) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["item_code"], name: "index_canonical_potions_on_item_code", unique: true
+  end
+
+  create_table "canonical_potions_alchemical_properties", force: :cascade do |t|
+    t.bigint "potion_id", null: false
+    t.bigint "alchemical_property_id", null: false
+    t.integer "strength"
+    t.integer "duration"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["alchemical_property_id"], name: "index_can_potions_properties_on_alc_property_id"
+    t.index ["potion_id", "alchemical_property_id"], name: "index_can_potions_properties_on_potion_and_property", unique: true
+    t.index ["potion_id"], name: "index_canonical_potions_alchemical_properties_on_potion_id"
   end
 
   create_table "canonical_powerables_powers", force: :cascade do |t|
@@ -396,6 +408,8 @@ ActiveRecord::Schema.define(version: 2022_05_25_005131) do
   add_foreign_key "canonical_enchantables_enchantments", "enchantments"
   add_foreign_key "canonical_ingredients_alchemical_properties", "alchemical_properties"
   add_foreign_key "canonical_ingredients_alchemical_properties", "canonical_ingredients", column: "ingredient_id"
+  add_foreign_key "canonical_potions_alchemical_properties", "alchemical_properties"
+  add_foreign_key "canonical_potions_alchemical_properties", "canonical_potions", column: "potion_id"
   add_foreign_key "canonical_powerables_powers", "powers"
   add_foreign_key "canonical_recipes_ingredients", "canonical_books", column: "recipe_id"
   add_foreign_key "canonical_recipes_ingredients", "canonical_ingredients", column: "ingredient_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_24_073420) do
+ActiveRecord::Schema.define(version: 2022_05_25_005131) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -158,6 +158,21 @@ ActiveRecord::Schema.define(version: 2022_05_24_073420) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["item_code"], name: "index_canonical_misc_items_on_item_code", unique: true
+  end
+
+  create_table "canonical_potions", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "item_code", null: false
+    t.decimal "unit_weight", null: false
+    t.string "potion_type", null: false
+    t.string "magical_effects"
+    t.boolean "purchasable", default: true, null: false
+    t.boolean "unique_item", default: false, null: false
+    t.boolean "rare_item", default: false, null: false
+    t.boolean "quest_item", default: false, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["item_code"], name: "index_canonical_potions_on_item_code", unique: true
   end
 
   create_table "canonical_powerables_powers", force: :cascade do |t|

--- a/docs/canonical_models/canonical-models.md
+++ b/docs/canonical_models/canonical-models.md
@@ -9,6 +9,7 @@ The following canonical models exist in the SIM database:
 * [`Canonical::JewelryItem`](/app/models/canonical/jewelry_item.rb): actual jewelry items available in-game, including both generic and unique pieces
 * [`Canonical::Material`](/app/models/canonical/material.rb): actual building and smithing materials present in the game
 * [`Canonical::MiscItem`](/app/models/canonical/misc_item.rb): miscellaneous items occurring in the game that may be either useful or decorative
+* [`Canonical::Potion`](/app/models/canonical/potion.rb): potions that may be purchased or found in-game (does not include player-created potions, which can be validated using only alchemical properties without needing an additional canonical model)
 * [`Canonical::Property`](/app/models/canonical/property.rb): actual properties (homes) the player character can own in the game
 * [`Canonical::Weapon`](/app/models/canonical/weapon.rb): actual weapons the player character can acquire in the game
 * [`Canonical::Staff`](/app/models/canonical/staff.rb): actual staves the player character can acquire in the game
@@ -26,6 +27,7 @@ Note that the lists above do not include join tables for the `has_many, :through
 
 * [`Canonical::EnchantablesEnchantment`](/app/models/canonical/enchantables_enchantment.rb): This polymorphic join table associates enchantments with any enchantable items, including armours, jewellery, clothing items, and weapons, adding a field called `strength` for the strength of the enchantment on that particular item
 * [`Canonical::CraftablesCraftingMaterial`](/app/models/canonical/craftables_crafting_material.rb): This polymorphic join table associates canonical materials with any items that are able to be crafted using those materials, including armours, jewellery, and weapons, adding a field called `quantity` for the quantity of a given material needed to craft that particular item
+* [`Canonical::PotionsAlchemicalProperty](/app/models/canonical/potions_alchemical_property.rb): This join table links canonical potions with their alchemical properties, setting a `strength` and `duration` on the association
 * [`Canonical::PowerablesPower](/app/models/canonical/powerables_power.rb): This polymorphic join table associates powers with any objects enchanted with them, including weapons and staves, adding no additional fields to the join table
 * [`Canonical::RecipesIngredient`](/app/models/canonical/recipes_ingredient.rb): This join table links canonical books that are recipes with the ingredients specified in the recipe; there are no fields on this table other than foreign keys and timestamps
 * [`Canonical::StavesSpell](/app/models/canonical/staves_spell.rb): This join table links enchanted staves to the spells they are enchanted with, adding a `strength` field in case the strength of the spell on the staff differs from the base strength of the spell

--- a/docs/canonical_models/syncing-canonical-models.md
+++ b/docs/canonical_models/syncing-canonical-models.md
@@ -26,7 +26,8 @@ The following idempotent Rake tasks can be used to sync the database with the ca
 * `rails canonical_models:sync:ingredients` (sync canonical ingredients with JSON data)
 * `rails canonical_models:sync:jewelry` (syncs canonical jewellery with JSON data)
 * `rails canonical_models:sync:materials` (syncs canonical materials with JSON data)
-* `rails canonical_models:sync:misc_items` (syncs misc items with JSON data)
+* `rails canonical_models:sync:misc_items` (syncs canonical misc items with JSON data)
+* `rails canonical_models:sync:potions` (syncs canonical potions with JSON data)
 * `rails canonical_models:sync:powers` (syncs powers and abilities with JSON data)
 * `rails canonical_models:sync:properties` (syncs canonical properties with JSON data)
 * `rails canonical_models:sync:spells` (syncs canonical spells with JSON data)
@@ -77,8 +78,9 @@ The following models have prerequisites:
 | `Canonical::Armor`        | `Enchantment`, `Canonical::Material` |
 | `Canonical::Book`         | `Canonical::Ingredient`              |
 | `Canonical::ClothingItem` | `Enchantment`                        |
-| `Canonical::Ingredient`   | AlchemicalProperty                   |
+| `Canonical::Ingredient`   | `AlchemicalProperty`                 |
 | `Canonical::JewelryItem`  | `Enchantment`, `Canonical::Material` |
+| `Canonical::Potion`       | `AlchemicalProperty`                 |
 | `Canonical::Staff`        | `Spell`, `Power`                     |
 | `Canonical::Weapon`       | `Enchantment`, `Canonical::Material` |
 

--- a/lib/tasks/canonical_models/alchemical_properties.json
+++ b/lib/tasks/canonical_models/alchemical_properties.json
@@ -209,6 +209,14 @@
   },
   {
     "attributes": {
+      "name": "Fortify Speech",
+      "description": "+<strength> Speechcraft for <duration> seconds.",
+      "strength_unit": "point",
+      "effects_cumulative": false
+    }
+  },
+  {
+    "attributes": {
       "name": "Fortify Stamina",
       "description": "Stamina is increased by <strength> points for <duration> seconds.",
       "strength_unit": "point",

--- a/lib/tasks/canonical_models/canonical_potions.json
+++ b/lib/tasks/canonical_models/canonical_potions.json
@@ -3727,7 +3727,7 @@
   {
     "attributes": {
       "name": "Potion of Extreme Stamina",
-      "item_code": "00039CF3",
+      "item_code": "0003EAE6",
       "unit_weight": 0.5,
       "potion_type": "potion",
       "magical_effects": null,

--- a/lib/tasks/canonical_models/canonical_potions.json
+++ b/lib/tasks/canonical_models/canonical_potions.json
@@ -1,0 +1,5671 @@
+[
+  {
+    "attributes": {
+      "name": "Aversion to Fire",
+      "item_code": "00073F49",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Weakness to Fire",
+        "strength": 55,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Aversion to Frost",
+      "item_code": "00073F4D",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Weakness to Frost",
+        "strength": 55,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Aversion to Magic",
+      "item_code": "00073F56",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Weakness to Magic",
+        "strength": 55,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Aversion to Shock",
+      "item_code": "00065A6D",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Weakness to Shock",
+        "strength": 55,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Blacksmith's Draught",
+      "item_code": "0003995D",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Smithing",
+        "strength": 30,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Blacksmith's Elixir",
+      "item_code": "00039967",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Smithing",
+        "strength": 50,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Blacksmith's Philter",
+      "item_code": "00039962",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Smithing",
+        "strength": 40,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Blacksmith's Potion",
+      "item_code": "0003EB2E",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Smithing",
+        "strength": 20,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Cliff Racer",
+      "item_code": "00065C39",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Restore Stamina",
+        "strength": 25,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Conjurer's Draught",
+      "item_code": "000398AD",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Conjuration",
+        "strength": 50,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Conjurer's Elixir",
+      "item_code": "000398ED",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Conjuration",
+        "strength": 100,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Conjurer's Philter",
+      "item_code": "000398EC",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Conjuration",
+        "strength": 75,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Conjurer's Potion",
+      "item_code": "0003EB37",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Conjuration",
+        "strength": 25,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Deadly Aversion to Fire",
+      "item_code": "00073F4C",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Weakness to Fire",
+        "strength": 100,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Deadly Aversion to Frost",
+      "item_code": "00073F50",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Weakness to Frost",
+        "strength": 100,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Deadly Aversion to Magic",
+      "item_code": "00073F59",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Weakness to Magic",
+        "strength": 100,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Deadly Aversion to Shock",
+      "item_code": "00073F55",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Weakness to Shock",
+        "strength": 100,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Deadly Fear Poison",
+      "item_code": "00073F61",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fear",
+        "strength": 23,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Deadly Frenzy Poison",
+      "item_code": "00073F5D",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Frenzy",
+        "strength": 23,
+        "duration": 10
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Deadly Lingering Poison",
+      "item_code": "00073F38",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Lingering Damage Health",
+        "strength": 3,
+        "duration": 20
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Deadly Magicka Poison",
+      "item_code": "00073F3C",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Damage Magicka",
+        "strength": 130,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Deadly Paralysis Poison",
+      "item_code": "00074A3B",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Paralysis",
+        "strength": null,
+        "duration": 15
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Deadly Poison",
+      "item_code": "00073F34",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Damage Health",
+        "strength": 65,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Deadly Recovery Poison",
+      "item_code": "00073F94",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Damage Magicka Regen",
+        "strength": 100,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Deadly Stamina Poison",
+      "item_code": "00073F44",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Damage Stamina",
+        "strength": 130,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Draught of Alteration",
+      "item_code": "0003988E",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Alteration",
+        "strength": 50,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Draught of Conflict",
+      "item_code": "000F84B6",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Light Armor",
+        "strength": 15,
+        "duration": 60
+      },
+      {
+        "name": "Fortify One-Handed",
+        "strength": 20,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Draught of Destruction",
+      "item_code": "000398EE",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Destruction",
+        "strength": 30,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Draught of Enhanced Stamina",
+      "item_code": "0003EB00",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Stamina",
+        "strength": 40,
+        "duration": 300
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Draught of Escape",
+      "item_code": "000F84AF",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Invisibility",
+        "strength": null,
+        "duration": 50
+      },
+      {
+        "name": "Restore Health",
+        "strength": 40,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Draught of Extra Magicka",
+      "item_code": "0003EAFA",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Magicka",
+        "strength": 40,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Draught of Glibness",
+      "item_code": "000D697F",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Speech",
+        "strength": 30,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Draught of Haggling",
+      "item_code": "00039970",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Barter",
+        "strength": 15,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Draught of Health",
+      "item_code": "0003EAF4",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Health",
+        "strength": 40,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Draught of Illusion",
+      "item_code": "0003994F",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Illusion",
+        "strength": 50,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Draught of Keenshot",
+      "item_code": "000F84BC",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Marksman",
+        "strength": 20,
+        "duration": 60
+      },
+      {
+        "name": "Regenerate Stamina",
+        "strength": 7,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Draught of Larceny",
+      "item_code": "000F84A8",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Lockpicking",
+        "strength": 20,
+        "duration": 60
+      },
+      {
+        "name": "Fortify Pickpocket",
+        "strength": 20,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Draught of Lasting Potency",
+      "item_code": "0003EB0E",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Regenerate Magicka",
+        "strength": 60,
+        "duration": 300
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Draught of Light Feet",
+      "item_code": "00039968",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Sneak",
+        "strength": 15,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Draught of Lockpicking",
+      "item_code": "00039945",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Lockpicking",
+        "strength": 30,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Draught of Pickpocketing",
+      "item_code": "00039957",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Pickpocket",
+        "strength": 30,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Draught of Plunder",
+      "item_code": "000F84C2",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Carry Weight",
+        "strength": 30,
+        "duration": 300
+      },
+      {
+        "name": "Fortify Stamina",
+        "strength": 30,
+        "duration": 300
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Draught of Regeneration",
+      "item_code": "0003EB0A",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Regenerate Health",
+        "strength": 60,
+        "duration": 300
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Draught of Resist Cold",
+      "item_code": "0003EAED",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Resist Frost",
+        "strength": 30,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Draught of Resist Fire",
+      "item_code": "0003EAE9",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Resist Fire",
+        "strength": 30,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Draught of Resist Magic",
+      "item_code": "00039E53",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Resist Magic",
+        "strength": 15,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Draught of Strength",
+      "item_code": "0003EB05",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Carry Weight",
+        "strength": 30,
+        "duration": 300
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Draught of True Shot",
+      "item_code": "00039949",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Marksman",
+        "strength": 30,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Draught of Vigor",
+      "item_code": "0003EB12",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Regenerate Stamina",
+        "strength": 60,
+        "duration": 300
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Draught of Waterbreathing",
+      "item_code": "0003AC2F",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Waterbreathing",
+        "strength": null,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Draught of the Berserker",
+      "item_code": "00039974",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Two-Handed",
+        "strength": 30,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Draught of the Defender",
+      "item_code": "0003989B",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Block",
+        "strength": 15,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Draught of the Healer",
+      "item_code": "0003995A",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Restoration",
+        "strength": 30,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Draught of the Knight",
+      "item_code": "000398F4",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Heavy Armor",
+        "strength": 15,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Draught of the Warrior",
+      "item_code": "00039954",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify One-Handed",
+        "strength": 30,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Elixir of Alteration",
+      "item_code": "0003989A",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Alteration",
+        "strength": 100,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Elixir of Conflict",
+      "item_code": "000F84B8",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Light Armor",
+        "strength": 30,
+        "duration": 60
+      },
+      {
+        "name": "Fortify One-Handed",
+        "strength": 35,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Elixir of Destruction",
+      "item_code": "000398F3",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Destruction",
+        "strength": 50,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Elixir of Enhanced Stamina",
+      "item_code": "000FFA01",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Stamina",
+        "strength": 100,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Elixir of Escape",
+      "item_code": "000F84B1",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Invisibility",
+        "strength": null,
+        "duration": 100
+      },
+      {
+        "name": "Restore Health",
+        "strength": 50,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Elixir of Extra Magicka",
+      "item_code": "000FF9FD",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Magicka",
+        "strength": 100,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Elixir of Glibness",
+      "item_code": "000D6980",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Speech",
+        "strength": 50,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Elixir of Haggling",
+      "item_code": "00039973",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Barter",
+        "strength": 25,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Elixir of Health",
+      "item_code": "000FF9FC",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Health",
+        "strength": 100,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Elixir of Illusion",
+      "item_code": "00039951",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Illusion",
+        "strength": 100,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Elixir of Keenshot",
+      "item_code": "000F84BE",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Marksman",
+        "strength": 30,
+        "duration": 60
+      },
+      {
+        "name": "Regenerate Stamina",
+        "strength": 11,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Elixir of Larceny",
+      "item_code": "000F84AA",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Lockpicking",
+        "strength": 30,
+        "duration": 60
+      },
+      {
+        "name": "Fortify Pickpocket",
+        "strength": 30,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Elixir of Lasting Potency",
+      "item_code": "000FFA00",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Regenerate Magicka",
+        "strength": 100,
+        "duration": 300
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Elixir of Light Feet",
+      "item_code": "0003996F",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Sneak",
+        "strength": 25,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Elixir of Lockpicking",
+      "item_code": "00039948",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Lockpicking",
+        "strength": 50,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Elixir of Pickpocketing",
+      "item_code": "00039958",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Pickpocket",
+        "strength": 50,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Elixir of Plunder",
+      "item_code": "000F84C4",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Carry Weight",
+        "strength": 50,
+        "duration": 300
+      },
+      {
+        "name": "Fortify Stamina",
+        "strength": 50,
+        "duration": 300
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Elixir of Regeneration",
+      "item_code": "000FF9FF",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Regenerate Health",
+        "strength": 100,
+        "duration": 300
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Elixir of Resist Cold",
+      "item_code": "0003EAF0",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Resist Frost",
+        "strength": 50,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Elixir of Resist Fire",
+      "item_code": "0003EAEF",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Resist Fire",
+        "strength": 50,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Elixir of Resist Magic",
+      "item_code": "00039E55",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Resist Magic",
+        "strength": 25,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Elixir of Strength",
+      "item_code": "000FF9FE",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Carry Weight",
+        "strength": 60,
+        "duration": 300
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Elixir of True Shot",
+      "item_code": "0003994E",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Marksman",
+        "strength": 50,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Elixir of Vigor",
+      "item_code": "000FFA02",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Regenerate Stamina",
+        "strength": 100,
+        "duration": 300
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Elixir of Waterbreathing",
+      "item_code": "0003AC31",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Waterbreathing",
+        "strength": null,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Elixir of the Berserker",
+      "item_code": "00039AA6",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Two-Handed",
+        "strength": 50,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Elixir of the Defender",
+      "item_code": "000398AC",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Block",
+        "strength": 25,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Elixir of the Healer",
+      "item_code": "0003995C",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Restoration",
+        "strength": 50,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Elixir of the Knight",
+      "item_code": "000398F6",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Heavy Armor",
+        "strength": 25,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Elixir of the Warrior",
+      "item_code": "00039956",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify One-Handed",
+        "strength": 50,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Enchanter's Draught",
+      "item_code": "00039D02",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Enchanting",
+        "strength": 15,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Enchanter's Elixir",
+      "item_code": "00039D12",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Enchanting",
+        "strength": 25,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Enchanter's Philter",
+      "item_code": "00039D0A",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Enchanting",
+        "strength": 20,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Enchanter's Potion",
+      "item_code": "00039CFB",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Enchanting",
+        "strength": 10,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Enduring Magicka Poison",
+      "item_code": "00073F3D",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Lingering Damage Magicka",
+        "strength": 1,
+        "duration": 15
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Enduring Stamina Poison",
+      "item_code": "00073F45",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Lingering Damage Stamina",
+        "strength": 2,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Esbern's Potion",
+      "item_code": "000E6DF5",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": "Grants Dragon Infusion perk.",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": true
+    },
+    "alchemical_properties": []
+  },
+  {
+    "attributes": {
+      "name": "Falmer Blood Elixir",
+      "item_code": "00076F17",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": true
+    },
+    "alchemical_properties": [
+      {
+        "name": "Restore Health",
+        "strength": 1,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Fear Poison",
+      "item_code": "00073F5E",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fear",
+        "strength": 8,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Frenzy Poison",
+      "item_code": "00073F5A",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Frenzy",
+        "strength": 8,
+        "duration": 10
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Frostbite Venom",
+      "item_code": "000E41B8",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Lingering Damage Health",
+        "strength": 5,
+        "duration": 4
+      },
+      {
+        "name": "Lingering Damage Stamina",
+        "strength": 5,
+        "duration": 4
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Grand Elixir of Conflict",
+      "item_code": "000F84B9",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Light Armor",
+        "strength": 40,
+        "duration": 60
+      },
+      {
+        "name": "Fortify One-Handed",
+        "strength": 45,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Grand Elixir of Escape",
+      "item_code": "000F84B2",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Invisibility",
+        "strength": null,
+        "duration": 125
+      },
+      {
+        "name": "Restore Health",
+        "strength": 55,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Grand Elixir of Keenshot",
+      "item_code": "000F84BF",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Marksman",
+        "strength": 35,
+        "duration": 60
+      },
+      {
+        "name": "Regenerate Stamina",
+        "strength": 13,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Grand Elixir of Larceny",
+      "item_code": "000F84AB",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Lockpicking",
+        "strength": 35,
+        "duration": 60
+      },
+      {
+        "name": "Fortify Pickpocket",
+        "strength": 35,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Grand Elixir of Plunder",
+      "item_code": "000F84C5",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Carry Weight",
+        "strength": 60,
+        "duration": 300
+      },
+      {
+        "name": "Fortify Stamina",
+        "strength": 60,
+        "duration": 300
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Ice Wraith Bane",
+      "item_code": "000E2D3D",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": "Does 50 points of poison damage if the target is an Ice Wraith",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": true
+    },
+    "alchemical_properties": []
+  },
+  {
+    "attributes": {
+      "name": "Ice Wraith Essence",
+      "item_code": "000F9642",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Resist Frost",
+        "strength": 20,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Lasting Magicka Poison",
+      "item_code": "00073F3E",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Lingering Damage Magicka",
+        "strength": 2,
+        "duration": 15
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Lasting Stamina Poison",
+      "item_code": "00073F46",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Lingering Damage Stamina",
+        "strength": 3,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Lingering Magicka Poison",
+      "item_code": "00065A70",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Lingering Damage Magicka",
+        "strength": 1,
+        "duration": 10
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Lingering Poison",
+      "item_code": "00073F35",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Lingering Damage Health",
+        "strength": 1,
+        "duration": 15
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Lingering Stamina Poison",
+      "item_code": "00065A71",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Lingering Damage Stamina",
+        "strength": 1,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Lotus Extract",
+      "item_code": "00058CFB",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": true
+    },
+    "alchemical_properties": [
+      {
+        "name": "Lingering Damage Health",
+        "strength": 6,
+        "duration": 10
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Magicka Poison",
+      "item_code": "00073F39",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Damage Magicka",
+        "strength": 50,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Magicka Recovery Poison",
+      "item_code": "00073F91",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Damage Magicka Regen",
+        "strength": 100,
+        "duration": 20
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Malign Aversion to Fire",
+      "item_code": "00073F4B",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Weakness to Fire",
+        "strength": 85,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Malign Aversion to Frost",
+      "item_code": "00073F4F",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Weakness to Frost",
+        "strength": 85,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Malign Aversion to Magic",
+      "item_code": "00073F58",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Weakness to Magic",
+        "strength": 85,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Malign Aversion to Shock",
+      "item_code": "00073F54",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Weakness to Shock",
+        "strength": 85,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Malign Lingering Poison",
+      "item_code": "00073F37",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Lingering Damage Health",
+        "strength": 2,
+        "duration": 20
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Malign Magicka Poison",
+      "item_code": "00073F3B",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Damage Magicka",
+        "strength": 100,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Malign Recovery Poison",
+      "item_code": "00073F93",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Damage Magicka Regen",
+        "strength": 100,
+        "duration": 45
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Malign Vigor Poison",
+      "item_code": "00073F8E",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Damage Stamina Regen",
+        "strength": 100,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Nightshade Extact",
+      "item_code": "000CD883",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    },
+    "alchemical_properties": [
+      {
+        "name": "Lingering Damage Health",
+        "strength": 1,
+        "duration": 10
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Paralysis Poison",
+      "item_code": "00074A38",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Paralysis",
+        "strength": null,
+        "duration": 5
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Persistent Stamina Poison",
+      "item_code": "00073F47",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Lingering Damage Stamina",
+        "strength": 4,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Persisting Magicka Poison",
+      "item_code": "00073F3F",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Lingering Damage Magicka",
+        "strength": 2,
+        "duration": 20
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Philter of Alteration",
+      "item_code": "00039899",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Alteration",
+        "strength": 75,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Philter of Conflict",
+      "item_code": "000F84B7",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Light Armor",
+        "strength": 20,
+        "duration": 60
+      },
+      {
+        "name": "Fortify One-Handed",
+        "strength": 25,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Philter of Destruction",
+      "item_code": "000398F1",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Destruction",
+        "strength": 40,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Philter of Enhanced Stamina",
+      "item_code": "0003EAFF",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Stamina",
+        "strength": 80,
+        "duration": 300
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Philter of Escape",
+      "item_code": "000F84B0",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Invisibility",
+        "strength": null,
+        "duration": 75
+      },
+      {
+        "name": "Restore Health",
+        "strength": 45,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Philter of Extra Magicka",
+      "item_code": "0003EAFC",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Magicka",
+        "strength": 80,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Philter of Glibness",
+      "item_code": "000D6949",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Speech",
+        "strength": 40,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Philter of Haggling",
+      "item_code": "00039971",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Barter",
+        "strength": 20,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Philter of Health",
+      "item_code": "0003EAF5",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Health",
+        "strength": 80,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Philter of Illusion",
+      "item_code": "00039950",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Illusion",
+        "strength": 75,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Philter of Keenshot",
+      "item_code": "000F84BD",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Marksman",
+        "strength": 25,
+        "duration": 60
+      },
+      {
+        "name": "Regenerate Stamina",
+        "strength": 9,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Philter of Larceny",
+      "item_code": "000F84A9",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Lockpicking",
+        "strength": 25,
+        "duration": 60
+      },
+      {
+        "name": "Fortify Pickpocket",
+        "strength": 25,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Philter of Lasting Potency",
+      "item_code": "0003EB10",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Regenerate Magicka",
+        "strength": 80,
+        "duration": 300
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Philter of Light Feet",
+      "item_code": "00039969",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Sneak",
+        "strength": 20,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Philter of Lockpicking",
+      "item_code": "00039946",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Lockpicking",
+        "strength": 40,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Philter of Pickpocketing",
+      "item_code": "00039959",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Pickpocket",
+        "strength": 40,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Philter of Plunder",
+      "item_code": "000F84C3",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Carry Weight",
+        "strength": 40,
+        "duration": 300
+      },
+      {
+        "name": "Fortify Stamina",
+        "strength": 40,
+        "duration": 300
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Philter of Regeneration",
+      "item_code": "0003EB0C",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Regenerate Health",
+        "strength": 80,
+        "duration": 300
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Philter of Resist Cold",
+      "item_code": "00039BDF",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Resist Frost",
+        "strength": 40,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Philter of Resist Fire",
+      "item_code": "00039B4B",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Resist Fire",
+        "strength": 40,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Philter of Resist Magic",
+      "item_code": "00039E54",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Resist Magic",
+        "strength": 20,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Philter of Strength",
+      "item_code": "0003EB04",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Carry Weight",
+        "strength": 50,
+        "duration": 300
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Philter of True Shot",
+      "item_code": "0003994B",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Marksman",
+        "strength": 40,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Philter of Vigor",
+      "item_code": "0003EB14",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Regenerate Stamina",
+        "strength": 80,
+        "duration": 300
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Philter of Waterbreathing",
+      "item_code": "0003AC30",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Waterbreathing",
+        "strength": null,
+        "duration": 45
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Philter of the Berserker",
+      "item_code": "00039980",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Two-Handed",
+        "strength": 40,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Philter of the Defender",
+      "item_code": "000398AB",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Block",
+        "strength": 20,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Philter of the Healer",
+      "item_code": "0003995B",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Restoration",
+        "strength": 40,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Philter of the Knight",
+      "item_code": "000398F5",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Heavy Armor",
+        "strength": 20,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Philter of the Phantom",
+      "item_code": "000663E1",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": "Appear spectral for 30 seconds.",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": []
+  },
+  {
+    "attributes": {
+      "name": "Philter of the Warrior",
+      "item_code": "00039955",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify One-Handed",
+        "strength": 40,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Poison",
+      "item_code": "00073F31",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Damage Health",
+        "strength": 25,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potent Aversion to Fire",
+      "item_code": "00073F4A",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Weakness to Fire",
+        "strength": 70,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potent Aversion to Frost",
+      "item_code": "00073F4E",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Weakness to Frost",
+        "strength": 70,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potent Aversion to Magic",
+      "item_code": "00073F57",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Weakness to Magic",
+        "strength": 70,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potent Aversion to Shock",
+      "item_code": "00073F53",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Weakness to Shock",
+        "strength": 70,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potent Fear Poison",
+      "item_code": "00073F5F",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fear",
+        "strength": 13,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potent Frenzy Poison",
+      "item_code": "00073F5B",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Frenzy",
+        "strength": 13,
+        "duration": 10
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potent Lingering Poison",
+      "item_code": "00073F36",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Lingering Damage Health",
+        "strength": 2,
+        "duration": 15
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potent Magicka Poison",
+      "item_code": "00073F3A",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Damage Magicka",
+        "strength": 70,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potent Paralysis Poison",
+      "item_code": "00074A39",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Paralysis",
+        "strength": null,
+        "duration": 7
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potent Poison",
+      "item_code": "00073F32",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Damage Health",
+        "strength": 35,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potent Recovery Poison",
+      "item_code": "00073F92",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Damage Magicka Regen",
+        "strength": 100,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potent Stamina Poison",
+      "item_code": "00073F42",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Damage Stamina",
+        "strength": 70,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potent Vigor Poison",
+      "item_code": "00073F8D",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Damage Stamina Regen",
+        "strength": 100,
+        "duration": 45
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Alteration",
+      "item_code": "0003EB36",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Alteration",
+        "strength": 20,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Blood",
+      "item_code": "XX018EF3",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": "Equivalent to feeding on human blood for vampires. Vampires heal 100 points of health.",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": true
+    },
+    "alchemical_properties": []
+  },
+  {
+    "attributes": {
+      "name": "Potion of Brief Invisibility",
+      "item_code": "0003EB3E",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Invisibility",
+        "strength": null,
+        "duration": 20
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Conflict",
+      "item_code": "000F84B5",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Light Armor",
+        "strength": 10,
+        "duration": 60
+      },
+      {
+        "name": "Fortify One-Handed",
+        "strength": 15,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Cure Disease",
+      "item_code": "000AE723",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": "Cures all diseases",
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Cure Disease",
+        "strength": null,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Cure Poison",
+      "item_code": "00065A64",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": "Stops poison's continuing effects",
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": []
+  },
+  {
+    "attributes": {
+      "name": "Potion of Destruction",
+      "item_code": "0003EB38",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Destruction",
+        "strength": 20,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Enduring Invisibility",
+      "item_code": "0003EB3F",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Invisibility",
+        "strength": null,
+        "duration": 40
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Enhanced Stamina",
+      "item_code": "0003EAFD",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Stamina",
+        "strength": 20,
+        "duration": 300
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Escape",
+      "item_code": "000F84AE",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Invisibility",
+        "strength": null,
+        "duration": 30
+      },
+      {
+        "name": "Restore Health",
+        "strength": 25,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Extended Invisibility",
+      "item_code": "0003EB40",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Invisibility",
+        "strength": null,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Extra Magicka",
+      "item_code": "0003EAF7",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Magicka",
+        "strength": 20,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Extreme Healing",
+      "item_code": "00039BE4",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Restore Health",
+        "strength": 150,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Extreme Magicka",
+      "item_code": "00039BE6",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Restore Magicka",
+        "strength": 150,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Extreme Stamina",
+      "item_code": "00039CF3",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Restore Stamina",
+        "strength": 150,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Extreme Well-being",
+      "item_code": "XX01AAE1",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Restore Health",
+        "strength": 90,
+        "duration": null
+      },
+      {
+        "name": "Restore Magicka",
+        "strength": 90,
+        "duration": null
+      },
+      {
+        "name": "Restore Stamina",
+        "strength": 90,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Glibness",
+      "item_code": "000D6948",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Speech",
+        "strength": 20,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Haggling",
+      "item_code": "0003EB35",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Barter",
+        "strength": 10,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Healing",
+      "item_code": "0003EADE",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Restore Health",
+        "strength": 50,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Health",
+      "item_code": "0003EAF2",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Health",
+        "strength": 20,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Illusion",
+      "item_code": "0003EB39",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Illusion",
+        "strength": 25,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Keenshot",
+      "item_code": "000F84BB",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Marksman",
+        "strength": 15,
+        "duration": 60
+      },
+      {
+        "name": "Regenerate Stamina",
+        "strength": 5,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Larceny",
+      "item_code": "000F84A7",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Lockpicking",
+        "strength": 15,
+        "duration": 60
+      },
+      {
+        "name": "Fortify Pickpocket",
+        "strength": 15,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Lasting Potency",
+      "item_code": "0003EB0D",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Regenerate Magicka",
+        "strength": 50,
+        "duration": 300
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Light Feet",
+      "item_code": "0003EB33",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Sneak",
+        "strength": 10,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Lockpicking",
+      "item_code": "00039930",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Lockpicking",
+        "strength": 20,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Magicka",
+      "item_code": "0003EAE1",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Restore Magicka",
+        "strength": 50,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Minor Healing",
+      "item_code": "0003EADD",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Restore Health",
+        "strength": 25,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Minor Magicka",
+      "item_code": "0003EAE0",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Restore Magicka",
+        "strength": 25,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Minor Stamina",
+      "item_code": "0003EAE5",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Restore Stamina",
+        "strength": 25,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Minor Well-being",
+      "item_code": "XX01AADD",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Restore Health",
+        "strength": 15,
+        "duration": null
+      },
+      {
+        "name": "Restore Magicka",
+        "strength": 15,
+        "duration": null
+      },
+      {
+        "name": "Restore Stamina",
+        "strength": 15,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Pickpocketing",
+      "item_code": "0003EB31",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Pickpocket",
+        "strength": 20,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Plentiful Healing",
+      "item_code": "0003EADF",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Restore Health",
+        "strength": 75,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Plentiful Magicka",
+      "item_code": "0003EAE2",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Restore Magicka",
+        "strength": 75,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Plentiful Stamina",
+      "item_code": "0003EAE7",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Restore Stamina",
+        "strength": 75,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Plentiful Well-being",
+      "item_code": "XX01AADF",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Restore Health",
+        "strength": 55,
+        "duration": null
+      },
+      {
+        "name": "Restore Magicka",
+        "strength": 55,
+        "duration": null
+      },
+      {
+        "name": "Restore Stamina",
+        "strength": 55,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Plunder",
+      "item_code": "000F84C1",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Carry Weight",
+        "strength": 20,
+        "duration": 300
+      },
+      {
+        "name": "Fortify Stamina",
+        "strength": 20,
+        "duration": 300
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Prolonged Invisibility",
+      "item_code": "0003EB41",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Invisibility",
+        "strength": null,
+        "duration": 50
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Regeneration",
+      "item_code": "0003EB09",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Regenerate Health",
+        "strength": 50,
+        "duration": 300
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Resist Cold",
+      "item_code": "00039B8A",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Resist Frost",
+        "strength": 20,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Resist Fire",
+      "item_code": "00039B4A",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Resist Fire",
+        "strength": 20,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Resist Magic",
+      "item_code": "00039E52",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Resist Magic",
+        "strength": 10,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Stamina",
+      "item_code": "00039BE8",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Restore Stamina",
+        "strength": 50,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Strength",
+      "item_code": "0003EB02",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Carry Weight",
+        "strength": 20,
+        "duration": 300
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of True Shot",
+      "item_code": "0003EB2C",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Marksman",
+        "strength": 20,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Ultimate Healing",
+      "item_code": "00039BE5",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": "Completely restore Health.",
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": []
+  },
+  {
+    "attributes": {
+      "name": "Potion of Ultimate Magicka",
+      "item_code": "00039BE7",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": "Completely restore Magicka.",
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": []
+  },
+  {
+    "attributes": {
+      "name": "Potion of Ultimate Stamina",
+      "item_code": "00039CF3",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": "Completely restore Stamina.",
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": []
+  },
+  {
+    "attributes": {
+      "name": "Potion of Ultimate Well-being",
+      "item_code": "XX01AAE2",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Restore Health",
+        "strength": 100,
+        "duration": null
+      },
+      {
+        "name": "Restore Magicka",
+        "strength": 100,
+        "duration": null
+      },
+      {
+        "name": "Restore Stamina",
+        "strength": 100,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Vigor",
+      "item_code": "0003EB11",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Regenerate Stamina",
+        "strength": 50,
+        "duration": 300
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Vigorous Healing",
+      "item_code": "0003EAE3",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Restore Health",
+        "strength": 100,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Vigorous Magicka",
+      "item_code": "0003EAE4",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Restore Magicka",
+        "strength": 100,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Vigorous Stamina",
+      "item_code": "0003EAE8",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Restore Stamina",
+        "strength": 100,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Vigorous Well-being",
+      "item_code": "XX01AAE0",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Restore Health",
+        "strength": 75,
+        "duration": null
+      },
+      {
+        "name": "Restore Magicka",
+        "strength": 75,
+        "duration": null
+      },
+      {
+        "name": "Restore Stamina",
+        "strength": 75,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Waterbreathing",
+      "item_code": "0003AC2E",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Waterbreathing",
+        "strength": null,
+        "duration": 15
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of Waterwalking",
+      "item_code": "XX0390E0",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": "Walk on the surface of water for 30 seconds.",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": []
+  },
+  {
+    "attributes": {
+      "name": "Potion of Well-being",
+      "item_code": "XX01AADE",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Restore Health",
+        "strength": 35,
+        "duration": null
+      },
+      {
+        "name": "Restore Magicka",
+        "strength": 35,
+        "duration": null
+      },
+      {
+        "name": "Restore Stamina",
+        "strength": 35,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of the Berserker",
+      "item_code": "0003EB2B",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Two-Handed",
+        "strength": 20,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of the Defender",
+      "item_code": "0003EB32",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Block",
+        "strength": 10,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of the Healer",
+      "item_code": "0003EB3A",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Restoration",
+        "strength": 20,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of the Knight",
+      "item_code": "0003EB2F",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Heavy Armor",
+        "strength": 10,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Potion of the Warrior",
+      "item_code": "0003EB2A",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify One-Handed",
+        "strength": 20,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Prime Elixir of Conflict",
+      "item_code": "000F84BA",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Light Armor",
+        "strength": 50,
+        "duration": 60
+      },
+      {
+        "name": "Fortify One-Handed",
+        "strength": 55,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Prime Elixir of Escape",
+      "item_code": "000F84B3",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Invisibility",
+        "strength": null,
+        "duration": 150
+      },
+      {
+        "name": "Restore Health",
+        "strength": 60,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Prime Elixir of Keenshot",
+      "item_code": "000F84C0",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Marksman",
+        "strength": 40,
+        "duration": 60
+      },
+      {
+        "name": "Regenerate Stamina",
+        "strength": 15,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Prime Elixir of Larceny",
+      "item_code": "000F84AC",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Lockpicking",
+        "strength": 40,
+        "duration": 60
+      },
+      {
+        "name": "Fortify Pickpocket",
+        "strength": 40,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Prime Elixir of Plunder",
+      "item_code": "000F84C6",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Carry Weight",
+        "strength": 70,
+        "duration": 300
+      },
+      {
+        "name": "Fortify Stamina",
+        "strength": 70,
+        "duration": 300
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Redwater Skooma",
+      "item_code": "XX01391D",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": "Slowed movement. Environment becomes red and purple. Sight becomes blurry.",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Restore Stamina",
+        "strength": 40,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Skirmisher's Draught",
+      "item_code": "000398FD",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Light Armor",
+        "strength": 15,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Skirmisher's Elixir",
+      "item_code": "00039904",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Light Armor",
+        "strength": 25,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Skirmisher's Philter",
+      "item_code": "00039903",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Light Armor",
+        "strength": 20,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Skirmisher's Potion",
+      "item_code": "0003EB30",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Light Armor",
+        "strength": 10,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Skooma",
+      "item_code": "00057A7A",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Restore Stamina",
+        "strength": 25,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Sleeping Tree Sap",
+      "item_code": "000AED90",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": "Drugged for 45 seconds.",
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Health",
+        "strength": 100,
+        "duration": 45
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Solution of Enhanced Stamina",
+      "item_code": "0003EAFE",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Stamina",
+        "strength": 60,
+        "duration": 300
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Solution of Extra Magicka",
+      "item_code": "0003EAFB",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Magicka",
+        "strength": 60,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Solution of Health",
+      "item_code": "0003EAF6",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Health",
+        "strength": 60,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Solution of Lasting Potency",
+      "item_code": "0003EB0F",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Regenerate Magicka",
+        "strength": 70,
+        "duration": 300
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Solution of Regeneration",
+      "item_code": "0003EB0B",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Regenerate Health",
+        "strength": 70,
+        "duration": 300
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Solution of Strength",
+      "item_code": "0003EB03",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Carry Weight",
+        "strength": 40,
+        "duration": 300
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Solution of Vigor",
+      "item_code": "00039B0C",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Regenerate Stamina",
+        "strength": 70,
+        "duration": 300
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Soul Husk Extract",
+      "item_code": "XX015A1E",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": "Interrupts the Soul Drain effect in the Soul Cairn.",
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Resist Magic",
+        "strength": 25,
+        "duration": 60
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Stamina Poison",
+      "item_code": "00073F41",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Damage Stamina",
+        "strength": 50,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "The White Phial",
+      "item_code": "0002C25A",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": "Contains an unlimited potion of your choice.",
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    },
+    "alchemical_properties": []
+  },
+  {
+    "attributes": {
+      "name": "Unceasing Magicka Poison",
+      "item_code": "00073F40",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Lingering Damage Magicka",
+        "strength": 3,
+        "duration": 20
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Unceasing Stamina Poison",
+      "item_code": "00073F48",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Lingering Damage Stamina",
+        "strength": 5,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Vaermina's Torpor",
+      "item_code": "0005F6DF",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": "Enter \"The Dreamstride\" for an unknown length of time.",
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    },
+    "alchemical_properties": []
+  },
+  {
+    "attributes": {
+      "name": "Velvet LeChance",
+      "item_code": "00065C37",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Restore Stamina",
+        "strength": 25,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Vigor Poison",
+      "item_code": "00073F8C",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Damage Stamina Regen",
+        "strength": 100,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Virulent Fear Poison",
+      "item_code": "00073F60",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fear",
+        "strength": 18,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Virulent Frenzy Poison",
+      "item_code": "00073F5C",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Frenzy",
+        "strength": 18,
+        "duration": 10
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Virulent Paralysis Poison",
+      "item_code": "00074A3A",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Paralysis",
+        "strength": null,
+        "duration": 10
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Virulent Poison",
+      "item_code": "00073F33",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Damage Health",
+        "strength": 50,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Virulent Stamina Poison",
+      "item_code": "00073F43",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Damage Stamina",
+        "strength": 100,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Weak Aversion to Fire",
+      "item_code": "00065A6B",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Weakness to Fire",
+        "strength": 40,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Weak Aversion to Frost",
+      "item_code": "00065A6C",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Weakness to Frost",
+        "strength": 40,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Weak Aversion to Magic",
+      "item_code": "00065A6E",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Weakness to Magic",
+        "strength": 40,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Weak Aversion to Shock",
+      "item_code": "00073F52",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Weakness to Shock",
+        "strength": 40,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Weak Fear Poison",
+      "item_code": "00065A68",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fear",
+        "strength": 5,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Weak Frenzy Poison",
+      "item_code": "00065A69",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Frenzy",
+        "strength": 5,
+        "duration": 10
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Weak Lingering Poison",
+      "item_code": "00065A6F",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Lingering Damage Health",
+        "strength": 1,
+        "duration": 10
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Weak Magicka Poison",
+      "item_code": "00065A65",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Damage Magicka",
+        "strength": 30,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Weak Paralysis Poison",
+      "item_code": "00065A6A",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Paralysis",
+        "strength": null,
+        "duration": 3
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Weak Poison",
+      "item_code": "0003A5A4",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Damage Health",
+        "strength": 15,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Weak Recovery Poison",
+      "item_code": "00073F90",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Damage Magicka Regen",
+        "strength": 100,
+        "duration": 10
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Weak Stamina Poison",
+      "item_code": "00065A66",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Damage Stamina",
+        "strength": 30,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Weak Vigor Poison",
+      "item_code": "00073F8B",
+      "unit_weight": 0.5,
+      "potion_type": "poison",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Damage Stamina Regen",
+        "strength": 100,
+        "duration": 15
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "White-Gold Tower",
+      "item_code": "00065C38",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Restore Stamina",
+        "strength": 25,
+        "duration": null
+      }
+    ]
+  }
+]

--- a/lib/tasks/canonical_models/canonical_potions.json
+++ b/lib/tasks/canonical_models/canonical_potions.json
@@ -1877,7 +1877,7 @@
       "potion_type": "potion",
       "magical_effects": "Grants Dragon Infusion perk.",
       "purchasable": false,
-      "unique_item": false,
+      "unique_item": true,
       "rare_item": true,
       "quest_item": true
     },

--- a/lib/tasks/sync_canonical_models.rake
+++ b/lib/tasks/sync_canonical_models.rake
@@ -130,6 +130,17 @@ namespace :canonical_models do
 
       Canonical::Sync.perform(:book, FALSEY_VALUES.exclude?(args[:preserve_existing_records]))
     end
+
+    desc 'Sync canonical potion models in the database with JSON data'
+    task :potions,
+         %i[preserve_existing_records] => %w[
+                                            environment
+                                            canonical_models:sync:alchemical_properties
+                                          ] do |_t, args|
+      args.with_defaults(preserve_existing_records: false)
+
+      Canonical::Sync.perform(:potion, FALSEY_VALUES.exclude?(args[:preserve_existing_records]))
+    end
     # rubocop:enable Layout/BlockAlignment
 
     desc 'Sync canonical misc items in the database with JSON data'

--- a/spec/factories/canonical/potions.rb
+++ b/spec/factories/canonical/potions.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :canonical_potion, class: Canonical::Potion do
+    name                 { 'My Potion' }
+    sequence(:item_code) {|n| "xx123x#{n}" }
+    unit_weight          { 0.5 }
+    potion_type          { 'potion' }
+    purchasable          { true }
+    unique_item          { false }
+    rare_item            { false }
+    quest_item           { false }
+  end
+end

--- a/spec/factories/canonical/potions_alchemical_properties.rb
+++ b/spec/factories/canonical/potions_alchemical_properties.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :canonical_potions_alchemical_property, class: Canonical::PotionsAlchemicalProperty do
+    alchemical_property
+    association(:potion, factory: :canonical_potion)
+    strength { 20 }
+    duration { 30 }
+  end
+end

--- a/spec/fixtures/canonical/sync/potions.json
+++ b/spec/fixtures/canonical/sync/potions.json
@@ -1,0 +1,81 @@
+[
+  {
+    "attributes": {
+      "name": "Blacksmith's Potion",
+      "item_code": "0003EB2E",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Smithing",
+        "strength": 20,
+        "duration": 30
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Cliff Racer",
+      "item_code": "00065C39",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Restore Stamina",
+        "strength": 25,
+        "duration": null
+      }
+    ]
+  },
+  {
+    "attributes": {
+      "name": "Esbern's Potion",
+      "item_code": "000E6DF5",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": "Grants Dragon Infusion perk.",
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": true
+    },
+    "alchemical_properties": []
+  },
+  {
+    "attributes": {
+      "name": "Grand Elixir of Larceny",
+      "item_code": "000F84AB",
+      "unit_weight": 0.5,
+      "potion_type": "potion",
+      "magical_effects": null,
+      "purchasable": false,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "name": "Fortify Lockpicking",
+        "strength": 35,
+        "duration": 60
+      },
+      {
+        "name": "Fortify Pickpocket",
+        "strength": 35,
+        "duration": 60
+      }
+    ]
+  }
+]

--- a/spec/models/canonical/potion_spec.rb
+++ b/spec/models/canonical/potion_spec.rb
@@ -97,6 +97,21 @@ RSpec.describe Canonical::Potion, type: :model do
     end
   end
 
+  describe 'associations' do
+    describe 'alchemical properties' do
+      let(:potion)              { create(:canonical_potion) }
+      let(:alchemical_property) { create(:alchemical_property) }
+
+      before do
+        potion.canonical_potions_alchemical_properties.create!(alchemical_property: alchemical_property, strength: 15, duration: 30)
+      end
+
+      it 'returns the alchemical property' do
+        expect(potion.alchemical_properties.first).to eq alchemical_property
+      end
+    end
+  end
+
   describe '::unique_identifier' do
     it 'returns ":item_code"' do
       expect(described_class.unique_identifier).to eq :item_code

--- a/spec/models/canonical/potion_spec.rb
+++ b/spec/models/canonical/potion_spec.rb
@@ -53,6 +53,22 @@ RSpec.describe Canonical::Potion, type: :model do
       end
     end
 
+    describe 'potion_type' do
+      it "can't be blank" do
+        model = build(:canonical_potion, potion_type: nil)
+
+        model.validate
+        expect(model.errors[:potion_type]).to include "can't be blank"
+      end
+
+      it 'must be a valid potion type' do
+        model = build(:canonical_potion, potion_type: 'beneficial')
+
+        model.validate
+        expect(model.errors[:potion_type]).to include 'must be "potion" or "poison"'
+      end
+    end
+
     describe 'purchasable' do
       it "can't be blank" do
         model = build(:canonical_potion, purchasable: nil)

--- a/spec/models/canonical/potion_spec.rb
+++ b/spec/models/canonical/potion_spec.rb
@@ -2,11 +2,11 @@
 
 require 'rails_helper'
 
-RSpec.describe Canonical::MiscItem, type: :model do
+RSpec.describe Canonical::Potion, type: :model do
   describe 'validations' do
     describe 'name' do
       it "can't be blank" do
-        model = build(:canonical_misc_item, name: nil)
+        model = build(:canonical_potion, name: nil)
 
         model.validate
         expect(model.errors[:name]).to include "can't be blank"
@@ -15,15 +15,15 @@ RSpec.describe Canonical::MiscItem, type: :model do
 
     describe 'item_code' do
       it "can't be blank" do
-        model = build(:canonical_misc_item, item_code: nil)
+        model = build(:canonical_potion, item_code: nil)
 
         model.validate
         expect(model.errors[:item_code]).to include "can't be blank"
       end
 
       it 'must be unique' do
-        create(:canonical_misc_item, item_code: 'foo')
-        model = build(:canonical_misc_item, item_code: 'foo')
+        create(:canonical_potion, item_code: 'foobar')
+        model = build(:canonical_potion, item_code: 'foobar')
 
         model.validate
         expect(model.errors[:item_code]).to include 'must be unique'
@@ -32,53 +32,30 @@ RSpec.describe Canonical::MiscItem, type: :model do
 
     describe 'unit_weight' do
       it "can't be blank" do
-        model = build(:canonical_misc_item, unit_weight: nil)
+        model = build(:canonical_potion, unit_weight: nil)
 
         model.validate
         expect(model.errors[:unit_weight]).to include "can't be blank"
       end
 
       it 'must be a number' do
-        model = build(:canonical_misc_item, unit_weight: 'foo')
+        model = build(:canonical_potion, unit_weight: 'foo')
 
         model.validate
         expect(model.errors[:unit_weight]).to include 'is not a number'
       end
 
       it 'must be at least zero' do
-        model = build(:canonical_misc_item, unit_weight: -2)
+        model = build(:canonical_potion, unit_weight: -0.5)
 
         model.validate
         expect(model.errors[:unit_weight]).to include 'must be greater than or equal to 0'
       end
     end
 
-    describe 'item_types' do
-      it "can't be blank" do
-        model = build(:canonical_misc_item, item_types: nil)
-
-        model.validate
-        expect(model.errors[:item_types]).to include "can't be blank"
-      end
-
-      it 'must include at least one valid type' do
-        model = build(:canonical_misc_item, item_types: [])
-
-        model.validate
-        expect(model.errors[:item_types]).to include 'must include at least one item type'
-      end
-
-      it 'must include only valid types' do
-        model = build(:canonical_misc_item, item_types: ['Dwemer artifact', 'industrial equipment'])
-
-        model.validate
-        expect(model.errors[:item_types]).to include 'can only include valid item types'
-      end
-    end
-
     describe 'purchasable' do
       it "can't be blank" do
-        model = build(:canonical_misc_item, purchasable: nil)
+        model = build(:canonical_potion, purchasable: nil)
 
         model.validate
         expect(model.errors[:purchasable]).to include 'must be true or false'
@@ -87,7 +64,7 @@ RSpec.describe Canonical::MiscItem, type: :model do
 
     describe 'unique_item' do
       it "can't be blank" do
-        model = build(:canonical_misc_item, unique_item: nil)
+        model = build(:canonical_potion, unique_item: nil)
 
         model.validate
         expect(model.errors[:unique_item]).to include 'must be true or false'
@@ -96,14 +73,14 @@ RSpec.describe Canonical::MiscItem, type: :model do
 
     describe 'rare_item' do
       it "can't be blank" do
-        model = build(:canonical_misc_item, rare_item: nil)
+        model = build(:canonical_potion, rare_item: nil)
 
         model.validate
         expect(model.errors[:rare_item]).to include 'must be true or false'
       end
 
-      it 'must be true if unique_item is true' do
-        model = build(:canonical_misc_item, unique_item: true, rare_item: false)
+      it 'must be true if item is unique' do
+        model = build(:canonical_potion, unique_item: true, rare_item: false)
 
         model.validate
         expect(model.errors[:rare_item]).to include 'must be true if item is unique'
@@ -112,11 +89,17 @@ RSpec.describe Canonical::MiscItem, type: :model do
 
     describe 'quest_item' do
       it "can't be blank" do
-        model = build(:canonical_misc_item, quest_item: nil)
+        model = build(:canonical_potion, quest_item: nil)
 
         model.validate
         expect(model.errors[:quest_item]).to include 'must be true or false'
       end
+    end
+  end
+
+  describe '::unique_identifier' do
+    it 'returns ":item_code"' do
+      expect(described_class.unique_identifier).to eq :item_code
     end
   end
 end

--- a/spec/models/canonical/potions_alchemical_property_spec.rb
+++ b/spec/models/canonical/potions_alchemical_property_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Canonical::PotionsAlchemicalProperty, type: :model do
+  describe 'validations' do
+    describe 'canonical potion and alchemical property' do
+      it 'must form a unique combination' do
+        model1 = create(:canonical_potions_alchemical_property)
+        model2 = build(:canonical_potions_alchemical_property, potion: model1.potion, alchemical_property: model1.alchemical_property)
+
+        model2.validate
+        expect(model2.errors[:alchemical_property_id]).to include 'must form a unique combination with canonical potion'
+      end
+    end
+
+    describe 'strength' do
+      it 'can be blank' do
+        model = build(:canonical_potions_alchemical_property, strength: nil)
+
+        expect(model).to be_valid
+      end
+
+      it 'must be a number' do
+        model = build(:canonical_potions_alchemical_property, strength: 'foo')
+
+        model.validate
+        expect(model.errors[:strength]).to include 'is not a number'
+      end
+
+      it 'must be an integer' do
+        model = build(:canonical_potions_alchemical_property, strength: 3.14159)
+
+        model.validate
+        expect(model.errors[:strength]).to include 'must be an integer'
+      end
+
+      it 'must be greater than zero' do
+        model = build(:canonical_potions_alchemical_property, strength: 0)
+
+        model.validate
+        expect(model.errors[:strength]).to include 'must be greater than 0'
+      end
+    end
+
+    describe 'duration' do
+      it 'can be blank' do
+        model = build(:canonical_potions_alchemical_property, duration: nil)
+
+        expect(model).to be_valid
+      end
+
+      it 'must be a number' do
+        model = build(:canonical_potions_alchemical_property, duration: 'foo')
+
+        model.validate
+        expect(model.errors[:duration]).to include 'is not a number'
+      end
+
+      it 'must be an integer' do
+        model = build(:canonical_potions_alchemical_property, duration: 3.14159)
+
+        model.validate
+        expect(model.errors[:duration]).to include 'must be an integer'
+      end
+
+      it 'must be greater than zero' do
+        model = build(:canonical_potions_alchemical_property, duration: 0)
+
+        model.validate
+        expect(model.errors[:duration]).to include 'must be greater than 0'
+      end
+    end
+  end
+end

--- a/spec/models/canonical/staff_spec.rb
+++ b/spec/models/canonical/staff_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Canonical::Staff, type: :model do
         model = build(:canonical_staff, daedric: nil)
 
         model.validate
-        expect(model.errors[:daedric]).to include 'boolean value must be present'
+        expect(model.errors[:daedric]).to include 'must be true or false'
       end
     end
 
@@ -112,7 +112,7 @@ RSpec.describe Canonical::Staff, type: :model do
         model = build(:canonical_staff, unique_item: nil)
 
         model.validate
-        expect(model.errors[:unique_item]).to include 'boolean value must be present'
+        expect(model.errors[:unique_item]).to include 'must be true or false'
       end
     end
 
@@ -121,7 +121,7 @@ RSpec.describe Canonical::Staff, type: :model do
         model = build(:canonical_staff, quest_item: nil)
 
         model.validate
-        expect(model.errors[:quest_item]).to include 'boolean value must be present'
+        expect(model.errors[:quest_item]).to include 'must be true or false'
       end
     end
   end

--- a/spec/models/canonical/sync/potions_spec.rb
+++ b/spec/models/canonical/sync/potions_spec.rb
@@ -1,0 +1,236 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Canonical::Sync::Potions do
+  # Use let! because if we wait to evaluate these until we've run the
+  # examples, the stub in the before block will prevent `File.read` from
+  # running.
+  let(:json_path)  { Rails.root.join('spec', 'fixtures', 'canonical', 'sync', 'potions.json') }
+  let!(:json_data) { File.read(json_path) }
+
+  before do
+    allow(File).to receive(:read).and_return(json_data)
+  end
+
+  describe '::perform' do
+    subject(:perform) { described_class.perform(preserve_existing_records) }
+
+    context 'when preserve_existing_records is false' do
+      let(:preserve_existing_records) { false }
+
+      context 'when there are no existing potions in the database' do
+        let(:syncer) { described_class.new(preserve_existing_records) }
+
+        before do
+          create(:alchemical_property, name: 'Fortify Smithing')
+          create(:alchemical_property, name: 'Restore Stamina')
+          create(:alchemical_property, name: 'Fortify Lockpicking')
+          create(:alchemical_property, name: 'Fortify Pickpocket')
+
+          allow(described_class).to receive(:new).and_return(syncer)
+        end
+
+        it 'instantiates itseslf' do
+          perform
+          expect(described_class).to have_received(:new).with(preserve_existing_records)
+        end
+
+        it 'populates the models from the JSON file' do
+          perform
+          expect(Canonical::Potion.count).to eq 4
+        end
+
+        it 'creates the associations to alchemical properties where they exist', :aggregate_failures do
+          perform
+          expect(Canonical::Potion.find_by(item_code: '0003EB2E').alchemical_properties.length).to eq 1
+          expect(Canonical::Potion.find_by(item_code: '00065C39').alchemical_properties.length).to eq 1
+          expect(Canonical::Potion.find_by(item_code: '000E6DF5').alchemical_properties.length).to eq 0
+          expect(Canonical::Potion.find_by(item_code: '000F84AB').alchemical_properties.length).to eq 2
+        end
+      end
+
+      context 'when there are existing potion records in the database' do
+        let!(:item_in_json)     { create(:canonical_potion, item_code: '0003EB2E', unit_weight: 1) }
+        let!(:item_not_in_json) { create(:canonical_potion, item_code: '12345678') }
+        let(:syncer)            { described_class.new(preserve_existing_records) }
+
+        before do
+          create(:alchemical_property, name: 'Fortify Smithing')
+          create(:alchemical_property, name: 'Restore Stamina')
+          create(:alchemical_property, name: 'Fortify Lockpicking')
+          create(:alchemical_property, name: 'Fortify Pickpocket')
+        end
+
+        it 'instantiates itself' do
+          allow(described_class).to receive(:new).and_return(syncer)
+          perform
+          expect(described_class).to have_received(:new).with(preserve_existing_records)
+        end
+
+        it 'updates models that were already in the database' do
+          perform
+          expect(item_in_json.reload.unit_weight).to eq 0.5
+        end
+
+        it "removes models in the database that aren't in the JSON data" do
+          perform
+          expect(Canonical::Potion.find_by(item_code: '12345678')).to be_nil
+        end
+
+        it 'adds new models to the database', :aggregate_failures do
+          perform
+          expect(Canonical::Potion.find_by(item_code: '00065C39')).to be_present
+          expect(Canonical::Potion.find_by(item_code: '000E6DF5')).to be_present
+          expect(Canonical::Potion.find_by(item_code: '000F84AB')).to be_present
+        end
+
+        it "removes alchemical properties that don't exist in the JSON data" do
+          item_in_json.canonical_potions_alchemical_properties.create!(
+            alchemical_property: AlchemicalProperty.find_by(name: 'Fortify Lockpicking'),
+            strength:            20,
+            duration:            30,
+          )
+          perform
+          expect(item_in_json.alchemical_properties.where(name: 'Fortify Destruction')).to be_empty
+        end
+
+        it 'adds alchemical properties if they exist' do
+          perform
+          expect(item_in_json.alchemical_properties.first.name).to eq 'Fortify Smithing'
+        end
+      end
+
+      context 'when there are no alchemical properties in the database' do
+        before do
+          allow(Rails.logger).to receive(:error)
+        end
+
+        it "logs an error and doesn't create models", :aggregate_failures do
+          expect { perform }
+            .to raise_error(Canonical::Sync::PrerequisiteNotMetError)
+          expect(Rails.logger).to have_received(:error).with('Prerequisite(s) not met: sync AlchemicalProperty before canonical potions')
+          expect(Canonical::Potion.count).to eq 0
+        end
+      end
+
+      context 'when an alchemical property is missing' do
+        before do
+          # prevent it from erroring out, which it will do if there are no
+          # enchantments all
+          create(:alchemical_property)
+          allow(Rails.logger).to receive(:error).twice
+        end
+
+        it 'logs a validation error', :aggregate_failures do
+          expect { perform }
+            .to raise_error ActiveRecord::RecordInvalid
+          expect(Rails.logger).to have_received(:error).with('Validation error saving associations for canonical potion "0003EB2E": Validation failed: Alchemical property must exist')
+        end
+      end
+    end
+
+    context 'when preserve_existing_records is true' do
+      let(:preserve_existing_records) { true }
+      let(:syncer)                    { described_class.new(preserve_existing_records) }
+      let!(:item_in_json)             { create(:canonical_potion, item_code: '0003EB2E', unit_weight: 1) }
+      let!(:item_not_in_json)         { create(:canonical_potion, item_code: '12345678') }
+
+      before do
+        create(:alchemical_property, name: 'Fortify Smithing')
+        create(:alchemical_property, name: 'Restore Stamina')
+        create(:alchemical_property, name: 'Fortify Lockpicking')
+        create(:alchemical_property, name: 'Fortify Pickpocket')
+
+        create(:canonical_potions_alchemical_property, potion: item_in_json, alchemical_property: create(:alchemical_property))
+        allow(described_class).to receive(:new).and_return(syncer)
+      end
+
+      it 'instantiates itself' do
+        perform
+        expect(described_class).to have_received(:new).with(preserve_existing_records)
+      end
+
+      it 'updates models found in the JSON data' do
+        perform
+        expect(item_in_json.reload.unit_weight).to eq 0.5
+      end
+
+      it 'adds models not already in the database', :aggregate_failures do
+        perform
+        expect(Canonical::Potion.find_by(item_code: '00065C39')).to be_present
+        expect(Canonical::Potion.find_by(item_code: '000E6DF5')).to be_present
+        expect(Canonical::Potion.find_by(item_code: '000F84AB')).to be_present
+      end
+
+      it "doesn't destroy models that aren't in the JSON data" do
+        perform
+        expect(item_not_in_json.reload).to be_present
+      end
+
+      it "doesn't destroy associations" do
+        perform
+        expect(item_in_json.reload.alchemical_properties.length).to eq 2
+      end
+    end
+
+    describe 'error logging' do
+      let(:preserve_existing_records) { false }
+
+      context 'when an ActiveRecord::RecordInvalid error is raised' do
+        let(:errored_model) do
+          instance_double Canonical::Potion,
+                          errors: errors,
+                          class:  class_double(Canonical::Potion, i18n_scope: :activerecord)
+        end
+
+        let(:errors) { double('errors', full_messages: ["Name can't be blank"]) }
+
+        before do
+          create(:alchemical_property)
+
+          allow_any_instance_of(Canonical::Potion)
+            .to receive(:save!)
+                  .and_raise(ActiveRecord::RecordInvalid, errored_model)
+          allow(Rails.logger).to receive(:error)
+        end
+
+        it 'logs and reraises the error', :aggregate_failures do
+          expect { perform }
+            .to raise_error(ActiveRecord::RecordInvalid)
+          expect(Rails.logger).to have_received(:error).with("Error saving canonical potion \"0003EB2E\": Validation failed: Name can't be blank")
+        end
+      end
+
+      context 'when another error is raised pertaining to a specific model' do
+        before do
+          create(:alchemical_property)
+
+          allow(Canonical::Potion).to receive(:find_or_initialize_by).and_raise(StandardError, 'foobar')
+          allow(Rails.logger).to receive(:error)
+        end
+
+        it 'logs and reraises the error', :aggregate_failures do
+          expect { perform }
+            .to raise_error(StandardError)
+          expect(Rails.logger).to have_received(:error).with('Unexpected error StandardError saving canonical potion "0003EB2E": foobar')
+        end
+      end
+
+      context 'when an error is raised not pertaining to a specific model' do
+        before do
+          create(:alchemical_property)
+
+          allow(Canonical::Potion).to receive(:where).and_raise(StandardError, 'foobar')
+          allow(Rails.logger).to receive(:error)
+        end
+
+        it 'logs and reraises the error', :aggregate_failures do
+          expect { perform }
+            .to raise_error(StandardError)
+          expect(Rails.logger).to have_received(:error).with('Unexpected error StandardError while syncing canonical potions: foobar')
+        end
+      end
+    end
+  end
+end

--- a/spec/models/canonical/sync_spec.rb
+++ b/spec/models/canonical/sync_spec.rb
@@ -202,5 +202,18 @@ RSpec.describe Canonical::Sync do
         expect(Canonical::Sync::MiscItems).to have_received(:perform).with(true)
       end
     end
+
+    context 'when the model is ":potion"' do
+      subject(:perform) { described_class.perform(:potion, true) }
+
+      before do
+        allow(Canonical::Sync::Potions).to receive(:perform)
+      end
+
+      it 'calls #perform on the correct syncer' do
+        perform
+        expect(Canonical::Sync::Potions).to have_received(:perform).with(true)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

[**Create Canonical::Potion model**](https://trello.com/c/mbtCSWDA/165-create-canonicalpotion-model)

The last canonical model we need to create as part of the Update Object Modelling epic is `Canonical::Potion`. This model will collate all potions and poisons available in Skyrim.

## Changes

* Migrations to create `canonical_potions` and `canonical_potions_alchemical_properties` tables
* `Canonical::Potion` and `Canonical::PotionsAlchemicalProperties` models
* Specs for the above
* A couple small refactors
* Corrections in JSON data
* JSON data for canonical potions and their properties

### Required Changes

* [ ] Added and updated RSpec tests as appropriate
* [ ] Added and updated API docs and developer docs as appropriate

## Considerations

There are countless possible potions in the game due to player-created potions, which can have a nearly infinite combination of strengths, durations, and effects resulting from player level, perks, and multiple matching properties of ingredients. Consequently, I decided the canonical potion model will only include potions that are purchased or found in the world, not those that can be crafted. Potions that can be crafted will be validated using properties of canonical alchemical ingredients.