### PR TITLE
Add more missing fields to canonical clothing item JSON data

### DIFF
--- a/lib/tasks/canonical_models/canonical_clothing.json
+++ b/lib/tasks/canonical_models/canonical_clothing.json
@@ -1275,8 +1275,10 @@
       "magical_effects": null,
       "body_slot": "feet",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2769,8 +2771,10 @@
       "magical_effects": null,
       "body_slot": "body",
       "unit_weight": 1,
+      "purchasable": false,
       "quest_item": false,
       "unique_item": false,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [
@@ -2931,8 +2935,10 @@
       "magical_effects": null,
       "body_slot": "head",
       "unit_weight": 0.5,
+      "purchasable": false,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
       "enchantable": false
     },
     "enchantments": [


### PR DESCRIPTION
## Context

[**Add missing booleans to canonical clothing items data**](https://trello.com/c/IXZefWFa/181-add-missing-booleans-to-canonical-clothing-items-data)

In #110 I missed a few objects in the JSON data that didn't have the new fields defined.

## Changes

* Add missing fields to remaining JSON objects that didn't have them

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~

## Considerations

This time I tested the sync locally like I should've done to begin with.
