### PR TITLE
Add new fields and validations to Canonical::Ingredient model

### DIFF
--- a/app/models/canonical/ingredient.rb
+++ b/app/models/canonical/ingredient.rb
@@ -4,6 +4,11 @@ module Canonical
   class Ingredient < ApplicationRecord
     self.table_name = 'canonical_ingredients'
 
+    VALID_TYPES                = %w[common uncommon rare Solstheim].freeze
+    TYPE_VALIDATION_MESSAGE    = 'must be "common", "uncommon", "rare", or "Solstheim"'
+    BOOLEAN_VALUES             = [true, false].freeze
+    BOOLEAN_VALIDATION_MESSAGE = 'must be true or false'
+
     has_many :canonical_ingredients_alchemical_properties,
              dependent:  :destroy,
              class_name: 'Canonical::IngredientsAlchemicalProperty'
@@ -17,10 +22,39 @@ module Canonical
 
     validates :name, presence: true
     validates :item_code, presence: true, uniqueness: { message: 'must be unique' }
+    validates :ingredient_type, inclusion: { in: VALID_TYPES, message: TYPE_VALIDATION_MESSAGE, allow_blank: true }
     validates :unit_weight, presence: true, numericality: { greater_than_or_equal_to: 0 }
+    validates :purchase_requires_perk,
+              inclusion: {
+                           in:      BOOLEAN_VALUES,
+                           message: "#{BOOLEAN_VALIDATION_MESSAGE} if purchasable is true",
+                         },
+              if:        -> { purchasable == true }
+    validates :unique_item, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }
+    validates :rare_item, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }
+    validates :quest_item, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }
+
+    validate :validate_purchasable
+    validate :validate_purchase_requires_perk
+    validate :validate_unique_item_also_rare, if: -> { unique_item == true }
 
     def self.unique_identifier
       :item_code
+    end
+
+    private
+
+    def validate_purchasable
+      errors.add(:purchasable, BOOLEAN_VALIDATION_MESSAGE) unless BOOLEAN_VALUES.include?(purchasable)
+      errors.add(:purchasable, 'must be true if ingredient_type is set') if ingredient_type && !purchasable
+    end
+
+    def validate_purchase_requires_perk
+      errors.add(:purchase_requires_perk, "can't be set if purchasable is false") if purchasable == false && !purchase_requires_perk.nil?
+    end
+
+    def validate_unique_item_also_rare
+      errors.add(:rare_item, 'must be true if item is unique') unless rare_item == true
     end
   end
 end

--- a/app/models/canonical/ingredient.rb
+++ b/app/models/canonical/ingredient.rb
@@ -24,6 +24,7 @@ module Canonical
     validates :item_code, presence: true, uniqueness: { message: 'must be unique' }
     validates :ingredient_type, inclusion: { in: VALID_TYPES, message: TYPE_VALIDATION_MESSAGE, allow_blank: true }
     validates :unit_weight, presence: true, numericality: { greater_than_or_equal_to: 0 }
+    validates :purchasable, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }
     validates :purchase_requires_perk,
               inclusion: {
                            in:      BOOLEAN_VALUES,
@@ -34,7 +35,8 @@ module Canonical
     validates :rare_item, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }
     validates :quest_item, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }
 
-    validate :validate_purchasable
+    validate :validate_ingredient_type_not_set, if: -> { purchasable == false }
+    validate :validate_ingredient_type_set, if: -> { purchasable == true }
     validate :validate_purchase_requires_perk
     validate :validate_unique_item_also_rare, if: -> { unique_item == true }
 
@@ -44,9 +46,12 @@ module Canonical
 
     private
 
-    def validate_purchasable
-      errors.add(:purchasable, BOOLEAN_VALIDATION_MESSAGE) unless BOOLEAN_VALUES.include?(purchasable)
-      errors.add(:purchasable, 'must be true if ingredient_type is set') if ingredient_type && !purchasable
+    def validate_ingredient_type_not_set
+      errors.add(:ingredient_type, 'can only be set for purchasable ingredients') unless ingredient_type.nil?
+    end
+
+    def validate_ingredient_type_set
+      errors.add(:ingredient_type, "can't be blank for purchasable ingredients") if ingredient_type.blank?
     end
 
     def validate_purchase_requires_perk

--- a/db/migrate/20220528233912_add_purchase_requires_perk_and_ingredient_type_to_canonical_ingredients.rb
+++ b/db/migrate/20220528233912_add_purchase_requires_perk_and_ingredient_type_to_canonical_ingredients.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddPurchaseRequiresPerkAndIngredientTypeToCanonicalIngredients < ActiveRecord::Migration[6.1]
+  def change
+    add_column :canonical_ingredients, :ingredient_type, :string
+    add_column :canonical_ingredients, :purchase_requires_perk, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_26_213259) do
+ActiveRecord::Schema.define(version: 2022_05_28_233912) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -111,6 +111,8 @@ ActiveRecord::Schema.define(version: 2022_05_26_213259) do
     t.boolean "quest_item", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "ingredient_type"
+    t.boolean "purchase_requires_perk"
     t.index ["item_code"], name: "index_canonical_ingredients_on_item_code", unique: true
   end
 

--- a/docs/canonical_models/README.md
+++ b/docs/canonical_models/README.md
@@ -14,6 +14,7 @@ The documentation in this directory covers the purpose of canonical models, the 
 * [Canonical Models](/docs/canonical_models/canonical-models.md): An overview of canonical models, which canonical models exist, and associations between them
 * [Canonical Data](/docs/canonical_models/canonical-data.md): Working with the JSON data and exporting CSV files
 * [Syncing Canonical Models](/docs/canonical_models/syncing-canonical-models.md): Using Rake tasks to sync canonical models in the database with authoritative JSON data
-* Specific Models
+* Specific Models:
   * [Canonical::Book](/docs/canonical_models/canonical-book.md): Additional details about special characteristics of the `Canonical::Book` model
+  * [`Canonical::Ingredient`](/docs/canonical_models/canonical-ingredient.md): Additional details about special characteristics of the `Canonical::Ingredient` model
   * [Canonical::IngredientsAlchemicalProperty](/docs/canonical_models//canonical-ingredients-alchemical-property.md): Additional details about special characteristics of the `Canonical::IngredientsAlchemicalProperty` model

--- a/docs/canonical_models/canonical-ingredient.md
+++ b/docs/canonical_models/canonical-ingredient.md
@@ -1,0 +1,49 @@
+# Canonical::Ingredient
+
+The `Canonical::Ingredient` model has a couple of special characteristics that set it apart from other canonical models.
+
+## Treatment of Rare Ingredients
+
+Ingredients differ from other objects in Skyrim in that they are consumable. For this reason, an ingredient can be considered a `rare_item` in situations where a non-consumable item would not be. The challenge presented by this is augmented by the fact that it's impossible to find detailed information online about acquisition of different ingredients, especially Solstheim ingredients (designated by `ingredient_type: 'Solstheim'`). For this reason, we've shot from the hip in determining which ingredients qualify as `rare_item`s, taking into account the subjective experience of how hard it is to find something in the game.
+
+The factors considered in determining whether an ingredient is rare include:
+
+* Whether it is [purchasable](#purchasability)
+* Whether purchasing it requires the [Merchant perk](#merchant-perk)
+* Its [ingredient type](#merchant-availability)
+* The number of locations where it is found
+* The number of guaranteed samples
+* Subjective experiences finding the ingredient in-game
+
+Unlike other canonical models, an ingredient can still be rare if a guaranteed sample is present in one of the ownable properties (Breezehome, Vlindrel Hall, Severin Manor, etc.). Ideally, instead of a boolean `rare_item` field, there would be a scaled field that could indicate _how_ rare an ingredient is. However, the absence of consistent information online would prevent this field from being populated with reliable values, so we've stuck to `rare_item` for consistency with other models.
+
+### Merchant Availability
+
+No merchant is guaranteed to carry a particular ingredient at a particular time. Merchant availability is indicated by the `ingredient_type` field. There are four possible values to this field: `"common"`, `"uncommon"`, `"rare"`, and `"Solstheim"`. A `NULL` value in this field means the ingredient cannot be purchased from merchants. **The `ingredient_type` field is not an indicator of how common or easy to find an ingredient actually is** - the value of this field has a specific meaning that pertains only to the likelihood of the ingredient being carried by a particular merchant at a particular time.
+
+Merchants carry the following:
+
+| Ingredient Type | Maximum Total Quantity | Probability of Particular Ingredient |
+| --------------- | ---------------------- | ------------------------------------ |
+| common          | 15                     | 36%                                  |
+| uncommon        | 10                     | 15%                                  |
+| rare            | 5                      | 21%                                  |
+| Solstheim*      | 6                      | ~60%                                 |
+
+The observant reader will notice that there is a higher probability of a given merchant carrying a given rare ingredient than a given uncommon ingredient. This is a result of the fact that there are considerably more uncommon ingredients than rare ones, and all of these are potentially represented in the 10 (uncommon) or 5 (rare) ingredients a merchant offers at a given time. Consequently, there are numerous ingredients with a `"rare"` ingredient type that have `rare_item` set to `false`.
+
+#### Solstheim Ingredients
+
+Solstheim ingredients may only be harvested, found, and purchased in Solstheim. No information is available online about the relative prevalence of each ingredient, so Solstheim ingredients are given their own ingredient type in SIM and presumed to be equally common, even though this is not necessarily the case. For this reason, the probability of 60% given in the table above is not necessarily uniformly distributed across all Solstheim ingredients.
+
+Solstheim ingredients can only be purchased through [Milore Ienth](https://en.uesp.net/wiki/Skyrim:Milore_Ienth) or, sometimes, the [Tel Mithryn Apothecary](https://en.uesp.net/wiki/Skyrim:Tel_Mithryn_Apothecary), as these are the only apothecary merchants in Solstheim.
+
+### Purchasability
+
+The `purchasable` column indicates whether an ingredient may be purchased from merchants or other NPCs. All `purchasable` ingredients also have a non-`NULL` `ingredient_type`. Conversely, ingredients that are not purchasable always have a `NULL` `ingredient_type`.
+
+Because purchasability can be determined based on the `ingredient_type` field, the `purchasable` field is redundant for ingredients. This column could probably be dropped. However, since it can be dropped at any time but not as easily recovered, we've decided to leave it for now, at least until the [ingredients epic](https://trello.com/c/WE1ztpCb/154-ingredient-features) has been kicked off. At that point, we'll know more about whether there is a benefit to having this column compared to just defining a `#purchasable` method that would give ingredients the same API as other canonical models.
+
+#### Merchant Perk
+
+Some ingredients are purchasable only with the Merchant perk (which requires a Speech level of 50). These ingredients are designated by the `purchase_requires_perk` boolean column. This column will be `NULL` if the ingredient is not purchasable at all. Purchasable ingredients will have this column set to `true` (if the ingredient can only be purchased with the perk) or `false` (if they are always purchasable).

--- a/lib/tasks/canonical_models/canonical_ingredients.json
+++ b/lib/tasks/canonical_models/canonical_ingredients.json
@@ -3,8 +3,12 @@
     "attributes": {
       "name": "Abecean Longfin",
       "item_code": "00106E1B",
+      "ingredient_type": "common",
       "unit_weight": 0.5,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -38,8 +42,12 @@
     "attributes": {
       "name": "Ancestor Moth Wing",
       "item_code": "XX0059BA",
+      "ingredient_type": null,
       "unit_weight": 0.1,
+      "purchasable": false,
+      "purchase_requires_perk": null,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -73,8 +81,12 @@
     "attributes": {
       "name": "Ash Creep Cluster",
       "item_code": "XX01CD74",
+      "ingredient_type": "Solstheim",
       "unit_weight": 0.25,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -108,8 +120,12 @@
     "attributes": {
       "name": "Ash Hopper Jelly",
       "item_code": "XX01CD71",
+      "ingredient_type": "Solstheim",
       "unit_weight": 0.25,
+      "purchasable": false,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -143,8 +159,12 @@
     "attributes": {
       "name": "Ashen Grass Pod",
       "item_code": "XX016E26",
+      "ingredient_type": "Solstheim",
       "unit_weight": 0.1,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -178,8 +198,12 @@
     "attributes": {
       "name": "Bear Claws",
       "item_code": "0006BC02",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.1,
+      "purchasable": true,
+      "purchase_requires_perk": true,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -213,8 +237,12 @@
     "attributes": {
       "name": "Bee",
       "item_code": "000A9195",
+      "ingredient_type": "common",
       "unit_weight": 0.1,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -248,8 +276,12 @@
     "attributes": {
       "name": "Beehive Husk",
       "item_code": "000A9191",
+      "ingredient_type": "common",
       "unit_weight": 1,
+      "purchasable": true,
+      "purchase_requires_perk":true,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -283,8 +315,12 @@
     "attributes": {
       "name": "Bleeding Crown",
       "item_code": "0004DA20",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.3,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -318,8 +354,12 @@
     "attributes": {
       "name": "Blisterwort",
       "item_code": "0004DA25",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.2,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -353,8 +393,12 @@
     "attributes": {
       "name": "Blue Butterfly Wing",
       "item_code": "000727DE",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.1,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -388,8 +432,12 @@
     "attributes": {
       "name": "Blue Dartwing",
       "item_code": "000E4F0C",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.1,
+      "purchasable": false,
+      "purchase_requires_perk": true,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -423,8 +471,12 @@
     "attributes": {
       "name": "Blue Mountain Flower",
       "item_code": "00077E1C",
+      "ingredient_type": "common",
       "unit_weight": 0.1,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -458,8 +510,12 @@
     "attributes": {
       "name": "Boar Tusk",
       "item_code": "XX01CD6F",
+      "ingredient_type": null,
       "unit_weight": 0.5,
+      "purchasable": false,
+      "purchase_requires_perk": null,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -493,8 +549,12 @@
     "attributes": {
       "name": "Bone Meal",
       "item_code": "00034CDD",
+      "ingredient_type": "common",
       "unit_weight": 0.5,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -528,8 +588,12 @@
     "attributes": {
       "name": "Briar Heart",
       "item_code": "0003AD61",
+      "ingredient_type": "rare",
       "unit_weight": 0.5,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -562,9 +626,13 @@
   {
     "attributes": {
       "name": "Burnt Spriggan Wood",
+      "ingredient_type": "Solstheim",
       "item_code": "XX01CD6E",
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unit_weight": 0.5,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -598,8 +666,12 @@
     "attributes": {
       "name": "Butterfly Wing",
       "item_code": "000727E0",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.5,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -633,8 +705,12 @@
     "attributes": {
       "name": "Canis Root",
       "item_code": "0006ABCB",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.1,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -668,8 +744,12 @@
     "attributes": {
       "name": "Charred Skeever Hide",
       "item_code": "00052695",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.5,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -703,8 +783,12 @@
     "attributes": {
       "name": "Chaurus Eggs",
       "item_code": "0003AD56",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.2,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -738,8 +822,12 @@
     "attributes": {
       "name": "Chaurus Hunter Antennae",
       "item_code": "XX0183B7",
+      "ingredient_type": null,
       "unit_weight": 0.1,
+      "purchasable": false,
+      "purchase_requires_perk": null,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -773,8 +861,12 @@
     "attributes": {
       "name": "Chicken's Egg",
       "item_code": "00023D77",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.5,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -808,8 +900,12 @@
     "attributes": {
       "name": "Creep Cluster",
       "item_code": "000B2183",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.2,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -843,8 +939,12 @@
     "attributes": {
       "name": "Crimson Nirnroot",
       "item_code": "000B701A",
+      "ingredient_type": null,
       "unit_weight": 0.2,
+      "purchasable": false,
+      "purchase_requires_perk": null,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": true
     },
     "alchemical_properties": [
@@ -878,8 +978,12 @@
     "attributes": {
       "name": "Cyrodilic Spadetail",
       "item_code": "00106E19",
+      "ingredient_type": "common",
       "unit_weight": 0.25,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -913,7 +1017,10 @@
     "attributes": {
       "name": "Daedra Heart",
       "item_code": "0003AD5B",
+      "ingredient_type": "rare",
       "unit_weight": 0.5,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
       "quest_item": false
     },
@@ -948,8 +1055,12 @@
     "attributes": {
       "name": "Deathbell",
       "item_code": "000516C8",
+      "ingredient_type": "rare",
       "unit_weight": 0.1,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": true
     },
     "alchemical_properties": [
@@ -983,8 +1094,12 @@
     "attributes": {
       "name": "Dragon's Tongue",
       "item_code": "000889A2",
+      "ingredient_type": "common",
       "unit_weight": 0.1,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -1018,8 +1133,12 @@
     "attributes": {
       "name": "Dwarven Oil",
       "item_code": "000F11C0",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.25,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -1053,8 +1172,12 @@
     "attributes": {
       "name": "Ectoplasm",
       "item_code": "0003AD63",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.1,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -1088,8 +1211,12 @@
     "attributes": {
       "name": "Elves Ear",
       "item_code": "00034D31",
+      "ingredient_type": "common",
       "unit_weight": 0.1,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -1123,8 +1250,12 @@
     "attributes": {
       "name": "Emperor Parasol Moss",
       "item_code": "XX01FF75",
+      "ingredient_type": "Solstheim",
       "unit_weight": 0.25,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -1158,8 +1289,12 @@
     "attributes": {
       "name": "Eye of Sabre Cat",
       "item_code": "0006BC07",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.1,
+      "purchasable": true,
+      "purchase_requires_perk": true,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -1193,8 +1328,12 @@
     "attributes": {
       "name": "Falmer Ear",
       "item_code": "0003AD5D",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.2,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -1228,8 +1367,12 @@
     "attributes": {
       "name": "Felsaad Tern Feathers",
       "item_code": "XX03CD8E",
+      "ingredient_type": "Solstheim",
       "unit_weight": 0.1,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -1263,8 +1406,12 @@
     "attributes": {
       "name": "Fire Salts",
       "item_code": "0003AD5E",
+      "ingredient_type": "rare",
       "unit_weight": 0.25,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": true
     },
     "alchemical_properties": [
@@ -1298,8 +1445,12 @@
     "attributes": {
       "name": "Fly Amanita",
       "item_code": "0004DA00",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.1,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -1331,10 +1482,53 @@
   },
   {
     "attributes": {
+      "name": "Frost Mirriam",
+      "item_code": "00034D32",
+      "ingredient_type": "uncommon",
+      "unit_weight": 0.1,
+      "purchasable": true,
+      "purchase_requires_perk": false,
+      "unique_item": false,
+      "rare_item": false,
+      "quest_item": false
+    },
+    "alchemical_properties": [
+      {
+        "priority": 1,
+        "name": "Resist Frost",
+        "strength_modifier": null,
+        "duration_modifier": null
+      },
+      {
+        "priority": 2,
+        "name": "Fortify Sneak",
+        "strength_modifier": null,
+        "duration_modifier": null
+      },
+      {
+        "priority": 3,
+        "name": "Ravage Magicka",
+        "strength_modifier": null,
+        "duration_modifier": null
+      },
+      {
+        "priority": 4,
+        "name": "Damage Stamina Regen",
+        "strength_modifier": null,
+        "duration_modifier": null
+      }
+    ]
+  },
+  {
+    "attributes": {
       "name": "Frost Salts",
       "item_code": "0003AD5F",
+      "ingredient_type": "rare",
       "unit_weight": 0.25,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -1368,8 +1562,12 @@
     "attributes": {
       "name": "Garlic",
       "item_code": "00034D22",
+      "ingredient_type": "common",
       "unit_weight": 0.25,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -1403,8 +1601,12 @@
     "attributes": {
       "name": "Giant Lichen",
       "item_code": "0007E8C1",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.25,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -1438,8 +1640,12 @@
     "attributes": {
       "name": "Giant's Toe",
       "item_code": "0003AD64",
+      "ingredient_type": "rare",
       "unit_weight": 1,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -1473,9 +1679,13 @@
     "attributes": {
       "name": "Gleamblossom",
       "item_code": "XX00B097",
+      "ingredient_type": null,
       "unit_weight": 0.1,
+      "purchasable": false,
+      "purchase_requires_perk": null,
       "unique_item": false,
-      "quest_item": false
+      "rare_item": true,
+      "quest_item": true
     },
     "alchemical_properties": [
       {
@@ -1508,8 +1718,12 @@
     "attributes": {
       "name": "Glow Dust",
       "item_code": "0003AD73",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.5,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -1543,8 +1757,12 @@
     "attributes": {
       "name": "Glowing Mushroom",
       "item_code": "0007EE01",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.2,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -1578,8 +1796,12 @@
     "attributes": {
       "name": "Grass Pod",
       "item_code": "00083E64",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.1,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -1613,8 +1835,12 @@
     "attributes": {
       "name": "Hagraven Claw",
       "item_code": "0006B689",
+      "ingredient_type": "rare",
       "unit_weight": 0.25,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -1648,8 +1874,12 @@
     "attributes": {
       "name": "Hagraven Feathers",
       "item_code": "0003AD66",
+      "ingredient_type": "rare",
       "unit_weight": 0.1,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -1683,8 +1913,12 @@
     "attributes": {
       "name": "Hanging Moss",
       "item_code": "00057F91",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.25,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -1718,8 +1952,12 @@
     "attributes": {
       "name": "Hawk Beak",
       "item_code": "000E7EBC",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.25,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -1753,8 +1991,12 @@
     "attributes": {
       "name": "Hawk Feathers",
       "item_code": "000E7ED0",
+      "ingredient_type": null,
       "unit_weight": 0.1,
+      "purchasable": false,
+      "purchase_requires_perk": null,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -1788,8 +2030,12 @@
     "attributes": {
       "name": "Hawk's Egg",
       "item_code": "XX00F1CC",
+      "ingredient_type": null,
       "unit_weight": 0.5,
+      "purchasable": false,
+      "purchase_requires_perk": null,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -1823,8 +2069,12 @@
     "attributes": {
       "name": "Histcarp",
       "item_code": "00106E18",
+      "ingredient_type": "common",
       "unit_weight": 0.25,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -1858,8 +2108,12 @@
     "attributes": {
       "name": "Honeycomb",
       "item_code": "000B08C5",
+      "ingredient_type": "common",
       "unit_weight": 1,
+      "purchasable": true,
+      "purchase_requires_perk": true,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -1893,8 +2147,12 @@
     "attributes": {
       "name": "Human Flesh",
       "item_code": "001016B3",
+      "ingredient_type": null,
       "unit_weight": 0.25,
+      "purchasable": false,
+      "purchase_requires_perk": null,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -1928,8 +2186,12 @@
     "attributes": {
       "name": "Human Heart",
       "item_code": "000B18CD",
+      "ingredient_type": null,
       "unit_weight": 1,
+      "purchasable": false,
+      "purchase_requires_perk": null,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -1963,8 +2225,12 @@
     "attributes": {
       "name": "Ice Wraith Teeth",
       "item_code": "0003AD6A",
+      "ingredient_type": "rare",
       "unit_weight": 0.25,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": true
     },
     "alchemical_properties": [
@@ -1998,8 +2264,12 @@
     "attributes": {
       "name": "Imp Stool",
       "item_code": "0004DA23",
+      "ingredient_type": "rare",
       "unit_weight": 0.3,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -2033,8 +2303,12 @@
     "attributes": {
       "name": "Jazbay Grapes",
       "item_code": "0006AC4A",
+      "ingredient_type": "rare",
       "unit_weight": 0.2,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": true
     },
     "alchemical_properties": [
@@ -2068,8 +2342,12 @@
     "attributes": {
       "name": "Juniper Berries",
       "item_code": "0005076E",
+      "ingredient_type": "common",
       "unit_weight": 0.1,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -2103,8 +2381,12 @@
     "attributes": {
       "name": "Large Antlers",
       "item_code": "0006BC0A",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.1,
+      "purchasable": true,
+      "purchase_requires_perk": true,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -2138,8 +2420,12 @@
     "attributes": {
       "name": "Lavender",
       "item_code": "00045C28",
+      "ingredient_type": "common",
       "unit_weight": 0.1,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -2173,8 +2459,12 @@
     "attributes": {
       "name": "Luna Moth Wing",
       "item_code": "000727DF",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.1,
+      "purchasable": true,
+      "purchase_requires_perk": true,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -2208,8 +2498,12 @@
     "attributes": {
       "name": "Moon Sugar",
       "item_code": "000D8E3F",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.25,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -2243,8 +2537,12 @@
     "attributes": {
       "name": "Mora Tapinella",
       "item_code": "000EC870",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.25,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -2278,8 +2576,12 @@
     "attributes": {
       "name": "Mudcrab Chitin",
       "item_code": "0006BC00",
+      "ingredient_type": "common",
       "unit_weight": 0.25,
+      "purchasable": true,
+      "purchase_requires_perk": true,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -2313,8 +2615,12 @@
     "attributes": {
       "name": "Namira's Rot",
       "item_code": "0004DA24",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.25,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -2348,8 +2654,12 @@
     "attributes": {
       "name": "Netch Jelly",
       "item_code": "XX01CD72",
+      "ingredient_type": "Solstheim",
       "unit_weight": 0.5,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -2383,8 +2693,12 @@
     "attributes": {
       "name": "Nightshade",
       "item_code": "XX042A41",
+      "ingredient_type": "rare",
       "unit_weight": 0.1,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": true
     },
     "alchemical_properties": [
@@ -2418,8 +2732,12 @@
     "attributes": {
       "name": "Nirnroot",
       "item_code": "00059B86",
+      "ingredient_type": "rare",
       "unit_weight": 0.2,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": true
     },
     "alchemical_properties": [
@@ -2453,8 +2771,12 @@
     "attributes": {
       "name": "Nordic Barnacle",
       "item_code": "0007EDF5",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.2,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -2488,8 +2810,12 @@
     "attributes": {
       "name": "Orange Dartwing",
       "item_code": "000BB956",
+      "ingredient_type": "common",
       "unit_weight": 0.1,
+      "purchasable": true,
+      "purchase_requires_perk": true,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -2523,8 +2849,12 @@
     "attributes": {
       "name": "Pearl",
       "item_code": "000854FE",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.1,
+      "purchasable": true,
+      "purchase_requires_perk": true,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -2558,8 +2888,12 @@
     "attributes": {
       "name": "Pine Thrush Egg",
       "item_code": "00023D6F",
+      "ingredient_type": "common",
       "unit_weight": 0.5,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -2593,8 +2927,12 @@
     "attributes": {
       "name": "Poison Bloom",
       "item_code": "XX0185FB",
+      "ingredient_type": null,
       "unit_weight": 0.25,
+      "purchasable": false,
+      "purchase_requires_perk": null,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -2628,8 +2966,12 @@
     "attributes": {
       "name": "Powdered Mammoth Tusk",
       "item_code": "0006BC10",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.1,
+      "purchasable": true,
+      "purchase_requires_perk": true,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -2663,8 +3005,12 @@
     "attributes": {
       "name": "Purple Mountain Flower",
       "item_code": "00077E1E",
+      "ingredient_type": "common",
       "unit_weight": 0.1,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -2698,8 +3044,12 @@
     "attributes": {
       "name": "Red Mountain Flower",
       "item_code": "00077E1D",
+      "ingredient_type": "common",
       "unit_weight": 0.1,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -2733,8 +3083,12 @@
     "attributes": {
       "name": "River Betty",
       "item_code": "00106E1A",
+      "ingredient_type": "common",
       "unit_weight": 0.25,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -2768,8 +3122,12 @@
     "attributes": {
       "name": "Rock Warbler Egg",
       "item_code": "0007E8C8",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.5,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -2803,8 +3161,12 @@
     "attributes": {
       "name": "Sabre Tooth Cat",
       "item_code": "0006BC04",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.1,
+      "purchasable": true,
+      "purchase_requires_perk": true,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -2838,8 +3200,12 @@
     "attributes": {
       "name": "Salmon Roe",
       "item_code": "XX003545",
+      "ingredient_type": null,
       "unit_weight": 0.2,
+      "purchasable": false,
+      "purchase_requires_perk": null,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -2873,8 +3239,12 @@
     "attributes": {
       "name": "Salt Pile",
       "item_code": "00074A19",
+      "ingredient_type": "common",
       "unit_weight": 0.2,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -2908,8 +3278,12 @@
     "attributes": {
       "name": "Scaly Pholiota",
       "item_code": "0006F950",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.25,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -2943,8 +3317,12 @@
     "attributes": {
       "name": "Scathecraw",
       "item_code": "XX017E97",
+      "ingredient_type": "Solstheim",
       "unit_weight": 0.1,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -2978,8 +3356,12 @@
     "attributes": {
       "name": "Silverside Perch",
       "item_code": "00106E1C",
+      "ingredient_type": "common",
       "unit_weight": 0.25,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -3013,8 +3395,12 @@
     "attributes": {
       "name": "Skeever Tail",
       "item_code": "0003AD6F",
+      "ingredient_type": "common",
       "unit_weight": 0.2,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -3048,8 +3434,12 @@
     "attributes": {
       "name": "Slaughterfish Egg",
       "item_code": "0007E8C5",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.2,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -3083,8 +3473,12 @@
     "attributes": {
       "name": "Slaughterfish Scales",
       "item_code": "0003AD70",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.1,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -3118,8 +3512,12 @@
     "attributes": {
       "name": "Small Antlers",
       "item_code": "0006BC0B",
+      "ingredient_type": "common",
       "unit_weight": 0.1,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -3153,8 +3551,12 @@
     "attributes": {
       "name": "Small Pearl",
       "item_code": "00085500",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.1,
+      "purchasable": true,
+      "purchase_requires_perk": true,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -3188,8 +3590,12 @@
     "attributes": {
       "name": "Snowberries",
       "item_code": "0001B3BD",
+      "ingredient_type": "common",
       "unit_weight": 0.1,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -3223,8 +3629,12 @@
     "attributes": {
       "name": "Spawn Ash",
       "item_code": "XX01CD6D",
+      "ingredient_type": "Solstheim",
       "unit_weight": 0.1,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -3258,8 +3668,12 @@
     "attributes": {
       "name": "Spider Egg",
       "item_code": "0009151B",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.2,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -3293,8 +3707,12 @@
     "attributes": {
       "name": "Spriggan Sap",
       "item_code": "00063B5F",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.2,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -3328,8 +3746,12 @@
     "attributes": {
       "name": "Swamp Fungal Pod",
       "item_code": "0007E8B7",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.25,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -3363,8 +3785,12 @@
     "attributes": {
       "name": "Taproot",
       "item_code": "0003AD71",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.5,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -3398,8 +3824,12 @@
     "attributes": {
       "name": "Thistle Branch",
       "item_code": "000134AA",
+      "ingredient_type": "common",
       "unit_weight": 0.1,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -3433,8 +3863,12 @@
     "attributes": {
       "name": "Torchbug Thorax",
       "item_code": "0004DA73",
+      "ingredient_type": "common",
       "unit_weight": 0.1,
+      "purchasable": true,
+      "purchase_requires_perk": true,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -3468,8 +3902,12 @@
     "attributes": {
       "name": "Trama Root",
       "item_code": "XX017008",
+      "ingredient_type": "Solstheim",
       "unit_weight": 0.2,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -3503,8 +3941,12 @@
     "attributes": {
       "name": "Troll Fat",
       "item_code": "0003AD72",
+      "ingredient_type": "uncommon",
       "unit_weight": 1,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": true
     },
     "alchemical_properties": [
@@ -3538,8 +3980,12 @@
     "attributes": {
       "name": "Tundra Cotton",
       "item_code": "0003F7F8",
+      "ingredient_type": "common",
       "unit_weight": 0.1,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -3573,8 +4019,12 @@
     "attributes": {
       "name": "Vampire Dust",
       "item_code": "0003AD76",
+      "ingredient_type": "rare",
       "unit_weight": 0.2,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -3608,8 +4058,12 @@
     "attributes": {
       "name": "Void Salts",
       "item_code": "0003AD60",
+      "ingredient_type": "rare",
       "unit_weight": 0.2,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -3643,8 +4097,12 @@
     "attributes": {
       "name": "Wheat",
       "item_code": "0004B0BA",
+      "ingredient_type": "common",
       "unit_weight": 0.1,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -3678,8 +4136,12 @@
     "attributes": {
       "name": "White Cap",
       "item_code": "0004DA22",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.3,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -3713,8 +4175,12 @@
     "attributes": {
       "name": "Wisp Wrappings",
       "item_code": "0006BC0E",
+      "ingredient_type": "uncommon",
       "unit_weight": 0.1,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -3748,8 +4214,12 @@
     "attributes": {
       "name": "Yellow Mountain Flower",
       "item_code": "XX002A78",
+      "ingredient_type": null,
       "unit_weight": 0.1,
+      "purchasable": false,
+      "purchase_requires_perk": null,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -3783,8 +4253,12 @@
     "attributes": {
       "name": "Berit's Ashes",
       "item_code": "000705B7",
+      "ingredient_type": null,
       "unit_weight": 0.2,
+      "purchasable": false,
+      "purchase_requires_perk": null,
       "unique_item": true,
+      "rare_item": true,
       "quest_item": true
     },
     "alchemical_properties": [
@@ -3818,8 +4292,12 @@
     "attributes": {
       "name": "Jarrin Root",
       "item_code": "0001BCBC",
+      "ingredient_type": null,
       "unit_weight": 0.5,
+      "purchasable": false,
+      "purchase_requires_perk": null,
       "unique_item": true,
+      "rare_item": true,
       "quest_item": true
     },
     "alchemical_properties": [

--- a/lib/tasks/canonical_models/canonical_ingredients.json
+++ b/lib/tasks/canonical_models/canonical_ingredients.json
@@ -122,7 +122,7 @@
       "item_code": "XX01CD71",
       "ingredient_type": "Solstheim",
       "unit_weight": 0.25,
-      "purchasable": false,
+      "purchasable": true,
       "purchase_requires_perk": false,
       "unique_item": false,
       "rare_item": true,
@@ -434,7 +434,7 @@
       "item_code": "000E4F0C",
       "ingredient_type": "uncommon",
       "unit_weight": 0.1,
-      "purchasable": false,
+      "purchasable": true,
       "purchase_requires_perk": true,
       "unique_item": false,
       "rare_item": false,
@@ -1022,6 +1022,7 @@
       "purchasable": true,
       "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false
     },
     "alchemical_properties": [

--- a/spec/models/canonical/ingredient_spec.rb
+++ b/spec/models/canonical/ingredient_spec.rb
@@ -5,33 +5,58 @@ require 'rails_helper'
 RSpec.describe Canonical::Ingredient, type: :model do
   describe 'validations' do
     it 'is valid with valid attributes' do
-      ingredient = described_class.new(name: 'Skeever Tail', item_code: 'foo', unit_weight: 1)
+      ingredient = described_class.new(
+                     name:                   'Skeever Tail',
+                     item_code:              'foo',
+                     ingredient_type:        'common',
+                     unit_weight:            1,
+                     purchasable:            true,
+                     purchase_requires_perk: false,
+                     unique_item:            false,
+                     rare_item:              true,
+                   )
+
       expect(ingredient).to be_valid
     end
 
     describe 'name' do
       it 'must be present' do
-        ingredient = described_class.new(item_code: 'foo')
+        model = build(:canonical_ingredient, name: nil)
 
-        ingredient.validate
-        expect(ingredient.errors[:name]).to include "can't be blank"
+        model.validate
+        expect(model.errors[:name]).to include "can't be blank"
       end
     end
 
     describe 'item_code' do
       it 'must be present' do
-        ingredient = described_class.new(name: 'Glowing Mushroom')
+        model = build(:canonical_ingredient, item_code: nil)
 
-        ingredient.validate
-        expect(ingredient.errors[:item_code]).to include "can't be blank"
+        model.validate
+        expect(model.errors[:item_code]).to include "can't be blank"
       end
 
       it 'must be unique' do
         create(:canonical_ingredient, item_code: 'foo')
-        ingredient = build(:canonical_ingredient, name: 'Thistle Branch', item_code: 'foo')
+        model = build(:canonical_ingredient, item_code: 'foo')
 
-        ingredient.validate
-        expect(ingredient.errors[:item_code]).to include 'must be unique'
+        model.validate
+        expect(model.errors[:item_code]).to include 'must be unique'
+      end
+    end
+
+    describe 'ingredient_type' do
+      it 'must have one of the valid values' do
+        model = build(:canonical_ingredient, ingredient_type: 'unique')
+
+        model.validate
+        expect(model.errors[:ingredient_type]).to include 'must be "common", "uncommon", "rare", or "Solstheim"'
+      end
+
+      it 'can be blank' do
+        model = build(:canonical_ingredient, ingredient_type: nil)
+
+        expect(model).to be_valid
       end
     end
 
@@ -48,6 +73,87 @@ RSpec.describe Canonical::Ingredient, type: :model do
 
         ingredient.validate
         expect(ingredient.errors[:unit_weight]).to include 'must be greater than or equal to 0'
+      end
+    end
+
+    describe 'purchasable' do
+      it 'must be true or false' do
+        model = build(:canonical_ingredient, purchasable: nil)
+
+        model.validate
+        expect(model.errors[:purchasable]).to include 'must be true or false'
+      end
+
+      it 'must be true if ingredient_type is defined' do
+        model = build(:canonical_ingredient, ingredient_type: 'rare', purchasable: false)
+
+        model.validate
+        expect(model.errors[:purchasable]).to include 'must be true if ingredient_type is set'
+      end
+    end
+
+    describe 'purchase_requires_perk' do
+      # Because non-nil values other than `true` or `false` will automatically
+      # be converted to `true` prior to validation, it is pointless to test
+      # that boolean values are validated when NULL is also allowed, since `nil`
+      # is the only value that won't be converted.
+
+      # This spec tests whether the model IS valid when purchase_requires_perk is nil and purchasable is false.
+      # The next spec tests the validation error/message.
+      it 'can be NULL if purchasable is false' do
+        model = build(:canonical_ingredient, ingredient_type: nil, purchasable: false, purchase_requires_perk: nil)
+
+        expect(model).to be_valid
+      end
+
+      # The above spec tests whether the model is valid when the value is nil and purchasable is false. This
+      # spec tests the validation error/message.
+      it 'must be NULL if purchasable is false' do
+        model = build(:canonical_ingredient, ingredient_type: nil, purchasable: false, purchase_requires_perk: false)
+
+        model.validate
+        expect(model.errors[:purchase_requires_perk]).to include "can't be set if purchasable is false"
+      end
+
+      it 'must be set if purchasable is true' do
+        model = build(:canonical_ingredient, ingredient_type: 'common', purchasable: true, purchase_requires_perk: nil)
+
+        model.validate
+        expect(model.errors[:purchase_requires_perk]).to include 'must be true or false if purchasable is true'
+      end
+    end
+
+    describe 'unique_item' do
+      it 'must be true or false' do
+        model = build(:canonical_ingredient, unique_item: nil)
+
+        model.validate
+        expect(model.errors[:unique_item]).to include 'must be true or false'
+      end
+    end
+
+    describe 'rare_item' do
+      it 'must be true or false' do
+        model = build(:canonical_ingredient, rare_item: nil)
+
+        model.validate
+        expect(model.errors[:rare_item]).to include 'must be true or false'
+      end
+
+      it 'must be true if the ingredient is unique' do
+        model = build(:canonical_ingredient, unique_item: true, rare_item: false)
+
+        model.validate
+        expect(model.errors[:rare_item]).to include 'must be true if item is unique'
+      end
+    end
+
+    describe 'quest_item' do
+      it 'must be true or false' do
+        model = build(:canonical_ingredient, quest_item: nil)
+
+        model.validate
+        expect(model.errors[:quest_item]).to include 'must be true or false'
       end
     end
   end

--- a/spec/models/canonical/ingredient_spec.rb
+++ b/spec/models/canonical/ingredient_spec.rb
@@ -53,10 +53,24 @@ RSpec.describe Canonical::Ingredient, type: :model do
         expect(model.errors[:ingredient_type]).to include 'must be "common", "uncommon", "rare", or "Solstheim"'
       end
 
-      it 'can be blank' do
-        model = build(:canonical_ingredient, ingredient_type: nil)
+      it 'can be blank if purchasable is false' do
+        model = build(:canonical_ingredient, ingredient_type: nil, purchasable: false, purchase_requires_perk: nil)
 
         expect(model).to be_valid
+      end
+
+      it 'must be blank if purchasable is false' do
+        model = build(:canonical_ingredient, purchasable: false, ingredient_type: 'uncommon')
+
+        model.validate
+        expect(model.errors[:ingredient_type]).to include 'can only be set for purchasable ingredients'
+      end
+
+      it "can't be blank if purchasable is true" do
+        model = build(:canonical_ingredient, purchasable: true, ingredient_type: nil)
+
+        model.validate
+        expect(model.errors[:ingredient_type]).to include "can't be blank for purchasable ingredients"
       end
     end
 
@@ -82,13 +96,6 @@ RSpec.describe Canonical::Ingredient, type: :model do
 
         model.validate
         expect(model.errors[:purchasable]).to include 'must be true or false'
-      end
-
-      it 'must be true if ingredient_type is defined' do
-        model = build(:canonical_ingredient, ingredient_type: 'rare', purchasable: false)
-
-        model.validate
-        expect(model.errors[:purchasable]).to include 'must be true if ingredient_type is set'
       end
     end
 

--- a/spec/models/canonical/sync/books_spec.rb
+++ b/spec/models/canonical/sync/books_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Canonical::Sync::Books do
         it "removes canonical ingredient associations that don't exist in the JSON data" do
           book_in_json
             .canonical_ingredients
-            .create!(item_code: '12345678', name: 'Venus Fly Trap', unit_weight: 1)
+            .create!(item_code: '12345678', name: 'Venus Fly Trap', unit_weight: 1, purchasable: false, rare_item: true)
 
           perform
 

--- a/spec/support/factories/canonical/ingredients.rb
+++ b/spec/support/factories/canonical/ingredients.rb
@@ -2,8 +2,13 @@
 
 FactoryBot.define do
   factory :canonical_ingredient, class: Canonical::Ingredient do
-    name                 { 'Blue Mountain Flower' }
-    sequence(:item_code) {|n| "xx123xx#{n}" }
-    unit_weight          { 0.5 }
+    name                   { 'Blue Mountain Flower' }
+    sequence(:item_code)   {|n| "xx123xx#{n}" }
+    ingredient_type        { 'common' }
+    unit_weight            { 0.5 }
+    purchasable            { true }
+    purchase_requires_perk { false }
+    unique_item            { false }
+    rare_item              { false }
   end
 end

--- a/spec/support/fixtures/canonical/sync/ingredients.json
+++ b/spec/support/fixtures/canonical/sync/ingredients.json
@@ -3,8 +3,12 @@
     "attributes": {
       "name": "Abecean Longfin",
       "item_code": "00106E1B",
+      "ingredient_type": "common",
       "unit_weight": 0.5,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -38,8 +42,12 @@
     "attributes": {
       "name": "Ash Hopper Jelly",
       "item_code": "XX01CD71",
+      "ingredient_type": "Solstheim",
       "unit_weight": 0.25,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -73,8 +81,12 @@
     "attributes": {
       "name": "Elves Ear",
       "item_code": "00034D31",
+      "ingredient_type": "common",
       "unit_weight": 0.1,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false
     },
     "alchemical_properties": [
@@ -108,8 +120,12 @@
     "attributes": {
       "name": "Fire Salts",
       "item_code": "0003AD5E",
+      "ingredient_type": "rare",
       "unit_weight": 0.25,
+      "purchasable": true,
+      "purchase_requires_perk": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": true
     },
     "alchemical_properties": [


### PR DESCRIPTION
## Context

[**Add missing booleans to canonical ingredients data**](https://trello.com/c/c0tsey38/182-add-missing-booleans-to-canonical-ingredients-data)

We want all canonical models for which it makes sense to have a common API with fields for `purchasable`, `unique_item`, `rare_item`, and `quest_item`. These columns were previously added to the `canonical_ingredients` table (without constraints), but the data have not been updated yet.

In the course of updating the data, it was determined that there were other useful fields canonical ingredients should include:

* `ingredient_type`: indicates merchant availability
* `purchase_requires_perk`: indicates whether the Merchant perk is required for an item to be available for purchase

## Changes

* Migration to add `ingredient_type` and `purchase_requires_perk` fields to `canonical_ingredients` table
* Updated test fixtures and JSON data for syncers
* Validations on the `Canonical::Ingredient` model testing for inclusion of required fields

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

The `purchasable` column, as discussed in the added docs, is probably redundant on canonical ingredients, as purchasability can be determined by the value, or lack thereof, of the `ingredient_type` column. It would've probably been just as good to drop the `purchasable` column and simply define a `#purchasable` method on the model to maintain the common API. However, this is more easily done than undone, and we'll know more about the requirements of this table once we've started the [ingredients epic](https://trello.com/c/WE1ztpCb/154-ingredient-features), so I've decided to leave it be for now.

Also discussed in the new docs are the complications involved in identifying an ingredient as a `rare_item` or not. Since ingredients are consumable, an ingredient available in less than 10 locations in the game would be rare indeed. Additionally, ingredients are never guaranteed to be available from a particular merchant at a particular time (or, indeed, ever). For this reason, I've taken a slightly different approach to categorising ingredients in this way, which takes into account several factors, including the subjective experience of how often I've come across the ingredient in the game when I've played it.