### PR TITLE
Add missing booleans to canonical clothing items data

### DIFF
--- a/app/models/canonical/clothing_item.rb
+++ b/app/models/canonical/clothing_item.rb
@@ -4,6 +4,10 @@ module Canonical
   class ClothingItem < ApplicationRecord
     self.table_name = 'canonical_clothing_items'
 
+    BODY_SLOTS                 = %w[head hands body feet].freeze
+    BOOLEAN_VALUES             = [true, false].freeze
+    BOOLEAN_VALIDATION_MESSAGE = 'must be true or false'
+
     has_many :canonical_enchantables_enchantments,
              dependent:  :destroy,
              class_name: 'Canonical::EnchantablesEnchantment',
@@ -17,10 +21,23 @@ module Canonical
     validates :unit_weight, presence: true, numericality: { greater_than_or_equal_to: 0 }
     validates :body_slot,
               presence:  true,
-              inclusion: { in: %w[head hands body feet], message: 'must be "head", "hands", "body", or "feet"' }
+              inclusion: { in: BODY_SLOTS, message: 'must be "head", "hands", "body", or "feet"' }
+    validates :purchasable, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }
+    validates :unique_item, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }
+    validates :rare_item, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }
+    validates :quest_item, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }
+    validates :enchantable, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }
+
+    validate :validate_unique_item_also_rare, if: -> { unique_item == true }
 
     def self.unique_identifier
       :item_code
+    end
+
+    private
+
+    def validate_unique_item_also_rare
+      errors.add(:rare_item, 'must be true if item is unique') unless rare_item == true
     end
   end
 end

--- a/lib/tasks/canonical_models/canonical_clothing.json
+++ b/lib/tasks/canonical_models/canonical_clothing.json
@@ -6,26 +6,10 @@
       "magical_effects": null,
       "body_slot": "head",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "enchantable": false
-    },
-    "enchantments": [
-      {
-        "name": "Fortify Magicka",
-        "strength": 50
-      }
-    ]
-  },
-  {
-    "attributes": {
-      "name": "Adept Hood",
-      "item_code": "0010DD3C",
-      "magical_effects": null,
-      "body_slot": "head",
-      "unit_weight": 1,
-      "quest_item": false,
-      "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [
@@ -42,8 +26,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [
@@ -60,8 +46,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [
@@ -82,39 +70,15 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [
       {
         "name": "Fortify Conjuration",
-        "strength": 17
-      },
-      {
-        "name": "Fortify Magicka Regen",
-        "strength": 100
-      }
-    ]
-  },
-  {
-    "attributes": {
-      "name": "Adept Robes of Conjuration \u0026 Illusion",
-      "item_code": "FEXXX837",
-      "magical_effects": null,
-      "body_slot": "body",
-      "unit_weight": 1,
-      "quest_item": false,
-      "unique_item": false,
-      "enchantable": false
-    },
-    "enchantments": [
-      {
-        "name": "Fortify Conjuration",
-        "strength": 17
-      },
-      {
-        "name": "Fortify Illusion",
         "strength": 17
       },
       {
@@ -130,39 +94,15 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [
       {
         "name": "Fortify Destruction",
-        "strength": 17
-      },
-      {
-        "name": "Fortify Magicka Regen",
-        "strength": 100
-      }
-    ]
-  },
-  {
-    "attributes": {
-      "name": "Adept Robes of Destruction \u0026 Alteration",
-      "item_code": "FEXXX82A",
-      "magical_effects": null,
-      "body_slot": "body",
-      "unit_weight": 1,
-      "quest_item": false,
-      "unique_item": false,
-      "enchantable": false
-    },
-    "enchantments": [
-      {
-        "name": "Fortify Destruction",
-        "strength": 17
-      },
-      {
-        "name": "Fortify Alteration",
         "strength": 17
       },
       {
@@ -178,8 +118,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [
@@ -200,8 +142,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [
@@ -222,8 +166,10 @@
       "magical_effects": null,
       "body_slot": "head",
       "unit_weight": 0.5,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": true
     },
     "enchantments": []
@@ -235,8 +181,10 @@
       "magical_effects": null,
       "body_slot": "head",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [
@@ -252,9 +200,11 @@
       "item_code": "0010D67D",
       "magical_effects": null,
       "body_slot": "body",
+      "purchasable": true,
       "unit_weight": 1,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [
@@ -271,8 +221,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [
@@ -293,39 +245,15 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [
       {
         "name": "Fortify Conjuration",
-        "strength": 15
-      },
-      {
-        "name": "Fortify Magicka Regen",
-        "strength": 75
-      }
-    ]
-  },
-  {
-    "attributes": {
-      "name": "Apprentice Robes of Conjuration \u0026 Illusion",
-      "item_code": "FEXXX836",
-      "magical_effects": null,
-      "body_slot": "body",
-      "unit_weight": 1,
-      "quest_item": false,
-      "unique_item": false,
-      "enchantable": false
-    },
-    "enchantments": [
-      {
-        "name": "Fortify Conjuration",
-        "strength": 15
-      },
-      {
-        "name": "Fortify Illusion",
         "strength": 15
       },
       {
@@ -341,39 +269,15 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [
       {
         "name": "Fortify Destruction",
-        "strength": 15
-      },
-      {
-        "name": "Fortify Magicka Regen",
-        "strength": 75
-      }
-    ]
-  },
-  {
-    "attributes": {
-      "name": "Apprentice Robes of Destruction \u0026 Alteration",
-      "item_code": "FEXXX829",
-      "magical_effects": null,
-      "body_slot": "body",
-      "unit_weight": 1,
-      "quest_item": false,
-      "unique_item": false,
-      "enchantable": false
-    },
-    "enchantments": [
-      {
-        "name": "Fortify Destruction",
-        "strength": 15
-      },
-      {
-        "name": "Fortify Alteration",
         "strength": 15
       },
       {
@@ -389,8 +293,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [
@@ -411,8 +317,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [
@@ -428,31 +336,15 @@
   },
   {
     "attributes": {
-      "name": "Arcane Blacksmith's Apron",
-      "item_code": "XX000AE4",
-      "magical_effects": null,
-      "body_slot": "body",
-      "unit_weight": 1,
-      "quest_item": false,
-      "unique_item": true,
-      "enchantable": false
-    },
-    "enchantments": [
-      {
-        "name": "Fortify Smithing",
-        "strength": 20
-      }
-    ]
-  },
-  {
-    "attributes": {
       "name": "Arch-Mage's Boots",
       "item_code": "0007C92E",
       "magical_effects": null,
       "body_slot": "feet",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -464,39 +356,15 @@
   },
   {
     "attributes": {
-      "name": "Ascendant Necromancer Robes",
-      "item_code": "FEXXX90F",
-      "magical_effects": "Conjuration spells last 25% longer. Increases summon limit by 1 for lesser conjured or reanimated undead.",
-      "body_slot": "body",
-      "unit_weight": 1,
-      "quest_item": false,
-      "unique_item": false,
-      "enchantable": false
-    },
-    "enchantments": []
-  },
-  {
-    "attributes": {
       "name": "Belted Tunic",
       "item_code": "0001BE1A",
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "enchantable": true
-    },
-    "enchantments": []
-  },
-  {
-    "attributes": {
-      "name": "Black Mage Hood",
-      "item_code": "XX017E9B",
-      "magical_effects": null,
-      "body_slot": "head",
-      "unit_weight": 0.5,
-      "quest_item": false,
-      "unique_item": false,
+      "rare_item": false,
       "enchantable": true
     },
     "enchantments": []
@@ -508,8 +376,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [
@@ -539,8 +409,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": true
     },
     "enchantments": []
@@ -552,8 +424,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [
@@ -570,8 +444,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": true
     },
     "enchantments": []
@@ -583,9 +459,86 @@
       "magical_effects": null,
       "body_slot": "feet",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": true
+    },
+    "enchantments": []
+  },
+  {
+    "attributes": {
+      "name": "Boy's Blue Tunic",
+      "item_code": "XX00C744",
+      "magical_effects": null,
+      "body_slot": "body",
+      "unit_weight": 2,
+      "purchasable": true,
+      "quest_item": false,
+      "unique_item": false,
+      "rare_item": false,
+      "enchantable": false
+    },
+    "enchantments": []
+  },
+  {
+    "attributes": {
+      "name": "Boy's Green Tunic",
+      "item_code": "XX00C743",
+      "magical_effects": null,
+      "body_slot": "body",
+      "unit_weight": 2,
+      "purchasable": true,
+      "quest_item": false,
+      "unique_item": false,
+      "rare_item": false,
+      "enchantable": false
+    },
+    "enchantments": []
+  },
+  {
+    "attributes": {
+      "name": "Boy's Grey Tunic",
+      "item_code": "XX00C745",
+      "magical_effects": null,
+      "body_slot": "body",
+      "unit_weight": 2,
+      "purchasable": true,
+      "quest_item": false,
+      "unique_item": false,
+      "rare_item": false,
+      "enchantable": false
+    },
+    "enchantments": []
+  },
+  {
+    "attributes": {
+      "name": "Boy's Red Tunic",
+      "item_code": "XX00C742",
+      "magical_effects": null,
+      "body_slot": "body",
+      "unit_weight": 2,
+      "purchasable": true,
+      "quest_item": false,
+      "unique_item": false,
+      "rare_item": false,
+      "enchantable": false
+    },
+    "enchantments": []
+  },
+  {
+    "attributes": {
+      "name": "Boy's Yellow Tunic",
+      "item_code": "XX00C746",
+      "magical_effects": null,
+      "body_slot": "body",
+      "unit_weight": 2,
+      "purchasable": true,
+      "quest_item": false,
+      "unique_item": false,
+      "rare_item": false,
+      "enchantable": false
     },
     "enchantments": []
   },
@@ -596,8 +549,10 @@
       "magical_effects": null,
       "body_slot": "head",
       "unit_weight": 0.5,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": true
     },
     "enchantments": []
@@ -609,22 +564,11 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": true
-    },
-    "enchantments": []
-  },
-  {
-    "attributes": {
-      "name": "Child's Clothes",
-      "item_code": "XX03C819",
-      "magical_effects": null,
-      "body_slot": "body",
-      "unit_weight": 1,
-      "quest_item": false,
-      "unique_item": false,
-      "enchantable": false
     },
     "enchantments": []
   },
@@ -635,8 +579,10 @@
       "magical_effects": null,
       "body_slot": "feet",
       "unit_weight": 0.5,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -653,8 +599,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -675,8 +623,10 @@
       "magical_effects": "Backstab - double sneak attack damage with one-handed weapons",
       "body_slot": "hands",
       "unit_weight": 0.5,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": []
@@ -688,8 +638,10 @@
       "magical_effects": null,
       "body_slot": "head",
       "unit_weight": 0.5,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -706,8 +658,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []
@@ -719,8 +673,10 @@
       "magical_effects": null,
       "body_slot": "feet",
       "unit_weight": 2,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []
@@ -732,8 +688,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []
@@ -745,21 +703,10 @@
       "magical_effects": null,
       "body_slot": "head",
       "unit_weight": 0.5,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "enchantable": true
-    },
-    "enchantments": []
-  },
-  {
-    "attributes": {
-      "name": "Cuffed Boots",
-      "item_code": "000CEE78",
-      "magical_effects": null,
-      "body_slot": "feet",
-      "unit_weight": 1,
-      "quest_item": false,
-      "unique_item": false,
+      "rare_item": false,
       "enchantable": true
     },
     "enchantments": []
@@ -771,8 +718,10 @@
       "magical_effects": null,
       "body_slot": "feet",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": true
     },
     "enchantments": []
@@ -784,8 +733,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [
@@ -797,39 +748,15 @@
   },
   {
     "attributes": {
-      "name": "Cyrus' Boots",
-      "item_code": "XX00089B",
-      "magical_effects": null,
-      "body_slot": "feet",
-      "unit_weight": 1,
-      "quest_item": false,
-      "unique_item": true,
-      "enchantable": true
-    },
-    "enchantments": []
-  },
-  {
-    "attributes": {
-      "name": "Cyrus' Clothes",
-      "item_code": "XX00089E",
-      "magical_effects": null,
-      "body_slot": "body",
-      "unit_weight": 1,
-      "quest_item": false,
-      "unique_item": true,
-      "enchantable": true
-    },
-    "enchantments": []
-  },
-  {
-    "attributes": {
       "name": "Dunmer Outfit",
       "item_code": "XX03706A",
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 2,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -846,8 +773,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 2,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []
@@ -859,8 +788,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []
@@ -872,8 +803,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -890,8 +823,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -912,8 +847,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -934,39 +871,15 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
       {
         "name": "Fortify Destruction",
-        "strength": 20
-      },
-      {
-        "name": "Fortify Magicka Regen",
-        "strength": 125
-      }
-    ]
-  },
-  {
-    "attributes": {
-      "name": "Expert Robes of Destruction \u0026 Alteration",
-      "item_code": "FEXXX82B",
-      "magical_effects": null,
-      "body_slot": "body",
-      "unit_weight": 1,
-      "quest_item": false,
-      "unique_item": false,
-      "enchantable": false
-    },
-    "enchantments": [
-      {
-        "name": "Fortify Destruction",
-        "strength": 20
-      },
-      {
-        "name": "Fortify Alteration",
         "strength": 20
       },
       {
@@ -982,8 +895,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1004,8 +919,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1026,8 +943,10 @@
       "magical_effects": null,
       "body_slot": "feet",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": true
     },
     "enchantments": []
@@ -1039,8 +958,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": true
     },
     "enchantments": []
@@ -1052,8 +973,10 @@
       "magical_effects": null,
       "body_slot": "head",
       "unit_weight": 0.5,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": true
     },
     "enchantments": []
@@ -1065,8 +988,10 @@
       "magical_effects": null,
       "body_slot": "feet",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []
@@ -1078,8 +1003,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []
@@ -1091,9 +1018,86 @@
       "magical_effects": null,
       "body_slot": "feet",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": true
+    },
+    "enchantments": []
+  },
+  {
+    "attributes": {
+      "name": "Girl's Blue Dress",
+      "item_code": "XX00D81E",
+      "magical_effects": null,
+      "body_slot": "body",
+      "unit_weight": 2,
+      "purchasable": true,
+      "quest_item": false,
+      "unique_item": false,
+      "rare_item": false,
+      "enchantable": false
+    },
+    "enchantments": []
+  },
+  {
+    "attributes": {
+      "name": "Girl's Green Dress",
+      "item_code": "XX00D81F",
+      "magical_effects": null,
+      "body_slot": "body",
+      "unit_weight": 2,
+      "purchasable": true,
+      "quest_item": false,
+      "unique_item": false,
+      "rare_item": false,
+      "enchantable": false
+    },
+    "enchantments": []
+  },
+  {
+    "attributes": {
+      "name": "Girl's Grey Dress",
+      "item_code": "XX00D820",
+      "magical_effects": null,
+      "body_slot": "body",
+      "unit_weight": 2,
+      "purchasable": true,
+      "quest_item": false,
+      "unique_item": false,
+      "rare_item": false,
+      "enchantable": false
+    },
+    "enchantments": []
+  },
+  {
+    "attributes": {
+      "name": "Girl's Red Dress",
+      "item_code": "XX00D821",
+      "magical_effects": null,
+      "body_slot": "body",
+      "unit_weight": 2,
+      "purchasable": true,
+      "quest_item": false,
+      "unique_item": false,
+      "rare_item": false,
+      "enchantable": false
+    },
+    "enchantments": []
+  },
+  {
+    "attributes": {
+      "name": "Girl's Yellow Dress",
+      "item_code": "XX00D822",
+      "magical_effects": null,
+      "body_slot": "body",
+      "unit_weight": 2,
+      "purchasable": true,
+      "quest_item": false,
+      "unique_item": false,
+      "rare_item": false,
+      "enchantable": false
     },
     "enchantments": []
   },
@@ -1104,8 +1108,10 @@
       "magical_effects": null,
       "body_slot": "hands",
       "unit_weight": 0.5,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": true
     },
     "enchantments": []
@@ -1117,8 +1123,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []
@@ -1130,8 +1138,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": true
     },
     "enchantments": []
@@ -1143,8 +1153,10 @@
       "magical_effects": null,
       "body_slot": "head",
       "unit_weight": 0.5,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": true
     },
     "enchantments": []
@@ -1156,8 +1168,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1174,8 +1188,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []
@@ -1187,8 +1203,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
-      "unique_item": false,
+      "unique_item": true,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []
@@ -1200,8 +1218,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []
@@ -1213,8 +1233,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1231,8 +1253,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 5,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1267,8 +1291,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1289,8 +1315,10 @@
       "magical_effects": "Backstab - double sneak attack damage with one-handed weapons",
       "body_slot": "hands",
       "unit_weight": 0.5,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": []
@@ -1302,8 +1330,10 @@
       "magical_effects": null,
       "body_slot": "head",
       "unit_weight": 0.5,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1320,8 +1350,10 @@
       "magical_effects": "When worn, rainstorms occur while fishing at temperate lakes and streams.",
       "body_slot": "head",
       "unit_weight": "0.5",
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": []
@@ -1333,8 +1365,10 @@
       "magical_effects": null,
       "body_slot": "head",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": true
     },
     "enchantments": []
@@ -1346,8 +1380,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
-      "unique_item": false,
+      "unique_item": true,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []
@@ -1359,8 +1395,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [
@@ -1377,8 +1415,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1399,8 +1439,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1421,8 +1463,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1447,39 +1491,15 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
       {
         "name": "Fortify Destruction",
-        "strength": 22
-      },
-      {
-        "name": "Fortify Magicka Regen",
-        "strength": 150
-      }
-    ]
-  },
-  {
-    "attributes": {
-      "name": "Master Robes of Destruction \u0026 Alteration",
-      "item_code": "FEXXX82C",
-      "magical_effects": null,
-      "body_slot": "body",
-      "unit_weight": 1,
-      "quest_item": false,
-      "unique_item": false,
-      "enchantable": false
-    },
-    "enchantments": [
-      {
-        "name": "Fortify Destruction",
-        "strength": 22
-      },
-      {
-        "name": "Fortify Alteration",
         "strength": 22
       },
       {
@@ -1495,8 +1515,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1517,8 +1539,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1539,8 +1563,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": true
     },
     "enchantments": []
@@ -1552,8 +1578,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []
@@ -1565,8 +1593,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": true
     },
     "enchantments": []
@@ -1578,8 +1608,10 @@
       "magical_effects": null,
       "body_slot": "head",
       "unit_weight": 0.5,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []
@@ -1591,8 +1623,10 @@
       "magical_effects": "Adds a hidden bonus to your Magicka Regen",
       "body_slot": "hands",
       "unit_weight": 0.25,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": []
@@ -1604,8 +1638,10 @@
       "magical_effects": null,
       "body_slot": "feet",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []
@@ -1617,8 +1653,10 @@
       "magical_effects": null,
       "body_slot": "hands",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []
@@ -1630,8 +1668,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 2,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -1648,8 +1688,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 3,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []
@@ -1661,26 +1703,10 @@
       "magical_effects": null,
       "body_slot": "head",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "enchantable": false
-    },
-    "enchantments": [
-      {
-        "name": "Fortify Magicka",
-        "strength": 30
-      }
-    ]
-  },
-  {
-    "attributes": {
-      "name": "Novice Hood",
-      "item_code": "0010DD3A",
-      "magical_effects": null,
-      "body_slot": "head",
-      "unit_weight": 1,
-      "quest_item": false,
-      "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [
@@ -1697,8 +1723,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [
@@ -1715,8 +1743,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [
@@ -1737,8 +1767,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [
@@ -1759,8 +1791,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [
@@ -1785,39 +1819,15 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [
       {
         "name": "Fortify Destruction",
-        "strength": 12
-      },
-      {
-        "name": "Fortify Magicka Regen",
-        "strength": 50
-      }
-    ]
-  },
-  {
-    "attributes": {
-      "name": "Novice Robes of Destruction \u0026 Alteration",
-      "item_code": "FEXXX827",
-      "magical_effects": null,
-      "body_slot": "body",
-      "unit_weight": 1,
-      "quest_item": false,
-      "unique_item": false,
-      "enchantable": false
-    },
-    "enchantments": [
-      {
-        "name": "Fortify Destruction",
-        "strength": 12
-      },
-      {
-        "name": "Fortify Alteration",
         "strength": 12
       },
       {
@@ -1833,8 +1843,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [
@@ -1855,8 +1867,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [
@@ -1877,8 +1891,10 @@
       "magical_effects": null,
       "body_slot": "feet",
       "unit_weight": 0,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []
@@ -1890,8 +1906,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []
@@ -1903,21 +1921,10 @@
       "magical_effects": null,
       "body_slot": "feet",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
-      "enchantable": true
-    },
-    "enchantments": []
-  },
-  {
-    "attributes": {
-      "name": "Prisoner's Cuffs",
-      "item_code": "0010E039",
-      "magical_effects": null,
-      "body_slot": "hands",
-      "unit_weight": 0,
-      "quest_item": false,
-      "unique_item": false,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []
@@ -1929,8 +1936,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []
@@ -1942,8 +1951,10 @@
       "magical_effects": null,
       "body_slot": "feet",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []
@@ -1955,8 +1966,10 @@
       "magical_effects": null,
       "body_slot": "head",
       "unit_weight": 0.5,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []
@@ -1968,8 +1981,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []
@@ -1981,8 +1996,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []
@@ -1994,8 +2011,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []
@@ -2007,8 +2026,10 @@
       "magical_effects": null,
       "body_slot": "feet",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []
@@ -2020,8 +2041,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []
@@ -2033,22 +2056,11 @@
       "magical_effects": null,
       "body_slot": "head",
       "unit_weight": 0.5,
+      "purchasable": false,
       "quest_item": false,
-      "unique_item": false,
+      "unique_item": true,
+      "rare_item": true,
       "enchantable": true
-    },
-    "enchantments": []
-  },
-  {
-    "attributes": {
-      "name": "Refined Tunic",
-      "item_code": "000E84C6",
-      "magical_effects": null,
-      "body_slot": "body",
-      "unit_weight": 3,
-      "quest_item": false,
-      "unique_item": false,
-      "enchantable": false
     },
     "enchantments": []
   },
@@ -2059,8 +2071,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2081,8 +2095,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2103,13 +2119,15 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
       {
-        "name": "Fortify Destruction",
+        "name": "Fortify Conjuration",
         "strength": 15
       },
       {
@@ -2125,8 +2143,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2147,8 +2167,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2169,8 +2191,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2191,8 +2215,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2213,8 +2239,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2235,8 +2263,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2256,9 +2286,11 @@
       "item_code": "00101741",
       "magical_effects": null,
       "body_slot": "body",
+      "purchasable": false,
       "unit_weight": 1,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2279,8 +2311,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2301,8 +2335,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2323,8 +2359,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2345,8 +2383,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2367,8 +2407,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2389,8 +2431,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2411,8 +2455,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2433,8 +2479,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2455,8 +2503,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2477,8 +2527,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2499,8 +2551,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2521,8 +2575,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2543,8 +2599,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2565,8 +2623,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2587,8 +2647,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2609,8 +2671,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2631,8 +2695,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2653,8 +2719,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2675,8 +2743,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2715,8 +2785,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2733,8 +2805,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2751,8 +2825,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2773,8 +2849,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2791,8 +2869,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []
@@ -2804,8 +2884,10 @@
       "magical_effects": null,
       "body_slot": "feet",
       "unit_weight": 0,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": true
     },
     "enchantments": []
@@ -2816,9 +2898,11 @@
       "item_code": "0005B69E",
       "magical_effects": null,
       "body_slot": "feet",
-      "unit_weight": 2,
+      "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": true
     },
     "enchantments": []
@@ -2830,8 +2914,10 @@
       "magical_effects": "Backstab - double sneak attack damage with one-handed weapons",
       "body_slot": "hands",
       "unit_weight": 0.5,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": []
@@ -2861,8 +2947,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 0.5,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2879,14 +2967,16 @@
       "magical_effects": null,
       "body_slot": "feet",
       "unit_weight": 0.5,
+      "purchasable": true,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
       {
         "name": "Muffle",
-        "strength": null
+        "strength": 1.0
       }
     ]
   },
@@ -2897,8 +2987,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2919,8 +3011,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": true
     },
     "enchantments": []
@@ -2932,8 +3026,10 @@
       "magical_effects": null,
       "body_slot": "feet",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []
@@ -2945,8 +3041,10 @@
       "magical_effects": null,
       "body_slot": "head",
       "unit_weight": 2,
+      "purchasable": false,
       "quest_item": false,
-      "unique_item": false,
+      "unique_item": true,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []
@@ -2958,8 +3056,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 2,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2976,8 +3076,10 @@
       "magical_effects": null,
       "body_slot": "feet",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": true
     },
     "enchantments": []
@@ -2989,8 +3091,10 @@
       "magical_effects": null,
       "body_slot": "hands",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []
@@ -3002,8 +3106,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 4,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [
@@ -3020,8 +3126,10 @@
       "magical_effects": null,
       "body_slot": "feet",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []
@@ -3033,8 +3141,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []
@@ -3046,8 +3156,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 5,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []
@@ -3059,8 +3171,10 @@
       "magical_effects": null,
       "body_slot": "feet",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []
@@ -3072,8 +3186,10 @@
       "magical_effects": null,
       "body_slot": "hands",
       "unit_weight": 0.5,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []
@@ -3085,21 +3201,10 @@
       "magical_effects": null,
       "body_slot": "head",
       "unit_weight": 0.5,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
-      "enchantable": true
-    },
-    "enchantments": []
-  },
-  {
-    "attributes": {
-      "name": "Vampire Leather Hood",
-      "item_code": "XX089EEF",
-      "magical_effects": null,
-      "body_slot": "head",
-      "unit_weight": 1,
-      "quest_item": false,
-      "unique_item": false,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []
@@ -3111,8 +3216,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": []
@@ -3124,8 +3231,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []
@@ -3137,8 +3246,10 @@
       "magical_effects": null,
       "body_slot": "feet",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []

--- a/spec/models/canonical/clothing_item_spec.rb
+++ b/spec/models/canonical/clothing_item_spec.rb
@@ -5,73 +5,133 @@ require 'rails_helper'
 RSpec.describe Canonical::ClothingItem, type: :model do
   describe 'validations' do
     it 'is valid with valid attributes' do
-      item = described_class.new(name: 'Clothes', item_code: 'foo', unit_weight: 1, body_slot: 'body')
+      model = described_class.new(
+                name:        'Clothes',
+                item_code:   'foo',
+                unit_weight: 1,
+                body_slot:   'body',
+                purchasable: true,
+                unique_item: false,
+                rare_item:   false,
+              )
 
-      expect(item).to be_valid
+      expect(model).to be_valid
     end
 
     describe 'name' do
-      it 'is invalid without a name' do
-        item = described_class.new(item_code: 'xxx', body_slot: 'hands', unit_weight: 4.2)
+      it "can't be blank" do
+        model = build(:canonical_clothing_item, name: nil)
 
-        item.validate
-        expect(item.errors[:name]).to include "can't be blank"
+        model.validate
+        expect(model.errors[:name]).to include "can't be blank"
       end
     end
 
     describe 'item_code' do
-      it 'is invalid without an item code' do
-        item = described_class.new(name: 'Fine Clothes', unit_weight: 1, body_slot: 'body')
+      it "can't be blank" do
+        model = build(:canonical_clothing_item, item_code: nil)
 
-        item.validate
-        expect(item.errors[:item_code]).to include "can't be blank"
+        model.validate
+        expect(model.errors[:item_code]).to include "can't be blank"
       end
 
-      it 'is invalid with a non-unique item code' do
+      it 'must be unique' do
         create(:canonical_clothing_item, item_code: 'xxx')
-        item = build(:canonical_clothing_item, item_code: 'xxx')
+        model = build(:canonical_clothing_item, item_code: 'xxx')
 
-        item.validate
-        expect(item.errors[:item_code]).to include 'must be unique'
+        model.validate
+        expect(model.errors[:item_code]).to include 'must be unique'
       end
     end
 
     describe 'unit_weight' do
-      it 'is invalid with no unit weight' do
-        item = described_class.new(name: 'Fine Clothes', item_code: 'foo', body_slot: 'body')
+      it "can't be blank" do
+        model = build(:canonical_clothing_item, unit_weight: nil)
 
-        item.validate
-        expect(item.errors[:unit_weight]).to include "can't be blank"
+        model.validate
+        expect(model.errors[:unit_weight]).to include "can't be blank"
       end
 
-      it 'is invalid with a non-numeric unit weight' do
-        item = build(:canonical_clothing_item, unit_weight: 'bar')
+      it 'must be a number' do
+        model = build(:canonical_clothing_item, unit_weight: 'bar')
 
-        item.validate
-        expect(item.errors[:unit_weight]).to include 'is not a number'
+        model.validate
+        expect(model.errors[:unit_weight]).to include 'is not a number'
       end
 
-      it 'is invalid with a negative unit weight' do
-        item = build(:canonical_clothing_item, unit_weight: -34)
+      it 'must be at least zero' do
+        model = build(:canonical_clothing_item, unit_weight: -34)
 
-        item.validate
-        expect(item.errors[:unit_weight]).to include 'must be greater than or equal to 0'
+        model.validate
+        expect(model.errors[:unit_weight]).to include 'must be greater than or equal to 0'
       end
     end
 
     describe 'body_slot' do
-      it 'is invalid without a body_slot' do
-        item = described_class.new(name: 'foo', unit_weight: 2.0)
+      it "can't be blank" do
+        model = build(:canonical_clothing_item, body_slot: nil)
 
-        item.validate
-        expect(item.errors[:body_slot]).to include "can't be blank"
+        model.validate
+        expect(model.errors[:body_slot]).to include "can't be blank"
       end
 
-      it 'is invalid with an invalid body_slot value' do
-        item = build(:canonical_clothing_item, body_slot: 'bar')
+      it 'must have one of the valid values' do
+        model = build(:canonical_clothing_item, body_slot: 'bar')
 
-        item.validate
-        expect(item.errors[:body_slot]).to include 'must be "head", "hands", "body", or "feet"'
+        model.validate
+        expect(model.errors[:body_slot]).to include 'must be "head", "hands", "body", or "feet"'
+      end
+    end
+
+    describe 'purchasable' do
+      it 'must be true or false' do
+        model = build(:canonical_clothing_item, purchasable: nil)
+
+        model.validate
+        expect(model.errors[:purchasable]).to include 'must be true or false'
+      end
+    end
+
+    describe 'unique_item' do
+      it 'must be true or false' do
+        model = build(:canonical_clothing_item, unique_item: nil)
+
+        model.validate
+        expect(model.errors[:unique_item]).to include 'must be true or false'
+      end
+    end
+
+    describe 'rare_item' do
+      it 'must be true or false' do
+        model = build(:canonical_clothing_item, rare_item: nil)
+
+        model.validate
+        expect(model.errors[:rare_item]).to include 'must be true or false'
+      end
+
+      it 'must be true if item is unique' do
+        model = build(:canonical_clothing_item, unique_item: true, rare_item: false)
+
+        model.validate
+        expect(model.errors[:rare_item]).to include 'must be true if item is unique'
+      end
+    end
+
+    describe 'quest_item' do
+      it 'must be true or false' do
+        model = build(:canonical_clothing_item, quest_item: nil)
+
+        model.validate
+        expect(model.errors[:quest_item]).to include 'must be true or false'
+      end
+    end
+
+    describe 'enchantable' do
+      it 'must be true or false' do
+        model = build(:canonical_clothing_item, enchantable: nil)
+
+        model.validate
+        expect(model.errors[:enchantable]).to include 'must be true or false'
       end
     end
   end

--- a/spec/support/factories/canonical/clothing_items.rb
+++ b/spec/support/factories/canonical/clothing_items.rb
@@ -6,6 +6,9 @@ FactoryBot.define do
     sequence(:item_code) {|n| "123xxx#{n}" }
     unit_weight          { 9.9 }
     body_slot            { 'body' }
+    purchasable          { true }
+    unique_item          { false }
+    rare_item            { false }
     quest_item           { false }
   end
 end

--- a/spec/support/fixtures/canonical/sync/clothing_items.json
+++ b/spec/support/fixtures/canonical/sync/clothing_items.json
@@ -6,8 +6,10 @@
       "magical_effects": null,
       "body_slot": "head",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [
@@ -24,8 +26,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": false
     },
     "enchantments": [
@@ -46,8 +50,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []
@@ -59,8 +65,10 @@
       "magical_effects": null,
       "body_slot": "feet",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": true
     },
     "enchantments": []


### PR DESCRIPTION
## Context

[**Add missing booleans to canonical clothing items data**](https://trello.com/c/IXZefWFa/181-add-missing-booleans-to-canonical-clothing-items-data)

We've added the following four fields to any canonical models where they make sense:

* `purchasable`: whether or not the item can be purchased from a merchant or other NPC
* `unique_item`: whether the item is unique in the game (includes items that are available in only one location but respawn)
* `rare_item`: whether the item is rare* in the game
* `quest_item`: whether the item is (a) required to complete a quest or (b) only obtainable by completing a quest

Since we decided late in the game (no pun intended) that we wanted these fields to be common to all canonical models, adding them as required fields like we wanted would entail adding the fields to the database, updating all the existing JSON data, loading the JSON data, and then adding the `NOT NULL` constraints. Since we didn't want the considerable work of updating the JSON data to block release of the [Update Object Modelling epic](https://trello.com/c/1G99z7sP/68-update-object-modelling) (feature branch #77) or MVP, we decided to release the epic without the `NOT NULL` constraints and gradually update JSON data as there was time. Luckily, updating the JSON data is not taking as long as expected.

In order to keep migrations to a minimum, we'll be adding the `NOT NULL` constraints in a separate PR, after all JSON data have been updated. However, it makes sense to add validations to models so that any new data added to the database, as well as any updated records, must include the fields.

*Rare items are defined, generally, as those that are not purchasable and available in fewer than 10 locations in the game or purchasable and available two or fewer other places in the game. There are a few exceptions to this, such as items whose few locations are so obvious players are all but guaranteed to find them. In particular, if any of an item's locations includes an ownable property (Breezehome, Lakeview Manor, etc.), it will not be considered rare.

## Changes

* Update JSON data for canonical clothing items to include missing fields
* Add validations to models to ensure fields aren't blank
* Update tests

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [ ] Added and updated API docs and developer docs as appropriate
