### PR TITLE
Add NOT NULL constraints to boolean fields on canonical models

### DIFF
--- a/db/migrate/20220607214236_add_not_null_constraint_to_boolean_fields.rb
+++ b/db/migrate/20220607214236_add_not_null_constraint_to_boolean_fields.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class AddNotNullConstraintToBooleanFields < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :canonical_armors, :purchasable, false
+    change_column_null :canonical_armors, :unique_item, false
+    change_column_null :canonical_armors, :rare_item, false
+    change_column_null :canonical_armors, :quest_item, false
+
+    change_column_null :canonical_clothing_items, :purchasable, false
+    change_column_null :canonical_clothing_items, :unique_item, false
+    change_column_null :canonical_clothing_items, :rare_item, false
+    change_column_null :canonical_clothing_items, :quest_item, false
+    change_column_null :canonical_clothing_items, :enchantable, false
+
+    change_column_null :canonical_ingredients, :purchasable, false
+    change_column_null :canonical_ingredients, :unique_item, false
+    change_column_null :canonical_ingredients, :rare_item, false
+    change_column_null :canonical_ingredients, :quest_item, false
+
+    change_column_null :canonical_jewelry_items, :purchasable, false
+    change_column_null :canonical_jewelry_items, :unique_item, false
+    change_column_null :canonical_jewelry_items, :rare_item, false
+    change_column_null :canonical_jewelry_items, :quest_item, false
+    change_column_null :canonical_jewelry_items, :enchantable, false
+
+    change_column_null :canonical_staves, :purchasable, false
+    change_column_null :canonical_staves, :rare_item, false
+
+    change_column_null :canonical_weapons, :purchasable, false
+    change_column_null :canonical_weapons, :unique_item, false
+    change_column_null :canonical_weapons, :rare_item, false
+    change_column_null :canonical_weapons, :quest_item, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_28_233912) do
+ActiveRecord::Schema.define(version: 2022_06_07_214236) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,10 +35,10 @@ ActiveRecord::Schema.define(version: 2022_05_28_233912) do
     t.boolean "dragon_priest_mask", default: false
     t.boolean "enchantable", default: true
     t.boolean "leveled", default: false
-    t.boolean "purchasable"
-    t.boolean "unique_item", default: false
-    t.boolean "rare_item"
-    t.boolean "quest_item", default: false
+    t.boolean "purchasable", null: false
+    t.boolean "unique_item", default: false, null: false
+    t.boolean "rare_item", null: false
+    t.boolean "quest_item", default: false, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "smithing_perks", default: [], array: true
@@ -69,11 +69,11 @@ ActiveRecord::Schema.define(version: 2022_05_28_233912) do
     t.string "body_slot", null: false
     t.string "magical_effects"
     t.decimal "unit_weight", precision: 5, scale: 2, null: false
-    t.boolean "purchasable"
-    t.boolean "unique_item", default: false
-    t.boolean "rare_item"
-    t.boolean "quest_item", default: false
-    t.boolean "enchantable", default: true
+    t.boolean "purchasable", null: false
+    t.boolean "unique_item", default: false, null: false
+    t.boolean "rare_item", null: false
+    t.boolean "quest_item", default: false, null: false
+    t.boolean "enchantable", default: true, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["item_code"], name: "index_canonical_clothing_items_on_item_code", unique: true
@@ -105,10 +105,10 @@ ActiveRecord::Schema.define(version: 2022_05_28_233912) do
     t.string "name", null: false
     t.string "item_code", null: false
     t.decimal "unit_weight", precision: 5, scale: 2, null: false
-    t.boolean "purchasable"
-    t.boolean "unique_item", default: false
-    t.boolean "rare_item"
-    t.boolean "quest_item", default: false
+    t.boolean "purchasable", null: false
+    t.boolean "unique_item", default: false, null: false
+    t.boolean "rare_item", null: false
+    t.boolean "quest_item", default: false, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "ingredient_type"
@@ -136,11 +136,11 @@ ActiveRecord::Schema.define(version: 2022_05_28_233912) do
     t.string "jewelry_type", null: false
     t.string "magical_effects"
     t.decimal "unit_weight", precision: 5, scale: 2, null: false
-    t.boolean "purchasable"
-    t.boolean "unique_item", default: false
-    t.boolean "rare_item"
-    t.boolean "quest_item", default: false
-    t.boolean "enchantable", default: true
+    t.boolean "purchasable", null: false
+    t.boolean "unique_item", default: false, null: false
+    t.boolean "rare_item", null: false
+    t.boolean "quest_item", default: false, null: false
+    t.boolean "enchantable", default: true, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["item_code"], name: "index_canonical_jewelry_items_on_item_code", unique: true
@@ -242,9 +242,9 @@ ActiveRecord::Schema.define(version: 2022_05_28_233912) do
     t.string "school"
     t.string "enemy"
     t.boolean "daedric", default: false, null: false
-    t.boolean "purchasable"
+    t.boolean "purchasable", null: false
     t.boolean "unique_item", default: false, null: false
-    t.boolean "rare_item"
+    t.boolean "rare_item", null: false
     t.boolean "quest_item", default: false, null: false
     t.boolean "leveled", default: false, null: false
     t.datetime "created_at", precision: 6, null: false
@@ -285,10 +285,10 @@ ActiveRecord::Schema.define(version: 2022_05_28_233912) do
     t.decimal "unit_weight", precision: 5, scale: 2, null: false
     t.boolean "leveled", default: false
     t.boolean "enchantable", default: true
-    t.boolean "purchasable"
-    t.boolean "unique_item", default: false
-    t.boolean "rare_item"
-    t.boolean "quest_item", default: false
+    t.boolean "purchasable", null: false
+    t.boolean "unique_item", default: false, null: false
+    t.boolean "rare_item", null: false
+    t.boolean "quest_item", default: false, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["item_code"], name: "index_canonical_weapons_on_item_code", unique: true

--- a/docs/canonical_models/canonical-models.md
+++ b/docs/canonical_models/canonical-models.md
@@ -71,7 +71,7 @@ The only exceptions to these rules are items that are consumable, including arro
 
 #### `quest_item`
 
-In Skyrim, a quest item is considered to be an item that is required to complete a quest. This is distinct from a quest reward, which is an item obtained by completing a quest. In SIM, both of these types of items are designated with the `quest_item` field. **An item that is a quest reward will not be designated as a `quest_item` if there is any other way of obtaining the item in the game.**
+In Skyrim, a quest item is considered to be an item that is required to complete a quest. This is distinct from a quest reward, which is an item obtained by completing a quest. In SIM, both of these types of items are designated with the `quest_item` field. **An item that is a quest reward will not be designated as a `quest_item` if there is any other way of obtaining the item in the game.** Additionally, items that are not quest rewards but are only found or able to be purchased after starting or completing a certain quest or questline are not designated as quest items in SIM.
 
 ## Syncing Canonical Models
 


### PR DESCRIPTION
## Context

[**Make boolean fields required on canonical models that have them**](https://trello.com/c/7N7Itd1K/186-make-boolean-fields-required-on-canonical-models-that-have-them)

We've added four standard columns to most canonical models (other than canonical materials* and a few other canonical models - `Canonical::Property`, join models, etc. - where adding them didn't make sense):

* `purchasable`: Whether the item is ever available for purchase from any vendors or other NPCs
* `unique_item`: Whether the item is unique in the game (items that respawn count as long as they occur in only one place and that place is not a vendor)
* `rare_item`: Whether the item is [rare](https://github.com/danascheider/skyrim_inventory_management/blob/main/docs/canonical_models/canonical-models.md)
* `quest_item`: Whether the item is (a) required to complete a quest or (b) only obtainable through completing a quest

Note that quest items encompass two types of items in Skyrim: quest items and quest rewards. _Quest items do not include items that are only found or available for sale after completing a quest._

For the models that have them, we want these fields to be required as `true` or `false`. Validations to this effect have already been added to the models, but database constraints weren't able to be added until all models already in the production database were updated to have them. This work was done as part of [this card](https://trello.com/c/rNjxj88l/179-add-boolean-columns-to-canonical-models-that-dont-have-them) (PRs attached to card).

A few models also had an additional field, `enchantable`, which I also went ahead and added a `NOT NULL` constraint to.

*I'm beginning to think canonical materials should have these fields as well.

## Changes

* Migration and schema updates making boolean columns required for canonical models that have them

### Required Changes

* [x] ~~Added and updated RSpec tests as appropriate~~
* [x] Added and updated API docs and developer docs as appropriate

