### PR TITLE
Add missing keys to JSON data that broke sync in production

### DIFF
--- a/lib/tasks/canonical_models/canonical_clothing.json
+++ b/lib/tasks/canonical_models/canonical_clothing.json
@@ -396,8 +396,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": true,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": false,
       "enchantable": true
     },
     "enchantments": []


### PR DESCRIPTION
## Context

[**Add missing booleans to canonical clothing items data**](https://trello.com/c/IXZefWFa/181-add-missing-booleans-to-canonical-clothing-items-data)

In #109 we updated the canonical clothing items JSON data to include two new fields: `purchasable` and `rare_item`. However, we apparently didn't update all of it because running `bundle exec rails canonical_models:sync:clothing` ended up raising an error in production since one of the JSON objects in the file was missing those two keys.

## Changes

* Add missing keys to JSON object that got missed

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~

## Considerations

I thought about looking for more objects that got missed but that would entail writing a script to find them or sifting through a massive JSON file manually, and there was frankly nothing to lose by just attempting to run the rake task in prod again and seeing if it works this time. It won't actually break anything if it fails - it just won't update any of the data.
