### PR TITLE
Run spell syncer earlier

### DIFF
--- a/app/models/canonical/sync.rb
+++ b/app/models/canonical/sync.rb
@@ -10,6 +10,7 @@ module Canonical
                 enchantment:         Canonical::Sync::Enchantments,
                 material:            Canonical::Sync::Materials,
                 power:               Canonical::Sync::Powers,
+                spell:               Canonical::Sync::Spells,
                 ingredient:          Canonical::Sync::Ingredients,
                 # Syncers that are not prerequisites for other syncers
                 armor:               Canonical::Sync::Armor,
@@ -19,7 +20,6 @@ module Canonical
                 misc_item:           Canonical::Sync::MiscItems,
                 potion:              Canonical::Sync::Potions,
                 property:            Canonical::Sync::Properties,
-                spell:               Canonical::Sync::Spells,
                 staff:               Canonical::Sync::Staves,
                 weapon:              Canonical::Sync::Weapons,
               }.freeze


### PR DESCRIPTION
## Context

When running the `canonical_models:sync:all` task in production, we noticed that spells were synced just before staves, which was adequate since the only other models that require them are staves and weapons (both of which are synced after). However, we've tried to put models that don't have prerequisites all early in the sync process, so it would be better to have spells synced around the same time as alchemical properties, enchantments, and powers.

## Changes

* Run spell syncer well before models that have prerequisites

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

Additional tests weren't exactly needed and would be hard to implement (since we'd have to test the order in which syncers are run, and I'm not sure if that can even be done with regular RSpec mocks/doubles. However, if the spell syncer ran at a time that actually broke things - i.e., after canonical staves or canonical weapons - the existing tests should fail.
