### PR TITLE
Add back NOT NULL constraint to description field on alchemical properties

### DIFF
--- a/db/migrate/20220526074029_add_not_null_constraint_to_description_on_alchemical_properties.rb
+++ b/db/migrate/20220526074029_add_not_null_constraint_to_description_on_alchemical_properties.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddNotNullConstraintToDescriptionOnAlchemicalProperties < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :alchemical_properties, :description, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_25_023945) do
+ActiveRecord::Schema.define(version: 2022_05_26_074029) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,7 +21,7 @@ ActiveRecord::Schema.define(version: 2022_05_25_023945) do
     t.boolean "effects_cumulative", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "description"
+    t.string "description", null: false
     t.index ["name"], name: "index_alchemical_properties_on_name", unique: true
   end
 


### PR DESCRIPTION
## Context

In #105, we had to remove a `NOT NULL` constraint from the migration creating the `description` column of the `alchemical_properties` table, because existing alchemical properties in the database would not have that value set (since the field didn't exist yet, for one thing). However, we actually want that column not to be `NULL`, and there are validations to that effect on the ActiveRecord model itself. This should be reflected in the database schema.

## Changes

* Migration to add back `NOT NULL` constraint to the `description` field now that all alchemical properties are synced with descriptions.

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~

## Considerations

Explain any design or implementation decisions you've made here, as well as any alternatives you considered or tried. Justify your approach. Include links to any blog posts, documentation, or other materials readers may find useful to understand your implementation or the alternatives.
