### PR TITLE
Add fields to canonical armors

### DIFF
--- a/app/models/canonical/armor.rb
+++ b/app/models/canonical/armor.rb
@@ -1,8 +1,13 @@
 # frozen_string_literal: true
 
+require 'skyrim'
+
 module Canonical
   class Armor < ApplicationRecord
     self.table_name = 'canonical_armors'
+
+    BOOLEAN_VALUES             = [true, false].freeze
+    BOOLEAN_VALIDATION_MESSAGE = 'must be true or false'
 
     has_many :canonical_enchantables_enchantments,
              dependent:  :destroy,
@@ -45,9 +50,30 @@ module Canonical
                            message: 'must be "head", "body", "hands", "feet", "hair", or "shield"',
                          }
     validates :unit_weight, presence: true, numericality: { greater_than_or_equal_to: 0 }
+    validates :purchasable, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }
+    validates :enchantable, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }
+    validates :leveled, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }
+    validates :unique_item, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }
+    validates :rare_item, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }
+    validates :quest_item, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }
+
+    validate :verify_all_smithing_perks_valid
+    validate :validate_unique_item_also_rare, if: -> { unique_item == true }
 
     def self.unique_identifier
       :item_code
+    end
+
+    private
+
+    def verify_all_smithing_perks_valid
+      smithing_perks&.each do |perk|
+        errors.add(:smithing_perks, "\"#{perk}\" is not a valid smithing perk") unless Skyrim::SMITHING_PERKS.include?(perk)
+      end
+    end
+
+    def validate_unique_item_also_rare
+      errors.add(:rare_item, 'must be true if item is unique') unless rare_item == true
     end
   end
 end

--- a/db/migrate/20220526213259_add_smithing_perks_and_leveled_to_canonical_armors.rb
+++ b/db/migrate/20220526213259_add_smithing_perks_and_leveled_to_canonical_armors.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-class AddSmithingPerksAndLeveledToCanonicalArmors < ActiveRecord::Migration[6.1]
-  def change
-    add_column :canonical_armors, :smithing_perks, :string, array: true, default: []
-    add_column :canonical_armors, :leveled, :string, default: false
-  end
-end

--- a/db/migrate/20220526213259_add_smithing_perks_and_leveled_to_canonical_armors.rb
+++ b/db/migrate/20220526213259_add_smithing_perks_and_leveled_to_canonical_armors.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddSmithingPerksAndLeveledToCanonicalArmors < ActiveRecord::Migration[6.1]
+  def change
+    add_column :canonical_armors, :smithing_perks, :string, array: true, default: []
+    add_column :canonical_armors, :leveled, :string, default: false
+  end
+end

--- a/db/migrate/20220526213259_add_smithing_perks_to_canonical_armors.rb
+++ b/db/migrate/20220526213259_add_smithing_perks_to_canonical_armors.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSmithingPerksToCanonicalArmors < ActiveRecord::Migration[6.1]
+  def change
+    add_column :canonical_armors, :smithing_perks, :string, array: true, default: []
+  end
+end

--- a/db/migrate/20220526213259_add_smithing_perks_to_canonical_armors.rb
+++ b/db/migrate/20220526213259_add_smithing_perks_to_canonical_armors.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class AddSmithingPerksToCanonicalArmors < ActiveRecord::Migration[6.1]
-  def change
-    add_column :canonical_armors, :smithing_perks, :string, array: true, default: []
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_26_074029) do
+ActiveRecord::Schema.define(version: 2022_05_26_213259) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,6 +38,7 @@ ActiveRecord::Schema.define(version: 2022_05_26_074029) do
     t.boolean "enchantable", default: true
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "smithing_perks", default: [], array: true
     t.index ["item_code"], name: "index_canonical_armors_on_item_code", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -33,13 +33,15 @@ ActiveRecord::Schema.define(version: 2022_05_26_213259) do
     t.string "magical_effects"
     t.decimal "unit_weight", precision: 5, scale: 2, null: false
     t.boolean "dragon_priest_mask", default: false
-    t.boolean "quest_item", default: false
-    t.boolean "unique_item", default: false
     t.boolean "enchantable", default: true
+    t.boolean "leveled", default: false
+    t.boolean "purchasable"
+    t.boolean "unique_item", default: false
+    t.boolean "rare_item"
+    t.boolean "quest_item", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "smithing_perks", default: [], array: true
-    t.string "leveled", default: "f"
     t.index ["item_code"], name: "index_canonical_armors_on_item_code", unique: true
   end
 
@@ -67,8 +69,10 @@ ActiveRecord::Schema.define(version: 2022_05_26_213259) do
     t.string "body_slot", null: false
     t.string "magical_effects"
     t.decimal "unit_weight", precision: 5, scale: 2, null: false
-    t.boolean "quest_item", default: false
+    t.boolean "purchasable"
     t.boolean "unique_item", default: false
+    t.boolean "rare_item"
+    t.boolean "quest_item", default: false
     t.boolean "enchantable", default: true
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -101,8 +105,10 @@ ActiveRecord::Schema.define(version: 2022_05_26_213259) do
     t.string "name", null: false
     t.string "item_code", null: false
     t.decimal "unit_weight", precision: 5, scale: 2, null: false
-    t.boolean "quest_item", default: false
+    t.boolean "purchasable"
     t.boolean "unique_item", default: false
+    t.boolean "rare_item"
+    t.boolean "quest_item", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["item_code"], name: "index_canonical_ingredients_on_item_code", unique: true
@@ -128,8 +134,10 @@ ActiveRecord::Schema.define(version: 2022_05_26_213259) do
     t.string "jewelry_type", null: false
     t.string "magical_effects"
     t.decimal "unit_weight", precision: 5, scale: 2, null: false
-    t.boolean "quest_item", default: false
+    t.boolean "purchasable"
     t.boolean "unique_item", default: false
+    t.boolean "rare_item"
+    t.boolean "quest_item", default: false
     t.boolean "enchantable", default: true
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -232,7 +240,9 @@ ActiveRecord::Schema.define(version: 2022_05_26_213259) do
     t.string "school"
     t.string "enemy"
     t.boolean "daedric", default: false, null: false
+    t.boolean "purchasable"
     t.boolean "unique_item", default: false, null: false
+    t.boolean "rare_item"
     t.boolean "quest_item", default: false, null: false
     t.boolean "leveled", default: false, null: false
     t.datetime "created_at", precision: 6, null: false
@@ -273,8 +283,10 @@ ActiveRecord::Schema.define(version: 2022_05_26_213259) do
     t.decimal "unit_weight", precision: 5, scale: 2, null: false
     t.boolean "leveled", default: false
     t.boolean "enchantable", default: true
-    t.boolean "quest_item", default: false
+    t.boolean "purchasable"
     t.boolean "unique_item", default: false
+    t.boolean "rare_item"
+    t.boolean "quest_item", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["item_code"], name: "index_canonical_weapons_on_item_code", unique: true
@@ -319,10 +331,8 @@ ActiveRecord::Schema.define(version: 2022_05_26_213259) do
     t.boolean "aggregate", default: false, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.bigint "property_id"
     t.index ["aggregate_list_id"], name: "index_inventory_lists_on_aggregate_list_id"
     t.index ["game_id"], name: "index_inventory_lists_on_game_id"
-    t.index ["property_id"], name: "index_inventory_lists_on_property_id"
     t.index ["title", "game_id"], name: "index_inventory_lists_on_title_and_game_id", unique: true
   end
 
@@ -374,10 +384,8 @@ ActiveRecord::Schema.define(version: 2022_05_26_213259) do
     t.string "title", null: false
     t.bigint "game_id", null: false
     t.bigint "aggregate_list_id"
-    t.bigint "property_id"
     t.index ["aggregate_list_id"], name: "index_shopping_lists_on_aggregate_list_id"
     t.index ["game_id"], name: "index_shopping_lists_on_game_id"
-    t.index ["property_id"], name: "index_shopping_lists_on_property_id"
     t.index ["title", "game_id"], name: "index_shopping_lists_on_title_and_game_id", unique: true
   end
 
@@ -422,11 +430,9 @@ ActiveRecord::Schema.define(version: 2022_05_26_213259) do
   add_foreign_key "inventory_items", "inventory_lists", column: "list_id"
   add_foreign_key "inventory_lists", "games"
   add_foreign_key "inventory_lists", "inventory_lists", column: "aggregate_list_id"
-  add_foreign_key "inventory_lists", "properties"
   add_foreign_key "properties", "canonical_properties"
   add_foreign_key "properties", "games"
   add_foreign_key "shopping_list_items", "shopping_lists", column: "list_id"
   add_foreign_key "shopping_lists", "games"
-  add_foreign_key "shopping_lists", "properties"
   add_foreign_key "shopping_lists", "shopping_lists", column: "aggregate_list_id"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -39,6 +39,7 @@ ActiveRecord::Schema.define(version: 2022_05_26_213259) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "smithing_perks", default: [], array: true
+    t.string "leveled", default: "f"
     t.index ["item_code"], name: "index_canonical_armors_on_item_code", unique: true
   end
 

--- a/lib/tasks/canonical_models/canonical_armor.json
+++ b/lib/tasks/canonical_models/canonical_armor.json
@@ -6672,12 +6672,14 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": false,
       "enchantable": true
     },
     "enchantments": [],
@@ -6710,12 +6712,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -6740,12 +6745,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -6770,12 +6778,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -6800,12 +6811,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -6830,12 +6844,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -6860,12 +6877,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -6890,12 +6910,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -6920,12 +6943,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -6950,12 +6976,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -6980,12 +7009,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -7010,12 +7042,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -7040,12 +7075,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -7070,12 +7108,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -7100,12 +7141,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -7130,12 +7174,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -7160,12 +7207,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -7190,12 +7240,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -7220,12 +7273,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -7250,12 +7306,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -7280,12 +7339,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -7310,12 +7372,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -7340,12 +7405,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -7370,12 +7438,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -7400,12 +7471,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -7430,12 +7504,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -7460,12 +7537,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -7490,12 +7570,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -7558,12 +7641,15 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -7588,12 +7674,15 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -7618,12 +7707,15 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -7648,12 +7740,15 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -7678,12 +7773,15 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -7708,12 +7806,15 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -7738,12 +7839,15 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -7768,12 +7872,15 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -7798,12 +7905,15 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -7828,12 +7938,15 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -7858,12 +7971,15 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -7888,12 +8004,15 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -7918,12 +8037,15 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -7948,12 +8070,15 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -7978,12 +8103,15 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -8046,12 +8174,15 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -8076,12 +8207,15 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -8106,12 +8240,15 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -8136,12 +8273,15 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -8166,12 +8306,15 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -8196,12 +8339,15 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -8226,12 +8372,15 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -8256,12 +8405,15 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -8286,12 +8438,15 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -8316,12 +8471,15 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -8346,12 +8504,15 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -8376,12 +8537,15 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -8406,12 +8570,15 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -8436,12 +8603,15 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -8466,12 +8636,15 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -8534,12 +8707,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -8564,12 +8740,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -8594,12 +8773,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -8624,12 +8806,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -8654,12 +8839,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -8684,12 +8872,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -8714,12 +8905,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -8744,12 +8938,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -8774,12 +8971,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -8804,12 +9004,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -8834,12 +9037,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -8864,12 +9070,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -8894,12 +9103,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -8924,12 +9136,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -8954,12 +9169,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -8984,12 +9202,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -9014,12 +9235,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -9044,12 +9268,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -9074,12 +9301,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -9104,12 +9334,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -9134,12 +9367,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -9164,12 +9400,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -9194,12 +9433,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -9224,12 +9466,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -9254,12 +9499,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -9284,12 +9532,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -9314,12 +9565,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -9344,12 +9598,15 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -9412,12 +9669,15 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -9442,12 +9702,15 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -9472,12 +9735,15 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -9502,12 +9768,15 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -9532,12 +9801,15 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -9562,12 +9834,15 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -9592,12 +9867,15 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -9622,12 +9900,15 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -9652,12 +9933,15 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -9682,12 +9966,15 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -9712,12 +9999,15 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -9742,12 +10032,15 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -9772,12 +10065,15 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -9802,12 +10098,15 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -9874,12 +10173,15 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -9904,12 +10206,15 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -9934,12 +10239,15 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -9964,12 +10272,15 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -9994,12 +10305,15 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -10024,12 +10338,15 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -10054,12 +10371,15 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -10084,12 +10404,15 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -10114,12 +10437,15 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -10144,12 +10470,15 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -10174,12 +10503,15 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -10204,12 +10536,15 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -10234,12 +10569,15 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -10264,12 +10602,15 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -10294,12 +10635,15 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -10324,12 +10668,15 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -10354,12 +10701,15 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -10384,12 +10734,15 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -10414,12 +10767,15 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -10444,12 +10800,15 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -10474,12 +10833,15 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -10504,12 +10866,15 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -10534,12 +10899,15 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -10564,12 +10932,15 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -10594,12 +10965,15 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -10624,12 +10998,15 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -10654,12 +11031,15 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -10726,12 +11106,15 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -10756,12 +11139,15 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -10786,12 +11172,15 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -10816,12 +11205,15 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -10846,12 +11238,15 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -10876,12 +11271,15 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -10906,12 +11304,15 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -10936,12 +11337,15 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -10966,12 +11370,15 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -10996,12 +11403,15 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -11026,12 +11436,15 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -11056,12 +11469,15 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -11086,12 +11502,15 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -11116,12 +11535,15 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -11146,12 +11568,15 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -11176,12 +11601,15 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -11206,12 +11634,15 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -11278,12 +11709,15 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -11308,12 +11742,15 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -11338,12 +11775,15 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -11368,12 +11808,15 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -11398,12 +11841,15 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -11428,12 +11874,15 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -11458,12 +11907,15 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -11488,12 +11940,15 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -11518,12 +11973,15 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -11548,12 +12006,15 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -11578,12 +12039,15 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -11608,12 +12072,15 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -11638,12 +12105,15 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -11668,12 +12138,15 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -11698,12 +12171,15 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -11728,12 +12204,15 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -11758,12 +12237,15 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -11788,12 +12270,15 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -11818,12 +12303,15 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -11848,12 +12336,15 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -11878,12 +12369,15 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -11950,12 +12444,15 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -11980,12 +12477,15 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -12010,12 +12510,15 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -12040,12 +12543,15 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -12070,12 +12576,15 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -12100,12 +12609,15 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -12130,12 +12642,15 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -12160,12 +12675,15 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -12190,12 +12708,15 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -12220,12 +12741,15 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -12250,12 +12774,15 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -12280,12 +12807,15 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -12310,12 +12840,15 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -12340,12 +12873,15 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -12370,12 +12906,15 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -12400,12 +12939,15 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -12430,12 +12972,15 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -12460,12 +13005,15 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -12490,12 +13038,15 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -12520,12 +13071,15 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -12550,12 +13104,15 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -12580,12 +13137,15 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -12610,12 +13170,15 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -12640,12 +13203,15 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -12670,12 +13236,15 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -12700,12 +13269,15 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -12730,12 +13302,15 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -12760,12 +13335,15 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -12828,12 +13406,15 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -12858,12 +13439,15 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -12888,12 +13472,15 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -12918,12 +13505,15 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -12948,12 +13538,15 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -12978,12 +13571,15 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -13008,12 +13604,15 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -13038,12 +13637,15 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -13068,12 +13670,15 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -13098,12 +13703,15 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -13128,12 +13736,15 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -13158,12 +13769,15 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -13188,12 +13802,15 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -13218,12 +13835,15 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [

--- a/lib/tasks/canonical_models/canonical_armor.json
+++ b/lib/tasks/canonical_models/canonical_armor.json
@@ -24,13 +24,13 @@
         "strength": 50
       }
     ],
+    "crafting_materials": [],
     "tempering_materials": [
       {
         "item_code": "0005AD9D",
         "quantity": 1
       }
-    ],
-    "crafting_materials": []
+    ]
   },
   {
     "attributes": {
@@ -277,13 +277,13 @@
         "strength": 40
       }
     ],
+    "crafting_materials": [],
     "tempering_materials": [
       {
         "item_code": "0005ACE4",
         "quantity": 1
       }
-    ],
-    "crafting_materials": []
+    ]
   },
   {
     "attributes": {
@@ -303,6 +303,7 @@
       "rare_item": true,
       "enchantable": false
     },
+    "enchantments": [],
     "crafting_materials": [
       {
         "item_code": "0005ACE4",
@@ -326,8 +327,7 @@
         "item_code": "0005ACE4",
         "quantity": 1
       }
-    ],
-    "enchantments": []
+    ]
   },
   {
     "attributes": {
@@ -485,13 +485,13 @@
         "strength": 100
       }
     ],
+    "crafting_materials": [],
     "tempering_materials": [
       {
         "item_code": "000DB5D2",
         "quantity": 1
       }
-    ],
-    "crafting_materials": []
+    ]
   },
   {
     "attributes": {
@@ -517,13 +517,13 @@
         "strength": 0.5
       }
     ],
+    "crafting_materials": [],
     "tempering_materials": [
       {
         "item_code": "000DB5D2",
         "quantity": 1
       }
-    ],
-    "crafting_materials": []
+    ]
   },
   {
     "attributes": {
@@ -603,13 +603,13 @@
         "strength": 15
       }
     ],
+    "crafting_materials": [],
     "tempering_materials": [
       {
         "item_code": "000DB5D2",
         "quantity": 1
       }
-    ],
-    "crafting_materials": []
+    ]
   },
   {
     "attributes": {
@@ -627,6 +627,7 @@
       "rare_item": false,
       "enchantable": true
     },
+    "enchantments": [],
     "crafting_materials": [
       {
         "item_code": "0005AD93",
@@ -646,8 +647,7 @@
         "item_code": "0005AD93",
         "quantity": 1
       }
-    ],
-    "enchantments": []
+    ]
   },
   {
     "attributes": {
@@ -913,7 +913,9 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": ["Arcane Blacksmith"],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
       "purchasable": true,
       "quest_item": false,
@@ -943,7 +945,9 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": ["Arcane Blacksmith"],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
       "purchasable": true,
       "quest_item": false,
@@ -973,7 +977,9 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": ["Arcane Blacksmith"],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
       "purchasable": true,
       "quest_item": false,
@@ -1003,11 +1009,14 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
       "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1032,9 +1041,14 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1059,9 +1073,14 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1086,9 +1105,14 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1113,9 +1137,14 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1140,9 +1169,14 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1167,9 +1201,14 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1194,9 +1233,14 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1221,9 +1265,14 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1248,9 +1297,14 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1275,9 +1329,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": true
     },
     "enchantments": [],
@@ -1310,9 +1367,14 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1337,9 +1399,14 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1364,9 +1431,14 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1391,9 +1463,14 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1418,9 +1495,14 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1445,9 +1527,14 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1472,9 +1559,14 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1499,9 +1591,14 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1526,9 +1623,14 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1553,9 +1655,14 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1580,9 +1687,14 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1607,9 +1719,14 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1634,9 +1751,14 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1661,9 +1783,14 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1688,9 +1815,14 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1715,9 +1847,14 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1726,13 +1863,13 @@
         "strength": 50
       }
     ],
+    "crafting_materials": [],
     "tempering_materials": [
       {
         "item_code": "000DB5D2",
         "quantity": 1
       }
-    ],
-    "crafting_materials": []
+    ]
   },
   {
     "attributes": {
@@ -1742,9 +1879,14 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1753,13 +1895,13 @@
         "strength": 40
       }
     ],
+    "crafting_materials": [],
     "tempering_materials": [
       {
         "item_code": "000DB5D2",
         "quantity": 1
       }
-    ],
-    "crafting_materials": []
+    ]
   },
   {
     "attributes": {
@@ -1769,9 +1911,14 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1780,13 +1927,13 @@
         "strength": 40
       }
     ],
+    "crafting_materials": [],
     "tempering_materials": [
       {
         "item_code": "000DB5D2",
         "quantity": 1
       }
-    ],
-    "crafting_materials": []
+    ]
   },
   {
     "attributes": {
@@ -1796,9 +1943,14 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1823,9 +1975,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": false,
       "quest_item": false,
-      "unique_item": true,
+      "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [],
@@ -1845,9 +2000,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": false,
       "quest_item": false,
-      "unique_item": true,
+      "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [],
@@ -1867,9 +2025,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": false,
       "quest_item": false,
-      "unique_item": true,
+      "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [],
@@ -1889,9 +2050,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": false,
       "quest_item": false,
-      "unique_item": true,
+      "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [],
@@ -1911,9 +2075,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": false,
       "quest_item": false,
-      "unique_item": true,
+      "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [],
@@ -1933,9 +2100,14 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": [],
@@ -1968,9 +2140,14 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": true
     },
     "enchantments": [],
@@ -2003,9 +2180,14 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": [],
@@ -2038,9 +2220,14 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": false,
       "quest_item": false,
-      "unique_item": false,
+      "unique_item": true,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": [],
@@ -2073,9 +2260,14 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": [],
@@ -2108,9 +2300,14 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": [],
@@ -2143,9 +2340,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": [],
@@ -2178,9 +2378,14 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2189,13 +2394,13 @@
         "strength": 20
       }
     ],
+    "crafting_materials": [],
     "tempering_materials": [
       {
         "item_code": "000DB5D2",
         "quantity": 1
       }
-    ],
-    "crafting_materials": []
+    ]
   },
   {
     "attributes": {
@@ -2205,9 +2410,14 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": true
     },
     "enchantments": [],
@@ -2240,9 +2450,14 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": true
     },
     "enchantments": [],
@@ -2275,9 +2490,14 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": true
     },
     "enchantments": [],
@@ -2310,9 +2530,14 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": true
     },
     "enchantments": [],
@@ -2345,9 +2570,14 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": true
     },
     "enchantments": [],
@@ -2380,9 +2610,14 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": true
     },
     "enchantments": [],
@@ -2415,9 +2650,14 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": true
     },
     "enchantments": [],
@@ -2450,9 +2690,14 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": true
     },
     "enchantments": [],
@@ -2485,9 +2730,14 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": true
     },
     "enchantments": [],
@@ -2520,9 +2770,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [],
@@ -2542,9 +2795,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [],
@@ -2564,9 +2820,14 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": true
     },
     "enchantments": [],
@@ -2599,9 +2860,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2626,9 +2893,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2653,9 +2926,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2680,9 +2959,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2707,9 +2992,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2734,9 +3025,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2761,9 +3058,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2788,9 +3091,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2815,9 +3124,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2842,9 +3157,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2869,9 +3190,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2896,9 +3223,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2923,9 +3256,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2950,9 +3289,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2977,9 +3322,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -3004,9 +3355,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -3031,9 +3388,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -3058,9 +3421,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -3085,9 +3454,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -3112,9 +3487,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -3139,9 +3520,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -3166,9 +3553,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -3193,9 +3586,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -3220,9 +3619,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -3247,9 +3652,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -3274,9 +3685,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -3301,9 +3718,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -3328,9 +3751,14 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": true
     },
     "enchantments": [],
@@ -3363,9 +3791,15 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -3390,9 +3824,15 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -3417,9 +3857,15 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -3444,9 +3890,15 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -3471,9 +3923,15 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -3498,9 +3956,15 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -3525,9 +3989,15 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -3552,9 +4022,15 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -3579,9 +4055,15 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -3606,9 +4088,15 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -3633,9 +4121,15 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -3660,9 +4154,15 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -3687,9 +4187,15 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -3714,9 +4220,15 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -3741,9 +4253,15 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -3768,9 +4286,14 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": true
     },
     "enchantments": [],
@@ -3803,9 +4326,15 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -3830,9 +4359,15 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -3857,9 +4392,15 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -3884,9 +4425,15 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -3911,9 +4458,15 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -3938,9 +4491,15 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -3965,9 +4524,15 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -3992,9 +4557,15 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -4019,9 +4590,15 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -4046,9 +4623,15 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -4073,9 +4656,15 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -4100,9 +4689,15 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -4127,9 +4722,15 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -4154,9 +4755,15 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -4181,9 +4788,15 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -4208,9 +4821,14 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": true
     },
     "enchantments": [],
@@ -4243,9 +4861,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -4270,9 +4894,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -4297,9 +4927,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -4324,9 +4960,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -4351,9 +4993,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -4378,9 +5026,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -4405,9 +5059,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -4432,9 +5092,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -4459,9 +5125,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -4486,9 +5158,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -4513,9 +5191,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -4540,9 +5224,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -4567,9 +5257,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -4594,9 +5290,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -4621,9 +5323,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -4648,9 +5356,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -4675,9 +5389,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -4702,9 +5422,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -4729,9 +5455,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -4756,9 +5488,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -4783,9 +5521,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -4810,9 +5554,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -4837,9 +5587,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -4864,9 +5620,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -4891,9 +5653,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -4918,9 +5686,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -4945,9 +5719,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -4972,9 +5752,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -4999,9 +5785,15 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": true
     },
     "enchantments": [],
@@ -5034,9 +5826,15 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -5061,9 +5859,15 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -5088,9 +5892,15 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -5115,9 +5925,15 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -5142,9 +5958,15 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -5169,9 +5991,15 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -5196,9 +6024,15 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -5223,9 +6057,15 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -5250,9 +6090,15 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -5277,9 +6123,15 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -5304,9 +6156,15 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -5331,9 +6189,15 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -5358,9 +6222,15 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -5385,9 +6255,15 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -5412,9 +6288,15 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": "Wearing a full set grants a 25% resistance against Vampire attacks, including the Vampiric Drain attack.",
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [],
@@ -5434,9 +6316,15 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": "Wearing a full set grants a 25% resistance against Vampire attacks, including the Vampiric Drain attack.",
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [],
@@ -5456,9 +6344,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": "Wearing a full set grants a 25% resistance against Vampire attacks, including the Vampiric Drain attack.",
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [],
@@ -5478,9 +6372,15 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": "Wearing a full set grants a 25% resistance against Vampire attacks, including the Vampiric Drain attack.",
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [],
@@ -5500,9 +6400,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": "Wearing a full set grants a 25% resistance against Vampire attacks, including the Vampiric Drain attack.",
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [],
@@ -5522,9 +6428,15 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": "Wearing a full set grants a 25% resistance against Vampire attacks, including the Vampiric Drain attack.",
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [],
@@ -5544,9 +6456,15 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": "Wearing a full set grants a 25% resistance against Vampire attacks, including the Vampiric Drain attack.",
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [],
@@ -5566,9 +6484,15 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": "Wearing a full set grants a 25% resistance against Vampire attacks, including the Vampiric Drain attack.",
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [],
@@ -5587,10 +6511,16 @@
       "unit_weight": 10,
       "body_slot": "shield",
       "weight": "heavy armor",
-      "magical_effects": "+5 Bash damage against vampires",
+      "magical_effects": "+10 Bash damage against vampires",
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [],
@@ -5610,9 +6540,15 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": "Increases your stamina by 15 for each Deathbrand item you wear.",
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "quest_item": false,
+      "purchasable": false,
+      "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [],
@@ -5632,9 +6568,15 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": "Increases your carrying capacity by 10 for each Deathbrand item you wear.",
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "quest_item": false,
+      "purchasable": false,
+      "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [],
@@ -5654,9 +6596,15 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": "While dual-wielding, your one-handed attacks do 10% more damage for each Deathbrand item you wear.",
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "quest_item": false,
+      "purchasable": false,
+      "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [],
@@ -5676,9 +6624,15 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": "+100 Armor while wearing a complete set of Deathbrand armor.",
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "quest_item": false,
+      "purchasable": false,
+      "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [],
@@ -5697,9 +6651,13 @@
       "unit_weight": 4,
       "body_slot": "head",
       "weight": "light armor",
-      "quest_item": true,
       "magical_effects": "Spells in all schools cost less Magicka to cast",
-      "unique_item": true,
+      "smithing_perks": [],
+      "dragon_priest_mask": null,
+      "purchasable": false,
+      "quest_item": true,
+      "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [],
@@ -5714,9 +6672,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -5749,9 +6710,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -5776,9 +6740,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -5803,9 +6770,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -5830,9 +6800,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -5857,9 +6830,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -5884,9 +6860,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -5911,9 +6890,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -5938,9 +6920,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -5965,9 +6950,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -5992,9 +6980,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -6019,9 +7010,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -6046,9 +7040,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -6073,9 +7070,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -6100,9 +7100,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -6127,9 +7130,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -6154,9 +7160,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -6181,9 +7190,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -6208,9 +7220,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -6235,9 +7250,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -6262,9 +7280,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -6289,9 +7310,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -6316,9 +7340,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -6343,9 +7370,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -6370,9 +7400,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -6397,9 +7430,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -6424,9 +7460,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -6451,9 +7490,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -6478,9 +7520,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -6513,9 +7558,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -6540,9 +7588,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -6567,9 +7618,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -6594,9 +7648,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -6621,9 +7678,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -6648,9 +7708,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -6675,9 +7738,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -6702,9 +7768,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -6729,9 +7798,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -6756,9 +7828,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -6783,9 +7858,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -6810,9 +7888,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -6837,9 +7918,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -6864,9 +7948,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -6891,9 +7978,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -6918,9 +8008,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -6953,9 +8046,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -6980,9 +8076,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -7007,9 +8106,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -7034,9 +8136,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -7061,9 +8166,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -7088,9 +8196,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -7115,9 +8226,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -7142,9 +8256,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -7169,9 +8286,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -7196,9 +8316,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -7223,9 +8346,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -7250,9 +8376,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -7277,9 +8406,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -7304,9 +8436,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -7331,9 +8466,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -7358,9 +8496,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -7393,9 +8534,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -7420,9 +8564,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -7447,9 +8594,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -7474,9 +8624,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -7501,9 +8654,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -7528,9 +8684,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -7555,9 +8714,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -7582,9 +8744,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -7609,9 +8774,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -7636,9 +8804,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -7663,9 +8834,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -7690,9 +8864,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -7717,9 +8894,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -7744,9 +8924,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -7771,9 +8954,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -7798,9 +8984,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -7825,9 +9014,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -7852,9 +9044,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -7879,9 +9074,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -7906,9 +9104,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -7933,9 +9134,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -7960,9 +9164,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -7987,9 +9194,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -8014,9 +9224,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -8041,9 +9254,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -8068,9 +9284,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -8095,9 +9314,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -8122,9 +9344,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -8149,9 +9374,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -8184,9 +9412,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -8211,9 +9442,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -8238,9 +9472,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -8265,9 +9502,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -8292,9 +9532,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -8319,9 +9562,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -8346,9 +9592,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -8373,9 +9622,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -8400,9 +9652,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -8427,9 +9682,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -8454,9 +9712,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -8481,9 +9742,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -8508,9 +9772,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -8535,9 +9802,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -8562,9 +9832,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -8601,9 +9874,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -8628,9 +9904,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -8655,9 +9934,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -8682,9 +9964,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -8709,9 +9994,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -8736,9 +10024,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -8763,9 +10054,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -8790,9 +10084,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -8817,9 +10114,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -8844,9 +10144,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -8871,9 +10174,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -8898,9 +10204,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -8925,9 +10234,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -8952,9 +10264,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -8979,9 +10294,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -9006,9 +10324,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -9033,9 +10354,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -9060,9 +10384,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -9087,9 +10414,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -9114,9 +10444,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -9141,9 +10474,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -9168,9 +10504,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -9195,9 +10534,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -9222,9 +10564,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -9249,9 +10594,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -9276,9 +10624,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -9303,9 +10654,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -9330,9 +10684,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -9369,9 +10726,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -9396,9 +10756,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -9423,9 +10786,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -9450,9 +10816,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -9477,9 +10846,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -9504,9 +10876,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -9531,9 +10906,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -9558,9 +10936,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -9585,9 +10966,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -9612,9 +10996,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -9639,9 +11026,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -9666,9 +11056,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -9693,9 +11086,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -9720,9 +11116,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -9747,9 +11146,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -9774,9 +11176,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -9801,9 +11206,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -9828,9 +11236,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -9867,9 +11278,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -9894,9 +11308,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -9921,9 +11338,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -9948,9 +11368,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -9975,9 +11398,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -10002,9 +11428,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -10029,9 +11458,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -10056,9 +11488,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -10083,9 +11518,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -10110,9 +11548,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -10137,9 +11578,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -10164,9 +11608,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -10191,9 +11638,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -10218,9 +11668,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -10245,9 +11698,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -10272,9 +11728,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -10299,9 +11758,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -10326,9 +11788,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -10353,9 +11818,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -10380,9 +11848,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -10407,9 +11878,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -10434,9 +11908,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -10473,9 +11950,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -10500,9 +11980,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -10527,9 +12010,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -10554,9 +12040,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -10581,9 +12070,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -10608,9 +12100,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -10635,9 +12130,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -10662,9 +12160,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -10689,9 +12190,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -10716,9 +12220,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -10743,9 +12250,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -10770,9 +12280,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -10797,9 +12310,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -10824,9 +12340,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -10851,9 +12370,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -10878,9 +12400,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -10905,9 +12430,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -10932,9 +12460,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -10959,9 +12490,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -10986,9 +12520,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -11013,9 +12550,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -11040,9 +12580,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -11067,9 +12610,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -11094,9 +12640,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -11121,9 +12670,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -11148,9 +12700,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -11175,9 +12730,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -11202,9 +12760,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -11229,9 +12790,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -11264,9 +12828,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -11291,9 +12858,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -11318,9 +12888,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -11345,9 +12918,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -11372,9 +12948,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -11399,9 +12978,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -11426,9 +13008,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -11453,9 +13038,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -11480,9 +13068,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -11507,9 +13098,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -11534,9 +13128,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -11561,9 +13158,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -11588,9 +13188,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -11615,9 +13218,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -11642,9 +13248,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": "Frost spells do 25% more damage.",
+      "smithing_perks": [],
       "dragon_priest_mask": true,
+      "purchasable": null,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -11653,13 +13262,13 @@
         "strength": 50
       }
     ],
+    "crafting_materials": [],
     "tempering_materials": [
       {
         "item_code": "0005AD9D",
         "quantity": 1
       }
-    ],
-    "crafting_materials": []
+    ]
   },
   {
     "attributes": {
@@ -11669,9 +13278,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -11708,9 +13320,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -11735,9 +13350,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -11762,9 +13380,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -11789,9 +13410,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -11816,9 +13440,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -11843,9 +13470,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -11870,9 +13500,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -11897,9 +13530,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -11924,9 +13560,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -11951,9 +13590,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -11978,9 +13620,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -12005,9 +13650,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -12032,9 +13680,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -12059,9 +13710,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -12086,9 +13740,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -12113,9 +13770,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -12140,9 +13800,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -12167,9 +13830,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -12194,9 +13860,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -12221,9 +13890,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -12248,9 +13920,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -12275,9 +13950,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -12314,9 +13992,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -12341,9 +14022,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -12368,9 +14052,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -12395,9 +14082,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -12422,9 +14112,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -12449,9 +14142,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -12476,9 +14172,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -12503,9 +14202,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -12530,9 +14232,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -12557,9 +14262,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -12584,9 +14292,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -12611,9 +14322,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -12638,9 +14352,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -12665,9 +14382,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -12692,9 +14412,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -12719,9 +14442,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -12746,9 +14472,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -12773,9 +14502,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -12800,9 +14532,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -12827,9 +14562,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -12854,9 +14592,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -12881,9 +14622,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -12908,9 +14652,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -12935,9 +14682,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -12962,9 +14712,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -12989,9 +14742,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -13016,9 +14772,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -13043,9 +14802,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -13070,9 +14832,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -13097,9 +14862,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -13124,9 +14892,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -13151,9 +14922,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -13190,9 +14964,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -13229,9 +15006,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -13256,9 +15036,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -13283,9 +15066,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -13310,9 +15096,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -13337,9 +15126,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -13364,9 +15156,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -13391,9 +15186,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -13418,9 +15216,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -13445,9 +15246,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -13472,9 +15276,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -13499,9 +15306,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -13526,9 +15336,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -13553,9 +15366,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -13580,9 +15396,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -13607,9 +15426,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -13634,9 +15456,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -13661,9 +15486,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -13688,9 +15516,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -13715,9 +15546,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -13742,9 +15576,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -13769,9 +15606,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -13796,9 +15636,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -13823,9 +15666,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -13850,9 +15696,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -13877,9 +15726,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -13916,9 +15768,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -13943,9 +15798,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -13970,9 +15828,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -13997,9 +15858,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -14024,9 +15888,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -14051,9 +15918,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -14078,9 +15948,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -14105,9 +15978,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -14132,9 +16008,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -14159,9 +16038,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -14186,9 +16068,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -14213,9 +16098,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -14240,9 +16128,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -14267,9 +16158,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -14294,9 +16188,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -14321,9 +16218,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -14352,9 +16252,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -14379,9 +16282,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -14406,9 +16312,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -14433,9 +16342,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -14460,9 +16372,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -14487,9 +16402,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -14514,9 +16432,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -14541,9 +16462,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -14568,9 +16492,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -14595,9 +16522,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -14622,9 +16552,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -14649,9 +16582,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -14676,9 +16612,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -14703,9 +16642,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -14730,9 +16672,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -14757,9 +16702,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -14784,9 +16732,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -14811,9 +16762,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -14838,9 +16792,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -14865,9 +16822,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -14892,9 +16852,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -14919,9 +16882,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -14946,9 +16912,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -14973,9 +16942,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -15000,9 +16972,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -15027,9 +17002,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -15054,9 +17032,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -15081,9 +17062,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -15112,9 +17096,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -15139,9 +17126,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -15166,9 +17156,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -15193,9 +17186,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -15220,9 +17216,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -15247,9 +17246,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -15274,9 +17276,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -15301,9 +17306,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -15328,9 +17336,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -15355,9 +17366,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -15382,9 +17396,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -15409,9 +17426,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -15436,9 +17456,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -15463,9 +17486,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -15490,9 +17516,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -15517,9 +17546,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -15544,9 +17576,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -15575,9 +17610,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -15602,9 +17640,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -15629,9 +17670,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -15656,9 +17700,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -15683,9 +17730,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -15710,9 +17760,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -15737,9 +17790,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -15764,9 +17820,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -15791,9 +17850,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -15818,9 +17880,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -15845,9 +17910,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -15872,9 +17940,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -15899,9 +17970,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -15926,9 +18000,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -15953,9 +18030,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -15980,9 +18060,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -16011,9 +18094,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -16038,9 +18124,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -16065,9 +18154,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -16092,9 +18184,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -16119,9 +18214,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -16146,9 +18244,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -16173,9 +18274,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -16200,9 +18304,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -16227,9 +18334,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -16254,9 +18364,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -16281,9 +18394,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -16308,9 +18424,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -16335,9 +18454,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -16362,9 +18484,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -16389,9 +18514,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -16416,9 +18544,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -16443,9 +18574,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -16470,9 +18604,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -16497,9 +18634,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -16524,9 +18664,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -16551,9 +18694,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -16578,9 +18724,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -16605,9 +18754,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -16632,9 +18784,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -16659,9 +18814,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -16686,9 +18844,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -16713,9 +18874,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -16740,9 +18904,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -16767,9 +18934,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": "Opponents that get too close take 5 points of poison damage per second.",
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -16778,13 +18948,13 @@
         "strength": 0.5
       }
     ],
+    "crafting_materials": [],
     "tempering_materials": [
       {
         "item_code": "0005AD9D",
         "quantity": 1
       }
-    ],
-    "crafting_materials": []
+    ]
   },
   {
     "attributes": {
@@ -16794,9 +18964,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -16825,9 +18998,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -16852,9 +19028,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -16879,9 +19058,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -16906,9 +19088,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -16933,9 +19118,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -16960,9 +19148,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -16987,9 +19178,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -17014,9 +19208,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -17041,9 +19238,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -17068,9 +19268,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -17095,9 +19298,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -17122,9 +19328,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -17149,9 +19358,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -17176,9 +19388,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -17203,9 +19418,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -17230,9 +19448,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -17269,9 +19490,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -17296,9 +19520,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -17323,9 +19550,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -17350,9 +19580,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -17377,9 +19610,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -17404,9 +19640,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -17431,9 +19670,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -17458,9 +19700,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -17485,9 +19730,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -17512,9 +19760,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -17539,9 +19790,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -17566,9 +19820,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -17593,9 +19850,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -17620,9 +19880,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -17647,9 +19910,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -17674,9 +19940,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -17701,9 +19970,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -17728,9 +20000,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -17755,9 +20030,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -17782,9 +20060,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -17809,9 +20090,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -17836,9 +20120,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -17875,9 +20162,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -17902,9 +20192,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -17929,9 +20222,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -17956,9 +20252,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -17983,9 +20282,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -18010,9 +20312,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -18037,9 +20342,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -18064,9 +20372,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -18091,9 +20402,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -18118,9 +20432,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -18145,9 +20462,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -18172,9 +20492,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -18199,9 +20522,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -18226,9 +20552,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -18253,9 +20582,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -18280,9 +20612,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -18307,9 +20642,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -18334,9 +20672,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -18361,9 +20702,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -18388,9 +20732,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -18415,9 +20762,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -18442,9 +20792,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -18469,9 +20822,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -18496,9 +20852,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -18523,9 +20882,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -18550,9 +20912,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -18577,9 +20942,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -18604,9 +20972,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -18631,9 +21002,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -18658,9 +21032,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -18685,9 +21062,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -18712,9 +21092,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -18739,9 +21122,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -18766,9 +21152,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -18793,9 +21182,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -18820,9 +21212,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -18847,9 +21242,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -18874,9 +21272,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -18901,9 +21302,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -18928,9 +21332,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -18967,9 +21374,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -19006,9 +21416,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -19028,9 +21441,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -19050,9 +21466,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -19072,9 +21491,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -19094,9 +21516,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -19116,9 +21541,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -19138,9 +21566,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -19160,9 +21591,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -19182,9 +21616,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -19204,9 +21641,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -19226,9 +21666,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -19248,9 +21691,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -19270,9 +21716,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -19292,9 +21741,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -19314,9 +21766,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -19336,9 +21791,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -19358,9 +21816,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -19380,9 +21841,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -19402,9 +21866,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -19424,9 +21891,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -19446,9 +21916,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -19468,9 +21941,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -19490,9 +21966,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -19512,9 +21991,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -19534,9 +22016,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -19556,9 +22041,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -19578,9 +22066,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -19600,9 +22091,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -19639,9 +22133,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -19666,9 +22163,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -19693,9 +22193,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -19720,9 +22223,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -19747,9 +22253,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -19774,9 +22283,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -19801,9 +22313,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -19828,9 +22343,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -19855,9 +22373,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -19882,9 +22403,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -19909,9 +22433,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -19936,9 +22463,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -19963,9 +22493,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -19990,9 +22523,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -20017,9 +22553,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -20044,9 +22583,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -20071,9 +22613,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -20098,9 +22643,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -20125,9 +22673,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -20152,9 +22703,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -20179,9 +22733,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -20206,9 +22763,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -20233,9 +22793,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -20260,9 +22823,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -20287,9 +22853,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -20309,9 +22878,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -20331,9 +22903,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -20353,9 +22928,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -20375,9 +22953,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -20410,9 +22991,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -20437,9 +23021,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -20464,9 +23051,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -20491,9 +23081,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -20518,9 +23111,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -20545,9 +23141,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -20572,9 +23171,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -20599,9 +23201,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -20626,9 +23231,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -20653,9 +23261,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -20680,9 +23291,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -20707,9 +23321,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -20734,9 +23351,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -20761,9 +23381,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -20788,9 +23411,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -20815,9 +23441,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -20837,9 +23466,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -20859,9 +23491,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -20881,9 +23516,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -20903,9 +23541,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -20925,9 +23566,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -20947,9 +23591,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -20969,9 +23616,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -20991,9 +23641,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -21013,9 +23666,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -21035,9 +23691,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -21057,9 +23716,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -21079,9 +23741,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -21101,9 +23766,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -21123,9 +23791,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -21145,9 +23816,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -21167,9 +23841,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -21189,9 +23866,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -21211,9 +23891,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -21233,9 +23916,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -21255,9 +23941,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -21277,19 +23966,22 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
+    "crafting_materials": [],
     "tempering_materials": [
       {
         "item_code": "000DB5D2",
         "quantity": 1
       }
-    ],
-    "crafting_materials": []
+    ]
   },
   {
     "attributes": {
@@ -21299,9 +23991,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -21321,19 +24016,22 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
+    "crafting_materials": [],
     "tempering_materials": [
       {
         "item_code": "000DB5D2",
         "quantity": 1
       }
-    ],
-    "crafting_materials": []
+    ]
   },
   {
     "attributes": {
@@ -21343,9 +24041,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -21365,9 +24066,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -21387,9 +24091,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -21398,13 +24105,13 @@
         "strength": 20
       }
     ],
+    "crafting_materials": [],
     "tempering_materials": [
       {
         "item_code": "000DB5D2",
         "quantity": 1
       }
-    ],
-    "crafting_materials": []
+    ]
   },
   {
     "attributes": {
@@ -21414,9 +24121,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": [],
@@ -21436,9 +24146,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": [],
@@ -21458,9 +24171,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -21497,9 +24213,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -21524,9 +24243,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -21551,9 +24273,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -21578,9 +24303,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -21605,9 +24333,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -21632,9 +24363,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -21659,9 +24393,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -21686,9 +24423,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -21713,9 +24453,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -21740,9 +24483,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -21767,9 +24513,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -21794,9 +24543,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -21821,9 +24573,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -21848,9 +24603,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -21875,9 +24633,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -21902,9 +24663,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -21929,9 +24693,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -21956,9 +24723,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -21983,9 +24753,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -22010,9 +24783,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -22037,9 +24813,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -22064,9 +24843,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -22091,9 +24873,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -22118,9 +24903,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -22145,9 +24933,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -22172,9 +24963,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -22199,9 +24993,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -22226,9 +25023,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -22248,9 +25048,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -22287,9 +25090,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -22314,9 +25120,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -22341,9 +25150,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -22368,9 +25180,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -22395,9 +25210,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -22422,9 +25240,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -22449,9 +25270,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -22476,9 +25300,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -22503,9 +25330,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -22530,9 +25360,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -22557,9 +25390,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -22584,9 +25420,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -22611,9 +25450,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -22638,9 +25480,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -22665,9 +25510,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -22692,9 +25540,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -22719,9 +25570,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -22746,9 +25600,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -22773,9 +25630,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -22800,9 +25660,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -22839,9 +25702,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -22866,9 +25732,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -22893,9 +25762,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -22920,9 +25792,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -22947,9 +25822,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -22974,9 +25852,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -23001,9 +25882,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -23028,9 +25912,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -23055,9 +25942,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -23082,9 +25972,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -23109,9 +26002,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -23136,9 +26032,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -23163,9 +26062,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -23190,9 +26092,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -23217,9 +26122,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -23244,9 +26152,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -23271,9 +26182,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -23298,9 +26212,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -23325,9 +26242,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -23352,9 +26272,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -23379,9 +26302,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -23406,9 +26332,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -23445,9 +26374,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -23472,9 +26404,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -23499,9 +26434,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -23526,9 +26464,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -23553,9 +26494,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -23580,9 +26524,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -23607,9 +26554,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -23634,9 +26584,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -23661,9 +26614,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -23688,9 +26644,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -23715,9 +26674,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -23742,9 +26704,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -23769,9 +26734,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -23796,9 +26764,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -23823,9 +26794,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -23850,9 +26824,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -23877,9 +26854,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -23904,9 +26884,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -23931,9 +26914,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -23958,9 +26944,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -23985,9 +26974,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -24012,9 +27004,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -24039,9 +27034,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -24066,9 +27064,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -24093,9 +27094,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -24120,9 +27124,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -24147,9 +27154,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -24174,9 +27184,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -24201,9 +27214,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -24236,9 +27252,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -24263,9 +27282,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -24290,9 +27312,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -24317,9 +27342,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -24344,9 +27372,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -24371,9 +27402,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -24398,9 +27432,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -24425,9 +27462,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -24452,9 +27492,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -24479,9 +27522,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -24506,9 +27552,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -24533,9 +27582,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -24560,9 +27612,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -24587,9 +27642,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -24614,9 +27672,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -24641,9 +27702,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -24672,9 +27736,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -24683,13 +27750,13 @@
         "strength": 50
       }
     ],
+    "crafting_materials": [],
     "tempering_materials": [
       {
         "item_code": "000DB5D2",
         "quantity": 1
       }
-    ],
-    "crafting_materials": []
+    ]
   },
   {
     "attributes": {
@@ -24699,9 +27766,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -24710,13 +27780,13 @@
         "strength": 35
       }
     ],
+    "crafting_materials": [],
     "tempering_materials": [
       {
         "item_code": "000DB5D2",
         "quantity": 1
       }
-    ],
-    "crafting_materials": []
+    ]
   },
   {
     "attributes": {
@@ -24726,9 +27796,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -24737,13 +27810,13 @@
         "strength": 35
       }
     ],
+    "crafting_materials": [],
     "tempering_materials": [
       {
         "item_code": "000DB5D2",
         "quantity": 1
       }
-    ],
-    "crafting_materials": []
+    ]
   },
   {
     "attributes": {
@@ -24753,9 +27826,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -24764,13 +27840,13 @@
         "strength": 20
       }
     ],
+    "crafting_materials": [],
     "tempering_materials": [
       {
         "item_code": "000DB5D2",
         "quantity": 1
       }
-    ],
-    "crafting_materials": []
+    ]
   },
   {
     "attributes": {
@@ -24780,9 +27856,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -24807,9 +27886,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -24818,13 +27900,13 @@
         "strength": 30
       }
     ],
+    "crafting_materials": [],
     "tempering_materials": [
       {
         "item_code": "000DB5D2",
         "quantity": 1
       }
-    ],
-    "crafting_materials": []
+    ]
   },
   {
     "attributes": {
@@ -24834,9 +27916,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": true,
+      "purchasable": null,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -24849,13 +27934,13 @@
         "strength": 100
       }
     ],
+    "crafting_materials": [],
     "tempering_materials": [
       {
         "item_code": "0005ACE4",
         "quantity": 1
       }
-    ],
-    "crafting_materials": []
+    ]
   },
   {
     "attributes": {
@@ -24865,9 +27950,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -24896,9 +27984,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -24923,9 +28014,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -24950,9 +28044,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -24977,9 +28074,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -25004,9 +28104,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -25031,9 +28134,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -25058,9 +28164,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -25085,9 +28194,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -25112,9 +28224,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -25139,9 +28254,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -25166,9 +28284,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -25193,9 +28314,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -25220,9 +28344,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -25247,9 +28374,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -25274,9 +28404,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -25301,9 +28434,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -25328,9 +28464,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -25355,9 +28494,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -25382,9 +28524,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -25409,9 +28554,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -25436,9 +28584,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -25463,9 +28614,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -25494,9 +28648,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -25521,9 +28678,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -25548,9 +28708,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -25575,9 +28738,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -25602,9 +28768,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -25629,9 +28798,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -25656,9 +28828,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -25683,9 +28858,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -25710,9 +28888,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -25737,9 +28918,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -25764,9 +28948,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -25791,9 +28978,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -25818,9 +29008,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -25845,9 +29038,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -25872,9 +29068,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -25899,9 +29098,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -25926,9 +29128,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -25953,9 +29158,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -25980,9 +29188,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -26011,9 +29222,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -26038,9 +29252,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -26065,9 +29282,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -26092,9 +29312,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -26119,9 +29342,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -26146,9 +29372,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -26173,9 +29402,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -26200,9 +29432,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -26227,9 +29462,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -26254,9 +29492,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -26281,9 +29522,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -26308,9 +29552,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -26335,9 +29582,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -26362,9 +29612,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -26389,9 +29642,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -26416,9 +29672,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -26443,9 +29702,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -26470,9 +29732,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -26497,9 +29762,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -26524,9 +29792,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -26551,9 +29822,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -26578,9 +29852,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -26609,9 +29886,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -26636,9 +29916,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -26663,9 +29946,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -26690,9 +29976,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -26717,9 +30006,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -26744,9 +30036,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -26771,9 +30066,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -26798,9 +30096,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -26825,9 +30126,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -26852,9 +30156,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -26879,9 +30186,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -26906,9 +30216,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -26933,9 +30246,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -26960,9 +30276,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -26987,9 +30306,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -27014,9 +30336,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -27041,9 +30366,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -27068,9 +30396,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -27095,9 +30426,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -27122,9 +30456,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -27149,9 +30486,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -27176,9 +30516,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -27203,9 +30546,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -27230,9 +30576,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -27257,9 +30606,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -27288,9 +30640,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -27315,9 +30670,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -27342,9 +30700,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -27369,9 +30730,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -27396,9 +30760,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -27423,9 +30790,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -27450,9 +30820,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -27477,9 +30850,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -27504,9 +30880,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -27531,9 +30910,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -27558,9 +30940,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -27585,9 +30970,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -27612,9 +31000,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -27639,9 +31030,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -27666,9 +31060,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -27693,9 +31090,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -27715,9 +31115,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -27737,9 +31140,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -27759,9 +31165,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -27794,9 +31203,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -27821,9 +31233,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -27848,9 +31263,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -27875,9 +31293,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -27902,9 +31323,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -27929,9 +31353,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -27956,9 +31383,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -27983,9 +31413,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -28010,9 +31443,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -28037,9 +31473,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -28064,9 +31503,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -28091,9 +31533,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -28118,9 +31563,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -28145,9 +31593,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -28180,9 +31631,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -28207,9 +31661,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -28234,9 +31691,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -28261,9 +31721,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -28288,9 +31751,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -28315,9 +31781,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -28342,9 +31811,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -28369,9 +31841,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -28396,9 +31871,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -28423,9 +31901,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -28450,9 +31931,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -28477,9 +31961,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -28504,9 +31991,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -28531,9 +32021,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -28558,9 +32051,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -28585,9 +32081,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -28612,9 +32111,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -28639,9 +32141,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -28666,9 +32171,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -28693,9 +32201,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -28720,9 +32231,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -28747,9 +32261,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -28774,9 +32291,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -28801,9 +32321,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -28828,9 +32351,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -28855,9 +32381,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -28882,9 +32411,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -28909,9 +32441,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -28936,9 +32471,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -28963,9 +32501,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -28990,9 +32531,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -29025,9 +32569,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -29052,9 +32599,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -29079,9 +32629,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -29106,9 +32659,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -29133,9 +32689,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -29160,9 +32719,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -29187,9 +32749,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -29214,9 +32779,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -29241,9 +32809,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -29268,9 +32839,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -29295,9 +32869,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -29322,9 +32899,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -29349,9 +32929,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -29376,9 +32959,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -29403,9 +32989,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -29430,9 +33019,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -29457,9 +33049,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -29484,9 +33079,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -29511,9 +33109,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -29538,9 +33139,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -29565,9 +33169,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -29592,9 +33199,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -29619,9 +33229,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -29646,9 +33259,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -29673,9 +33289,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -29700,9 +33319,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -29727,9 +33349,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -29754,9 +33379,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -29781,9 +33409,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -29808,9 +33439,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -29835,9 +33469,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -29862,9 +33499,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -29889,9 +33529,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -29916,9 +33559,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -29943,9 +33589,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -29970,9 +33619,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -29997,9 +33649,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -30024,9 +33679,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -30051,9 +33709,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -30078,9 +33739,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -30105,9 +33769,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -30132,9 +33799,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -30159,9 +33829,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -30186,9 +33859,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -30213,9 +33889,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -30240,9 +33919,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -30267,9 +33949,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -30294,9 +33979,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -30321,9 +34009,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -30348,9 +34039,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -30375,9 +34069,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -30402,9 +34099,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -30429,9 +34129,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -30456,9 +34159,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -30483,9 +34189,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -30518,9 +34227,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -30545,9 +34257,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -30572,9 +34287,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -30599,9 +34317,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -30626,9 +34347,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -30653,9 +34377,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -30680,9 +34407,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -30707,9 +34437,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -30734,9 +34467,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -30761,9 +34497,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -30788,9 +34527,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -30815,9 +34557,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -30842,9 +34587,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -30869,9 +34617,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -30896,9 +34647,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -30923,9 +34677,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -30950,9 +34707,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -30977,9 +34737,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -31004,9 +34767,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -31031,9 +34797,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -31058,9 +34827,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -31085,9 +34857,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -31112,9 +34887,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -31139,9 +34917,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -31174,9 +34955,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -31209,9 +34993,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -31244,9 +35031,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -31279,9 +35069,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -31301,9 +35094,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -31323,9 +35119,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -31345,9 +35144,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -31367,9 +35169,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -31389,9 +35194,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -31411,9 +35219,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -31433,9 +35244,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -31455,9 +35269,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -31477,9 +35294,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -31499,9 +35319,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -31521,9 +35344,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -31543,9 +35369,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -31565,9 +35394,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -31587,9 +35419,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -31609,9 +35444,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -31631,9 +35469,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -31653,9 +35494,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -31675,9 +35519,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -31706,9 +35553,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -31728,9 +35578,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -31750,9 +35603,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -31772,9 +35628,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -31794,9 +35653,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -31816,9 +35678,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -31838,9 +35703,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -31860,9 +35728,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -31882,9 +35753,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -31904,9 +35778,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -31926,9 +35803,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -31948,9 +35828,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -31970,9 +35853,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -31992,9 +35878,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -32023,9 +35912,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -32040,9 +35932,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -32087,9 +35982,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -32134,9 +36032,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -32181,9 +36082,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -32228,9 +36132,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -32275,9 +36182,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -32306,9 +36216,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -32333,9 +36246,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -32360,9 +36276,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -32387,9 +36306,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -32414,9 +36336,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -32441,9 +36366,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -32468,9 +36396,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -32495,9 +36426,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -32522,9 +36456,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -32549,9 +36486,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -32576,9 +36516,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -32603,9 +36546,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -32630,9 +36576,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -32657,9 +36606,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -32684,9 +36636,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -32711,9 +36666,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -32738,9 +36696,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -32765,9 +36726,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -32792,9 +36756,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -32819,9 +36786,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -32846,9 +36816,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -32873,9 +36846,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -32904,9 +36880,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -32931,9 +36910,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -32958,9 +36940,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -32985,9 +36970,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -33012,9 +37000,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -33039,9 +37030,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -33066,9 +37060,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -33093,9 +37090,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -33120,9 +37120,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -33147,9 +37150,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -33174,9 +37180,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -33201,9 +37210,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -33228,9 +37240,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -33255,9 +37270,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -33282,9 +37300,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -33309,9 +37330,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -33340,9 +37364,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -33367,9 +37394,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -33394,9 +37424,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -33421,9 +37454,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -33448,9 +37484,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -33475,9 +37514,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -33502,9 +37544,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -33529,9 +37574,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -33556,9 +37604,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -33583,9 +37634,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -33610,9 +37664,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -33637,9 +37694,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -33664,9 +37724,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -33691,9 +37754,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -33718,9 +37784,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -33745,9 +37814,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -33776,9 +37848,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -33803,9 +37878,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -33830,9 +37908,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -33857,9 +37938,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -33884,9 +37968,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -33911,9 +37998,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -33938,9 +38028,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -33965,9 +38058,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -33992,9 +38088,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -34019,9 +38118,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -34046,9 +38148,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -34073,9 +38178,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -34100,9 +38208,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -34127,9 +38238,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -34154,9 +38268,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -34181,9 +38298,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -34208,9 +38328,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -34235,9 +38358,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -34262,9 +38388,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -34289,9 +38418,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -34316,9 +38448,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -34343,9 +38478,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -34370,9 +38508,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -34397,9 +38538,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -34424,9 +38568,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -34455,9 +38602,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -34482,9 +38632,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -34509,9 +38662,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -34536,9 +38692,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -34563,9 +38722,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -34590,9 +38752,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -34617,9 +38782,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -34644,9 +38812,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -34671,9 +38842,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -34698,9 +38872,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -34725,9 +38902,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -34752,9 +38932,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -34779,9 +38962,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -34806,9 +38992,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -34833,9 +39022,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -34860,9 +39052,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -34871,13 +39066,13 @@
         "strength": 15
       }
     ],
+    "crafting_materials": [],
     "tempering_materials": [
       {
         "item_code": "0005ACE4",
         "quantity": 1
       }
-    ],
-    "crafting_materials": []
+    ]
   },
   {
     "attributes": {
@@ -34887,9 +39082,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": "Whenever the wearer is struck while below 15% health, there is a 15% chance that the mask will heal the wearer and any nearby allies with the Grand Healing spell, and grant a Flame Cloak for 10 seconds. Whenever the wearer is struck while below 15% health, there is a 3% chance that the mask will not only restore the user's health, but also summon a Spectral Dragon Priest ally.",
+      "smithing_perks": [],
       "dragon_priest_mask": true,
+      "purchasable": null,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [],
@@ -34909,9 +39107,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": true,
+      "purchasable": null,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -34944,9 +39145,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -34975,9 +39179,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -35002,9 +39209,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -35029,9 +39239,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -35056,9 +39269,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -35083,9 +39299,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -35110,9 +39329,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -35137,9 +39359,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -35164,9 +39389,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -35191,9 +39419,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -35218,9 +39449,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -35245,9 +39479,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -35272,9 +39509,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -35299,9 +39539,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -35326,9 +39569,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -35353,9 +39599,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -35380,9 +39629,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -35407,9 +39659,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -35434,9 +39689,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -35461,9 +39719,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -35488,9 +39749,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -35515,9 +39779,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -35542,9 +39809,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -35573,9 +39843,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -35600,9 +39873,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -35627,9 +39903,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -35654,9 +39933,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -35681,9 +39963,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -35708,9 +39993,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -35735,9 +40023,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -35762,9 +40053,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -35789,9 +40083,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -35816,9 +40113,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -35843,9 +40143,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -35870,9 +40173,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -35897,9 +40203,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -35924,9 +40233,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -35951,9 +40263,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -35978,9 +40293,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -36005,9 +40323,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -36032,9 +40353,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -36059,9 +40383,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -36090,9 +40417,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -36117,9 +40447,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -36144,9 +40477,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -36171,9 +40507,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -36198,9 +40537,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -36225,9 +40567,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -36252,9 +40597,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -36279,9 +40627,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -36306,9 +40657,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -36333,9 +40687,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -36360,9 +40717,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -36387,9 +40747,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -36414,9 +40777,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -36441,9 +40807,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -36468,9 +40837,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -36495,9 +40867,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -36522,9 +40897,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -36549,9 +40927,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -36576,9 +40957,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -36603,9 +40987,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -36630,9 +41017,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -36657,9 +41047,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -36688,9 +41081,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -36715,9 +41111,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -36742,9 +41141,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -36769,9 +41171,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -36796,9 +41201,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -36823,9 +41231,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -36850,9 +41261,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -36877,9 +41291,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -36904,9 +41321,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -36931,9 +41351,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -36958,9 +41381,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -36985,9 +41411,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -37012,9 +41441,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -37039,9 +41471,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -37066,9 +41501,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -37093,9 +41531,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -37120,9 +41561,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -37147,9 +41591,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -37174,9 +41621,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -37201,9 +41651,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -37228,9 +41681,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -37255,9 +41711,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -37282,9 +41741,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -37309,9 +41771,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -37336,9 +41801,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -37347,13 +41815,13 @@
         "strength": 15
       }
     ],
+    "crafting_materials": [],
     "tempering_materials": [
       {
         "item_code": "000DB5D2",
         "quantity": 1
       }
-    ],
-    "crafting_materials": []
+    ]
   },
   {
     "attributes": {
@@ -37363,9 +41831,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -37374,13 +41845,13 @@
         "strength": 15
       }
     ],
+    "crafting_materials": [],
     "tempering_materials": [
       {
         "item_code": "000DB5D2",
         "quantity": 1
       }
-    ],
-    "crafting_materials": []
+    ]
   },
   {
     "attributes": {
@@ -37390,9 +41861,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -37417,9 +41891,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -37444,9 +41921,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -37466,9 +41946,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -37488,9 +41971,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -37510,9 +41996,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": "+10 Speechcraft",
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -37536,9 +42025,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": true,
+      "purchasable": null,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -37558,9 +42050,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -37580,9 +42075,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -37602,9 +42100,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -37624,9 +42125,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -37646,9 +42150,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": true,
+      "purchasable": null,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -37673,9 +42180,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -37695,9 +42205,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": true,
+      "purchasable": null,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -37714,13 +42227,13 @@
         "strength": 20
       }
     ],
+    "crafting_materials": [],
     "tempering_materials": [
       {
         "item_code": "0005AD9D",
         "quantity": 1
       }
-    ],
-    "crafting_materials": []
+    ]
   },
   {
     "attributes": {
@@ -37730,9 +42243,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -37761,9 +42277,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -37788,9 +42307,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -37819,9 +42341,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -37846,9 +42371,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -37885,9 +42413,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -37924,9 +42455,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -37963,9 +42497,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -38002,9 +42539,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -38037,9 +42577,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -38072,9 +42615,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -38099,9 +42645,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -38126,9 +42675,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -38153,9 +42705,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -38180,9 +42735,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -38207,9 +42765,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -38234,9 +42795,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -38261,9 +42825,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -38288,9 +42855,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -38315,9 +42885,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -38342,9 +42915,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -38369,9 +42945,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -38396,9 +42975,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -38423,9 +43005,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -38450,9 +43035,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -38477,9 +43065,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -38504,9 +43095,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -38531,9 +43125,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -38558,9 +43155,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -38585,9 +43185,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -38612,9 +43215,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -38639,9 +43245,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -38666,9 +43275,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -38693,9 +43305,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -38720,9 +43335,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -38755,9 +43373,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -38782,9 +43403,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -38809,9 +43433,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -38836,9 +43463,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -38863,9 +43493,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -38890,9 +43523,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -38917,9 +43553,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -38944,9 +43583,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -38971,9 +43613,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -38998,9 +43643,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -39025,9 +43673,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -39052,9 +43703,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -39079,9 +43733,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -39106,9 +43763,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -39141,9 +43801,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -39168,9 +43831,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -39195,9 +43861,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -39222,9 +43891,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -39249,9 +43921,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -39276,9 +43951,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -39303,9 +43981,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -39330,9 +44011,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -39357,9 +44041,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -39384,9 +44071,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -39411,9 +44101,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -39438,9 +44131,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -39465,9 +44161,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -39492,9 +44191,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -39519,9 +44221,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -39546,9 +44251,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -39581,9 +44289,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -39608,9 +44319,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -39635,9 +44349,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -39662,9 +44379,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -39689,9 +44409,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -39716,9 +44439,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -39743,9 +44469,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -39770,9 +44499,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -39797,9 +44529,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -39824,9 +44559,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -39851,9 +44589,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -39878,9 +44619,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -39905,9 +44649,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -39932,9 +44679,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -39959,9 +44709,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -39986,9 +44739,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -40013,9 +44769,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -40040,9 +44799,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -40067,9 +44829,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -40094,9 +44859,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -40121,9 +44889,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -40148,9 +44919,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -40175,9 +44949,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -40202,9 +44979,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -40229,9 +45009,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -40256,9 +45039,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -40291,9 +45077,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -40318,9 +45107,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -40345,9 +45137,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -40372,9 +45167,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -40399,9 +45197,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -40426,9 +45227,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -40453,9 +45257,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -40480,9 +45287,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -40507,9 +45317,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -40534,9 +45347,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -40561,9 +45377,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -40588,9 +45407,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -40615,9 +45437,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -40642,9 +45467,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -40669,9 +45497,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -40696,9 +45527,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": true,
+      "purchasable": null,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -40731,9 +45565,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -40753,9 +45590,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -40775,9 +45615,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -40797,9 +45640,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -40819,9 +45665,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -40841,9 +45690,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -40863,9 +45715,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -40885,9 +45740,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -40900,13 +45758,13 @@
         "strength": 1
       }
     ],
+    "crafting_materials": [],
     "tempering_materials": [
       {
         "item_code": "0005ACE4",
         "quantity": 1
       }
-    ],
-    "crafting_materials": []
+    ]
   },
   {
     "attributes": {
@@ -40916,9 +45774,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": true,
+      "purchasable": null,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -40927,13 +45788,13 @@
         "strength": 70
       }
     ],
+    "crafting_materials": [],
     "tempering_materials": [
       {
         "item_code": "0005AD99",
         "quantity": 1
       }
-    ],
-    "crafting_materials": []
+    ]
   },
   {
     "attributes": {
@@ -40943,9 +45804,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -40965,9 +45829,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -40987,9 +45854,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -41009,9 +45879,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -41040,9 +45913,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -41079,9 +45955,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -41106,9 +45985,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -41133,9 +46015,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -41160,9 +46045,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -41187,9 +46075,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -41214,9 +46105,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -41241,9 +46135,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -41268,9 +46165,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -41295,9 +46195,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -41322,9 +46225,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -41349,9 +46255,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -41376,9 +46285,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -41403,9 +46315,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -41430,9 +46345,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -41457,9 +46375,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -41484,9 +46405,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -41511,9 +46435,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -41538,9 +46465,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -41565,9 +46495,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -41592,9 +46525,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -41619,9 +46555,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -41646,9 +46585,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -41685,9 +46627,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -41712,9 +46657,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -41739,9 +46687,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -41766,9 +46717,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -41793,9 +46747,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -41820,9 +46777,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -41847,9 +46807,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -41874,9 +46837,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -41901,9 +46867,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -41928,9 +46897,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -41955,9 +46927,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -41982,9 +46957,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -42009,9 +46987,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -42036,9 +47017,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -42063,9 +47047,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -42090,9 +47077,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -42117,9 +47107,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -42144,9 +47137,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -42171,9 +47167,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -42210,9 +47209,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -42237,9 +47239,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -42264,9 +47269,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -42291,9 +47299,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -42318,9 +47329,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -42345,9 +47359,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -42372,9 +47389,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -42399,9 +47419,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -42426,9 +47449,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -42453,9 +47479,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -42480,9 +47509,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -42507,9 +47539,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -42534,9 +47569,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -42561,9 +47599,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -42588,9 +47629,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -42615,9 +47659,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -42642,9 +47689,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -42669,9 +47719,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -42696,9 +47749,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -42723,9 +47779,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -42750,9 +47809,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -42777,9 +47839,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -42816,9 +47881,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -42843,9 +47911,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -42870,9 +47941,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -42897,9 +47971,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -42924,9 +48001,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -42951,9 +48031,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -42978,9 +48061,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -43005,9 +48091,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -43032,9 +48121,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -43059,9 +48151,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -43086,9 +48181,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -43113,9 +48211,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -43140,9 +48241,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -43167,9 +48271,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -43194,9 +48301,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -43221,9 +48331,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -43248,9 +48361,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -43275,9 +48391,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -43302,9 +48421,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -43329,9 +48451,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -43356,9 +48481,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -43383,9 +48511,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -43410,9 +48541,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -43437,9 +48571,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -43464,9 +48601,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -43491,9 +48631,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -43513,9 +48656,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -43544,9 +48690,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -43571,9 +48720,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -43582,13 +48734,13 @@
         "strength": 50
       }
     ],
+    "crafting_materials": [],
     "tempering_materials": [
       {
         "item_code": "000DB5D2",
         "quantity": 1
       }
-    ],
-    "crafting_materials": []
+    ]
   },
   {
     "attributes": {
@@ -43598,9 +48750,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -43609,13 +48764,13 @@
         "strength": 0.5
       }
     ],
+    "crafting_materials": [],
     "tempering_materials": [
       {
         "item_code": "000DB5D2",
         "quantity": 1
       }
-    ],
-    "crafting_materials": []
+    ]
   },
   {
     "attributes": {
@@ -43625,9 +48780,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -43636,13 +48794,13 @@
         "strength": 20
       }
     ],
+    "crafting_materials": [],
     "tempering_materials": [
       {
         "item_code": "000DB5D2",
         "quantity": 1
       }
-    ],
-    "crafting_materials": []
+    ]
   },
   {
     "attributes": {
@@ -43652,9 +48810,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": "Backstab does double damage",
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [],
@@ -43674,9 +48835,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -43691,9 +48855,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -43708,9 +48875,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -43725,9 +48895,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -43742,9 +48915,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -43764,9 +48940,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -43786,9 +48965,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -43808,9 +48990,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": "Frost enchantments are 25% stronger when placed on Stalhrim items. Chaos damage enchantments are also 25% stronger.",
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -43843,9 +49028,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": "Frost enchantments are 25% stronger when placed on Stalhrim items. Chaos damage enchantments are also 25% stronger.",
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -43878,9 +49066,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": "Frost enchantments are 25% stronger when placed on Stalhrim items. Chaos damage enchantments are also 25% stronger.",
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -43913,9 +49104,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": "Frost enchantments are 25% stronger when placed on Stalhrim items. Chaos damage enchantments are also 25% stronger.",
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -43948,9 +49142,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": "Frost enchantments are 25% stronger when placed on Stalhrim items. Chaos damage enchantments are also 25% stronger.",
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -43983,9 +49180,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": "Frost enchantments are 25% stronger when placed on Stalhrim items. Chaos damage enchantments are also 25% stronger.",
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -44018,9 +49218,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": "Frost enchantments are 25% stronger when placed on Stalhrim items. Chaos damage enchantments are also 25% stronger.",
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -44053,9 +49256,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": "Frost enchantments are 25% stronger when placed on Stalhrim items. Chaos damage enchantments are also 25% stronger.",
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -44088,9 +49294,12 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": "Frost enchantments are 25% stronger when placed on Stalhrim items. Chaos damage enchantments are also 25% stronger.",
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -44123,9 +49332,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -44158,9 +49370,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -44185,9 +49400,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -44212,9 +49430,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -44239,9 +49460,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -44266,9 +49490,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -44293,9 +49520,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -44320,9 +49550,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -44347,9 +49580,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -44374,9 +49610,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -44401,9 +49640,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -44428,9 +49670,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -44455,9 +49700,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -44482,9 +49730,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -44509,9 +49760,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -44536,9 +49790,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -44563,9 +49820,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -44590,9 +49850,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -44617,9 +49880,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -44644,9 +49910,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -44671,9 +49940,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -44698,9 +49970,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -44725,9 +50000,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -44752,9 +50030,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -44779,9 +50060,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -44806,9 +50090,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -44833,9 +50120,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -44860,9 +50150,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -44887,9 +50180,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -44914,9 +50210,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -44941,9 +50240,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -44968,9 +50270,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -44995,9 +50300,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -45022,9 +50330,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -45049,9 +50360,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -45076,9 +50390,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -45103,9 +50420,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -45130,9 +50450,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -45157,9 +50480,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -45192,9 +50518,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -45219,9 +50548,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -45246,9 +50578,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -45273,9 +50608,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -45300,9 +50638,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -45327,9 +50668,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -45354,9 +50698,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -45381,9 +50728,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -45408,9 +50758,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -45435,9 +50788,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -45462,9 +50818,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -45489,9 +50848,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -45516,9 +50878,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -45543,9 +50908,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -45570,9 +50938,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -45597,9 +50968,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -45632,9 +51006,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -45659,9 +51036,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -45686,9 +51066,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -45713,9 +51096,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -45740,9 +51126,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -45767,9 +51156,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -45794,9 +51186,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -45821,9 +51216,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -45848,9 +51246,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -45875,9 +51276,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -45902,9 +51306,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -45929,9 +51336,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -45956,9 +51366,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -45983,9 +51396,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -46010,9 +51426,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -46037,9 +51456,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -46064,9 +51486,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -46091,9 +51516,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -46118,9 +51546,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -46145,9 +51576,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -46172,9 +51606,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -46199,9 +51636,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -46226,9 +51666,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -46253,9 +51696,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -46280,9 +51726,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -46307,9 +51756,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -46342,9 +51794,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -46377,9 +51832,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -46412,9 +51870,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -46451,9 +51912,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -46478,9 +51942,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -46505,9 +51972,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -46532,9 +52002,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -46559,9 +52032,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -46586,9 +52062,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -46613,9 +52092,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -46640,9 +52122,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -46667,9 +52152,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -46694,9 +52182,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -46721,9 +52212,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -46748,9 +52242,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -46775,9 +52272,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -46802,9 +52302,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -46829,9 +52332,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -46856,9 +52362,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -46883,9 +52392,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -46910,9 +52422,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -46937,9 +52452,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -46964,9 +52482,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -46991,9 +52512,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -47018,9 +52542,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -47057,9 +52584,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -47084,9 +52614,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -47111,9 +52644,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -47138,9 +52674,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -47165,9 +52704,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -47192,9 +52734,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -47219,9 +52764,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -47246,9 +52794,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -47273,9 +52824,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -47300,9 +52854,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -47327,9 +52884,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -47354,9 +52914,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -47381,9 +52944,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -47408,9 +52974,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -47435,9 +53004,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -47462,9 +53034,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -47489,9 +53064,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -47516,9 +53094,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -47543,9 +53124,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -47570,9 +53154,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -47597,9 +53184,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -47624,9 +53214,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -47651,9 +53244,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -47678,9 +53274,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -47705,9 +53304,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -47732,9 +53334,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -47759,9 +53364,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -47786,9 +53394,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -47813,9 +53424,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -47840,9 +53454,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -47867,9 +53484,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -47894,9 +53514,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -47933,9 +53556,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -47972,9 +53598,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -47999,9 +53628,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -48026,9 +53658,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -48053,9 +53688,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -48080,9 +53718,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -48107,9 +53748,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -48134,9 +53778,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -48161,9 +53808,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -48188,9 +53838,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -48215,9 +53868,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -48242,9 +53898,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -48269,9 +53928,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -48296,9 +53958,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -48323,9 +53988,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -48350,9 +54018,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -48377,9 +54048,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -48404,9 +54078,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -48431,9 +54108,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -48458,9 +54138,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -48485,9 +54168,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -48512,9 +54198,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -48539,9 +54228,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -48566,9 +54258,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -48593,9 +54288,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -48620,9 +54318,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -48647,9 +54348,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -48682,9 +54386,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -48709,9 +54416,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -48736,9 +54446,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -48763,9 +54476,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -48790,9 +54506,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -48817,9 +54536,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -48844,9 +54566,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -48871,9 +54596,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -48898,9 +54626,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -48925,9 +54656,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -48952,9 +54686,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -48979,9 +54716,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -49006,9 +54746,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -49033,9 +54776,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -49060,9 +54806,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -49087,9 +54836,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -49122,9 +54874,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -49144,9 +54899,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -49166,9 +54924,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -49188,9 +54949,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -49210,9 +54974,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -49232,9 +54999,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -49254,9 +55024,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -49289,9 +55062,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -49311,9 +55087,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -49333,9 +55112,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -49355,9 +55137,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -49377,9 +55162,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -49399,9 +55187,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -49421,9 +55212,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -49448,9 +55242,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -49475,9 +55272,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -49502,9 +55302,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -49529,9 +55332,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -49556,9 +55362,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -49583,9 +55392,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -49610,9 +55422,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -49637,9 +55452,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -49648,13 +55466,13 @@
         "strength": 15
       }
     ],
+    "crafting_materials": [],
     "tempering_materials": [
       {
         "item_code": "000DB5D2",
         "quantity": 1
       }
-    ],
-    "crafting_materials": []
+    ]
   },
   {
     "attributes": {
@@ -49664,9 +55482,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -49675,13 +55496,13 @@
         "strength": 10
       }
     ],
+    "crafting_materials": [],
     "tempering_materials": [
       {
         "item_code": "000DB5D2",
         "quantity": 1
       }
-    ],
-    "crafting_materials": []
+    ]
   },
   {
     "attributes": {
@@ -49691,9 +55512,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": [],
@@ -49708,9 +55532,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -49730,9 +55557,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": [],
@@ -49747,9 +55577,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -49769,9 +55602,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -49795,9 +55631,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -49821,9 +55660,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -49847,9 +55689,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -49873,9 +55718,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -49899,9 +55747,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -49925,9 +55776,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -49947,9 +55801,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -49969,9 +55826,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -49991,9 +55851,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -50013,9 +55876,12 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -50035,9 +55901,12 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -50057,9 +55926,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -50079,9 +55951,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [
@@ -50090,13 +55965,13 @@
         "strength": 125
       }
     ],
+    "crafting_materials": [],
     "tempering_materials": [
       {
         "item_code": "000DB5D2",
         "quantity": 1
       }
-    ],
-    "crafting_materials": []
+    ]
   },
   {
     "attributes": {
@@ -50106,9 +55981,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": "Allows wearer to release the Breath of Nchuak, a powerful steam attack.",
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -50117,13 +55995,13 @@
         "strength": 60
       }
     ],
+    "crafting_materials": [],
     "tempering_materials": [
       {
         "item_code": "000DB8A2",
         "quantity": 1
       }
-    ],
-    "crafting_materials": []
+    ]
   },
   {
     "attributes": {
@@ -50133,9 +56011,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": true,
+      "purchasable": null,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -50152,13 +56033,13 @@
         "strength": 20
       }
     ],
+    "crafting_materials": [],
     "tempering_materials": [
       {
         "item_code": "0005ACE5",
         "quantity": 1
       }
-    ],
-    "crafting_materials": []
+    ]
   },
   {
     "attributes": {
@@ -50168,9 +56049,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": true,
+      "purchasable": null,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -50187,13 +56071,13 @@
         "strength": null
       }
     ],
+    "crafting_materials": [],
     "tempering_materials": [
       {
         "item_code": "0005AD93",
         "quantity": 1
       }
-    ],
-    "crafting_materials": []
+    ]
   },
   {
     "attributes": {
@@ -50203,9 +56087,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -50225,9 +56112,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -50247,9 +56137,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -50269,9 +56162,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -50291,9 +56187,12 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -50313,9 +56212,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": true
     },
     "enchantments": [],
@@ -50335,9 +56237,12 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": [],
@@ -50357,9 +56262,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [],
@@ -50379,9 +56287,12 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [],
@@ -50401,9 +56312,12 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [],
@@ -50423,9 +56337,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": null,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": null,
       "enchantable": false
     },
     "enchantments": [],
@@ -50445,9 +56362,12 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": "The wooden mask hums with an unfamiliar energy.",
+      "smithing_perks": [],
       "dragon_priest_mask": true,
+      "purchasable": null,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [],
@@ -50462,9 +56382,12 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": "Shock spells do 25% more damage.",
+      "smithing_perks": [],
       "dragon_priest_mask": true,
+      "purchasable": null,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -50473,12 +56396,12 @@
         "strength": 50
       }
     ],
+    "crafting_materials": [],
     "tempering_materials": [
       {
         "item_code": "0005AD9D",
         "quantity": 1
       }
-    ],
-    "crafting_materials": []
+    ]
   }
 ]

--- a/lib/tasks/canonical_models/canonical_armor.json
+++ b/lib/tasks/canonical_models/canonical_armor.json
@@ -7,9 +7,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": "Fire spells do 25% more damage.",
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": true,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -34,9 +40,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": "Enemies who strike you with a melee attack have a small chance of being paralyzed.",
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Advanced Armors"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [],
@@ -56,9 +68,15 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": "Waterwalking. If you wear any four Relics of Ahzidal, +10 Enchanting.",
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Advanced Armors"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [],
@@ -78,9 +96,15 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": "Your Wards are 25% less effective, but absorb 50% of the magicka from incoming spells",
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Advanced Armors"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [],
@@ -100,9 +124,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": "Your Conjuration and Rune spells cost more, but can be cast at greater range",
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Advanced Armors"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [],
@@ -122,9 +152,14 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": false,
       "quest_item": false,
-      "unique_item": false,
+      "unique_item": true,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": [],
@@ -144,9 +179,14 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": [],
@@ -166,9 +206,14 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": false,
       "quest_item": false,
-      "unique_item": false,
+      "unique_item": true,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": [],
@@ -188,9 +233,14 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": false,
       "quest_item": false,
-      "unique_item": false,
+      "unique_item": true,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": [],
@@ -210,9 +260,15 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": false,
       "quest_item": false,
-      "unique_item": false,
+      "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -237,9 +293,14 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "crafting_materials": [
@@ -276,9 +337,14 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [],
@@ -315,9 +381,14 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [],
@@ -354,9 +425,14 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [],
@@ -393,9 +469,14 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "quest_item": false,
+      "purchasable": false,
+      "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -420,9 +501,14 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "quest_item": false,
+      "purchasable": false,
+      "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -447,9 +533,14 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "quest_item": false,
+      "purchasable": false,
+      "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -474,9 +565,14 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": "Double sneak attack damage with one-handed weapons",
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [],
@@ -491,9 +587,14 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -518,9 +619,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": true
     },
     "crafting_materials": [
@@ -553,9 +657,14 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -580,9 +689,14 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -607,9 +721,14 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -634,9 +753,14 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -661,9 +785,14 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -688,9 +817,14 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -715,9 +849,14 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -742,9 +881,14 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -769,9 +913,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": ["Arcane Blacksmith"],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -796,9 +943,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": ["Arcane Blacksmith"],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [
@@ -823,9 +973,12 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": ["Arcane Blacksmith"],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -851,8 +1004,10 @@
       "weight": "heavy armor",
       "magical_effects": null,
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [

--- a/lib/tasks/canonical_models/canonical_armor.json
+++ b/lib/tasks/canonical_models/canonical_armor.json
@@ -16,7 +16,8 @@
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -49,7 +50,8 @@
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -77,7 +79,8 @@
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -105,7 +108,8 @@
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -133,7 +137,8 @@
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -160,7 +165,8 @@
       "quest_item": false,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": true
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -187,7 +193,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": true
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -214,7 +221,8 @@
       "quest_item": false,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": true
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -241,7 +249,8 @@
       "quest_item": false,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": true
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -269,7 +278,8 @@
       "quest_item": false,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -301,7 +311,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -345,7 +356,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -389,7 +401,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -433,7 +446,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -477,7 +491,8 @@
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -509,7 +524,8 @@
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -541,7 +557,8 @@
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -573,7 +590,8 @@
       "quest_item": false,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -595,7 +613,8 @@
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -625,7 +644,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": false,
-      "enchantable": true
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -665,7 +685,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -697,7 +718,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -729,7 +751,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -761,7 +784,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -793,7 +817,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -825,7 +850,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -857,7 +883,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -889,7 +916,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -921,7 +949,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -953,7 +982,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": false,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -985,7 +1015,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -1017,7 +1048,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -1049,7 +1081,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -1081,7 +1114,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -1113,7 +1147,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -1145,7 +1180,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -1177,7 +1213,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -1209,7 +1246,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -1241,7 +1279,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -1273,7 +1312,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -1305,7 +1345,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -1335,7 +1376,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": false,
-      "enchantable": true
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -1375,7 +1417,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -1407,7 +1450,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -1439,7 +1483,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -1471,7 +1516,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -1503,7 +1549,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -1535,7 +1582,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -1567,7 +1615,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -1599,7 +1648,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -1631,7 +1681,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -1663,7 +1714,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -1695,7 +1747,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -1727,7 +1780,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -1759,7 +1813,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -1791,7 +1846,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -1823,7 +1879,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -1855,7 +1912,8 @@
       "quest_item": false,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -1887,7 +1945,8 @@
       "quest_item": false,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -1919,7 +1978,8 @@
       "quest_item": false,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -1951,7 +2011,8 @@
       "quest_item": false,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -1981,7 +2042,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -2006,7 +2068,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -2031,7 +2094,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -2056,7 +2120,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -2081,7 +2146,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -2108,7 +2174,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": true
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -2148,7 +2215,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": false,
-      "enchantable": true
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -2188,7 +2256,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": true
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -2228,7 +2297,8 @@
       "quest_item": false,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": true
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -2268,7 +2338,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": true
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -2308,7 +2379,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": true
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -2346,7 +2418,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": true
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -2386,7 +2459,8 @@
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -2418,7 +2492,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": false,
-      "enchantable": true
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -2458,7 +2533,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": false,
-      "enchantable": true
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -2498,7 +2574,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": false,
-      "enchantable": true
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -2538,7 +2615,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": false,
-      "enchantable": true
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -2578,7 +2656,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": false,
-      "enchantable": true
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -2618,7 +2697,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": false,
-      "enchantable": true
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -2658,7 +2738,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": false,
-      "enchantable": true
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -2698,7 +2779,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": false,
-      "enchantable": true
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -2738,7 +2820,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": false,
-      "enchantable": true
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -2776,7 +2859,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": false,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -2801,7 +2885,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": false,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -2828,7 +2913,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": false,
-      "enchantable": true
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -2869,7 +2955,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -2902,7 +2989,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -2935,7 +3023,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -2968,7 +3057,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -3001,7 +3091,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -3034,7 +3125,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -3067,7 +3159,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -3100,7 +3193,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -3133,7 +3227,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -3166,7 +3261,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -3199,7 +3295,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -3232,7 +3329,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -3265,7 +3363,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -3298,7 +3397,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -3331,7 +3431,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -3364,7 +3465,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -3397,7 +3499,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -3430,7 +3533,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -3463,7 +3567,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -3496,7 +3601,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -3529,7 +3635,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -3562,7 +3669,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -3595,7 +3703,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -3628,7 +3737,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -3661,7 +3771,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -3694,7 +3805,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -3727,7 +3839,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -3759,7 +3872,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": false,
-      "enchantable": true
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -3800,7 +3914,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -3833,7 +3948,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -3866,7 +3982,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -3899,7 +4016,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -3932,7 +4050,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -3965,7 +4084,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -3998,7 +4118,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -4031,7 +4152,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -4064,7 +4186,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -4097,7 +4220,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -4130,7 +4254,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -4163,7 +4288,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -4196,7 +4322,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -4229,7 +4356,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -4262,7 +4390,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -4294,7 +4423,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": false,
-      "enchantable": true
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -4335,7 +4465,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -4368,7 +4499,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -4401,7 +4533,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -4434,7 +4567,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -4467,7 +4601,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -4500,7 +4635,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -4533,7 +4669,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -4566,7 +4703,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -4599,7 +4737,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -4632,7 +4771,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -4665,7 +4805,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -4698,7 +4839,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -4731,7 +4873,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -4764,7 +4907,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -4797,7 +4941,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -4829,7 +4974,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": false,
-      "enchantable": true
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -4870,7 +5016,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -4903,7 +5050,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -4936,7 +5084,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -4969,7 +5118,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -5002,7 +5152,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -5035,7 +5186,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -5068,7 +5220,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -5101,7 +5254,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -5134,7 +5288,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -5167,7 +5322,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -5200,7 +5356,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -5233,7 +5390,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -5266,7 +5424,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -5299,7 +5458,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -5332,7 +5492,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -5365,7 +5526,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -5398,7 +5560,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -5431,7 +5594,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -5464,7 +5628,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -5497,7 +5662,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -5530,7 +5696,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -5563,7 +5730,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -5596,7 +5764,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -5629,7 +5798,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -5662,7 +5832,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -5695,7 +5866,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -5728,7 +5900,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -5761,7 +5934,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -5794,7 +5968,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": false,
-      "enchantable": true
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -5835,7 +6010,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -5868,7 +6044,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -5901,7 +6078,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -5934,7 +6112,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -5967,7 +6146,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -6000,7 +6180,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -6033,7 +6214,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -6066,7 +6248,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -6099,7 +6282,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -6132,7 +6316,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -6165,7 +6350,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -6198,7 +6384,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -6231,7 +6418,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -6264,7 +6452,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -6297,7 +6486,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": false,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -6325,7 +6515,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": false,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -6353,7 +6544,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": false,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -6381,7 +6573,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": false,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -6409,7 +6602,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": false,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -6437,7 +6631,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": false,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -6465,7 +6660,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": false,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -6493,7 +6689,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": false,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -6521,7 +6718,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": false,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -6549,7 +6747,8 @@
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -6577,7 +6776,8 @@
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -6605,7 +6805,8 @@
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -6633,7 +6834,8 @@
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -6658,7 +6860,8 @@
       "quest_item": true,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -6680,7 +6883,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": false,
-      "enchantable": true
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -6721,7 +6925,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -6754,7 +6959,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -6787,7 +6993,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -6820,7 +7027,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -6853,7 +7061,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -6886,7 +7095,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -6919,7 +7129,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -6952,7 +7163,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -6985,7 +7197,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -7018,7 +7231,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -7051,7 +7265,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -7084,7 +7299,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -7117,7 +7333,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -7150,7 +7367,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -7183,7 +7401,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -7216,7 +7435,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -7249,7 +7469,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -7282,7 +7503,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -7315,7 +7537,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -7348,7 +7571,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -7381,7 +7605,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -7414,7 +7639,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -7447,7 +7673,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -7480,7 +7707,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -7513,7 +7741,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -7546,7 +7775,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -7579,7 +7809,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -7603,13 +7834,16 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -7650,7 +7884,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -7683,7 +7918,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -7716,7 +7952,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -7749,7 +7986,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -7782,7 +8020,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -7815,7 +8054,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -7848,7 +8088,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -7881,7 +8122,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -7914,7 +8156,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -7947,7 +8190,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -7980,7 +8224,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -8013,7 +8258,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -8046,7 +8292,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -8079,7 +8326,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -8112,7 +8360,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -8136,13 +8385,16 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -8183,7 +8435,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -8216,7 +8469,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -8249,7 +8503,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -8282,7 +8537,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -8315,7 +8571,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -8348,7 +8605,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -8381,7 +8639,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -8414,7 +8673,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -8447,7 +8707,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -8480,7 +8741,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -8513,7 +8775,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -8546,7 +8809,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -8579,7 +8843,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -8612,7 +8877,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -8645,7 +8911,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -8669,13 +8936,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -8716,7 +8986,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -8749,7 +9020,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -8782,7 +9054,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -8815,7 +9088,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -8848,7 +9122,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -8881,7 +9156,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -8914,7 +9190,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -8947,7 +9224,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -8980,7 +9258,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -9013,7 +9292,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -9046,7 +9326,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -9079,7 +9360,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -9112,7 +9394,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -9145,7 +9428,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -9178,7 +9462,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -9211,7 +9496,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -9244,7 +9530,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -9277,7 +9564,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -9310,7 +9598,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -9343,7 +9632,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -9376,7 +9666,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -9409,7 +9700,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -9442,7 +9734,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -9475,7 +9768,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -9508,7 +9802,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -9541,7 +9836,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -9574,7 +9870,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -9607,7 +9904,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -9631,13 +9929,16 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -9678,7 +9979,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -9711,7 +10013,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -9744,7 +10047,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -9777,7 +10081,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -9810,7 +10115,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -9843,7 +10149,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -9876,7 +10183,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -9909,7 +10217,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -9942,7 +10251,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -9975,7 +10285,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -10008,7 +10319,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -10041,7 +10353,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -10074,7 +10387,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -10107,7 +10421,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -10131,13 +10446,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -10182,7 +10500,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -10215,7 +10534,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -10248,7 +10568,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -10281,7 +10602,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -10314,7 +10636,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -10347,7 +10670,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -10380,7 +10704,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -10413,7 +10738,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -10446,7 +10772,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -10479,7 +10806,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -10512,7 +10840,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -10545,7 +10874,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -10578,7 +10908,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -10611,7 +10942,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -10644,7 +10976,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -10677,7 +11010,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -10710,7 +11044,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -10743,7 +11078,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -10776,7 +11112,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -10809,7 +11146,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -10842,7 +11180,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -10875,7 +11214,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -10908,7 +11248,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -10941,7 +11282,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -10974,7 +11316,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -11007,7 +11350,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -11040,7 +11384,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -11064,13 +11409,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -11115,7 +11463,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -11148,7 +11497,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -11181,7 +11531,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -11214,7 +11565,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -11247,7 +11599,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -11280,7 +11633,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -11313,7 +11667,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -11346,7 +11701,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -11379,7 +11735,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -11412,7 +11769,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -11445,7 +11803,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -11478,7 +11837,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -11511,7 +11871,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -11544,7 +11905,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -11577,7 +11939,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -11610,7 +11973,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -11643,7 +12007,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -11667,13 +12032,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -11718,7 +12086,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -11751,7 +12120,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -11784,7 +12154,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -11817,7 +12188,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -11850,7 +12222,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -11883,7 +12256,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -11916,7 +12290,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -11949,7 +12324,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -11982,7 +12358,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -12015,7 +12392,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -12048,7 +12426,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -12081,7 +12460,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -12114,7 +12494,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -12147,7 +12528,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -12180,7 +12562,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -12213,7 +12596,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -12246,7 +12630,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -12279,7 +12664,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -12312,7 +12698,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -12345,7 +12732,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -12378,7 +12766,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -12402,13 +12791,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -12453,7 +12845,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -12486,7 +12879,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -12519,7 +12913,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -12552,7 +12947,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -12585,7 +12981,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -12618,7 +13015,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -12651,7 +13049,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -12684,7 +13083,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -12717,7 +13117,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -12750,7 +13151,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -12783,7 +13185,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -12816,7 +13219,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -12849,7 +13253,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -12882,7 +13287,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -12915,7 +13321,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -12948,7 +13355,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -12981,7 +13389,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -13014,7 +13423,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -13047,7 +13457,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -13080,7 +13491,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -13113,7 +13525,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -13146,7 +13559,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -13179,7 +13593,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -13212,7 +13627,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -13245,7 +13661,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -13278,7 +13695,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -13311,7 +13729,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -13344,7 +13763,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -13368,13 +13788,16 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -13415,7 +13838,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -13448,7 +13872,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -13481,7 +13906,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -13514,7 +13940,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -13547,7 +13974,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -13580,7 +14008,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -13613,7 +14042,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -13646,7 +14076,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -13679,7 +14110,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -13712,7 +14144,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -13745,7 +14178,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -13778,7 +14212,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -13811,7 +14246,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -13844,7 +14280,8 @@
       "quest_item": false,
       "unique_item": false,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -13868,13 +14305,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": "Frost spells do 25% more damage.",
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": true,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -13898,13 +14339,16 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -13940,13 +14384,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -13970,13 +14418,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -14000,13 +14452,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -14030,13 +14486,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -14060,13 +14520,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -14090,13 +14554,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -14120,13 +14588,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -14150,13 +14622,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -14180,13 +14656,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -14210,13 +14690,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -14240,13 +14724,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -14270,13 +14758,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -14300,13 +14792,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -14330,13 +14826,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -14360,13 +14860,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -14390,13 +14894,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -14420,13 +14928,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -14450,13 +14962,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -14480,13 +14996,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -14510,13 +15030,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -14540,13 +15064,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -14570,13 +15098,16 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -14612,13 +15143,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -14642,13 +15177,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -14672,13 +15211,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -14702,13 +15245,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -14732,13 +15279,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -14762,13 +15313,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -14792,13 +15347,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -14822,13 +15381,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -14852,13 +15415,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -14882,13 +15449,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -14912,13 +15483,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -14942,13 +15517,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -14972,13 +15551,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -15002,13 +15585,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -15032,13 +15619,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -15062,13 +15653,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -15092,13 +15687,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -15122,13 +15721,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -15152,13 +15755,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -15182,13 +15789,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -15212,13 +15823,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -15242,13 +15857,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -15272,13 +15891,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -15302,13 +15925,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -15332,13 +15959,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -15362,13 +15993,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -15392,13 +16027,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -15422,13 +16061,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -15452,13 +16095,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -15482,13 +16129,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -15512,13 +16163,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -15542,13 +16197,16 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -15584,13 +16242,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -15626,13 +16287,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -15656,13 +16321,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -15686,13 +16355,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -15716,13 +16389,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -15746,13 +16423,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -15776,13 +16457,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -15806,13 +16491,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -15836,13 +16525,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -15866,13 +16559,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -15896,13 +16593,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -15926,13 +16627,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -15956,13 +16661,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -15986,13 +16695,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -16016,13 +16729,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -16046,13 +16763,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -16076,13 +16797,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -16106,13 +16831,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -16136,13 +16865,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -16166,13 +16899,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -16196,13 +16933,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -16226,13 +16967,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -16256,13 +17001,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -16286,13 +17035,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -16316,13 +17069,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -16346,13 +17103,16 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -16388,13 +17148,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -16418,13 +17182,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -16448,13 +17216,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -16478,13 +17250,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -16508,13 +17284,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -16538,13 +17318,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -16568,13 +17352,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -16598,13 +17386,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -16628,13 +17420,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -16658,13 +17454,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -16688,13 +17488,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -16718,13 +17522,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -16748,13 +17556,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -16778,13 +17590,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -16808,13 +17624,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -16838,13 +17658,16 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -16872,13 +17695,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -16902,13 +17729,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -16932,13 +17763,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -16962,13 +17797,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -16992,13 +17831,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -17022,13 +17865,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -17052,13 +17899,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -17082,13 +17933,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -17112,13 +17967,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -17142,13 +18001,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -17172,13 +18035,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -17202,13 +18069,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -17232,13 +18103,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -17262,13 +18137,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -17292,13 +18171,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -17322,13 +18205,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -17352,13 +18239,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -17382,13 +18273,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -17412,13 +18307,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -17442,13 +18341,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -17472,13 +18375,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -17502,13 +18409,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -17532,13 +18443,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -17562,13 +18477,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -17592,13 +18511,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -17622,13 +18545,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -17652,13 +18579,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -17682,13 +18613,16 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -17716,13 +18650,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -17746,13 +18684,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -17776,13 +18718,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -17806,13 +18752,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -17836,13 +18786,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -17866,13 +18820,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -17896,13 +18854,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -17926,13 +18888,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -17956,13 +18922,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -17986,13 +18956,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -18016,13 +18990,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -18046,13 +19024,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -18076,13 +19058,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -18106,13 +19092,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -18136,13 +19126,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -18166,13 +19160,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -18196,13 +19194,16 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -18230,13 +19231,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -18260,13 +19265,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -18290,13 +19299,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -18320,13 +19333,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -18350,13 +19367,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -18380,13 +19401,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -18410,13 +19435,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -18440,13 +19469,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -18470,13 +19503,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -18500,13 +19537,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -18530,13 +19571,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -18560,13 +19605,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -18590,13 +19639,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -18620,13 +19673,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -18650,13 +19707,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -18680,13 +19741,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -18714,13 +19778,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -18744,13 +19812,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -18774,13 +19846,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -18804,13 +19880,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -18834,13 +19914,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -18864,13 +19948,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -18894,13 +19982,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -18924,13 +20016,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -18954,13 +20050,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -18984,13 +20084,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -19014,13 +20118,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -19044,13 +20152,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -19074,13 +20186,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -19104,13 +20220,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -19134,13 +20254,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -19164,13 +20288,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -19194,13 +20322,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -19224,13 +20356,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -19254,13 +20390,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -19284,13 +20424,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -19314,13 +20458,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -19344,13 +20492,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -19374,13 +20526,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -19404,13 +20560,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -19434,13 +20594,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -19464,13 +20628,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -19494,13 +20662,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -19524,13 +20696,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -19554,13 +20730,16 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": "Opponents that get too close take 5 points of poison damage per second.",
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -19584,13 +20763,16 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -19618,13 +20800,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -19648,13 +20834,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -19678,13 +20868,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -19708,13 +20902,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -19738,13 +20936,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -19768,13 +20970,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -19798,13 +21004,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -19828,13 +21038,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -19858,13 +21072,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -19888,13 +21106,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -19918,13 +21140,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -19948,13 +21174,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -19978,13 +21208,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -20008,13 +21242,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -20038,13 +21276,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -20068,13 +21310,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -20110,13 +21355,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -20140,13 +21389,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -20170,13 +21423,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -20200,13 +21457,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -20230,13 +21491,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -20260,13 +21525,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -20290,13 +21559,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -20320,13 +21593,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -20350,13 +21627,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -20380,13 +21661,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -20410,13 +21695,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -20440,13 +21729,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -20470,13 +21763,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -20500,13 +21797,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -20530,13 +21831,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -20560,13 +21865,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -20590,13 +21899,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -20620,13 +21933,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -20650,13 +21967,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -20680,13 +22001,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -20710,13 +22035,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -20740,13 +22069,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -20782,13 +22114,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -20812,13 +22148,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -20842,13 +22182,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -20872,13 +22216,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -20902,13 +22250,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -20932,13 +22284,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -20962,13 +22318,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -20992,13 +22352,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -21022,13 +22386,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -21052,13 +22420,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -21082,13 +22454,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -21112,13 +22488,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -21142,13 +22522,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -21172,13 +22556,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -21202,13 +22590,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -21232,13 +22624,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -21262,13 +22658,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -21292,13 +22692,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -21322,13 +22726,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -21352,13 +22760,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -21382,13 +22794,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -21412,13 +22828,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -21442,13 +22862,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -21472,13 +22896,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -21502,13 +22930,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -21532,13 +22964,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -21562,13 +22998,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -21592,13 +23032,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -21622,13 +23066,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -21652,13 +23100,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -21682,13 +23134,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -21712,13 +23168,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -21742,13 +23202,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -21772,13 +23236,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -21802,13 +23270,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -21832,13 +23304,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -21862,13 +23338,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -21892,13 +23372,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -21922,13 +23406,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -21952,13 +23440,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -21994,13 +23485,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -22036,13 +23530,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -22061,13 +23559,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -22086,13 +23588,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -22111,13 +23617,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -22136,13 +23646,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -22161,13 +23675,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -22186,13 +23704,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -22211,13 +23733,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -22236,13 +23762,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -22261,13 +23791,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -22286,13 +23820,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -22311,13 +23849,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -22336,13 +23878,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -22361,13 +23907,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -22386,13 +23936,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -22411,13 +23965,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -22436,13 +23994,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -22461,13 +24023,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -22486,13 +24052,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -22511,13 +24081,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -22536,13 +24110,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -22561,13 +24139,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -22586,13 +24168,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -22611,13 +24197,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -22636,13 +24226,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -22661,13 +24255,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -22686,13 +24284,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -22711,13 +24313,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -22753,13 +24358,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -22783,13 +24392,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -22813,13 +24426,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -22843,13 +24460,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -22873,13 +24494,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -22903,13 +24528,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -22933,13 +24562,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -22963,13 +24596,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -22993,13 +24630,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -23023,13 +24664,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -23053,13 +24698,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -23083,13 +24732,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -23113,13 +24766,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -23143,13 +24800,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -23173,13 +24834,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -23203,13 +24868,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -23233,13 +24902,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -23263,13 +24936,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -23293,13 +24970,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -23323,13 +25004,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -23353,13 +25038,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -23383,13 +25072,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -23413,13 +25106,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -23443,13 +25140,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -23473,13 +25174,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": true,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -23498,13 +25202,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": true,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -23523,13 +25230,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": true,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -23548,13 +25258,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": true,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -23573,13 +25286,16 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -23611,13 +25327,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -23641,13 +25361,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -23671,13 +25395,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -23701,13 +25429,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -23731,13 +25463,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -23761,13 +25497,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -23791,13 +25531,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -23821,13 +25565,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -23851,13 +25599,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -23881,13 +25633,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -23911,13 +25667,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -23941,13 +25701,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -23971,13 +25735,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -24001,13 +25769,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -24031,13 +25803,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -24063,11 +25839,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -24088,11 +25865,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -24113,11 +25891,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -24136,13 +25915,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": true,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -24161,13 +25944,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
-      "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "unique_item": true,
+      "rare_item": true,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -24186,13 +25973,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
-      "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "unique_item": true,
+      "rare_item": true,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -24211,13 +26002,16 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -24236,13 +26030,16 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": true,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -24261,13 +26058,16 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -24286,13 +26086,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -24311,13 +26114,16 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -24336,13 +26142,16 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": true,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -24361,13 +26170,16 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -24386,13 +26198,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -24411,13 +26226,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -24436,13 +26254,16 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -24463,11 +26284,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -24488,11 +26310,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -24513,11 +26336,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -24538,11 +26362,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -24563,11 +26388,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -24588,11 +26414,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -24613,11 +26440,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -24638,11 +26466,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -24663,11 +26492,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -24688,11 +26518,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -24711,13 +26542,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -24743,11 +26577,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": true
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -24768,20 +26603,16 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": true
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
-    "tempering_materials": [
-      {
-        "item_code": "000DB5D2",
-        "quantity": 1
-      }
-    ]
+    "tempering_materials": []
   },
   {
     "attributes": {
@@ -24791,13 +26622,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -24833,13 +26667,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -24863,13 +26701,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -24893,13 +26735,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -24923,13 +26769,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -24953,13 +26803,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -24983,13 +26837,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -25013,13 +26871,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -25043,13 +26905,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -25073,13 +26939,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -25103,13 +26973,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -25133,13 +27007,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -25163,13 +27041,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -25193,13 +27075,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -25223,13 +27109,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -25253,13 +27143,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -25283,13 +27177,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -25313,13 +27211,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -25343,13 +27245,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -25373,13 +27279,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -25403,13 +27313,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -25433,13 +27347,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -25463,13 +27381,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -25493,13 +27415,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -25523,13 +27449,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -25553,13 +27483,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -25583,13 +27517,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -25613,13 +27551,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -25637,19 +27579,23 @@
   },
   {
     "attributes": {
-      "name": "Glass Armorof Eminent Destruction",
+      "name": "Glass Armor of Eminent Destruction",
       "item_code": "0010CFA0",
       "unit_weight": 7,
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": false,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -25668,13 +27614,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -25710,13 +27659,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -25740,13 +27693,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -25770,13 +27727,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -25800,13 +27761,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -25830,13 +27795,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -25860,13 +27829,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -25890,13 +27863,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -25920,13 +27897,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -25950,13 +27931,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -25980,13 +27965,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -26010,13 +27999,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -26040,13 +28033,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -26070,13 +28067,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -26100,13 +28101,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -26130,13 +28135,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -26160,13 +28169,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -26190,13 +28203,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -26220,13 +28237,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -26250,13 +28271,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -26280,13 +28305,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -26322,13 +28350,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -26352,13 +28384,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -26382,13 +28418,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -26412,13 +28452,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -26442,13 +28486,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -26472,13 +28520,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -26502,13 +28554,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -26532,13 +28588,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -26562,13 +28622,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -26592,13 +28656,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -26622,13 +28690,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -26652,13 +28724,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -26682,13 +28758,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -26712,13 +28792,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -26742,13 +28826,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -26772,13 +28860,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -26802,13 +28894,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -26832,13 +28928,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -26862,13 +28962,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -26892,13 +28996,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -26922,13 +29030,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -26952,13 +29064,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -26994,13 +29109,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -27024,13 +29143,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -27054,13 +29177,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -27084,13 +29211,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -27114,13 +29245,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -27144,13 +29279,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -27174,13 +29313,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -27204,13 +29347,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -27234,13 +29381,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -27264,13 +29415,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -27294,13 +29449,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -27324,13 +29483,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -27354,13 +29517,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -27384,13 +29551,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -27414,13 +29585,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -27444,13 +29619,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -27474,13 +29653,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -27504,13 +29687,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -27534,13 +29721,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -27564,13 +29755,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -27594,13 +29789,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -27624,13 +29823,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -27654,13 +29857,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -27684,13 +29891,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -27714,13 +29925,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -27744,13 +29959,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -27774,13 +29993,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -27804,13 +30027,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -27834,13 +30061,16 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -27872,13 +30102,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -27902,13 +30136,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -27932,13 +30170,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -27962,13 +30204,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -27992,13 +30238,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -28022,13 +30272,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -28052,13 +30306,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -28082,13 +30340,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -28112,13 +30374,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -28142,13 +30408,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -28172,13 +30442,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -28202,13 +30476,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -28232,13 +30510,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -28262,13 +30544,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -28292,13 +30578,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Glass Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -28324,11 +30614,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -28356,13 +30647,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -28386,13 +30680,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -28416,13 +30713,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -28446,13 +30746,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -28476,13 +30779,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -28506,13 +30812,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -28536,13 +30845,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": true,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -28572,11 +30885,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -28604,13 +30918,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -28634,13 +30951,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -28664,13 +30984,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -28694,13 +31017,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -28724,13 +31050,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -28754,13 +31083,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -28784,13 +31116,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -28814,13 +31149,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -28844,13 +31182,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -28874,13 +31215,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -28904,13 +31248,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -28934,13 +31281,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -28964,13 +31314,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -28994,13 +31347,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -29024,13 +31380,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -29054,13 +31413,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -29084,13 +31446,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -29114,13 +31479,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -29144,13 +31512,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -29174,13 +31545,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -29204,13 +31578,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -29236,11 +31613,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -29268,13 +31646,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -29298,13 +31679,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -29328,13 +31712,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -29358,13 +31745,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -29388,13 +31778,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -29418,13 +31811,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -29448,13 +31844,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -29478,13 +31877,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -29508,13 +31910,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -29538,13 +31943,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -29568,13 +31976,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -29598,13 +32009,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -29628,13 +32042,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -29658,13 +32075,16 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -29688,13 +32108,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -29718,13 +32141,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -29748,13 +32174,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -29778,13 +32207,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -29810,11 +32242,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -29842,13 +32275,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -29872,13 +32308,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -29902,13 +32341,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -29932,13 +32374,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -29962,13 +32407,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -29992,13 +32440,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -30022,13 +32473,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -30052,13 +32506,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -30082,13 +32539,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -30112,13 +32572,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -30142,13 +32605,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -30172,13 +32638,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -30202,13 +32671,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -30232,13 +32704,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -30262,13 +32737,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -30292,13 +32770,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -30322,13 +32803,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -30352,13 +32836,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -30382,13 +32869,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -30412,13 +32902,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -30442,13 +32935,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -30474,11 +32970,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -30506,13 +33003,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -30536,13 +33036,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -30566,13 +33069,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -30596,13 +33102,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -30626,13 +33135,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -30656,13 +33168,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -30686,13 +33201,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -30716,13 +33234,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -30746,13 +33267,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -30776,13 +33300,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -30806,13 +33333,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -30836,13 +33366,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -30866,13 +33399,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -30896,13 +33432,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -30926,13 +33465,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -30956,13 +33498,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -30986,13 +33531,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -31016,13 +33564,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -31046,13 +33597,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -31076,13 +33630,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -31106,13 +33663,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -31136,13 +33696,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -31166,13 +33729,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -31196,13 +33762,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -31228,11 +33797,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -31260,13 +33830,16 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -31290,13 +33863,16 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -31320,13 +33896,16 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -31350,13 +33929,16 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -31380,13 +33962,16 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -31410,13 +33995,16 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -31440,13 +34028,16 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -31470,13 +34061,16 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -31500,13 +34094,16 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -31530,13 +34127,16 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -31560,13 +34160,16 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -31590,13 +34193,16 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -31620,13 +34226,16 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -31650,13 +34259,16 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -31680,13 +34292,16 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -31712,11 +34327,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -31737,11 +34353,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -31762,11 +34379,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -31785,13 +34403,16 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -31823,13 +34444,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -31853,13 +34478,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -31883,13 +34512,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -31913,13 +34546,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -31943,13 +34580,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -31973,13 +34614,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -32003,13 +34648,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -32033,13 +34682,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -32063,13 +34716,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -32093,13 +34750,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -32123,13 +34784,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -32153,13 +34818,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -32183,13 +34852,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -32213,13 +34886,16 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -32251,13 +34927,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -32281,13 +34961,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -32311,13 +34995,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -32341,13 +35029,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -32371,13 +35063,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -32401,13 +35097,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -32431,13 +35131,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -32461,13 +35165,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -32491,13 +35199,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -32521,13 +35233,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -32551,13 +35267,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -32581,13 +35301,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -32611,13 +35335,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -32641,13 +35369,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -32671,13 +35403,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -32701,13 +35437,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -32731,13 +35471,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -32761,13 +35505,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -32791,13 +35539,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -32821,13 +35573,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -32851,13 +35607,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -32881,13 +35641,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -32911,13 +35675,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -32941,13 +35709,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -32971,13 +35743,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -33001,13 +35777,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -33031,13 +35811,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -33061,13 +35845,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -33091,13 +35879,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -33121,13 +35913,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -33151,13 +35947,16 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -33189,13 +35988,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -33219,13 +36022,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -33249,13 +36056,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -33279,13 +36090,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -33309,13 +36124,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -33339,13 +36158,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -33369,13 +36192,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -33399,13 +36226,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -33429,13 +36260,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -33459,13 +36294,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -33489,13 +36328,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -33519,13 +36362,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -33549,13 +36396,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -33579,13 +36430,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -33609,13 +36464,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -33639,13 +36498,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -33669,13 +36532,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -33699,13 +36566,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -33729,13 +36600,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -33759,13 +36634,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -33789,13 +36668,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -33819,13 +36702,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -33849,13 +36736,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -33879,13 +36770,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -33909,13 +36804,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -33939,13 +36838,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -33969,13 +36872,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -33999,13 +36906,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -34029,13 +36940,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -34059,13 +36974,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -34089,13 +37008,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -34119,13 +37042,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -34149,13 +37076,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -34179,13 +37110,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -34209,13 +37144,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -34239,13 +37178,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -34269,13 +37212,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -34299,13 +37246,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -34329,13 +37280,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -34359,13 +37314,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -34389,13 +37348,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -34419,13 +37382,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -34449,13 +37416,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -34479,13 +37450,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -34509,13 +37484,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -34539,13 +37518,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -34569,13 +37552,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -34599,13 +37586,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -34629,13 +37620,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -34659,13 +37654,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -34689,13 +37688,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -34719,13 +37722,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -34749,13 +37756,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -34779,13 +37790,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -34809,13 +37824,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": true,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -34847,13 +37865,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -34877,13 +37899,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -34907,13 +37933,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -34937,13 +37967,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -34967,13 +38001,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -34997,13 +38035,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -35027,13 +38069,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -35057,13 +38103,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -35087,13 +38137,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -35117,13 +38171,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -35147,13 +38205,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -35177,13 +38239,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -35207,13 +38273,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -35237,13 +38307,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -35267,13 +38341,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -35297,13 +38375,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -35327,13 +38409,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -35357,13 +38443,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -35387,13 +38477,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -35417,13 +38511,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -35447,13 +38545,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -35477,13 +38579,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -35507,13 +38613,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -35537,13 +38647,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -35575,13 +38688,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -35613,13 +38729,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -35651,13 +38770,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -35689,13 +38811,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -35704,7 +38830,12 @@
       }
     ],
     "crafting_materials": [],
-    "tempering_materials": []
+    "tempering_materials": [
+      {
+        "item_code": "000DB5D2",
+        "quantity": 1
+      }
+    ]
   },
   {
     "attributes": {
@@ -35714,13 +38845,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -35729,7 +38864,12 @@
       }
     ],
     "crafting_materials": [],
-    "tempering_materials": []
+    "tempering_materials": [
+      {
+        "item_code": "000DB5D2",
+        "quantity": 1
+      }
+    ]
   },
   {
     "attributes": {
@@ -35739,13 +38879,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -35754,7 +38898,12 @@
       }
     ],
     "crafting_materials": [],
-    "tempering_materials": []
+    "tempering_materials": [
+      {
+        "item_code": "000DB5D2",
+        "quantity": 1
+      }
+    ]
   },
   {
     "attributes": {
@@ -35764,13 +38913,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -35779,7 +38932,12 @@
       }
     ],
     "crafting_materials": [],
-    "tempering_materials": []
+    "tempering_materials": [
+      {
+        "item_code": "000DB5D2",
+        "quantity": 1
+      }
+    ]
   },
   {
     "attributes": {
@@ -35789,13 +38947,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -35804,7 +38966,12 @@
       }
     ],
     "crafting_materials": [],
-    "tempering_materials": []
+    "tempering_materials": [
+      {
+        "item_code": "000DB5D2",
+        "quantity": 1
+      }
+    ]
   },
   {
     "attributes": {
@@ -35814,13 +38981,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -35829,7 +39000,12 @@
       }
     ],
     "crafting_materials": [],
-    "tempering_materials": []
+    "tempering_materials": [
+      {
+        "item_code": "000DB5D2",
+        "quantity": 1
+      }
+    ]
   },
   {
     "attributes": {
@@ -35839,13 +39015,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -35854,7 +39034,12 @@
       }
     ],
     "crafting_materials": [],
-    "tempering_materials": []
+    "tempering_materials": [
+      {
+        "item_code": "000DB5D2",
+        "quantity": 1
+      }
+    ]
   },
   {
     "attributes": {
@@ -35864,13 +39049,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -35879,7 +39068,12 @@
       }
     ],
     "crafting_materials": [],
-    "tempering_materials": []
+    "tempering_materials": [
+      {
+        "item_code": "000DB5D2",
+        "quantity": 1
+      }
+    ]
   },
   {
     "attributes": {
@@ -35889,13 +39083,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -35904,7 +39102,12 @@
       }
     ],
     "crafting_materials": [],
-    "tempering_materials": []
+    "tempering_materials": [
+      {
+        "item_code": "000DB5D2",
+        "quantity": 1
+      }
+    ]
   },
   {
     "attributes": {
@@ -35914,13 +39117,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -35929,7 +39136,12 @@
       }
     ],
     "crafting_materials": [],
-    "tempering_materials": []
+    "tempering_materials": [
+      {
+        "item_code": "000DB5D2",
+        "quantity": 1
+      }
+    ]
   },
   {
     "attributes": {
@@ -35939,13 +39151,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -35954,7 +39170,12 @@
       }
     ],
     "crafting_materials": [],
-    "tempering_materials": []
+    "tempering_materials": [
+      {
+        "item_code": "000DB5D2",
+        "quantity": 1
+      }
+    ]
   },
   {
     "attributes": {
@@ -35964,13 +39185,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -35979,7 +39204,12 @@
       }
     ],
     "crafting_materials": [],
-    "tempering_materials": []
+    "tempering_materials": [
+      {
+        "item_code": "000DB5D2",
+        "quantity": 1
+      }
+    ]
   },
   {
     "attributes": {
@@ -35989,13 +39219,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -36004,7 +39238,12 @@
       }
     ],
     "crafting_materials": [],
-    "tempering_materials": []
+    "tempering_materials": [
+      {
+        "item_code": "000DB5D2",
+        "quantity": 1
+      }
+    ]
   },
   {
     "attributes": {
@@ -36014,13 +39253,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -36029,7 +39272,12 @@
       }
     ],
     "crafting_materials": [],
-    "tempering_materials": []
+    "tempering_materials": [
+      {
+        "item_code": "000DB5D2",
+        "quantity": 1
+      }
+    ]
   },
   {
     "attributes": {
@@ -36039,13 +39287,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -36054,7 +39306,12 @@
       }
     ],
     "crafting_materials": [],
-    "tempering_materials": []
+    "tempering_materials": [
+      {
+        "item_code": "000DB5D2",
+        "quantity": 1
+      }
+    ]
   },
   {
     "attributes": {
@@ -36064,13 +39321,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -36079,7 +39340,12 @@
       }
     ],
     "crafting_materials": [],
-    "tempering_materials": []
+    "tempering_materials": [
+      {
+        "item_code": "000DB5D2",
+        "quantity": 1
+      }
+    ]
   },
   {
     "attributes": {
@@ -36089,13 +39355,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -36104,7 +39374,12 @@
       }
     ],
     "crafting_materials": [],
-    "tempering_materials": []
+    "tempering_materials": [
+      {
+        "item_code": "000DB5D2",
+        "quantity": 1
+      }
+    ]
   },
   {
     "attributes": {
@@ -36114,13 +39389,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -36129,7 +39408,12 @@
       }
     ],
     "crafting_materials": [],
-    "tempering_materials": []
+    "tempering_materials": [
+      {
+        "item_code": "000DB5D2",
+        "quantity": 1
+      }
+    ]
   },
   {
     "attributes": {
@@ -36139,13 +39423,16 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -36173,13 +39460,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -36188,7 +39479,12 @@
       }
     ],
     "crafting_materials": [],
-    "tempering_materials": []
+    "tempering_materials": [
+      {
+        "item_code": "000DB5D2",
+        "quantity": 1
+      }
+    ]
   },
   {
     "attributes": {
@@ -36198,13 +39494,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -36213,7 +39513,12 @@
       }
     ],
     "crafting_materials": [],
-    "tempering_materials": []
+    "tempering_materials": [
+      {
+        "item_code": "000DB5D2",
+        "quantity": 1
+      }
+    ]
   },
   {
     "attributes": {
@@ -36223,13 +39528,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -36238,7 +39547,12 @@
       }
     ],
     "crafting_materials": [],
-    "tempering_materials": []
+    "tempering_materials": [
+      {
+        "item_code": "000DB5D2",
+        "quantity": 1
+      }
+    ]
   },
   {
     "attributes": {
@@ -36248,13 +39562,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -36263,7 +39581,12 @@
       }
     ],
     "crafting_materials": [],
-    "tempering_materials": []
+    "tempering_materials": [
+      {
+        "item_code": "000DB5D2",
+        "quantity": 1
+      }
+    ]
   },
   {
     "attributes": {
@@ -36273,13 +39596,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -36288,7 +39615,12 @@
       }
     ],
     "crafting_materials": [],
-    "tempering_materials": []
+    "tempering_materials": [
+      {
+        "item_code": "000DB5D2",
+        "quantity": 1
+      }
+    ]
   },
   {
     "attributes": {
@@ -36298,13 +39630,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -36313,7 +39649,12 @@
       }
     ],
     "crafting_materials": [],
-    "tempering_materials": []
+    "tempering_materials": [
+      {
+        "item_code": "000DB5D2",
+        "quantity": 1
+      }
+    ]
   },
   {
     "attributes": {
@@ -36323,13 +39664,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -36338,7 +39683,12 @@
       }
     ],
     "crafting_materials": [],
-    "tempering_materials": []
+    "tempering_materials": [
+      {
+        "item_code": "000DB5D2",
+        "quantity": 1
+      }
+    ]
   },
   {
     "attributes": {
@@ -36348,13 +39698,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -36363,7 +39717,12 @@
       }
     ],
     "crafting_materials": [],
-    "tempering_materials": []
+    "tempering_materials": [
+      {
+        "item_code": "000DB5D2",
+        "quantity": 1
+      }
+    ]
   },
   {
     "attributes": {
@@ -36373,13 +39732,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -36388,7 +39751,12 @@
       }
     ],
     "crafting_materials": [],
-    "tempering_materials": []
+    "tempering_materials": [
+      {
+        "item_code": "000DB5D2",
+        "quantity": 1
+      }
+    ]
   },
   {
     "attributes": {
@@ -36398,13 +39766,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -36413,7 +39785,12 @@
       }
     ],
     "crafting_materials": [],
-    "tempering_materials": []
+    "tempering_materials": [
+      {
+        "item_code": "000DB5D2",
+        "quantity": 1
+      }
+    ]
   },
   {
     "attributes": {
@@ -36423,13 +39800,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -36438,7 +39819,12 @@
       }
     ],
     "crafting_materials": [],
-    "tempering_materials": []
+    "tempering_materials": [
+      {
+        "item_code": "000DB5D2",
+        "quantity": 1
+      }
+    ]
   },
   {
     "attributes": {
@@ -36448,13 +39834,17 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -36463,7 +39853,12 @@
       }
     ],
     "crafting_materials": [],
-    "tempering_materials": []
+    "tempering_materials": [
+      {
+        "item_code": "000DB5D2",
+        "quantity": 1
+      }
+    ]
   },
   {
     "attributes": {
@@ -36473,13 +39868,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -36498,13 +39896,16 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -36526,39 +39927,22 @@
   },
   {
     "attributes": {
-      "name": "Imperial Studded Armor",
-      "item_code": "00013ED8",
-      "unit_weight": 6,
-      "body_slot": "body",
-      "weight": "light armor",
-      "magical_effects": null,
-      "smithing_perks": [],
-      "dragon_priest_mask": false,
-      "purchasable": null,
-      "quest_item": false,
-      "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
-    },
-    "enchantments": [],
-    "crafting_materials": [],
-    "tempering_materials": []
-  },
-  {
-    "attributes": {
       "name": "Improved Bonemold Armor",
       "item_code": "XX03AB26",
       "unit_weight": 43,
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": true,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -36602,13 +39986,16 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": true,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -36652,13 +40039,16 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": true,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -36704,11 +40094,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": true,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -36754,11 +40145,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": true,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -36804,11 +40196,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -36836,13 +40229,16 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -36866,13 +40262,16 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -36896,13 +40295,16 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -36926,13 +40328,16 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -36956,13 +40361,16 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -36986,13 +40394,16 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -37016,13 +40427,16 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -37046,13 +40460,16 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -37076,13 +40493,16 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -37106,13 +40526,16 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -37136,13 +40559,16 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -37166,13 +40592,16 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -37196,13 +40625,16 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -37226,13 +40658,16 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -37256,13 +40691,16 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -37286,13 +40724,16 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -37316,13 +40757,16 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -37346,13 +40790,16 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -37376,13 +40823,16 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -37406,13 +40856,16 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -37436,13 +40889,16 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -37468,11 +40924,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -37500,13 +40957,16 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -37530,13 +40990,16 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -37560,13 +41023,16 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -37590,13 +41056,16 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -37620,13 +41089,16 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -37650,13 +41122,16 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -37680,13 +41155,16 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -37710,13 +41188,16 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -37740,13 +41221,16 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -37770,13 +41254,16 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -37800,13 +41287,16 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -37830,13 +41320,16 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -37860,13 +41353,16 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -37890,13 +41386,16 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -37920,13 +41419,16 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -37952,11 +41454,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -37984,13 +41487,16 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -38014,13 +41520,16 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -38044,13 +41553,16 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -38074,13 +41586,16 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -38104,13 +41619,16 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -38134,13 +41652,16 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -38164,13 +41685,16 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -38194,13 +41718,16 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -38224,13 +41751,16 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -38254,13 +41784,16 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -38284,13 +41817,16 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -38314,13 +41850,16 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -38344,13 +41883,16 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -38374,13 +41916,16 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -38404,13 +41949,16 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -38436,11 +41984,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -38468,13 +42017,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -38498,13 +42050,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -38528,13 +42083,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -38558,13 +42116,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -38588,13 +42149,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -38618,13 +42182,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -38648,13 +42215,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -38678,13 +42248,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -38708,13 +42281,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -38738,13 +42314,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -38768,13 +42347,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -38798,13 +42380,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -38828,13 +42413,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -38858,13 +42446,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -38888,13 +42479,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -38918,13 +42512,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -38948,13 +42545,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -38978,13 +42578,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -39008,13 +42611,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -39038,13 +42644,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -39068,13 +42677,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -39098,13 +42710,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -39128,13 +42743,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -39158,13 +42776,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -39190,11 +42811,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -39222,13 +42844,16 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -39252,13 +42877,16 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -39282,13 +42910,16 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -39312,13 +42943,16 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -39342,13 +42976,16 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -39372,13 +43009,16 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -39402,13 +43042,16 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -39432,13 +43075,16 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -39462,13 +43108,16 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -39492,13 +43141,16 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -39522,13 +43174,16 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -39552,13 +43207,16 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -39582,13 +43240,16 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -39612,13 +43273,16 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -39642,13 +43306,16 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -39672,13 +43339,16 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -39702,13 +43372,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": "Whenever the wearer is struck while below 15% health, there is a 15% chance that the mask will heal the wearer and any nearby allies with the Grand Healing spell, and grant a Flame Cloak for 10 seconds. Whenever the wearer is struck while below 15% health, there is a 3% chance that the mask will not only restore the user's health, but also summon a Spectral Dragon Priest ally.",
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": true,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -39727,13 +43400,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": true,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -39767,11 +43444,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -39799,13 +43477,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -39829,13 +43510,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -39859,13 +43543,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -39889,13 +43576,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -39919,13 +43609,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -39949,13 +43642,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -39979,13 +43675,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -40009,13 +43708,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -40039,13 +43741,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -40069,13 +43774,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -40099,13 +43807,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -40129,13 +43840,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -40159,13 +43873,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -40189,13 +43906,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -40219,13 +43939,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -40249,13 +43972,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -40279,13 +44005,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -40309,13 +44038,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -40339,13 +44071,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -40369,13 +44104,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -40399,13 +44137,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -40431,11 +44172,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -40463,13 +44205,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -40493,13 +44238,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -40523,13 +44271,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -40553,13 +44304,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -40583,13 +44337,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -40613,13 +44370,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -40643,13 +44403,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -40673,13 +44436,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -40703,13 +44469,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -40733,13 +44502,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -40763,13 +44535,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -40793,13 +44568,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -40823,13 +44601,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -40853,13 +44634,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -40883,13 +44667,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -40913,13 +44700,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -40943,13 +44733,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -40973,13 +44766,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -41005,11 +44801,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -41037,13 +44834,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -41067,13 +44867,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -41097,13 +44900,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -41127,13 +44933,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -41157,13 +44966,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -41187,13 +44999,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -41217,13 +45032,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -41247,13 +45065,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -41277,13 +45098,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -41307,13 +45131,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -41337,13 +45164,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -41367,13 +45197,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -41397,13 +45230,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -41427,13 +45263,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -41457,13 +45296,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -41487,13 +45329,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -41517,13 +45362,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -41547,13 +45395,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -41577,13 +45428,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -41607,13 +45461,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -41637,13 +45494,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -41669,11 +45529,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -41701,13 +45562,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -41731,13 +45595,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -41761,13 +45628,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -41791,13 +45661,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -41821,13 +45694,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -41851,13 +45727,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -41881,13 +45760,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -41911,13 +45793,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -41941,13 +45826,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -41971,13 +45859,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -42001,13 +45892,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -42031,13 +45925,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -42061,13 +45958,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -42091,13 +45991,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -42121,13 +46024,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -42151,13 +46057,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -42181,13 +46090,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -42211,13 +46123,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -42241,13 +46156,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -42271,13 +46189,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -42301,13 +46222,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -42331,13 +46255,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -42361,13 +46288,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -42391,13 +46321,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -42421,13 +46354,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -42451,13 +46387,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -42481,13 +46420,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -42511,13 +46453,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -42543,11 +46488,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -42568,11 +46514,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -42593,11 +46540,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -42618,11 +46566,12 @@
       "magical_effects": "+10 Speechcraft",
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -42640,18 +46589,45 @@
   {
     "attributes": {
       "name": "Miraak",
-      "item_code": "XX039FA1",
+      "item_code": "XX039FA2",
       "unit_weight": 9,
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": true,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": true
+    },
+    "enchantments": [
+      {
+        "name": "Fortify Magicka",
+        "strength": 40
+      }
+    ],
+    "crafting_materials": [],
+    "tempering_materials": []
+  },
+  {
+    "attributes": {
+      "name": "Miraak",
+      "item_code": "XX039D2E",
+      "unit_weight": 9,
+      "body_slot": "head",
+      "weight": "light armor",
+      "magical_effects": null,
+      "smithing_perks": [],
+      "dragon_priest_mask": true,
+      "purchasable": false,
+      "quest_item": true,
+      "unique_item": true,
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": true
     },
     "enchantments": [
       {
@@ -42670,13 +46646,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": true,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -42695,13 +46674,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": true,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -42720,13 +46702,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": true,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -42745,13 +46730,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": true,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -42770,13 +46758,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": true,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -42802,11 +46794,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -42825,13 +46818,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": true,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -42863,13 +46860,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -42897,13 +46897,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -42927,13 +46930,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -42961,13 +46967,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -42991,13 +47000,16 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -43033,13 +47045,16 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -43075,13 +47090,16 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -43117,13 +47135,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -43159,13 +47180,16 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -43197,13 +47221,16 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -43235,13 +47262,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -43265,13 +47296,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -43295,13 +47330,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -43325,13 +47364,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -43355,13 +47398,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -43385,13 +47432,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -43415,13 +47466,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -43445,13 +47500,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -43475,13 +47534,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -43505,13 +47568,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -43535,13 +47602,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -43565,13 +47636,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -43595,13 +47670,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -43625,13 +47704,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -43655,13 +47738,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -43685,13 +47772,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -43715,13 +47806,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -43745,13 +47840,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -43775,13 +47874,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -43805,13 +47908,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -43835,13 +47942,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -43865,13 +47976,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -43895,13 +48010,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -43925,13 +48044,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -43955,13 +48078,16 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -43993,13 +48119,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -44023,13 +48153,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -44053,13 +48187,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -44083,13 +48221,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -44113,13 +48255,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -44143,13 +48289,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -44173,13 +48323,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -44203,13 +48357,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -44233,13 +48391,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -44263,13 +48425,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -44293,13 +48459,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -44323,13 +48493,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -44353,13 +48527,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -44383,13 +48561,16 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -44421,13 +48602,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -44451,13 +48636,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -44481,13 +48670,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -44511,13 +48704,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -44541,13 +48738,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -44571,13 +48772,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -44601,13 +48806,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -44631,13 +48840,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -44661,13 +48874,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -44691,13 +48908,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -44721,13 +48942,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -44751,13 +48976,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -44781,13 +49010,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -44811,13 +49044,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -44841,13 +49078,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -44871,13 +49112,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -44909,13 +49153,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -44939,13 +49187,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -44969,13 +49221,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -44999,13 +49255,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -45029,13 +49289,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -45059,13 +49323,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -45089,13 +49357,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -45119,13 +49391,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -45149,13 +49425,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -45179,13 +49459,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -45209,13 +49493,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -45239,13 +49527,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -45269,13 +49561,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -45299,13 +49595,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -45329,13 +49629,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -45359,13 +49663,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -45389,13 +49697,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -45419,13 +49731,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -45449,13 +49765,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -45479,13 +49799,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -45509,13 +49833,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -45539,13 +49867,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -45569,13 +49901,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -45599,13 +49935,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -45629,13 +49969,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -45659,13 +50003,16 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -45697,13 +50044,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -45727,13 +50078,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -45757,13 +50112,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -45787,13 +50146,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -45817,13 +50180,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -45847,13 +50214,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -45877,13 +50248,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -45907,13 +50282,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -45937,13 +50316,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -45967,13 +50350,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -45997,13 +50384,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -46027,13 +50418,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -46057,13 +50452,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -46087,13 +50486,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -46117,13 +50520,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Orcish Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -46147,13 +50554,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": true,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -46187,11 +50598,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -46212,11 +50624,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -46237,11 +50650,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -46262,11 +50676,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -46287,11 +50702,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -46312,11 +50728,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -46337,11 +50754,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -46360,13 +50778,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -46394,13 +50815,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": true,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -46426,11 +50851,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -46451,11 +50877,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -46476,11 +50903,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -46499,13 +50927,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -46533,13 +50965,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -46575,13 +51010,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -46605,13 +51044,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -46635,13 +51078,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -46665,13 +51112,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -46695,13 +51146,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -46725,13 +51180,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -46755,13 +51214,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -46785,13 +51248,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -46815,13 +51282,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -46845,13 +51316,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -46875,13 +51350,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -46905,13 +51384,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -46935,13 +51418,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -46965,13 +51452,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -46995,13 +51486,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -47025,13 +51520,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -47055,13 +51554,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -47085,13 +51588,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -47115,13 +51622,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -47145,13 +51656,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -47175,13 +51690,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -47205,13 +51724,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -47247,13 +51769,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -47277,13 +51803,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -47307,13 +51837,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -47337,13 +51871,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -47367,13 +51905,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -47397,13 +51939,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -47427,13 +51973,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -47457,13 +52007,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -47487,13 +52041,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -47517,13 +52075,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -47547,13 +52109,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -47577,13 +52143,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -47607,13 +52177,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -47637,13 +52211,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -47667,13 +52245,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -47697,13 +52279,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -47727,13 +52313,17 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -47757,13 +52347,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -47787,13 +52381,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -47829,13 +52426,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -47859,13 +52460,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -47889,13 +52494,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -47919,13 +52528,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -47949,13 +52562,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -47979,13 +52596,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -48009,13 +52630,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -48039,13 +52664,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -48069,13 +52698,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -48099,13 +52732,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -48129,13 +52766,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -48159,13 +52800,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -48189,13 +52834,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -48219,13 +52868,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -48249,13 +52902,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -48279,13 +52936,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -48309,13 +52970,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -48339,13 +53004,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -48369,13 +53038,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -48399,13 +53072,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -48429,13 +53106,17 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -48459,13 +53140,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -48501,13 +53185,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -48531,13 +53219,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -48561,13 +53253,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -48591,13 +53287,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -48621,13 +53321,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -48651,13 +53355,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -48681,13 +53389,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -48711,13 +53423,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -48741,13 +53457,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -48771,13 +53491,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -48801,13 +53525,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -48831,13 +53559,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -48861,13 +53593,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -48891,13 +53627,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -48921,13 +53661,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -48951,13 +53695,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -48981,13 +53729,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -49011,13 +53763,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -49041,13 +53797,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -49071,13 +53831,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -49101,13 +53865,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -49131,13 +53899,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -49161,13 +53933,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -49191,13 +53967,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -49221,13 +54001,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -49253,20 +54037,16 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
-    "tempering_materials": [
-      {
-        "item_code": "0005AD93",
-        "quantity": 1
-      }
-    ]
+    "tempering_materials": []
   },
   {
     "attributes": {
@@ -49276,13 +54056,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": true,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -49312,11 +54095,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -49342,11 +54126,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -49370,13 +54155,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -49400,13 +54188,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -49430,13 +54221,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": "Backstab does double damage",
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -49457,11 +54251,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": true,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -49477,11 +54272,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": true,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -49497,11 +54293,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": true,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -49517,11 +54314,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": true,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -49537,11 +54335,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -49562,11 +54361,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -49587,11 +54387,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -49610,13 +54411,16 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": "Frost enchantments are 25% stronger when placed on Stalhrim items. Chaos damage enchantments are also 25% stronger.",
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -49648,13 +54452,16 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": "Frost enchantments are 25% stronger when placed on Stalhrim items. Chaos damage enchantments are also 25% stronger.",
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -49686,13 +54493,16 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": "Frost enchantments are 25% stronger when placed on Stalhrim items. Chaos damage enchantments are also 25% stronger.",
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -49724,13 +54534,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": "Frost enchantments are 25% stronger when placed on Stalhrim items. Chaos damage enchantments are also 25% stronger.",
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -49762,13 +54575,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": "Frost enchantments are 25% stronger when placed on Stalhrim items. Chaos damage enchantments are also 25% stronger.",
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -49800,13 +54616,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": "Frost enchantments are 25% stronger when placed on Stalhrim items. Chaos damage enchantments are also 25% stronger.",
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -49838,13 +54657,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": "Frost enchantments are 25% stronger when placed on Stalhrim items. Chaos damage enchantments are also 25% stronger.",
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -49876,13 +54698,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": "Frost enchantments are 25% stronger when placed on Stalhrim items. Chaos damage enchantments are also 25% stronger.",
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -49914,13 +54739,16 @@
       "body_slot": "shield",
       "weight": "light armor",
       "magical_effects": "Frost enchantments are 25% stronger when placed on Stalhrim items. Chaos damage enchantments are also 25% stronger.",
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Ebony Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -49952,13 +54780,16 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -49990,13 +54821,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -50020,13 +54855,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -50050,13 +54889,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -50080,13 +54923,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -50110,13 +54957,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -50140,13 +54991,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -50170,13 +55025,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -50200,13 +55059,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -50230,13 +55093,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -50260,13 +55127,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -50290,13 +55161,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -50320,13 +55195,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -50350,13 +55229,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -50380,13 +55263,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -50410,13 +55297,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -50440,13 +55331,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -50470,13 +55365,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -50500,13 +55399,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -50530,13 +55433,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -50560,13 +55467,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -50590,13 +55501,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -50620,13 +55535,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -50650,13 +55569,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -50680,13 +55603,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -50710,13 +55637,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -50740,13 +55671,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -50770,13 +55705,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -50800,13 +55739,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -50830,13 +55773,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -50860,13 +55807,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -50890,13 +55841,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -50920,13 +55875,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -50950,13 +55909,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -50980,13 +55943,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -51010,13 +55977,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -51040,13 +56011,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -51070,13 +56045,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -51100,13 +56079,16 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -51138,13 +56120,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -51168,13 +56154,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -51198,13 +56188,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -51228,13 +56222,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -51258,13 +56256,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -51288,13 +56290,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -51318,13 +56324,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -51348,13 +56358,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -51378,13 +56392,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -51408,13 +56426,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -51438,13 +56460,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -51468,13 +56494,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -51498,13 +56528,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -51528,13 +56562,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -51558,13 +56596,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -51588,13 +56630,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -51626,13 +56671,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -51656,13 +56705,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -51686,13 +56739,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -51716,13 +56773,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -51746,13 +56807,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -51776,13 +56841,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -51806,13 +56875,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -51836,13 +56909,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -51866,13 +56943,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -51896,13 +56977,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -51926,13 +57011,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -51956,13 +57045,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -51986,13 +57079,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -52016,13 +57113,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -52046,13 +57147,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -52076,13 +57181,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -52106,13 +57215,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -52136,13 +57249,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -52166,13 +57283,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -52196,13 +57317,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -52226,13 +57351,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -52256,13 +57385,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -52286,13 +57419,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -52316,13 +57453,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -52346,13 +57487,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -52376,13 +57521,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -52414,13 +57562,16 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -52452,13 +57603,16 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -52490,13 +57644,16 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -52532,13 +57689,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -52562,13 +57723,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -52592,13 +57757,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -52622,13 +57791,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -52652,13 +57825,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -52682,13 +57859,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -52712,13 +57893,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -52742,13 +57927,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -52772,13 +57961,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -52802,13 +57995,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -52832,13 +58029,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -52862,13 +58063,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -52892,13 +58097,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -52922,13 +58131,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -52952,13 +58165,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -52982,13 +58199,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -53012,13 +58233,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -53042,13 +58267,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -53072,13 +58301,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -53102,13 +58335,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -53132,13 +58369,17 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -53162,13 +58403,16 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -53204,13 +58448,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -53234,13 +58482,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -53264,13 +58516,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -53294,13 +58550,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -53324,13 +58584,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -53354,13 +58618,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -53384,13 +58652,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -53414,13 +58686,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -53444,13 +58720,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -53474,13 +58754,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -53504,13 +58788,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -53534,13 +58822,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -53564,13 +58856,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -53594,13 +58890,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -53624,13 +58924,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -53654,13 +58958,17 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -53684,13 +58992,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -53714,13 +59026,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -53744,13 +59060,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -53774,13 +59094,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -53804,13 +59128,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -53834,13 +59162,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -53864,13 +59196,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -53894,13 +59230,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -53924,13 +59264,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -53954,13 +59298,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -53984,13 +59332,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -54014,13 +59366,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -54044,13 +59400,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -54074,13 +59434,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -54104,13 +59468,17 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -54134,13 +59502,16 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -54176,13 +59547,16 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -54218,13 +59592,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -54248,13 +59626,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -54278,13 +59660,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -54308,13 +59694,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -54338,13 +59728,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -54368,13 +59762,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -54398,13 +59796,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -54428,13 +59830,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -54458,13 +59864,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -54488,13 +59898,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -54518,13 +59932,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -54548,13 +59966,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -54578,13 +60000,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -54608,13 +60034,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -54638,13 +60068,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -54668,13 +60102,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -54698,13 +60136,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -54728,13 +60170,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -54758,13 +60204,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -54788,13 +60238,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -54818,13 +60272,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -54848,13 +60306,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -54878,13 +60340,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -54908,13 +60374,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -54938,13 +60408,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -54968,13 +60442,16 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -55006,13 +60483,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -55036,13 +60517,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -55066,13 +60551,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -55096,13 +60585,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -55126,13 +60619,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -55156,13 +60653,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -55186,13 +60687,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -55216,13 +60721,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -55246,13 +60755,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -55276,13 +60789,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -55306,13 +60823,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -55336,13 +60857,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -55366,13 +60891,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -55396,13 +60925,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -55426,13 +60959,17 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -55456,13 +60993,16 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -55496,11 +61036,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -55521,11 +61062,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -55546,11 +61088,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": true,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -55571,11 +61114,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": true,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -55596,11 +61140,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": true,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -55621,11 +61166,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": true,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -55646,11 +61192,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [
@@ -55682,13 +61229,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -55707,13 +61258,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -55732,13 +61287,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -55757,13 +61316,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -55782,13 +61345,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -55807,13 +61374,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -55821,6 +61392,27 @@
         "strength": 15
       }
     ],
+    "crafting_materials": [],
+    "tempering_materials": []
+  },
+  {
+    "attributes": {
+      "name": "Studded Imperial Armor",
+      "item_code": "00013ED8",
+      "unit_weight": 6,
+      "body_slot": "body",
+      "weight": "light armor",
+      "magical_effects": null,
+      "smithing_perks": [],
+      "dragon_priest_mask": false,
+      "purchasable": false,
+      "quest_item": false,
+      "unique_item": false,
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
+    },
+    "enchantments": [],
     "crafting_materials": [],
     "tempering_materials": []
   },
@@ -55834,11 +61426,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -55864,11 +61457,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -55894,11 +61488,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -55924,11 +61519,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -55954,11 +61550,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -55984,11 +61581,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -56012,13 +61610,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -56042,13 +61643,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -56072,13 +61676,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -56102,13 +61709,16 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -56134,11 +61744,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
-      "unique_item": true,
+      "unique_item": false,
       "rare_item": true,
-      "enchantable": true
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -56154,11 +61765,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -56179,11 +61791,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": true
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -56197,13 +61810,16 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -56222,13 +61838,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -56251,13 +61871,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -56280,13 +61904,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -56309,13 +61937,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -56338,13 +61970,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -56367,13 +62003,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -56396,13 +62036,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -56421,13 +62065,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -56446,13 +62094,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -56471,13 +62123,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -56496,13 +62152,16 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -56521,13 +62180,16 @@
       "body_slot": "hands",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": true,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -56546,13 +62208,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -56571,13 +62237,17 @@
       "body_slot": "body",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Advanced Armors",
+        "Arcane Blacksmith"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -56601,13 +62271,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": "Allows wearer to release the Breath of Nchuak, a powerful steam attack.",
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Dwarven Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -56631,13 +62305,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": true,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -56669,13 +62347,17 @@
       "body_slot": "head",
       "weight": "light armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": true,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {
@@ -56709,11 +62391,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -56734,11 +62417,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -56759,11 +62443,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -56784,11 +62469,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -56809,11 +62495,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -56834,11 +62521,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": true
+      "rare_item": false,
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -56859,11 +62547,12 @@
       "magical_effects": null,
       "smithing_perks": [],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": true
+      "enchantable": true,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -56882,13 +62571,16 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -56907,13 +62599,16 @@
       "body_slot": "feet",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -56932,13 +62627,16 @@
       "body_slot": "hands",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -56957,13 +62655,16 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": null,
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "rare_item": null,
-      "enchantable": false
+      "rare_item": true,
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -56984,11 +62685,12 @@
       "magical_effects": "The wooden mask hums with an unfamiliar energy.",
       "smithing_perks": [],
       "dragon_priest_mask": true,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -57002,13 +62704,17 @@
       "body_slot": "head",
       "weight": "heavy armor",
       "magical_effects": "Shock spells do 25% more damage.",
-      "smithing_perks": [],
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": true,
-      "purchasable": null,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
       "rare_item": true,
-      "enchantable": false
+      "enchantable": false,
+      "leveled": false
     },
     "enchantments": [
       {

--- a/lib/tasks/export_csvs.rake
+++ b/lib/tasks/export_csvs.rake
@@ -46,6 +46,8 @@ namespace :csv do
           crafting_material_codes, crafting_material_quantities   = concatenate_values(item[:crafting_materials], :item_code, :quantity)
           tempering_material_codes, tempering_material_quantities = concatenate_values(item[:tempering_materials], :item_code, :quantity)
 
+          item[:attributes][:smithing_perks] = item[:attributes][:smithing_perks].join(',')
+
           csv << item[:attributes].values + [enchantment_names, enchantment_strengths, tempering_material_codes, tempering_material_quantities, crafting_material_codes, crafting_material_quantities]
         end
       end

--- a/spec/models/canonical/armor_spec.rb
+++ b/spec/models/canonical/armor_spec.rb
@@ -96,6 +96,76 @@ RSpec.describe Canonical::Armor, type: :model do
         expect(armor).to be_valid
       end
     end
+
+    describe 'smithing_perks' do
+      it 'must include only valid smithing perks' do
+        model = build(:canonical_armor, smithing_perks: ['Titanium Smithing'])
+
+        model.validate
+        expect(model.errors[:smithing_perks]).to include '"Titanium Smithing" is not a valid smithing perk'
+      end
+    end
+
+    describe 'leveled' do
+      it 'must be true or false' do
+        model = build(:canonical_armor, leveled: nil)
+
+        model.validate
+        expect(model.errors[:leveled]).to include 'must be true or false'
+      end
+    end
+
+    describe 'purchasable' do
+      it 'must be true or false' do
+        model = build(:canonical_armor, purchasable: nil)
+
+        model.validate
+        expect(model.errors[:purchasable]).to include 'must be true or false'
+      end
+    end
+
+    describe 'unique_item' do
+      it 'must be true or false' do
+        model = build(:canonical_armor, unique_item: nil)
+
+        model.validate
+        expect(model.errors[:unique_item]).to include 'must be true or false'
+      end
+    end
+
+    describe 'rare_item' do
+      it 'must be true or false' do
+        model = build(:canonical_armor, rare_item: nil)
+
+        model.validate
+        expect(model.errors[:rare_item]).to include 'must be true or false'
+      end
+
+      it 'must be true if the item is unique' do
+        model = build(:canonical_armor, unique_item: true, rare_item: false)
+
+        model.validate
+        expect(model.errors[:rare_item]).to include 'must be true if item is unique'
+      end
+    end
+
+    describe 'quest_item' do
+      it 'must be true or false' do
+        model = build(:canonical_armor, quest_item: nil)
+
+        model.validate
+        expect(model.errors[:quest_item]).to include 'must be true or false'
+      end
+    end
+
+    describe 'enchantable' do
+      it 'must be true or false' do
+        model = build(:canonical_armor, enchantable: nil)
+
+        model.validate
+        expect(model.errors[:enchantable]).to include 'must be true or false'
+      end
+    end
   end
 
   describe 'associations' do

--- a/spec/support/factories/canonical/armors.rb
+++ b/spec/support/factories/canonical/armors.rb
@@ -2,10 +2,15 @@
 
 FactoryBot.define do
   factory :canonical_armor, class: Canonical::Armor do
-    name                 { 'fur armor' }
+    name                 { 'Steel Plate Armor' }
     sequence(:item_code) {|n| "123abc#{n}" }
-    weight               { 'light armor' }
+    weight               { 'heavy armor' }
     body_slot            { 'body' }
     unit_weight          { 1.0 }
+    smithing_perks       { ['Steel Smithing'] }
+    purchasable          { true }
+    unique_item          { false }
+    rare_item            { false }
+    quest_item           { false }
   end
 end

--- a/spec/support/fixtures/canonical/sync/armor.json
+++ b/spec/support/fixtures/canonical/sync/armor.json
@@ -7,9 +7,15 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": "Enemies who strike you with a melee attack have a small chance of being paralyzed.",
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Daedric Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [],
@@ -29,9 +35,15 @@
       "body_slot": "shield",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Arcane Blacksmith",
+        "Steel Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -56,9 +68,14 @@
       "body_slot": "feet",
       "weight": "light armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Elven Smithing"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": true
     },
     "enchantments": [],
@@ -95,9 +112,14 @@
       "body_slot": "body",
       "weight": "heavy armor",
       "magical_effects": null,
+      "smithing_perks": [
+        "Dragon Armor"
+      ],
       "dragon_priest_mask": false,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": true
     },
     "enchantments": [],


### PR DESCRIPTION
## Context

[**Add boolean columns to canonical models that don't have them**](https://trello.com/c/rNjxj88l/179-add-boolean-columns-to-canonical-models-that-dont-have-them)

Canonical models representing in-game items should all have four attributes:

* `purchasable`: Whether the item can be purchased from merchants or other NPCs
* `unique_item`: Whether the item is unique in the game (items that respawn can still be unique as long as they aren't found in any other locations in the game)
* `rare_item`: Whether an item is rare*
* `quest_item`: Whether an item is (a) required to complete a quest or (b) only obtainable through completing a quest

Additionally, since `Canonical::Weapon` models have a `smithing_perks` field (indicating which smithing perks the items require or benefit from), I figured `Canonical::Armor` should too.

*Rare items include non-purchasable items that are found in 10 or fewer locations in the game, purchasable items that are found in two or fewer other locations in the game, or items that are theoretically purchasable but are not routinely a part of any particular merchant's inventory.

## Changes

* Migration to add `smithing_perks` array column to `canonical_armors` table
* Update schema to reflect changes made in previous migrations
* Add all missing values to each item in the JSON data for canonical armors
* Update specs, factories, and fixtures
* Add validations and specs

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

Although the new fields should all be `NOT NULL` (as should all boolean fields, in fact), creating a constraint now would make it impossible to migrate the database in production since existing models won't have these values defined. However, since we want all new models to include them, I have added validations to the model class.
