### PR TITLE
Remove NOT NULL constraint preventing migration from running in prod

### DIFF
--- a/db/migrate/20220524073420_add_description_to_alchemical_properties.rb
+++ b/db/migrate/20220524073420_add_description_to_alchemical_properties.rb
@@ -2,6 +2,6 @@
 
 class AddDescriptionToAlchemicalProperties < ActiveRecord::Migration[6.1]
   def change
-    add_column :alchemical_properties, :description, :string, null: false
+    add_column :alchemical_properties, :description, :string
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -21,7 +21,7 @@ ActiveRecord::Schema.define(version: 2022_05_25_023945) do
     t.boolean "effects_cumulative", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "description", null: false
+    t.string "description"
     t.index ["name"], name: "index_alchemical_properties_on_name", unique: true
   end
 


### PR DESCRIPTION
## Context

When running migrations in production, we failed to account for the fact that existing alchemical properties in the database would not have `description` fields and would therefore violate the `NOT NULL` constraint on the field. We need to remove the constraint, deploy, sync canonical models, and then add it back.

## Changes

* Remove `NOT NULL` constraint from the `description` field on the `alchemical_properties` table

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~

## Considerations

I considered dropping and re-creating the database so it wouldn't have any records in it. Since even the "production" environment is basically a staging environment at this point, it wouldn't have been that big a deal. But still, it's a thing to avoid. So I decided to do it this way.

Additionally, note that I did not remove the validation on the model for this. Since Rubocop hasn't made it an issue I'm not going to remove it, because we do want all future models to include this field. Once we sync the database and add the constraint back it will be fine.