### PR TITLE
Add missing booleans to canonical staves data

### DIFF
--- a/app/models/canonical/staff.rb
+++ b/app/models/canonical/staff.rb
@@ -32,11 +32,22 @@ module Canonical
                             }
     validates :school, inclusion: { in: Skyrim::MAGIC_SCHOOLS, message: 'must be a valid school of magic', allow_blank: true }
     validates :daedric, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }
+    validates :purchasable, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }
     validates :unique_item, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }
+    validates :rare_item, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }
     validates :quest_item, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }
+    validates :leveled, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }
+
+    validate :validate_unique_item_also_rare, if: -> { unique_item == true }
 
     def self.unique_identifier
       :item_code
+    end
+
+    private
+
+    def validate_unique_item_also_rare
+      errors.add(:rare_item, 'must be true if item is unique') unless rare_item == true
     end
   end
 end

--- a/docs/canonical_models/canonical-models.md
+++ b/docs/canonical_models/canonical-models.md
@@ -38,7 +38,9 @@ Note that weapons and armour items have multiple associations to the same table 
 
 ## Common API
 
-All canonical models, not including join tables, must have a class method, `::unique_identifier`, defined, which returns a symbol that is the column (other than the primary key) to be used as the unique identifier for that model. If a table includes an `:item_code` column, this will be the unique identifier. For models that don't include an item code, another unique identifier, such as `:name` may be used. The `::unique_identifier` method is called in the [syncer](/app/models/canonical/sync/syncer.rb) to indicate how models being synced should be uniquely identified and matched with corresponding records existing in the database. The Rake tasks that [sync the canonical models](/docs/canonical_models/syncing-canonical-models.md) will not function without this method defined.
+### Class API
+
+All canonical models, not including join tables, must have a class method, `::unique_identifier`, defined, which returns a symbol that is the column (other than the primary key) to be used as the unique identifier for that model. If a table includes an `:item_code` column, this will be the unique identifier. For models that don't include an item code, another unique identifier, such as `:name`, may be used. The `::unique_identifier` method is called in the [syncer](/app/models/canonical/sync/syncer.rb) to indicate how models being synced should be uniquely identified and matched with corresponding records already existing in the database. The Rake tasks that [sync the canonical models](/docs/canonical_models/syncing-canonical-models.md) will not function without this method defined.
 
 ## Syncing Canonical Models
 

--- a/lib/tasks/canonical_models/canonical_staves.json
+++ b/lib/tasks/canonical_models/canonical_staves.json
@@ -9,7 +9,9 @@
       "school": "Destruction",
       "enemy": "Rahgot",
       "daedric": false,
+      "purchasable": false,
       "unique_item": true,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -31,7 +33,9 @@
       "school": "Destruction",
       "enemy": "Nahkriin",
       "daedric": false,
+      "purchasable": false,
       "unique_item": true,
+      "rare_item": true,
       "quest_item": true,
       "leveled": false
     },
@@ -53,7 +57,9 @@
       "school": "Destruction",
       "enemy": null,
       "daedric": false,
+      "purchasable": false,
       "unique_item": true,
+      "rare_item": true,
       "quest_item": true,
       "leveled": false
     },
@@ -75,7 +81,9 @@
       "school": null,
       "enemy": null,
       "daedric": false,
+      "purchasable": false,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -92,7 +100,9 @@
       "school": null,
       "enemy": null,
       "daedric": false,
+      "purchasable": false,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -109,7 +119,9 @@
       "school": "Illusion",
       "enemy": null,
       "daedric": false,
+      "purchasable": false,
       "unique_item": true,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -131,8 +143,10 @@
       "school": "Illusion",
       "enemy": null,
       "daedric": false,
+      "purchasable": false,
       "unique_item": true,
       "quest_item": true,
+      "rare_item": true,
       "leveled": false
     },
     "spells": [
@@ -153,7 +167,9 @@
       "school": "Restoration",
       "enemy": null,
       "daedric": false,
+      "purchasable": true,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -175,7 +191,9 @@
       "school": "Restoration",
       "enemy": null,
       "daedric": false,
+      "purchasable": true,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -197,7 +215,9 @@
       "school": "Illusion",
       "enemy": "Halldir",
       "daedric": false,
+      "purchasable": false,
       "unique_item": true,
+      "rare_item": true,
       "quest_item": true,
       "leveled": false
     },
@@ -223,7 +243,9 @@
       "school": "Restoration",
       "enemy": null,
       "daedric": false,
+      "purchasable": true,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -245,7 +267,9 @@
       "school": null,
       "enemy": "Miraak",
       "daedric": false,
+      "purchasable": false,
       "unique_item": true,
+      "rare_item": true,
       "quest_item": true,
       "leveled": true
     },
@@ -266,7 +290,9 @@
       "school": "Conjuration",
       "enemy": "Sanguine",
       "daedric": true,
+      "purchasable": false,
       "unique_item": true,
+      "rare_item": true,
       "quest_item": true,
       "leveled": false
     },
@@ -283,7 +309,9 @@
       "school": null,
       "enemy": "Vaermina",
       "daedric": true,
+      "purchasable": false,
       "unique_item": true,
+      "rare_item": true,
       "quest_item": true,
       "leveled": false
     },
@@ -300,7 +328,9 @@
       "school": "Illusion",
       "enemy": null,
       "daedric": false,
+      "purchasable": false,
       "unique_item": true,
+      "rare_item": true,
       "quest_item": true,
       "leveled": false
     },
@@ -322,7 +352,9 @@
       "school": "Conjuration",
       "enemy": null,
       "daedric": false,
+      "purchasable": true,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false,
       "leveled": false
     },
@@ -344,7 +376,9 @@
       "school": "Illusion",
       "enemy": null,
       "daedric": false,
+      "purchasable": true,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -366,7 +400,9 @@
       "school": "Destruction",
       "enemy": null,
       "daedric": false,
+      "purchasable": false,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -388,7 +424,9 @@
       "school": "Destruction",
       "enemy": null,
       "daedric": false,
+      "purchasable": true,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false,
       "leveled": false
     },
@@ -410,7 +448,9 @@
       "school": "Illusion",
       "enemy": null,
       "daedric": false,
+      "purchasable": true,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -432,7 +472,9 @@
       "school": "Conjuration",
       "enemy": null,
       "daedric": false,
+      "purchasable": false,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -454,7 +496,9 @@
       "school": "Conjuration",
       "enemy": null,
       "daedric": false,
+      "purchasable": true,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -476,7 +520,9 @@
       "school": "Conjuration",
       "enemy": null,
       "daedric": false,
+      "purchasable": true,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -498,7 +544,9 @@
       "school": "Illusion",
       "enemy": null,
       "daedric": false,
+      "purchasable": true,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false,
       "leveled": false
     },
@@ -520,7 +568,9 @@
       "school": "Destruction",
       "enemy": null,
       "daedric": false,
+      "purchasable": false,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -542,7 +592,9 @@
       "school": "Destruction",
       "enemy": null,
       "daedric": false,
+      "purchasable": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false,
       "leveled": false
     },
@@ -564,7 +616,9 @@
       "school": "Destruction",
       "enemy": null,
       "daedric": false,
+      "purchasable": false,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -586,7 +640,9 @@
       "school": "Destruction",
       "enemy": null,
       "daedric": false,
+      "purchasable": true,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -608,7 +664,9 @@
       "school": "Destruction",
       "enemy": null,
       "daedric": false,
+      "purchasable": true,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -630,7 +688,9 @@
       "school": "Illusion",
       "enemy": null,
       "daedric": false,
+      "purchasable": true,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false,
       "leveled": false
     },
@@ -652,7 +712,9 @@
       "school": "Destruction",
       "enemy": null,
       "daedric": false,
+      "purchasable": true,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false,
       "leveled": false
     },
@@ -674,7 +736,9 @@
       "school": "Illusion",
       "enemy": null,
       "daedric": false,
+      "purchasable": false,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -696,7 +760,9 @@
       "school": "Destruction",
       "enemy": null,
       "daedric": false,
+      "purchasable": false,
       "unique_item": true,
+      "rare_item": true,
       "quest_item": true,
       "leveled": false
     },
@@ -718,7 +784,9 @@
       "school": "Destruction",
       "enemy": null,
       "daedric": false,
+      "purchasable": false,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -740,7 +808,9 @@
       "school": "Destruction",
       "enemy": null,
       "daedric": false,
+      "purchasable": false,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false,
       "leveled": false
     },
@@ -762,7 +832,9 @@
       "school": "Destruction",
       "enemy": null,
       "daedric": false,
+      "purchasable": false,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -784,7 +856,9 @@
       "school": "Destruction",
       "enemy": null,
       "daedric": false,
+      "purchasable": true,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -806,7 +880,9 @@
       "school": "Destruction",
       "enemy": null,
       "daedric": false,
+      "purchasable": false,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -828,7 +904,9 @@
       "school": "Destruction",
       "enemy": null,
       "daedric": false,
+      "purchasable": true,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -850,7 +928,9 @@
       "school": "Illusion",
       "enemy": null,
       "daedric": false,
+      "purchasable": true,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -872,7 +952,9 @@
       "school": "Destruction",
       "enemy": "Jyrik Gauldurson",
       "daedric": false,
+      "purchasable": false,
       "unique_item": true,
+      "rare_item": true,
       "quest_item": true,
       "leveled": false
     },
@@ -894,7 +976,9 @@
       "school": "Destruction",
       "enemy": null,
       "daedric": false,
+      "purchasable": false,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -916,7 +1000,9 @@
       "school": "Destruction",
       "enemy": null,
       "daedric": false,
+      "purchasable": true,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -938,7 +1024,9 @@
       "school": "Alteration",
       "enemy": null,
       "daedric": false,
+      "purchasable": false,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -960,7 +1048,9 @@
       "school": "Destruction",
       "enemy": "Morokei",
       "daedric": false,
+      "purchasable": false,
       "unique_item": true,
+      "rare_item": true,
       "quest_item": true,
       "leveled": false
     },
@@ -977,7 +1067,9 @@
       "school": "Restoration",
       "enemy": null,
       "daedric": false,
+      "purchasable": true,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -999,7 +1091,9 @@
       "school": "Alteration",
       "enemy": null,
       "daedric": false,
+      "purchasable": true,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -1021,7 +1115,9 @@
       "school": "Conjuration",
       "enemy": null,
       "daedric": false,
+      "purchasable": true,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -1043,7 +1139,9 @@
       "school": "Restoration",
       "enemy": null,
       "daedric": false,
+      "purchasable": false,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -1065,7 +1163,9 @@
       "school": "Conjuration",
       "enemy": null,
       "daedric": false,
+      "purchasable": true,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -1087,7 +1187,9 @@
       "school": "Conjuration",
       "enemy": null,
       "daedric": false,
+      "purchasable": true,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -1109,7 +1211,9 @@
       "school": "Destruction",
       "enemy": null,
       "daedric": false,
+      "purchasable": true,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false,
       "leveled": false
     },
@@ -1131,7 +1235,9 @@
       "school": "Illusion",
       "enemy": null,
       "daedric": false,
+      "purchasable": false,
       "unique_item": true,
+      "rare_item": true,
       "quest_item": true,
       "leveled": false
     },
@@ -1153,7 +1259,9 @@
       "school": "Destruction",
       "enemy": null,
       "daedric": false,
+      "purchasable": true,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -1175,7 +1283,9 @@
       "school": "Restoration",
       "enemy": null,
       "daedric": false,
+      "purchasable": true,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -1197,7 +1307,9 @@
       "school": "Illusion",
       "enemy": null,
       "daedric": false,
+      "purchasable": true,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -1219,7 +1331,9 @@
       "school": "Conjuration",
       "enemy": null,
       "daedric": false,
+      "purchasable": false,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -1241,7 +1355,9 @@
       "school": "Conjuration",
       "enemy": null,
       "daedric": false,
+      "purchasable": true,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false,
       "leveled": false
     },
@@ -1263,7 +1379,9 @@
       "school": "Conjuration",
       "enemy": null,
       "daedric": false,
+      "purchasable": false,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -1285,7 +1403,9 @@
       "school": "Conjuration",
       "enemy": null,
       "daedric": false,
+      "purchasable": false,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -1307,7 +1427,9 @@
       "school": "Destruction",
       "enemy": null,
       "daedric": false,
+      "purchasable": false,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -1329,7 +1451,9 @@
       "school": "Conjuration",
       "enemy": null,
       "daedric": false,
+      "purchasable": false,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -1351,7 +1475,9 @@
       "school": "Conjuration",
       "enemy": null,
       "daedric": false,
+      "purchasable": true,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false,
       "leveled": false
     },
@@ -1373,7 +1499,9 @@
       "school": "Destruction",
       "enemy": null,
       "daedric": false,
+      "purchasable": true,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -1395,7 +1523,9 @@
       "school": "Restoration",
       "enemy": null,
       "daedric": false,
+      "purchasable": true,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -1417,7 +1547,9 @@
       "school": "Conjuration",
       "enemy": null,
       "daedric": false,
+      "purchasable": true,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -1437,9 +1569,11 @@
       "base_damage": 0,
       "magical_effects": null,
       "school": "Destruction",
-      "enemy": null,
+      "enemy": "Otar the Mad",
       "daedric": false,
+      "purchasable": false,
       "unique_item": false,
+      "rare_item": true,
       "quest_item": false,
       "leveled": false
     },
@@ -1461,7 +1595,9 @@
       "school": null,
       "enemy": "Sheogorath",
       "daedric": true,
+      "purchasable": false,
       "unique_item": true,
+      "rare_item": true,
       "quest_item": true,
       "leveled": false
     },

--- a/spec/models/canonical/staff_spec.rb
+++ b/spec/models/canonical/staff_spec.rb
@@ -107,6 +107,15 @@ RSpec.describe Canonical::Staff, type: :model do
       end
     end
 
+    describe 'purchasable' do
+      it "can't be blank" do
+        model = build(:canonical_staff, purchasable: nil)
+
+        model.validate
+        expect(model.errors[:purchasable]).to include 'must be true or false'
+      end
+    end
+
     describe 'unique_item' do
       it "can't be blank" do
         model = build(:canonical_staff, unique_item: nil)
@@ -116,12 +125,37 @@ RSpec.describe Canonical::Staff, type: :model do
       end
     end
 
+    describe 'rare_item' do
+      it "can't be blank" do
+        model = build(:canonical_staff, rare_item: nil)
+
+        model.validate
+        expect(model.errors[:rare_item]).to include 'must be true or false'
+      end
+
+      it 'must be true if the item is unique' do
+        model = build(:canonical_staff, unique_item: true, rare_item: false)
+
+        model.validate
+        expect(model.errors[:rare_item]).to include 'must be true if item is unique'
+      end
+    end
+
     describe 'quest_item' do
       it "can't be blank" do
         model = build(:canonical_staff, quest_item: nil)
 
         model.validate
         expect(model.errors[:quest_item]).to include 'must be true or false'
+      end
+    end
+
+    describe 'leveled' do
+      it "can't be blank" do
+        model = build(:canonical_staff, leveled: nil)
+
+        model.validate
+        expect(model.errors[:leveled]).to include 'must be true or false'
       end
     end
   end

--- a/spec/support/factories/canonical/staves.rb
+++ b/spec/support/factories/canonical/staves.rb
@@ -7,7 +7,9 @@ FactoryBot.define do
     unit_weight          { 8 }
     base_damage          { 0 }
     daedric              { false }
+    purchasable          { true }
     unique_item          { false }
+    rare_item            { false }
     quest_item           { false }
     leveled              { false }
   end

--- a/spec/support/fixtures/canonical/sync/staves.json
+++ b/spec/support/fixtures/canonical/sync/staves.json
@@ -9,7 +9,9 @@
       "school": "Illusion",
       "enemy": "Halldir",
       "daedric": false,
+      "purchasable": false,
       "unique_item": true,
+      "rare_item": true,
       "quest_item": true,
       "leveled": false
     },
@@ -35,7 +37,9 @@
       "school": "Restoration",
       "enemy": null,
       "daedric": false,
+      "purchasable": true,
       "unique_item": false,
+      "rare_item": false,
       "quest_item": false,
       "leveled": false
     },
@@ -57,7 +61,9 @@
       "school": null,
       "enemy": "Miraak",
       "daedric": false,
+      "purchasable": false,
       "unique_item": true,
+      "rare_item": true,
       "quest_item": true,
       "leveled": true
     },
@@ -76,7 +82,9 @@
       "school": "Conjuration",
       "enemy": "Sanguine",
       "daedric": true,
+      "purchasable": false,
       "unique_item": true,
+      "rare_item": true,
       "quest_item": true,
       "leveled": false
     },


### PR DESCRIPTION
## Context

* [**Add boolean columns to canonical models that don't have them**](https://trello.com/c/rNjxj88l/179-add-boolean-columns-to-canonical-models-that-dont-have-them)
* [**Add missing booleans to canonical staves data**](https://trello.com/c/wAlkDLZE/184-add-missing-booleans-to-canonical-staves-data)

We want canonical models, as much as possible, to have a uniform API that includes the following four fields:

* `purchasable`: whether the item can be purchased from merchants or other NPCs
* `unique_item`: whether the item is unique (includes items that respawn as long as they only occur in one location)
* `rare_item`: whether the item is rare (as defined below)
* `quest_item`: whether the item is (a) required to complete a quest or (b) only obtainable through completing a quest

In general, rare items are defined as those that:

a. Are not purchasable and are found in fewer than 10 fixed locations in the game
b. Are purchasable and are found in fewer than 3 fixed locations other than vendors

Additionally, random loot and random drops count as half of a fixed location (so an item that's available from one vendor, a fixed location, random loot, and random drops would still be considered rare, but an item that's available from 9 fixed locations and random loot would not be). The exception is if the item is always dropped by a common type of enemy or is otherwise ubiquitous in the game.

These fields were previously added to the `canonical_staves` table, however, the JSON data we currently have in production doesn't include `purchasable` or `rare_item`, and the `Canonical::Staff` model doesn't include validations for all its boolean fields.

## Changes

* Update JSON data and fixtures to include `purchasable` and `rare_item` fields
* Add validations to the `Canonical::Staff` model for these fields
* Add and update specs to test these validations

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [ ] ~~Added and updated API docs and developer docs as appropriate~~

## Considerations

Instead of updating developer docs now, I've decided to update them once JSON data and validations have been updated for all canonical models.