### PR TITLE
Update hash syntax to use value omission

### DIFF
--- a/app/controller_services/inventory_items_controller/create_service.rb
+++ b/app/controller_services/inventory_items_controller/create_service.rb
@@ -21,7 +21,7 @@ class InventoryItemsController < ApplicationController
       return Service::MethodNotAllowedResult.new(errors: [AGGREGATE_LIST_ERROR]) if inventory_list.aggregate == true
 
       preexisting_item = inventory_list.list_items.find_by('description ILIKE ?', params[:description])
-      item             = InventoryItem.combine_or_new(params.merge(list_id: list_id))
+      item             = InventoryItem.combine_or_new(params.merge(list_id:))
 
       ActiveRecord::Base.transaction do
         item.save!
@@ -30,13 +30,13 @@ class InventoryItemsController < ApplicationController
           aggregate_list_item = aggregate_list.add_item_from_child_list(item)
 
           resource = params[:unit_weight] ? all_matching_list_items : [aggregate_list_item, item]
-          Service::CreatedResult.new(resource: resource)
+          Service::CreatedResult.new(resource:)
         else
           aggregate_list_item = aggregate_list.update_item_from_child_list(params[:description], params[:quantity], params[:unit_weight], nil, params[:notes])
 
           resource = params[:unit_weight] ? all_matching_list_items : [aggregate_list_item, item]
 
-          Service::OKResult.new(resource: resource)
+          Service::OKResult.new(resource:)
         end
       end
     rescue ActiveRecord::RecordInvalid

--- a/app/controller_services/inventory_items_controller/update_service.rb
+++ b/app/controller_services/inventory_items_controller/update_service.rb
@@ -31,7 +31,7 @@ class InventoryItemsController < ApplicationController
 
       resource = params[:unit_weight] ? all_matching_items : [aggregate_list_item, list_item]
 
-      Service::OKResult.new(resource: resource)
+      Service::OKResult.new(resource:)
     rescue ActiveRecord::RecordInvalid
       Service::UnprocessableEntityResult.new(errors: list_item.error_array)
     rescue ActiveRecord::RecordNotFound

--- a/app/controller_services/inventory_lists_controller/create_service.rb
+++ b/app/controller_services/inventory_lists_controller/create_service.rb
@@ -23,7 +23,7 @@ class InventoryListsController < ApplicationController
 
       if inventory_list.save
         resource = preexisting_aggregate_list ? inventory_list : [game.aggregate_inventory_list, inventory_list]
-        Service::CreatedResult.new(resource: resource)
+        Service::CreatedResult.new(resource:)
       else
         Service::UnprocessableEntityResult.new(errors: inventory_list.error_array)
       end

--- a/app/controller_services/shopping_list_items_controller/create_service.rb
+++ b/app/controller_services/shopping_list_items_controller/create_service.rb
@@ -21,7 +21,7 @@ class ShoppingListItemsController < ApplicationController
       return Service::MethodNotAllowedResult.new(errors: [AGGREGATE_LIST_ERROR]) if shopping_list.aggregate == true
 
       preexisting_item = shopping_list.list_items.find_by('description ILIKE ?', params[:description])
-      item             = ShoppingListItem.combine_or_new(params.merge(list_id: list_id))
+      item             = ShoppingListItem.combine_or_new(params.merge(list_id:))
 
       ActiveRecord::Base.transaction do
         item.save!
@@ -31,13 +31,13 @@ class ShoppingListItemsController < ApplicationController
 
           resource = params[:unit_weight] ? all_matching_list_items : [aggregate_list_item, item]
 
-          Service::CreatedResult.new(resource: resource)
+          Service::CreatedResult.new(resource:)
         else
           aggregate_list_item = aggregate_list.update_item_from_child_list(params[:description], params[:quantity], params[:unit_weight], nil, params[:notes])
 
           resource = params[:unit_weight] ? all_matching_list_items : [aggregate_list_item, item]
 
-          Service::OKResult.new(resource: resource)
+          Service::OKResult.new(resource:)
         end
       end
     rescue ActiveRecord::RecordInvalid

--- a/app/controller_services/shopping_list_items_controller/update_service.rb
+++ b/app/controller_services/shopping_list_items_controller/update_service.rb
@@ -31,7 +31,7 @@ class ShoppingListItemsController < ApplicationController
 
       resource = params[:unit_weight] ? all_matching_items : [aggregate_list_item, list_item]
 
-      Service::OKResult.new(resource: resource)
+      Service::OKResult.new(resource:)
     rescue ActiveRecord::RecordInvalid
       Service::UnprocessableEntityResult.new(errors: list_item.error_array)
     rescue ActiveRecord::RecordNotFound

--- a/app/controller_services/shopping_lists_controller/create_service.rb
+++ b/app/controller_services/shopping_lists_controller/create_service.rb
@@ -26,7 +26,7 @@ class ShoppingListsController < ApplicationController
       if shopping_list.save
         # Check if the aggregate shopping list is newly created and return it too if so
         resource = preexisting_aggregate_list ? shopping_list : [game.aggregate_shopping_list, shopping_list]
-        Service::CreatedResult.new(resource: resource)
+        Service::CreatedResult.new(resource:)
       else
         Service::UnprocessableEntityResult.new(errors: shopping_list.error_array)
       end

--- a/app/models/concerns/aggregatable.rb
+++ b/app/models/concerns/aggregatable.rb
@@ -118,7 +118,7 @@ module Aggregatable
       other_items = child_lists.all.map(&:list_items)
       other_items.flatten!
 
-      other_items.each {|item| item.update!(unit_weight: unit_weight) if item.description.casecmp(description).zero? }
+      other_items.each {|item| item.update!(unit_weight:) if item.description.casecmp(description).zero? }
     end
 
     existing_item.save!
@@ -136,11 +136,11 @@ module Aggregatable
   end
 
   def set_aggregate_list
-    self.aggregate_list ||= self.class.find_or_create_by!(game: game, aggregate: true)
+    self.aggregate_list ||= self.class.find_or_create_by!(game:, aggregate: true)
   end
 
   def create_aggregate_list
-    self.class.find_or_create_by!(game: game, aggregate: true)
+    self.class.find_or_create_by!(game:, aggregate: true)
   end
 
   def set_title_to_all_items
@@ -167,7 +167,7 @@ module Aggregatable
   end
 
   def one_aggregate_list_per_game
-    scope = self.class.where(game: game, aggregate: true)
+    scope = self.class.where(game:, aggregate: true)
 
     errors.add(:aggregate, 'can only be one list per game') if scope.count > 1 || (scope.count > 0 && scope.exclude?(self))
   end

--- a/spec/controller_services/games_controller/update_service_spec.rb
+++ b/spec/controller_services/games_controller/update_service_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe GamesController::UpdateService do
 
     context 'when the params are invalid' do
       let!(:game)       { create(:game) }
-      let!(:other_game) { create(:game, user: user) }
+      let!(:other_game) { create(:game, user:) }
       let(:user)        { game.user }
       let(:params)      { { name: other_game.name } }
 

--- a/spec/controller_services/inventory_items_controller/create_service_spec.rb
+++ b/spec/controller_services/inventory_items_controller/create_service_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe InventoryItemsController::CreateService do
     subject(:perform) { described_class.new(user, inventory_list.id, params).perform }
 
     let(:user)            { create(:user) }
-    let(:game)            { create(:game, user: user) }
-    let!(:aggregate_list) { create(:aggregate_inventory_list, game: game) }
-    let!(:inventory_list) { create(:inventory_list, game: game, aggregate_list: aggregate_list) }
+    let(:game)            { create(:game, user:) }
+    let!(:aggregate_list) { create(:aggregate_inventory_list, game:) }
+    let!(:inventory_list) { create(:inventory_list, game:, aggregate_list:) }
 
     context 'when all goes well' do
       let(:params) { { description: 'Necklace', quantity: 2, notes: 'Hello world' } }
@@ -41,7 +41,7 @@ RSpec.describe InventoryItemsController::CreateService do
         end
 
         context 'when there is an existing matching item on another list' do
-          let(:other_list)  { create(:inventory_list, game: aggregate_list.game, aggregate_list: aggregate_list) }
+          let(:other_list)  { create(:inventory_list, game: aggregate_list.game, aggregate_list:) }
           let!(:other_item) { create(:inventory_item, list: other_list, description: 'Necklace', quantity: 1) }
 
           before do
@@ -102,7 +102,7 @@ RSpec.describe InventoryItemsController::CreateService do
       end
 
       context 'when there is an existing matching item on the same list' do
-        let(:other_list)  { create(:inventory_list, game: game) }
+        let(:other_list)  { create(:inventory_list, game:) }
         let!(:other_item) { create(:inventory_item, list: other_list, description: 'Necklace', quantity: 2) }
         let!(:list_item)  { create(:inventory_item, list: inventory_list, description: 'Necklace', quantity: 1) }
 

--- a/spec/controller_services/inventory_items_controller/destroy_service_spec.rb
+++ b/spec/controller_services/inventory_items_controller/destroy_service_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe InventoryItemsController::DestroyService do
     subject(:perform) { described_class.new(user, list_item.id).perform }
 
     let(:user) { create(:user) }
-    let(:game) { create(:game, user: user) }
+    let(:game) { create(:game, user:) }
 
-    let!(:aggregate_list) { create(:aggregate_inventory_list, game: game) }
-    let!(:inventory_list) { create(:inventory_list, game: game, aggregate_list: aggregate_list) }
+    let!(:aggregate_list) { create(:aggregate_inventory_list, game:) }
+    let!(:inventory_list) { create(:inventory_list, game:, aggregate_list:) }
 
     context 'when all goes well' do
       context 'when there is no matching item on another list' do
@@ -42,7 +42,7 @@ RSpec.describe InventoryItemsController::DestroyService do
 
       context 'when there is a matching item on another list' do
         let!(:list_item)  { create(:inventory_item, list: inventory_list) }
-        let(:other_list)  { create(:inventory_list, game: game) }
+        let(:other_list)  { create(:inventory_list, game:) }
         let!(:other_item) { create(:inventory_item, description: list_item.description, list: other_list) }
 
         before do

--- a/spec/controller_services/inventory_items_controller/update_service_spec.rb
+++ b/spec/controller_services/inventory_items_controller/update_service_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe InventoryItemsController::UpdateService do
     subject(:perform) { described_class.new(user, list_item.id, params).perform }
 
     let(:user)            { create(:user) }
-    let(:game)            { create(:game, user: user) }
-    let!(:aggregate_list) { create(:aggregate_inventory_list, game: game) }
-    let!(:inventory_list) { create(:inventory_list, game: game, aggregate_list: aggregate_list) }
+    let(:game)            { create(:game, user:) }
+    let!(:aggregate_list) { create(:aggregate_inventory_list, game:) }
+    let!(:inventory_list) { create(:inventory_list, game:, aggregate_list:) }
 
     context 'when all goes well' do
       context 'when there is no matching item on another list' do
@@ -49,7 +49,7 @@ RSpec.describe InventoryItemsController::UpdateService do
 
       context 'when there is a matching item on another list' do
         let!(:list_item)          { create(:inventory_item, list: inventory_list, quantity: 4) }
-        let(:other_list)          { create(:inventory_list, game: game, aggregate_list: aggregate_list) }
+        let(:other_list)          { create(:inventory_list, game:, aggregate_list:) }
         let!(:other_item)         { create(:inventory_item, description: list_item.description, list: other_list, quantity: 3) }
         let(:aggregate_list_item) { aggregate_list.list_items.first }
 
@@ -155,7 +155,7 @@ RSpec.describe InventoryItemsController::UpdateService do
 
     context 'when the attributes are invalid' do
       let!(:list_item)          { create(:inventory_item, list: inventory_list, quantity: 2) }
-      let(:other_list)          { create(:inventory_list, game: game) }
+      let(:other_list)          { create(:inventory_list, game:) }
       let!(:other_item)         { create(:inventory_item, list: other_list, description: list_item.description, quantity: 1) }
       let(:aggregate_list_item) { aggregate_list.list_items.first }
       let(:params)              { { quantity: -4, unit_weight: 2 } }

--- a/spec/controller_services/inventory_lists_controller/create_service_spec.rb
+++ b/spec/controller_services/inventory_lists_controller/create_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe InventoryListsController::CreateService do
     let(:user) { create(:user) }
 
     context 'when the params are valid' do
-      let!(:game)  { create(:game, user: user) }
+      let!(:game)  { create(:game, user:) }
       let(:params) { { title: 'Hjerim' } }
 
       context 'when the game has no aggregate inventory list' do
@@ -51,7 +51,7 @@ RSpec.describe InventoryListsController::CreateService do
 
       context 'when the game has an aggregate inventory list' do
         before do
-          create(:aggregate_inventory_list, game: game)
+          create(:aggregate_inventory_list, game:)
         end
 
         it 'creates an inventory list for the given game' do
@@ -70,7 +70,7 @@ RSpec.describe InventoryListsController::CreateService do
     end
 
     context 'when the params are invalid' do
-      let(:game)    { create(:game, user: user) }
+      let(:game)    { create(:game, user:) }
       let(:game_id) { game.id }
       let(:params)  { { title: '|nvalid Tit|e' } }
 
@@ -115,7 +115,7 @@ RSpec.describe InventoryListsController::CreateService do
     end
 
     context 'when the request tries to create an aggregate list' do
-      let(:game) { create(:game, user: user) }
+      let(:game) { create(:game, user:) }
       let(:params) do
         {
           title:     'All Items',
@@ -133,7 +133,7 @@ RSpec.describe InventoryListsController::CreateService do
     end
 
     context 'when something unexpected goes wrong' do
-      let(:game)   { create(:game, user: user) }
+      let(:game)   { create(:game, user:) }
       let(:params) { { title: 'Foobar' } }
 
       before do

--- a/spec/controller_services/inventory_lists_controller/destroy_service_spec.rb
+++ b/spec/controller_services/inventory_lists_controller/destroy_service_spec.rb
@@ -11,11 +11,11 @@ RSpec.describe InventoryListsController::DestroyService do
     subject(:perform) { described_class.new(user, inventory_list.id).perform }
 
     let(:user) { create(:user) }
-    let(:game) { create(:game, user: user) }
+    let(:game) { create(:game, user:) }
 
     context 'when all goes well' do
-      let!(:aggregate_list) { create(:aggregate_inventory_list, game: game) }
-      let!(:inventory_list) { create(:inventory_list_with_list_items, game: game) }
+      let!(:aggregate_list) { create(:aggregate_inventory_list, game:) }
+      let!(:inventory_list) { create(:inventory_list_with_list_items, game:) }
 
       before do
         inventory_list.list_items.each do |list_item|
@@ -24,7 +24,7 @@ RSpec.describe InventoryListsController::DestroyService do
       end
 
       context 'when the game has additional regular lists' do
-        let!(:third_list) { create(:inventory_list_with_list_items, game: game, aggregate_list: aggregate_list) }
+        let!(:third_list) { create(:inventory_list_with_list_items, game:, aggregate_list:) }
 
         before do
           third_list.list_items.each do |list_item|
@@ -85,7 +85,7 @@ RSpec.describe InventoryListsController::DestroyService do
     end
 
     context 'when the list is an aggregate list' do
-      let!(:inventory_list) { create(:aggregate_inventory_list, game: game) }
+      let!(:inventory_list) { create(:aggregate_inventory_list, game:) }
 
       it 'returns a Service::MethodNotAllowedResult' do
         expect(perform).to be_a(Service::MethodNotAllowedResult)
@@ -128,7 +128,7 @@ RSpec.describe InventoryListsController::DestroyService do
     end
 
     context 'when something unexpected goes wrong' do
-      let!(:inventory_list) { create(:inventory_list, game: game) }
+      let!(:inventory_list) { create(:inventory_list, game:) }
 
       before do
         allow_any_instance_of(InventoryList).to receive(:aggregate_list).and_raise(StandardError.new('Something went horribly wrong'))

--- a/spec/controller_services/inventory_lists_controller/index_service_spec.rb
+++ b/spec/controller_services/inventory_lists_controller/index_service_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe InventoryListsController::IndexService do
     let(:user) { create(:user) }
 
     context 'when there are no inventory lists for that game' do
-      let(:game) { create(:game, user: user) }
+      let(:game) { create(:game, user:) }
 
       it 'returns a Service::OKResult' do
         expect(perform).to be_a(Service::OKResult)
@@ -24,7 +24,7 @@ RSpec.describe InventoryListsController::IndexService do
     end
 
     context 'when there are inventory lists for that game' do
-      let(:game) { create(:game_with_inventory_lists, user: user) }
+      let(:game) { create(:game_with_inventory_lists, user:) }
 
       it 'returns a Service::OKResult' do
         expect(perform).to be_a(Service::OKResult)
@@ -60,7 +60,7 @@ RSpec.describe InventoryListsController::IndexService do
     end
 
     context 'when something unexpected goes wrong' do
-      let(:game) { create(:game, user: user) }
+      let(:game) { create(:game, user:) }
 
       before do
         allow(user.games).to receive(:find).and_raise(StandardError.new('Something went horribly wrong'))

--- a/spec/controller_services/inventory_lists_controller/update_service_spec.rb
+++ b/spec/controller_services/inventory_lists_controller/update_service_spec.rb
@@ -11,12 +11,12 @@ RSpec.describe InventoryListsController::UpdateService do
   describe '#perform' do
     subject(:perform) { described_class.new(user, inventory_list.id, params).perform }
 
-    let!(:aggregate_list) { create(:aggregate_inventory_list, game: game) }
+    let!(:aggregate_list) { create(:aggregate_inventory_list, game:) }
     let(:user)            { create(:user) }
-    let(:game)            { create(:game, user: user) }
+    let(:game)            { create(:game, user:) }
 
     context 'when all goes well' do
-      let(:inventory_list) { create(:inventory_list, game: game, aggregate_list: aggregate_list) }
+      let(:inventory_list) { create(:inventory_list, game:, aggregate_list:) }
       let(:params)         { { title: 'My New Title' } }
 
       it 'updates the inventory list' do
@@ -42,7 +42,7 @@ RSpec.describe InventoryListsController::UpdateService do
     end
 
     context 'when the params are invalid' do
-      let(:inventory_list) { create(:inventory_list, game: game) }
+      let(:inventory_list) { create(:inventory_list, game:) }
       let(:params)         { { title: '|nvalid Tit|e' } }
 
       it 'returns a Service::UnprocessableEntityResult' do
@@ -69,7 +69,7 @@ RSpec.describe InventoryListsController::UpdateService do
     end
 
     context "when the inventory list doesn't belong to the user" do
-      let(:inventory_list) { create(:inventory_list, game: game) }
+      let(:inventory_list) { create(:inventory_list, game:) }
       let(:game)           { create(:game) }
       let(:params)         { { title: 'Valid New Title' } }
 
@@ -102,7 +102,7 @@ RSpec.describe InventoryListsController::UpdateService do
     end
 
     context 'when the request tries to set aggregate to true' do
-      let(:inventory_list) { create(:inventory_list, game: game) }
+      let(:inventory_list) { create(:inventory_list, game:) }
       let(:params)         { { aggregate: true } }
 
       it 'returns a Service::UnprocessableEntityResult' do
@@ -115,7 +115,7 @@ RSpec.describe InventoryListsController::UpdateService do
     end
 
     context 'when something unexpected goes wrong' do
-      let(:inventory_list) { create(:inventory_list, game: game) }
+      let(:inventory_list) { create(:inventory_list, game:) }
       let(:params)         { { title: 'New Title' } }
 
       before do

--- a/spec/controller_services/shopping_list_items_controller/create_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/create_service_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe ShoppingListItemsController::CreateService do
     subject(:perform) { described_class.new(user, shopping_list.id, params).perform }
 
     let(:user)            { create(:user) }
-    let(:game)            { create(:game, user: user) }
-    let!(:aggregate_list) { create(:aggregate_shopping_list, game: game) }
-    let!(:shopping_list)  { create(:shopping_list, game: game, aggregate_list: aggregate_list) }
+    let(:game)            { create(:game, user:) }
+    let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
+    let!(:shopping_list)  { create(:shopping_list, game:, aggregate_list:) }
 
     context 'when all goes well' do
       let(:params) { { description: 'Necklace', quantity: 2, notes: 'Hello world' } }
@@ -41,7 +41,7 @@ RSpec.describe ShoppingListItemsController::CreateService do
         end
 
         context 'when there is an existing matching item on another list' do
-          let(:other_list)  { create(:shopping_list, game: aggregate_list.game, aggregate_list: aggregate_list) }
+          let(:other_list)  { create(:shopping_list, game: aggregate_list.game, aggregate_list:) }
           let!(:other_item) { create(:shopping_list_item, list: other_list, description: 'Necklace', quantity: 1) }
 
           before do
@@ -102,7 +102,7 @@ RSpec.describe ShoppingListItemsController::CreateService do
       end
 
       context 'when there is an existing matching item on the same list' do
-        let(:other_list)  { create(:shopping_list, game: game) }
+        let(:other_list)  { create(:shopping_list, game:) }
         let!(:other_item) { create(:shopping_list_item, list: other_list, description: 'Necklace', quantity: 2) }
         let!(:list_item)  { create(:shopping_list_item, list: shopping_list, description: 'Necklace', quantity: 1) }
 

--- a/spec/controller_services/shopping_list_items_controller/destroy_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/destroy_service_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe ShoppingListItemsController::DestroyService do
     subject(:perform) { described_class.new(user, list_item.id).perform }
 
     let(:game)            { create(:game) }
-    let!(:aggregate_list) { create(:aggregate_shopping_list, game: game) }
-    let!(:shopping_list)  { create(:shopping_list, game: game, aggregate_list: aggregate_list) }
+    let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
+    let!(:shopping_list)  { create(:shopping_list, game:, aggregate_list:) }
 
     context 'when all goes well' do
       let(:list_item) { create(:shopping_list_item, list: shopping_list, notes: 'some notes') }
@@ -58,7 +58,7 @@ RSpec.describe ShoppingListItemsController::DestroyService do
 
       context 'when the quantity on the aggregate list exceeds the quantity on the regular list' do
         let(:user) { game.user }
-        let(:second_list) { create(:shopping_list, game: game, aggregate_list: aggregate_list) }
+        let(:second_list) { create(:shopping_list, game:, aggregate_list:) }
         let(:second_list_item) do
           create(:shopping_list_item,
                  list:        second_list,

--- a/spec/controller_services/shopping_list_items_controller/update_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/update_service_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe ShoppingListItemsController::UpdateService do
     subject(:perform) { described_class.new(user, list_item.id, params).perform }
 
     let(:user)            { create(:user) }
-    let(:game)            { create(:game, user: user) }
-    let!(:aggregate_list) { create(:aggregate_shopping_list, game: game) }
-    let!(:shopping_list)  { create(:shopping_list, game: game, aggregate_list: aggregate_list) }
+    let(:game)            { create(:game, user:) }
+    let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
+    let!(:shopping_list)  { create(:shopping_list, game:, aggregate_list:) }
 
     context 'when all goes well' do
       context 'when there is no matching item on another list' do
@@ -49,7 +49,7 @@ RSpec.describe ShoppingListItemsController::UpdateService do
 
       context 'when there is a matching item on another list' do
         let!(:list_item)          { create(:shopping_list_item, list: shopping_list, quantity: 4) }
-        let(:other_list)          { create(:shopping_list, game: game, aggregate_list: aggregate_list) }
+        let(:other_list)          { create(:shopping_list, game:, aggregate_list:) }
         let!(:other_item)         { create(:shopping_list_item, description: list_item.description, list: other_list, quantity: 3) }
         let(:aggregate_list_item) { aggregate_list.list_items.first }
 
@@ -155,7 +155,7 @@ RSpec.describe ShoppingListItemsController::UpdateService do
 
     context 'when the attributes are invalid' do
       let!(:list_item)          { create(:shopping_list_item, list: shopping_list, quantity: 2) }
-      let(:other_list)          { create(:shopping_list, game: game) }
+      let(:other_list)          { create(:shopping_list, game:) }
       let!(:other_item)         { create(:shopping_list_item, list: other_list, description: list_item.description, quantity: 1) }
       let(:aggregate_list_item) { aggregate_list.list_items.first }
       let(:params)              { { quantity: -4, unit_weight: 2 } }

--- a/spec/controller_services/shopping_lists_controller/create_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/create_service_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe ShoppingListsController::CreateService do
     end
 
     context 'when the request tries to create an aggregate list' do
-      let(:game) { create(:game, user: user) }
+      let(:game) { create(:game, user:) }
       let(:params) do
         {
           title:     'All Items',
@@ -57,12 +57,12 @@ RSpec.describe ShoppingListsController::CreateService do
     end
 
     context 'when params are valid' do
-      let!(:game)  { create(:game, user: user) }
+      let!(:game)  { create(:game, user:) }
       let(:params) { { title: 'Proudspire Manor' } }
 
       context 'when the game has an aggregate shopping list' do
         before do
-          create(:aggregate_shopping_list, game: game)
+          create(:aggregate_shopping_list, game:)
         end
 
         it 'creates a shopping list for the given game' do
@@ -122,7 +122,7 @@ RSpec.describe ShoppingListsController::CreateService do
     end
 
     context 'when params are invalid' do
-      let(:game)    { create(:game, user: user) }
+      let(:game)    { create(:game, user:) }
       let(:game_id) { game.id }
       let(:params)  { { title: '|nvalid Tit|e' } }
 
@@ -141,7 +141,7 @@ RSpec.describe ShoppingListsController::CreateService do
     end
 
     context 'when something unexpected goes wrong' do
-      let(:game)   { create(:game, user: user) }
+      let(:game)   { create(:game, user:) }
       let(:params) { { title: 'Foobar' } }
 
       before do

--- a/spec/controller_services/shopping_lists_controller/destroy_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/destroy_service_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe ShoppingListsController::DestroyService do
     let(:user) { create(:user) }
 
     context 'when all goes well' do
-      let!(:aggregate_list) { create(:aggregate_shopping_list, game: game) }
-      let!(:shopping_list)  { create(:shopping_list_with_list_items, game: game) }
-      let(:game)            { create(:game, user: user) }
+      let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
+      let!(:shopping_list)  { create(:shopping_list_with_list_items, game:) }
+      let(:game)            { create(:game, user:) }
 
       context 'when the game has additional regular lists' do
-        let!(:third_list) { create(:shopping_list, game: game, aggregate_list: aggregate_list) }
+        let!(:third_list) { create(:shopping_list, game:, aggregate_list:) }
 
         before do
           shopping_list.list_items.each do |list_item|
@@ -99,8 +99,8 @@ RSpec.describe ShoppingListsController::DestroyService do
     end
 
     context 'when the list is an aggregate list' do
-      let!(:shopping_list) { create(:aggregate_shopping_list, game: game) }
-      let(:game)           { create(:game, user: user) }
+      let!(:shopping_list) { create(:aggregate_shopping_list, game:) }
+      let(:game)           { create(:game, user:) }
 
       it 'returns a Service::MethodNotAllowedResult' do
         expect(perform).to be_a(Service::MethodNotAllowedResult)
@@ -138,8 +138,8 @@ RSpec.describe ShoppingListsController::DestroyService do
     end
 
     context 'when something unexpected goes wrong' do
-      let!(:shopping_list) { create(:shopping_list, game: game) }
-      let(:game)           { create(:game, user: user) }
+      let!(:shopping_list) { create(:shopping_list, game:) }
+      let(:game)           { create(:game, user:) }
 
       before do
         allow_any_instance_of(ShoppingList).to receive(:aggregate_list).and_raise(StandardError.new('Something went horribly wrong'))

--- a/spec/controller_services/shopping_lists_controller/index_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/index_service_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe ShoppingListsController::IndexService do
     end
 
     context 'when there are no shopping lists for that game' do
-      let(:game) { create(:game, user: user) }
+      let(:game) { create(:game, user:) }
       let(:game_id) { game.id }
 
       it 'returns a Service::OKResult' do
@@ -49,7 +49,7 @@ RSpec.describe ShoppingListsController::IndexService do
     end
 
     context 'when there are shopping lists for that game' do
-      let(:game) { create(:game_with_shopping_lists, user: user) }
+      let(:game) { create(:game_with_shopping_lists, user:) }
       let(:game_id) { game.id }
 
       it 'returns a Service::OKResult' do
@@ -62,7 +62,7 @@ RSpec.describe ShoppingListsController::IndexService do
     end
 
     context 'when something unexpected goes wrong' do
-      let(:game) { create(:game, user: user) }
+      let(:game) { create(:game, user:) }
       let(:game_id) { game.id }
 
       before do

--- a/spec/controller_services/shopping_lists_controller/update_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/update_service_spec.rb
@@ -11,12 +11,12 @@ RSpec.describe ShoppingListsController::UpdateService do
   describe '#perform' do
     subject(:perform) { described_class.new(user, shopping_list.id, params).perform }
 
-    let!(:aggregate_list) { create(:aggregate_shopping_list, game: game) }
+    let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
     let(:user)            { create(:user) }
 
     context 'when all goes well' do
-      let(:shopping_list) { create(:shopping_list, game: game, aggregate_list: aggregate_list) }
-      let(:game)   { create(:game, user: user) }
+      let(:shopping_list) { create(:shopping_list, game:, aggregate_list:) }
+      let(:game)   { create(:game, user:) }
       let(:params) { { title: 'My New Title' } }
 
       it 'updates the shopping list' do
@@ -42,8 +42,8 @@ RSpec.describe ShoppingListsController::UpdateService do
     end
 
     context 'when the params are invalid' do
-      let(:shopping_list) { create(:shopping_list, game: game) }
-      let(:game)          { create(:game, user: user) }
+      let(:shopping_list) { create(:shopping_list, game:) }
+      let(:game)          { create(:game, user:) }
       let(:params)        { { title: '|nvalid Tit|e' } }
 
       it 'returns a Service::UnprocessableEntityResult' do
@@ -71,7 +71,7 @@ RSpec.describe ShoppingListsController::UpdateService do
     end
 
     context 'when the shopping list does not belong to the user' do
-      let(:shopping_list) { create(:shopping_list, game: game) }
+      let(:shopping_list) { create(:shopping_list, game:) }
       let(:game)          { create(:game) }
       let(:params)        { { title: 'Valid New Title' } }
 
@@ -92,7 +92,7 @@ RSpec.describe ShoppingListsController::UpdateService do
 
     context 'when the shopping list is an aggregate shopping list' do
       let(:shopping_list) { aggregate_list }
-      let(:game)          { create(:game, user: user) }
+      let(:game)          { create(:game, user:) }
       let(:params)        { { title: 'New Title' } }
 
       it 'returns a Service::MethodNotAllowedResult' do
@@ -105,8 +105,8 @@ RSpec.describe ShoppingListsController::UpdateService do
     end
 
     context 'when the request tries to set aggregate to true' do
-      let(:shopping_list) { create(:shopping_list, game: game) }
-      let(:game)          { create(:game, user: user) }
+      let(:shopping_list) { create(:shopping_list, game:) }
+      let(:game)          { create(:game, user:) }
       let(:params)        { { aggregate: true } }
 
       it 'returns a Service::UnprocessableEntityResult' do
@@ -119,8 +119,8 @@ RSpec.describe ShoppingListsController::UpdateService do
     end
 
     context 'when something unexpected goes wrong' do
-      let!(:shopping_list) { create(:shopping_list, game: game) }
-      let(:game)           { create(:game, user: user) }
+      let!(:shopping_list) { create(:shopping_list, game:) }
+      let(:game)           { create(:game, user:) }
       let(:params)         { { title: 'New Title' } }
 
       before do

--- a/spec/lib/controller/response_spec.rb
+++ b/spec/lib/controller/response_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Controller::Response do
     context 'when there is a resource' do
       let(:controller) { instance_double(ShoppingListsController, render: nil) }
       let(:options)    { {} }
-      let(:result)     { Service::OKResult.new(resource: resource) }
+      let(:result)     { Service::OKResult.new(resource:) }
 
       let(:resource) do
         {
@@ -58,11 +58,11 @@ RSpec.describe Controller::Response do
       let(:controller) { instance_double(ShoppingListsController, render: nil) }
       let(:errors)     { ['Cannot manually update an aggregate shopping list'] }
       let(:options)    { {} }
-      let(:result)     { Service::MethodNotAllowedResult.new(errors: errors) }
+      let(:result)     { Service::MethodNotAllowedResult.new(errors:) }
 
       it 'renders the errors with the result status' do
         execute
-        expect(controller).to have_received(:render).with(json: { errors: errors }, status: :method_not_allowed)
+        expect(controller).to have_received(:render).with(json: { errors: }, status: :method_not_allowed)
       end
     end
 
@@ -71,11 +71,11 @@ RSpec.describe Controller::Response do
         let(:controller) { instance_double(ShoppingListsController, render: nil) }
         let(:options)    { {} }
         let(:errors)     { ['Title is already taken', 'Cannot manually create or update an aggregate shopping list'] }
-        let(:result)     { Service::UnprocessableEntityResult.new(errors: errors, resource: { foo: 'bar' }) }
+        let(:result)     { Service::UnprocessableEntityResult.new(errors:, resource: { foo: 'bar' }) }
 
         it 'renders the errors' do
           execute
-          expect(controller).to have_received(:render).with(json: { errors: errors }, status: :unprocessable_entity)
+          expect(controller).to have_received(:render).with(json: { errors: }, status: :unprocessable_entity)
         end
       end
     end

--- a/spec/models/canonical/armor_spec.rb
+++ b/spec/models/canonical/armor_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe Canonical::Armor, type: :model do
       let(:enchantment) { create(:enchantment) }
 
       before do
-        armor.canonical_enchantables_enchantments.create!(enchantment: enchantment, strength: 40)
+        armor.canonical_enchantables_enchantments.create!(enchantment:, strength: 40)
       end
 
       it 'gives the enchantment strength' do
@@ -187,7 +187,7 @@ RSpec.describe Canonical::Armor, type: :model do
       let(:material) { create(:canonical_material) }
 
       before do
-        armor.canonical_craftables_crafting_materials.create!(material: material, quantity: 4)
+        armor.canonical_craftables_crafting_materials.create!(material:, quantity: 4)
       end
 
       it 'gives the quantity needed' do
@@ -200,7 +200,7 @@ RSpec.describe Canonical::Armor, type: :model do
       let(:material) { create(:canonical_material) }
 
       before do
-        armor.canonical_temperables_tempering_materials.create!(material: material, quantity: 1)
+        armor.canonical_temperables_tempering_materials.create!(material:, quantity: 1)
       end
 
       it 'gives the quantity needed' do

--- a/spec/models/canonical/clothing_item_spec.rb
+++ b/spec/models/canonical/clothing_item_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe Canonical::ClothingItem, type: :model do
       let(:enchantment) { create(:enchantment) }
 
       before do
-        item.canonical_enchantables_enchantments.create!(enchantment: enchantment, strength: 14)
+        item.canonical_enchantables_enchantments.create!(enchantment:, strength: 14)
       end
 
       it 'gives the enchantment strength' do

--- a/spec/models/canonical/craftables_crafting_material_spec.rb
+++ b/spec/models/canonical/craftables_crafting_material_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Canonical::CraftablesCraftingMaterial, type: :model do
     it 'is valid with valid attributes' do
       armor    = create(:canonical_armor)
       material = create(:canonical_material)
-      model    = described_class.new(quantity: 2, craftable: armor, material: material)
+      model    = described_class.new(quantity: 2, craftable: armor, material:)
 
       expect(model).to be_valid
     end
@@ -16,7 +16,7 @@ RSpec.describe Canonical::CraftablesCraftingMaterial, type: :model do
       it 'must be greater than zero' do
         weapon   = create(:canonical_weapon)
         material = create(:canonical_material)
-        model    = described_class.new(quantity: 0, craftable: weapon, material: material)
+        model    = described_class.new(quantity: 0, craftable: weapon, material:)
 
         model.validate
         expect(model.errors[:quantity]).to include 'must be greater than 0'
@@ -25,7 +25,7 @@ RSpec.describe Canonical::CraftablesCraftingMaterial, type: :model do
       it 'must be an integer' do
         item     = create(:canonical_jewelry_item)
         material = create(:canonical_material)
-        model    = described_class.new(quantity: 1.3, craftable: item, material: material)
+        model    = described_class.new(quantity: 1.3, craftable: item, material:)
 
         model.validate
         expect(model.errors[:quantity]).to include 'must be an integer'
@@ -37,8 +37,8 @@ RSpec.describe Canonical::CraftablesCraftingMaterial, type: :model do
       let(:armor)    { create(:canonical_armor) }
 
       it 'must form a unique combination' do
-        create(:canonical_craftables_crafting_material, material: material, craftable: armor)
-        model = build(:canonical_craftables_crafting_material, quantity: 2, material: material, craftable: armor)
+        create(:canonical_craftables_crafting_material, material:, craftable: armor)
+        model = build(:canonical_craftables_crafting_material, quantity: 2, material:, craftable: armor)
 
         model.validate
         expect(model.errors[:material_id]).to include 'must form a unique combination with craftable item'

--- a/spec/models/canonical/enchantables_enchantment_spec.rb
+++ b/spec/models/canonical/enchantables_enchantment_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Canonical::EnchantablesEnchantment, type: :model do
       let(:armor)       { create(:canonical_armor) }
 
       it 'must form a unique combination' do
-        create(:canonical_enchantables_enchantment, :for_armor, enchantable: armor, enchantment: enchantment)
-        model = build(:canonical_enchantables_enchantment, :for_armor, enchantable: armor, enchantment: enchantment)
+        create(:canonical_enchantables_enchantment, :for_armor, enchantable: armor, enchantment:)
+        model = build(:canonical_enchantables_enchantment, :for_armor, enchantable: armor, enchantment:)
 
         model.validate
         expect(model.errors[:enchantment_id]).to include 'must form a unique combination with enchantable item'

--- a/spec/models/canonical/ingredients_alchemical_property_spec.rb
+++ b/spec/models/canonical/ingredients_alchemical_property_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Canonical::IngredientsAlchemicalProperty, type: :model do
           )
         end
 
-        new_association = build(:canonical_ingredients_alchemical_property, ingredient: ingredient)
+        new_association = build(:canonical_ingredients_alchemical_property, ingredient:)
 
         new_association.validate
         expect(new_association.errors[:ingredient]).to include 'already has 4 alchemical properties'
@@ -30,7 +30,7 @@ RSpec.describe Canonical::IngredientsAlchemicalProperty, type: :model do
           create(
             :canonical_ingredients_alchemical_property,
             priority:   1,
-            ingredient: ingredient,
+            ingredient:,
           )
         end
 
@@ -38,7 +38,7 @@ RSpec.describe Canonical::IngredientsAlchemicalProperty, type: :model do
           model = build(
                     :canonical_ingredients_alchemical_property,
                     priority:   1,
-                    ingredient: ingredient,
+                    ingredient:,
                   )
 
           model.validate

--- a/spec/models/canonical/jewelry_item_spec.rb
+++ b/spec/models/canonical/jewelry_item_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe Canonical::JewelryItem, type: :model do
       let(:enchantment) { create(:enchantment) }
 
       before do
-        item.canonical_enchantables_enchantments.create!(enchantment: enchantment, strength: 17)
+        item.canonical_enchantables_enchantments.create!(enchantment:, strength: 17)
       end
 
       it 'gives the enchantment strength' do
@@ -147,7 +147,7 @@ RSpec.describe Canonical::JewelryItem, type: :model do
       let(:material) { create(:canonical_material) }
 
       before do
-        item.canonical_craftables_crafting_materials.create!(material: material, quantity: 2)
+        item.canonical_craftables_crafting_materials.create!(material:, quantity: 2)
       end
 
       it 'gives the quantity needed' do

--- a/spec/models/canonical/potion_spec.rb
+++ b/spec/models/canonical/potion_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Canonical::Potion, type: :model do
       let(:alchemical_property) { create(:alchemical_property) }
 
       before do
-        potion.canonical_potions_alchemical_properties.create!(alchemical_property: alchemical_property, strength: 15, duration: 30)
+        potion.canonical_potions_alchemical_properties.create!(alchemical_property:, strength: 15, duration: 30)
       end
 
       it 'returns the alchemical property' do

--- a/spec/models/canonical/powerables_power_spec.rb
+++ b/spec/models/canonical/powerables_power_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Canonical::PowerablesPower, type: :model do
       let(:staff) { create(:canonical_staff) }
 
       it 'must form a unique combination' do
-        create(:canonical_powerables_power, :for_staff, powerable: staff, power: power)
-        model = build(:canonical_powerables_power, :for_staff, powerable: staff, power: power)
+        create(:canonical_powerables_power, :for_staff, powerable: staff, power:)
+        model = build(:canonical_powerables_power, :for_staff, powerable: staff, power:)
 
         model.validate
         expect(model.errors[:power_id]).to include 'must form a unique combination with powerable item'

--- a/spec/models/canonical/staff_spec.rb
+++ b/spec/models/canonical/staff_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe Canonical::Staff, type: :model do
       let(:power) { create(:power) }
 
       it 'returns the power' do
-        staff.canonical_powerables_powers.create!(power: power)
+        staff.canonical_powerables_powers.create!(power:)
         expect(staff.powers.first).to eq power
       end
     end
@@ -176,7 +176,7 @@ RSpec.describe Canonical::Staff, type: :model do
       let(:spell) { create(:spell) }
 
       it 'returns the spell' do
-        staff.canonical_staves_spells.create!(spell: spell)
+        staff.canonical_staves_spells.create!(spell:)
         expect(staff.spells.first).to eq spell
       end
     end

--- a/spec/models/canonical/staves_spell_spec.rb
+++ b/spec/models/canonical/staves_spell_spec.rb
@@ -38,8 +38,8 @@ RSpec.describe Canonical::StavesSpell, type: :model do
       let(:staff) { create(:canonical_staff) }
 
       it 'must form a unique combination' do
-        create(:canonical_staves_spell, staff: staff, spell: spell)
-        model = build(:canonical_staves_spell, staff: staff, spell: spell)
+        create(:canonical_staves_spell, staff:, spell:)
+        model = build(:canonical_staves_spell, staff:, spell:)
 
         model.validate
         expect(model.errors[:staff_id]).to include 'must form a unique combination with spell'

--- a/spec/models/canonical/sync/alchemical_properties_spec.rb
+++ b/spec/models/canonical/sync/alchemical_properties_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Canonical::Sync::AlchemicalProperties do
       context 'when an ActiveRecord::RecordInvalid error is raised' do
         let(:errored_model) do
           instance_double AlchemicalProperty,
-                          errors: errors,
+                          errors:,
                           class:  class_double(AlchemicalProperty, i18n_scope: :activerecord)
         end
 

--- a/spec/models/canonical/sync/armor_spec.rb
+++ b/spec/models/canonical/sync/armor_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe Canonical::Sync::Armor do
       context 'when an ActiveRecord::RecordInvalid error is raised' do
         let(:errored_model) do
           instance_double Canonical::Armor,
-                          errors: errors,
+                          errors:,
                           class:  class_double(Canonical::Armor, i18n_scope: :activerecord)
         end
 

--- a/spec/models/canonical/sync/books_spec.rb
+++ b/spec/models/canonical/sync/books_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe Canonical::Sync::Books do
       context 'when an ActiveRecord::RecordInvalid error is raised' do
         let(:errored_model) do
           instance_double Canonical::Book,
-                          errors: errors,
+                          errors:,
                           class:  class_double(Canonical::Book, i18n_scope: :activerecord)
         end
 

--- a/spec/models/canonical/sync/clothing_items_spec.rb
+++ b/spec/models/canonical/sync/clothing_items_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Canonical::Sync::ClothingItems do
         let(:syncer) { described_class.new(preserve_existing_records) }
 
         before do
-          enchantment_names.each {|name| create(:enchantment, name: name) }
+          enchantment_names.each {|name| create(:enchantment, name:) }
 
           allow(described_class).to receive(:new).and_return(syncer)
         end
@@ -55,7 +55,7 @@ RSpec.describe Canonical::Sync::ClothingItems do
         let(:syncer)            { described_class.new(preserve_existing_records) }
 
         before do
-          enchantment_names.each {|name| create(:enchantment, name: name) }
+          enchantment_names.each {|name| create(:enchantment, name:) }
         end
 
         it 'instantiates itself' do
@@ -141,7 +141,7 @@ RSpec.describe Canonical::Sync::ClothingItems do
       let!(:item_not_in_json)         { create(:canonical_clothing_item, item_code: '12345678') }
 
       before do
-        enchantment_names.each {|name| create(:enchantment, name: name) }
+        enchantment_names.each {|name| create(:enchantment, name:) }
         create(
           :canonical_enchantables_enchantment,
           :for_clothing,
@@ -190,7 +190,7 @@ RSpec.describe Canonical::Sync::ClothingItems do
       context 'when an ActiveRecord::RecordInvalid error is raised' do
         let(:errored_model) do
           instance_double Canonical::ClothingItem,
-                          errors: errors,
+                          errors:,
                           class:  class_double(Canonical::ClothingItem, i18n_scope: :activerecord)
         end
 

--- a/spec/models/canonical/sync/enchantments_spec.rb
+++ b/spec/models/canonical/sync/enchantments_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Canonical::Sync::Enchantments do
       context 'when an ActiveRecord::RecordInvalid error is raised' do
         let(:errored_model) do
           instance_double Enchantment,
-                          errors: errors,
+                          errors:,
                           class:  class_double(Enchantment, i18n_scope: :activerecord)
         end
 

--- a/spec/models/canonical/sync/ingredients_spec.rb
+++ b/spec/models/canonical/sync/ingredients_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Canonical::Sync::Ingredients do
         let(:syncer) { described_class.new(preserve_existing_records) }
 
         before do
-          alchemical_property_names.each {|name| create(:alchemical_property, name: name) }
+          alchemical_property_names.each {|name| create(:alchemical_property, name:) }
         end
 
         it 'instantiates itseslf' do
@@ -62,7 +62,7 @@ RSpec.describe Canonical::Sync::Ingredients do
         let(:syncer)            { described_class.new(preserve_existing_records) }
 
         before do
-          alchemical_property_names.each {|name| create(:alchemical_property, name: name) }
+          alchemical_property_names.each {|name| create(:alchemical_property, name:) }
         end
 
         it 'instantiates itself' do
@@ -148,7 +148,7 @@ RSpec.describe Canonical::Sync::Ingredients do
       let!(:item_not_in_json)         { create(:canonical_ingredient, item_code: '12345678') }
 
       before do
-        alchemical_property_names.each {|name| create(:alchemical_property, name: name) }
+        alchemical_property_names.each {|name| create(:alchemical_property, name:) }
 
         create(
           :canonical_ingredients_alchemical_property,
@@ -203,7 +203,7 @@ RSpec.describe Canonical::Sync::Ingredients do
       context 'when an ActiveRecord::RecordInvalid error is raised' do
         let(:errored_model) do
           instance_double Canonical::Ingredient,
-                          errors: errors,
+                          errors:,
                           class:  class_double(Canonical::Ingredient, i18n_scope: :activerecord)
         end
 

--- a/spec/models/canonical/sync/jewelry_items_spec.rb
+++ b/spec/models/canonical/sync/jewelry_items_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe Canonical::Sync::JewelryItems do
       context 'when an ActiveRecord::RecordInvalid error is raised' do
         let(:errored_model) do
           instance_double Canonical::JewelryItem,
-                          errors: errors,
+                          errors:,
                           class:  class_double(Canonical::JewelryItem, i18n_scope: :activerecord)
         end
 

--- a/spec/models/canonical/sync/materials_spec.rb
+++ b/spec/models/canonical/sync/materials_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Canonical::Sync::Materials do
       context 'when an ActiveRecord::RecordInvalid error is raised' do
         let(:errored_model) do
           instance_double Canonical::Material,
-                          errors: errors,
+                          errors:,
                           class:  class_double(Canonical::Material, i18n_scope: :activerecord)
         end
 

--- a/spec/models/canonical/sync/misc_items_spec.rb
+++ b/spec/models/canonical/sync/misc_items_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Canonical::Sync::MiscItems do
       context 'when an ActiveRecord::RecordInvalid error is raised' do
         let(:errored_model) do
           instance_double Canonical::MiscItem,
-                          errors: errors,
+                          errors:,
                           class:  class_double(Canonical::MiscItem, i18n_scope: :activerecord)
         end
 

--- a/spec/models/canonical/sync/potions_spec.rb
+++ b/spec/models/canonical/sync/potions_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Canonical::Sync::Potions do
         let(:syncer) { described_class.new(preserve_existing_records) }
 
         before do
-          alchemical_property_names.each {|name| create(:alchemical_property, name: name) }
+          alchemical_property_names.each {|name| create(:alchemical_property, name:) }
         end
 
         it 'instantiates itseslf' do
@@ -61,7 +61,7 @@ RSpec.describe Canonical::Sync::Potions do
         let(:syncer)            { described_class.new(preserve_existing_records) }
 
         before do
-          alchemical_property_names.each {|name| create(:alchemical_property, name: name) }
+          alchemical_property_names.each {|name| create(:alchemical_property, name:) }
         end
 
         it 'instantiates itself' do
@@ -146,7 +146,7 @@ RSpec.describe Canonical::Sync::Potions do
       let!(:item_not_in_json)         { create(:canonical_potion, item_code: '12345678') }
 
       before do
-        alchemical_property_names.each {|name| create(:alchemical_property, name: name) }
+        alchemical_property_names.each {|name| create(:alchemical_property, name:) }
 
         create(:canonical_potions_alchemical_property, potion: item_in_json, alchemical_property: create(:alchemical_property))
       end
@@ -186,7 +186,7 @@ RSpec.describe Canonical::Sync::Potions do
       context 'when an ActiveRecord::RecordInvalid error is raised' do
         let(:errored_model) do
           instance_double Canonical::Potion,
-                          errors: errors,
+                          errors:,
                           class:  class_double(Canonical::Potion, i18n_scope: :activerecord)
         end
 

--- a/spec/models/canonical/sync/powers_spec.rb
+++ b/spec/models/canonical/sync/powers_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Canonical::Sync::Powers do
       context 'when an ActiveRecord::RecordInvalid error is raised' do
         let(:errored_model) do
           instance_double Power,
-                          errors: errors,
+                          errors:,
                           class:  class_double(Power, i18n_scope: :activerecord)
         end
 

--- a/spec/models/canonical/sync/properties_spec.rb
+++ b/spec/models/canonical/sync/properties_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Canonical::Sync::Properties do
       context 'when an ActiveRecord::RecordInvalid error is raised' do
         let(:errored_model) do
           instance_double Canonical::Property,
-                          errors: errors,
+                          errors:,
                           class:  class_double(Spell, i18n_scope: :activerecord)
         end
 

--- a/spec/models/canonical/sync/spells_spec.rb
+++ b/spec/models/canonical/sync/spells_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe Canonical::Sync::Spells do
       context 'when an ActiveRecord::RecordInvalid error is raised' do
         let(:errored_model) do
           instance_double Spell,
-                          errors: errors,
+                          errors:,
                           class:  class_double(Spell, i18n_scope: :activerecord)
         end
 

--- a/spec/models/canonical/sync/staves_spec.rb
+++ b/spec/models/canonical/sync/staves_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Canonical::Sync::Staves do
         let(:syncer) { described_class.new(preserve_existing_records) }
 
         before do
-          spell_names.each {|name| create(:spell, name: name) }
+          spell_names.each {|name| create(:spell, name:) }
 
           create(:power, name: "Mora's Agony")
         end
@@ -70,7 +70,7 @@ RSpec.describe Canonical::Sync::Staves do
         let(:syncer)            { described_class.new(preserve_existing_records) }
 
         before do
-          spell_names.each {|name| create(:spell, name: name) }
+          spell_names.each {|name| create(:spell, name:) }
 
           create(:power, name: "Mora's Agony")
         end
@@ -132,7 +132,7 @@ RSpec.describe Canonical::Sync::Staves do
           # prevent it from erroring out, which it will do if there are no
           # powers or spells at all
           create(:power)
-          spell_names.each {|name| create(:spell, name: name) }
+          spell_names.each {|name| create(:spell, name:) }
 
           allow(Rails.logger).to receive(:error).twice
         end
@@ -155,7 +155,7 @@ RSpec.describe Canonical::Sync::Staves do
       let!(:item_not_in_json)         { create(:canonical_staff, item_code: '12345678') }
 
       before do
-        spell_names.each {|name| create(:spell, name: name) }
+        spell_names.each {|name| create(:spell, name:) }
         create(:power, name: "Mora's Agony")
         create(:canonical_powerables_power, powerable: item_in_json, power: create(:power))
       end
@@ -195,7 +195,7 @@ RSpec.describe Canonical::Sync::Staves do
       context 'when an ActiveRecord::RecordInvalid error is raised' do
         let(:errored_model) do
           instance_double Canonical::Staff,
-                          errors: errors,
+                          errors:,
                           class:  class_double(Canonical::Staff, i18n_scope: :activerecord)
         end
 

--- a/spec/models/canonical/sync/weapons_spec.rb
+++ b/spec/models/canonical/sync/weapons_spec.rb
@@ -215,7 +215,7 @@ RSpec.describe Canonical::Sync::Weapons do
       context 'when an ActiveRecord::RecordInvalid error is raised' do
         let(:errored_model) do
           instance_double Canonical::Weapon,
-                          errors: errors,
+                          errors:,
                           class:  class_double(Canonical::Weapon, i18n_scope: :activerecord)
         end
 

--- a/spec/models/canonical/temperables_tempering_material_spec.rb
+++ b/spec/models/canonical/temperables_tempering_material_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Canonical::TemperablesTemperingMaterial, type: :model do
     it 'is valid with valid attributes' do
       material = create(:canonical_material)
       armor    = create(:canonical_armor)
-      model    = described_class.new(quantity: 3, material: material, temperable: armor)
+      model    = described_class.new(quantity: 3, material:, temperable: armor)
 
       expect(model).to be_valid
     end
@@ -33,8 +33,8 @@ RSpec.describe Canonical::TemperablesTemperingMaterial, type: :model do
       let(:weapon)   { create(:canonical_weapon) }
 
       it 'must be a unique combination' do
-        create(:canonical_temperables_tempering_material, material: material, temperable: weapon)
-        model = build(:canonical_temperables_tempering_material, material: material, temperable: weapon)
+        create(:canonical_temperables_tempering_material, material:, temperable: weapon)
+        model = build(:canonical_temperables_tempering_material, material:, temperable: weapon)
 
         model.validate
         expect(model.errors[:material_id]).to include 'must form a unique combination with temperable item'

--- a/spec/models/canonical/weapon_spec.rb
+++ b/spec/models/canonical/weapon_spec.rb
@@ -220,7 +220,7 @@ RSpec.describe Canonical::Weapon, type: :model do
       let(:enchantment) { create(:enchantment) }
 
       before do
-        weapon.canonical_enchantables_enchantments.create!(enchantment: enchantment, strength: 40)
+        weapon.canonical_enchantables_enchantments.create!(enchantment:, strength: 40)
       end
 
       it 'gives the enchantment strength' do
@@ -233,7 +233,7 @@ RSpec.describe Canonical::Weapon, type: :model do
       let(:power)  { create(:power) }
 
       before do
-        weapon.canonical_powerables_powers.create!(power: power)
+        weapon.canonical_powerables_powers.create!(power:)
       end
 
       it 'retrieves the power' do
@@ -246,7 +246,7 @@ RSpec.describe Canonical::Weapon, type: :model do
       let(:material) { create(:canonical_material) }
 
       before do
-        weapon.canonical_craftables_crafting_materials.create!(material: material, quantity: 4)
+        weapon.canonical_craftables_crafting_materials.create!(material:, quantity: 4)
       end
 
       it 'gives the quantity needed' do
@@ -259,7 +259,7 @@ RSpec.describe Canonical::Weapon, type: :model do
       let(:material) { create(:canonical_material) }
 
       before do
-        weapon.canonical_temperables_tempering_materials.create!(material: material, quantity: 4)
+        weapon.canonical_temperables_tempering_materials.create!(material:, quantity: 4)
       end
 
       it 'gives the quantity needed' do

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe Game, type: :model do
   describe 'validations' do
     describe 'name' do
       describe 'uniqueness' do
-        let(:game) { build(:game, name: 'My Game', user: user) }
+        let(:game) { build(:game, name: 'My Game', user:) }
 
         it 'is unique per user' do
-          create(:game, name: 'My Game', user: user)
+          create(:game, name: 'My Game', user:)
 
           game.validate
           expect(game.errors[:name]).to include 'must be unique'
@@ -57,7 +57,7 @@ RSpec.describe Game, type: :model do
   end
 
   describe '#destroy!' do
-    let!(:game) { create(:game_with_everything, user: user) }
+    let!(:game) { create(:game_with_everything, user:) }
 
     # This is a regression test. Games were failing to be destroyed because, when
     # destroying their shopping lists, the aggregate list wasn't necessarily
@@ -105,7 +105,7 @@ RSpec.describe Game, type: :model do
           # Create games for a different user to make sure the name of this game's
           # name isn't affected by them
           create_list(:game, 2, name: nil)
-          create_list(:game, 2, name: nil, user: user)
+          create_list(:game, 2, name: nil, user:)
         end
 
         it 'sets the title based on the highest numbered default title' do
@@ -116,9 +116,9 @@ RSpec.describe Game, type: :model do
       context 'when the user has differently titled games' do
         before do
           create(:game, name: nil)
-          create(:game, user: user, name: nil)
-          create(:game, user: user, name: 'New Game')
-          create(:game, user: user, name: nil)
+          create(:game, user:, name: nil)
+          create(:game, user:, name: 'New Game')
+          create(:game, user:, name: nil)
         end
 
         it 'uses the next highest number in default-named games' do
@@ -128,8 +128,8 @@ RSpec.describe Game, type: :model do
 
       context 'when the user has a game with a similar name' do
         before do
-          create(:game, user: user, name: 'This Game is Called My Game 4')
-          create_list(:game, 2, user: user, name: nil)
+          create(:game, user:, name: 'This Game is Called My Game 4')
+          create_list(:game, 2, user:, name: nil)
         end
 
         it 'sets the name based on the highest numbered game called "My Game N"' do
@@ -139,8 +139,8 @@ RSpec.describe Game, type: :model do
 
       context 'when there is a game called "My Game <non-integer>"' do
         before do
-          create(:game, user: user, name: 'My Game Is the Best Game')
-          create_list(:game, 2, user: user, name: nil)
+          create(:game, user:, name: 'My Game Is the Best Game')
+          create_list(:game, 2, user:, name: nil)
         end
 
         it 'sets the name based on the highest numbered game called "My Game N"' do
@@ -150,7 +150,7 @@ RSpec.describe Game, type: :model do
 
       context 'when there is a game called "My Game <negative integer>"' do
         before do
-          create(:game, user: user, name: 'My Game -4')
+          create(:game, user:, name: 'My Game -4')
         end
 
         it 'ignores the game name with the negative integer' do
@@ -176,10 +176,10 @@ RSpec.describe Game, type: :model do
     subject(:aggregate_shopping_list) { game.aggregate_shopping_list }
 
     let(:game)            { create(:game) }
-    let!(:aggregate_list) { create(:aggregate_shopping_list, game: game) }
+    let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
 
     before do
-      create_list(:shopping_list, 2, game: game)
+      create_list(:shopping_list, 2, game:)
     end
 
     it "returns that game's aggregate shopping list" do
@@ -191,10 +191,10 @@ RSpec.describe Game, type: :model do
     subject(:aggregate_inventory_list) { game.aggregate_inventory_list }
 
     let(:game)            { create(:game) }
-    let!(:aggregate_list) { create(:aggregate_inventory_list, game: game) }
+    let!(:aggregate_list) { create(:aggregate_inventory_list, game:) }
 
     before do
-      create_list(:inventory_list, 2, game: game)
+      create_list(:inventory_list, 2, game:)
     end
 
     it "returns that game's aggregate inventory list" do
@@ -205,11 +205,11 @@ RSpec.describe Game, type: :model do
   describe '#shopping_list_items' do
     subject(:shopping_list_items) { game.shopping_list_items.to_a.sort }
 
-    let(:game) { create(:game, user: user) }
+    let(:game) { create(:game, user:) }
 
     before do
-      create_list(:shopping_list_with_list_items, 2, game: game)
-      create(:game_with_shopping_lists_and_items, user: user) # one that shouldn't be included
+      create_list(:shopping_list_with_list_items, 2, game:)
+      create(:game_with_shopping_lists_and_items, user:) # one that shouldn't be included
     end
 
     it 'returns all list items belonging to the game' do
@@ -224,11 +224,11 @@ RSpec.describe Game, type: :model do
   describe '#inventory_items' do
     subject(:inventory_items) { game.inventory_items.to_a.sort }
 
-    let(:game) { create(:game, user: user) }
+    let(:game) { create(:game, user:) }
 
     before do
-      create_list(:inventory_list_with_list_items, 2, game: game)
-      create(:game_with_inventory_lists_and_items, user: user) # one that shouldn't be included
+      create_list(:inventory_list_with_list_items, 2, game:)
+      create(:game_with_inventory_lists_and_items, user:) # one that shouldn't be included
     end
 
     it 'returns all list items belonging to the game' do

--- a/spec/models/inventory_item_spec.rb
+++ b/spec/models/inventory_item_spec.rb
@@ -4,8 +4,8 @@ require 'rails_helper'
 
 RSpec.describe InventoryItem, type: :model do
   let!(:game)          { create(:game) }
-  let(:aggregate_list) { create(:aggregate_inventory_list, game: game) }
-  let(:inventory_list) { create(:inventory_list, game: game, aggregate_list: aggregate_list) }
+  let(:aggregate_list) { create(:aggregate_inventory_list, game:) }
+  let(:inventory_list) { create(:inventory_list, game:, aggregate_list:) }
 
   describe 'delegation' do
     let(:list_item) { create(:inventory_item, list: inventory_list) }
@@ -25,11 +25,11 @@ RSpec.describe InventoryItem, type: :model do
 
   describe 'scopes' do
     describe '::index_order' do
-      let!(:list_item1) { create(:inventory_item, list: list) }
-      let!(:list_item2) { create(:inventory_item, list: list) }
-      let!(:list_item3) { create(:inventory_item, list: list) }
+      let!(:list_item1) { create(:inventory_item, list:) }
+      let!(:list_item2) { create(:inventory_item, list:) }
+      let!(:list_item3) { create(:inventory_item, list:) }
 
-      let(:list) { create(:inventory_list, game: game) }
+      let(:list) { create(:inventory_list, game:) }
 
       before do
         list_item2.update!(quantity: 3)
@@ -41,9 +41,9 @@ RSpec.describe InventoryItem, type: :model do
     end
 
     describe '::belonging_to_game' do
-      let!(:list1) { create(:inventory_list_with_list_items, game: game, aggregate_list: aggregate_list) }
-      let!(:list2) { create(:inventory_list_with_list_items, game: game, aggregate_list: aggregate_list) }
-      let!(:list3) { create(:inventory_list_with_list_items, game: game, aggregate_list: aggregate_list) }
+      let!(:list1) { create(:inventory_list_with_list_items, game:, aggregate_list:) }
+      let!(:list2) { create(:inventory_list_with_list_items, game:, aggregate_list:) }
+      let!(:list3) { create(:inventory_list_with_list_items, game:, aggregate_list:) }
 
       before do
         # There should be some that don't belong to the game to make sure they
@@ -71,9 +71,9 @@ RSpec.describe InventoryItem, type: :model do
       let(:user) { game.user }
 
       before do
-        create(:inventory_list_with_list_items, game: game, aggregate_list: aggregate_list)
-        create(:game_with_inventory_lists_and_items, user: user)
-        create(:game_with_inventory_lists_and_items, user: user)
+        create(:inventory_list_with_list_items, game:, aggregate_list:)
+        create(:game_with_inventory_lists_and_items, user:)
+        create(:game_with_inventory_lists_and_items, user:)
         create(:inventory_list_with_list_items) # one from a different user
       end
 
@@ -128,7 +128,7 @@ RSpec.describe InventoryItem, type: :model do
     context 'when there is an existing item on a different list with the same (case-insensitive) description' do
       subject(:combine_or_create) { described_class.combine_or_create!(description: 'New Item', quantity: 1, list: inventory_list, unit_weight: nil) }
 
-      let(:other_list) { create(:inventory_list, game: game, aggregate_list: aggregate_list) }
+      let(:other_list) { create(:inventory_list, game:, aggregate_list:) }
       let!(:other_item) { create(:inventory_item, description: 'New Item', list: other_list, unit_weight: 1) }
 
       before do
@@ -199,7 +199,7 @@ RSpec.describe InventoryItem, type: :model do
       end
 
       context 'when unit weight is nil and there are matching items on other lists' do
-        let!(:other_list) { create(:inventory_list, game: game, aggregate_list: aggregate_list) }
+        let!(:other_list) { create(:inventory_list, game:, aggregate_list:) }
         let!(:other_item) { create(:inventory_item, description: 'new item', list: other_list, unit_weight: 1) }
 
         before do

--- a/spec/models/inventory_list_spec.rb
+++ b/spec/models/inventory_list_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe InventoryList, type: :model do
       subject(:index_order) { game.inventory_lists.index_order.to_a }
 
       let!(:game)            { create(:game) }
-      let!(:aggregate_list)  { create(:aggregate_inventory_list, game: game) }
-      let!(:inventory_list1) { create(:inventory_list, game: game) }
-      let!(:inventory_list2) { create(:inventory_list, game: game) }
-      let!(:inventory_list3) { create(:inventory_list, game: game) }
+      let!(:aggregate_list)  { create(:aggregate_inventory_list, game:) }
+      let!(:inventory_list1) { create(:inventory_list, game:) }
+      let!(:inventory_list2) { create(:inventory_list, game:) }
+      let!(:inventory_list3) { create(:inventory_list, game:) }
 
       before do
         inventory_list2.update!(title: 'Windstad Manor')
@@ -27,8 +27,8 @@ RSpec.describe InventoryList, type: :model do
       subject(:includes_items) { game.inventory_lists.includes_items }
 
       let!(:game)           { create(:game) }
-      let!(:aggregate_list) { create(:aggregate_inventory_list, game: game) }
-      let!(:lists)          { create_list(:inventory_list_with_list_items, 2, game: game) }
+      let!(:aggregate_list) { create(:aggregate_inventory_list, game:) }
+      let!(:lists)          { create_list(:inventory_list_with_list_items, 2, game:) }
 
       it 'includes the inventory list items' do
         expect(includes_items).to eq game.inventory_lists.includes(:list_items)
@@ -40,8 +40,8 @@ RSpec.describe InventoryList, type: :model do
       subject(:aggregate_first) { game.inventory_lists.aggregate_first.to_a }
 
       let!(:game)           { create(:game) }
-      let!(:aggregate_list) { create(:aggregate_inventory_list, game: game) }
-      let!(:inventory_list) { create(:inventory_list, game: game) }
+      let!(:aggregate_list) { create(:aggregate_inventory_list, game:) }
+      let!(:inventory_list) { create(:inventory_list, game:) }
 
       it 'returns the inventory lists with the aggregate list first' do
         expect(aggregate_first).to eq([aggregate_list, inventory_list])
@@ -50,9 +50,9 @@ RSpec.describe InventoryList, type: :model do
 
     describe '::belongs_to_user' do
       let(:user)   { create(:user) }
-      let!(:game1) { create(:game_with_inventory_lists, user: user) }
-      let!(:game2) { create(:game_with_inventory_lists, user: user) }
-      let!(:game3) { create(:game_with_inventory_lists, user: user) }
+      let!(:game1) { create(:game_with_inventory_lists, user:) }
+      let!(:game2) { create(:game_with_inventory_lists, user:) }
+      let!(:game3) { create(:game_with_inventory_lists, user:) }
 
       it "returns all the inventory lists from all the user's games" do
         # These are going to be rearranged in the output since game.inventory_lists
@@ -83,7 +83,7 @@ RSpec.describe InventoryList, type: :model do
     describe 'aggregate lists' do
       context 'when there are no aggregate lists' do
         let(:game)           { create(:game) }
-        let(:aggregate_list) { build(:aggregate_inventory_list, game: game) }
+        let(:aggregate_list) { build(:aggregate_inventory_list, game:) }
 
         it 'is valid' do
           expect(aggregate_list).to be_valid
@@ -92,7 +92,7 @@ RSpec.describe InventoryList, type: :model do
 
       context 'when there is an existing aggregate list belonging to another user' do
         let(:game)           { create(:game) }
-        let(:aggregate_list) { build(:aggregate_inventory_list, game: game) }
+        let(:aggregate_list) { build(:aggregate_inventory_list, game:) }
 
         before do
           create(:aggregate_inventory_list)
@@ -105,10 +105,10 @@ RSpec.describe InventoryList, type: :model do
 
       context 'when the user already has an aggregate list' do
         let(:game)           { create(:game) }
-        let(:aggregate_list) { build(:aggregate_inventory_list, game: game) }
+        let(:aggregate_list) { build(:aggregate_inventory_list, game:) }
 
         before do
-          create(:aggregate_inventory_list, game: game)
+          create(:aggregate_inventory_list, game:)
         end
 
         it 'is invalid', :aggregate_failures do
@@ -214,7 +214,7 @@ RSpec.describe InventoryList, type: :model do
               # Create lists for a different game to make sure the name of this game's
               # list isn't affected by them
               create_list(:inventory_list, 2, title: nil)
-              create_list(:inventory_list, 2, title: nil, game: game)
+              create_list(:inventory_list, 2, title: nil, game:)
             end
 
             it 'sets the title based on the highest numbered default title' do
@@ -225,9 +225,9 @@ RSpec.describe InventoryList, type: :model do
           context 'when the game has differently titled regular lists' do
             before do
               create(:inventory_list, title: nil)
-              create(:inventory_list, game: game, title: nil)
-              create(:inventory_list, game: game, title: 'Windstad Manor')
-              create(:inventory_list, game: game, title: nil)
+              create(:inventory_list, game:, title: nil)
+              create(:inventory_list, game:, title: 'Windstad Manor')
+              create(:inventory_list, game:, title: nil)
             end
 
             it 'uses the next highest number in default lists' do
@@ -237,8 +237,8 @@ RSpec.describe InventoryList, type: :model do
 
           context 'when the game has an inventory list with a similar title' do
             before do
-              create(:inventory_list, game: game, title: 'This List is Called My List 4')
-              create_list(:inventory_list, 2, game: game, title: nil)
+              create(:inventory_list, game:, title: 'This List is Called My List 4')
+              create_list(:inventory_list, 2, game:, title: nil)
             end
 
             it 'sets the title based on the highest numbered list called "My List N"' do
@@ -248,8 +248,8 @@ RSpec.describe InventoryList, type: :model do
 
           context 'when there is an inventory list called "My List <non-integer>"' do
             before do
-              create(:inventory_list, game: game, title: 'My List Is the Best List')
-              create_list(:inventory_list, 2, game: game, title: nil)
+              create(:inventory_list, game:, title: 'My List Is the Best List')
+              create_list(:inventory_list, 2, game:, title: nil)
             end
 
             it 'sets the title based on the highest numbered list called "My List N"' do
@@ -259,7 +259,7 @@ RSpec.describe InventoryList, type: :model do
 
           context 'when there is an inventory list called "My List <negative integer>"' do
             before do
-              create(:inventory_list, game: game, title: 'My List -4')
+              create(:inventory_list, game:, title: 'My List -4')
             end
 
             it 'ignores the list title with the negative integer' do
@@ -351,13 +351,13 @@ RSpec.describe InventoryList, type: :model do
   describe 'after destroy hook' do
     subject(:destroy_list) { inventory_list.destroy! }
 
-    let!(:aggregate_list) { create(:aggregate_inventory_list, game: game) }
-    let!(:inventory_list) { create(:inventory_list, game: game) }
+    let!(:aggregate_list) { create(:aggregate_inventory_list, game:) }
+    let!(:inventory_list) { create(:inventory_list, game:) }
     let(:game)            { create(:game) }
 
     context 'when the game has additional regular lists' do
       before do
-        create(:inventory_list, game: game)
+        create(:inventory_list, game:)
       end
 
       it "doesn't destroy the aggregate list" do
@@ -399,7 +399,7 @@ RSpec.describe InventoryList, type: :model do
       end
 
       context 'when there is a matching item on the aggregate list' do
-        let(:other_list)          { create(:inventory_list, game: aggregate_list.game, aggregate_list: aggregate_list) }
+        let(:other_list)          { create(:inventory_list, game: aggregate_list.game, aggregate_list:) }
         let!(:item_on_other_list) { create(:inventory_item, description: 'Dwarven metal ingot', list: other_list, unit_weight: 0.3) }
 
         context 'when both have notes' do
@@ -636,7 +636,7 @@ RSpec.describe InventoryList, type: :model do
         let(:new_notes) { 'another thing' }
 
         before do
-          aggregate_list.list_items.create(description: description, quantity: 3, notes: old_notes)
+          aggregate_list.list_items.create(description:, quantity: 3, notes: old_notes)
         end
 
         it 'adds the negative quantity delta to the existing one' do
@@ -654,7 +654,7 @@ RSpec.describe InventoryList, type: :model do
         subject(:update_item) { aggregate_list.update_item_from_child_list(description, 0, unit_weight, 'something', 'another thing') }
 
         before do
-          aggregate_list.list_items.create(description: description, quantity: 3, notes: 'something')
+          aggregate_list.list_items.create(description:, quantity: 3, notes: 'something')
         end
 
         it "doesn't change the quantity" do
@@ -667,7 +667,7 @@ RSpec.describe InventoryList, type: :model do
         subject(:update_item) { aggregate_list.update_item_from_child_list(description, 1, nil, 'something', 'another thing') }
 
         before do
-          aggregate_list.list_items.create(description: description, quantity: 3, unit_weight: 1, notes: 'something')
+          aggregate_list.list_items.create(description:, quantity: 3, unit_weight: 1, notes: 'something')
         end
 
         it 'leaves the existing unit_weight as-is' do
@@ -679,12 +679,12 @@ RSpec.describe InventoryList, type: :model do
       context 'when there is a unit_weight given' do
         subject(:update_item) { aggregate_list.update_item_from_child_list(description, 1, 2, 'something', 'another thing') }
 
-        let(:other_list) { create(:inventory_list, game: aggregate_list.game, aggregate_list: aggregate_list) }
-        let!(:item_on_other_list)  { create(:inventory_item, list: other_list, description: description, unit_weight: 1) }
-        let!(:aggregate_list_item) { create(:inventory_item, list: aggregate_list, description: description, quantity: 3, unit_weight: 1, notes: 'something') }
+        let(:other_list) { create(:inventory_list, game: aggregate_list.game, aggregate_list:) }
+        let!(:item_on_other_list)  { create(:inventory_item, list: other_list, description:, unit_weight: 1) }
+        let!(:aggregate_list_item) { create(:inventory_item, list: aggregate_list, description:, quantity: 3, unit_weight: 1, notes: 'something') }
 
         before do
-          aggregate_list.list_items.create(description: description, quantity: 3, unit_weight: 1, notes: 'something')
+          aggregate_list.list_items.create(description:, quantity: 3, unit_weight: 1, notes: 'something')
         end
 
         it 'updates the unit_weight on the aggregate list' do
@@ -704,7 +704,7 @@ RSpec.describe InventoryList, type: :model do
         let(:new_notes) { 'something' }
 
         before do
-          aggregate_list.list_items.create(description: description, quantity: 3, notes: "#{old_notes} -- something else")
+          aggregate_list.list_items.create(description:, quantity: 3, notes: "#{old_notes} -- something else")
         end
 
         it "doesn't mess with the notes" do
@@ -718,7 +718,7 @@ RSpec.describe InventoryList, type: :model do
         let(:existing_notes) { 'notes 1 -- notes 2 -- notes 3' }
 
         before do
-          aggregate_list.list_items.create!(description: description, quantity: 3, notes: existing_notes)
+          aggregate_list.list_items.create!(description:, quantity: 3, notes: existing_notes)
         end
 
         context 'when replacing the middle notes' do
@@ -811,7 +811,7 @@ RSpec.describe InventoryList, type: :model do
         let(:new_notes)   { nil }
 
         before do
-          aggregate_list.list_items.create!(description: description)
+          aggregate_list.list_items.create!(description:)
         end
 
         it 'raises an error' do
@@ -827,7 +827,7 @@ RSpec.describe InventoryList, type: :model do
         let(:new_notes)   { nil }
 
         before do
-          aggregate_list.list_items.create!(description: description, quantity: 1)
+          aggregate_list.list_items.create!(description:, quantity: 1)
         end
 
         it 'raises an error' do
@@ -873,10 +873,10 @@ RSpec.describe InventoryList, type: :model do
 
   describe 'parent model' do
     let(:game)           { create(:game) }
-    let(:aggregate_list) { create(:aggregate_inventory_list, game: game) }
+    let(:aggregate_list) { create(:aggregate_inventory_list, game:) }
 
     it 'is invalid without a game' do
-      list = described_class.new(aggregate_list: aggregate_list)
+      list = described_class.new(aggregate_list:)
 
       list.validate
       expect(list.errors[:game]).to include 'must exist'

--- a/spec/models/property_spec.rb
+++ b/spec/models/property_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Property, type: :model do
     it 'only allows up to 10 per game', :aggregate_failures do
       Canonical::Property.all.each do |canonical_property|
         game.properties.create!(
-          canonical_property: canonical_property,
+          canonical_property:,
           name:               canonical_property.name,
           hold:               canonical_property.hold,
           city:               canonical_property.city,
@@ -80,7 +80,7 @@ RSpec.describe Property, type: :model do
 
       before do
         game.properties.create!(
-          canonical_property: canonical_property,
+          canonical_property:,
           name:               canonical_property.name,
           hold:               canonical_property.hold,
           city:               canonical_property.city,

--- a/spec/models/shopping_list_item_spec.rb
+++ b/spec/models/shopping_list_item_spec.rb
@@ -4,8 +4,8 @@ require 'rails_helper'
 
 RSpec.describe ShoppingListItem, type: :model do
   let!(:game)          { create(:game) }
-  let(:aggregate_list) { create(:aggregate_shopping_list, game: game) }
-  let(:shopping_list)  { create(:shopping_list, game: game, aggregate_list: aggregate_list) }
+  let(:aggregate_list) { create(:aggregate_shopping_list, game:) }
+  let(:shopping_list)  { create(:shopping_list, game:, aggregate_list:) }
 
   describe 'delegation' do
     let(:list_item) { create(:shopping_list_item, list: shopping_list) }
@@ -25,11 +25,11 @@ RSpec.describe ShoppingListItem, type: :model do
 
   describe 'scopes' do
     describe '::index_order' do
-      let!(:list_item1) { create(:shopping_list_item, list: list) }
-      let!(:list_item2) { create(:shopping_list_item, list: list) }
-      let!(:list_item3) { create(:shopping_list_item, list: list) }
+      let!(:list_item1) { create(:shopping_list_item, list:) }
+      let!(:list_item2) { create(:shopping_list_item, list:) }
+      let!(:list_item3) { create(:shopping_list_item, list:) }
 
-      let(:list) { create(:shopping_list, game: game) }
+      let(:list) { create(:shopping_list, game:) }
 
       before do
         list_item2.update!(quantity: 3)
@@ -41,9 +41,9 @@ RSpec.describe ShoppingListItem, type: :model do
     end
 
     describe '::belonging_to_game' do
-      let!(:list1) { create(:shopping_list_with_list_items, game: game, aggregate_list: aggregate_list) }
-      let!(:list2) { create(:shopping_list_with_list_items, game: game, aggregate_list: aggregate_list) }
-      let!(:list3) { create(:shopping_list_with_list_items, game: game, aggregate_list: aggregate_list) }
+      let!(:list1) { create(:shopping_list_with_list_items, game:, aggregate_list:) }
+      let!(:list2) { create(:shopping_list_with_list_items, game:, aggregate_list:) }
+      let!(:list3) { create(:shopping_list_with_list_items, game:, aggregate_list:) }
 
       before do
         # There should be some that don't belong to the game to make sure they
@@ -71,9 +71,9 @@ RSpec.describe ShoppingListItem, type: :model do
       let(:user) { game.user }
 
       before do
-        create(:shopping_list_with_list_items, game: game, aggregate_list: aggregate_list)
-        create(:game_with_shopping_lists_and_items, user: user)
-        create(:game_with_shopping_lists_and_items, user: user)
+        create(:shopping_list_with_list_items, game:, aggregate_list:)
+        create(:game_with_shopping_lists_and_items, user:)
+        create(:game_with_shopping_lists_and_items, user:)
         create(:shopping_list_with_list_items) # one from a different user
       end
 
@@ -128,7 +128,7 @@ RSpec.describe ShoppingListItem, type: :model do
     context 'when there is an existing item on a different list with the same (case-insensitive) description' do
       subject(:combine_or_create) { described_class.combine_or_create!(description: 'New Item', quantity: 1, list: shopping_list, unit_weight: nil) }
 
-      let(:other_list) { create(:shopping_list, game: game, aggregate_list: aggregate_list) }
+      let(:other_list) { create(:shopping_list, game:, aggregate_list:) }
       let!(:other_item) { create(:shopping_list_item, description: 'New Item', list: other_list, unit_weight: 1) }
 
       before do
@@ -199,7 +199,7 @@ RSpec.describe ShoppingListItem, type: :model do
       end
 
       context 'when unit weight is nil and there are matching items on other lists' do
-        let!(:other_list) { create(:shopping_list, game: game, aggregate_list: aggregate_list) }
+        let!(:other_list) { create(:shopping_list, game:, aggregate_list:) }
         let!(:other_item) { create(:shopping_list_item, description: 'new item', list: other_list, unit_weight: 1) }
 
         before do

--- a/spec/models/shopping_list_spec.rb
+++ b/spec/models/shopping_list_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe ShoppingList, type: :model do
       subject(:index_order) { game.shopping_lists.index_order.to_a }
 
       let!(:game)           { create(:game) }
-      let!(:aggregate_list) { create(:aggregate_shopping_list, game: game) }
-      let!(:shopping_list1) { create(:shopping_list, game: game) }
-      let!(:shopping_list2) { create(:shopping_list, game: game) }
-      let!(:shopping_list3) { create(:shopping_list, game: game) }
+      let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
+      let!(:shopping_list1) { create(:shopping_list, game:) }
+      let!(:shopping_list2) { create(:shopping_list, game:) }
+      let!(:shopping_list3) { create(:shopping_list, game:) }
 
       before do
         shopping_list2.update!(title: 'Windstad Manor')
@@ -27,8 +27,8 @@ RSpec.describe ShoppingList, type: :model do
       subject(:includes_items) { game.shopping_lists.includes_items }
 
       let!(:game)           { create(:game) }
-      let!(:aggregate_list) { create(:aggregate_shopping_list, game: game) }
-      let!(:lists)          { create_list(:shopping_list_with_list_items, 2, game: game) }
+      let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
+      let!(:lists)          { create_list(:shopping_list_with_list_items, 2, game:) }
 
       it 'includes the shopping list items' do
         expect(includes_items).to eq game.shopping_lists.includes(:list_items)
@@ -40,8 +40,8 @@ RSpec.describe ShoppingList, type: :model do
       subject(:aggregate_first) { game.shopping_lists.aggregate_first.to_a }
 
       let!(:game)           { create(:game) }
-      let!(:aggregate_list) { create(:aggregate_shopping_list, game: game) }
-      let!(:shopping_list)  { create(:shopping_list, game: game) }
+      let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
+      let!(:shopping_list)  { create(:shopping_list, game:) }
 
       it 'returns the shopping lists with the aggregate list first' do
         expect(aggregate_first).to eq([aggregate_list, shopping_list])
@@ -50,9 +50,9 @@ RSpec.describe ShoppingList, type: :model do
 
     describe '::belongs_to_user' do
       let(:user)   { create(:user) }
-      let!(:game1) { create(:game_with_shopping_lists, user: user) }
-      let!(:game2) { create(:game_with_shopping_lists, user: user) }
-      let!(:game3) { create(:game_with_shopping_lists, user: user) }
+      let!(:game1) { create(:game_with_shopping_lists, user:) }
+      let!(:game2) { create(:game_with_shopping_lists, user:) }
+      let!(:game3) { create(:game_with_shopping_lists, user:) }
 
       it "returns all the shopping lists from all the user's games" do
         # These are going to be rearranged in the output since game.shopping_lists
@@ -83,7 +83,7 @@ RSpec.describe ShoppingList, type: :model do
     describe 'aggregate lists' do
       context 'when there are no aggregate lists' do
         let(:game)           { create(:game) }
-        let(:aggregate_list) { build(:aggregate_shopping_list, game: game) }
+        let(:aggregate_list) { build(:aggregate_shopping_list, game:) }
 
         it 'is valid' do
           expect(aggregate_list).to be_valid
@@ -92,7 +92,7 @@ RSpec.describe ShoppingList, type: :model do
 
       context 'when there is an existing aggregate list belonging to another user' do
         let(:game)           { create(:game) }
-        let(:aggregate_list) { build(:aggregate_shopping_list, game: game) }
+        let(:aggregate_list) { build(:aggregate_shopping_list, game:) }
 
         before do
           create(:aggregate_shopping_list)
@@ -105,10 +105,10 @@ RSpec.describe ShoppingList, type: :model do
 
       context 'when the user already has an aggregate list' do
         let(:game)           { create(:game) }
-        let(:aggregate_list) { build(:aggregate_shopping_list, game: game) }
+        let(:aggregate_list) { build(:aggregate_shopping_list, game:) }
 
         before do
-          create(:aggregate_shopping_list, game: game)
+          create(:aggregate_shopping_list, game:)
         end
 
         it 'is invalid', :aggregate_failures do
@@ -208,7 +208,7 @@ RSpec.describe ShoppingList, type: :model do
               # Create lists for a different game to make sure the name of this game's
               # list isn't affected by them
               create_list(:shopping_list, 2, title: nil)
-              create_list(:shopping_list, 2, title: nil, game: game)
+              create_list(:shopping_list, 2, title: nil, game:)
             end
 
             it 'sets the title based on the highest numbered default title' do
@@ -219,9 +219,9 @@ RSpec.describe ShoppingList, type: :model do
           context 'when the game has differently titled regular lists' do
             before do
               create(:shopping_list, title: nil)
-              create(:shopping_list, game: game, title: nil)
-              create(:shopping_list, game: game, title: 'Windstad Manor')
-              create(:shopping_list, game: game, title: nil)
+              create(:shopping_list, game:, title: nil)
+              create(:shopping_list, game:, title: 'Windstad Manor')
+              create(:shopping_list, game:, title: nil)
             end
 
             it 'uses the next highest number in default lists' do
@@ -231,8 +231,8 @@ RSpec.describe ShoppingList, type: :model do
 
           context 'when the game has a shopping list with a similar title' do
             before do
-              create(:shopping_list, game: game, title: 'This List is Called My List 4')
-              create_list(:shopping_list, 2, game: game, title: nil)
+              create(:shopping_list, game:, title: 'This List is Called My List 4')
+              create_list(:shopping_list, 2, game:, title: nil)
             end
 
             it 'sets the title based on the highest numbered list called "My List N"' do
@@ -242,8 +242,8 @@ RSpec.describe ShoppingList, type: :model do
 
           context 'when there is a shopping list called "My List <non-integer>"' do
             before do
-              create(:shopping_list, game: game, title: 'My List Is the Best List')
-              create_list(:shopping_list, 2, game: game, title: nil)
+              create(:shopping_list, game:, title: 'My List Is the Best List')
+              create_list(:shopping_list, 2, game:, title: nil)
             end
 
             it 'sets the title based on the highest numbered list called "My List N"' do
@@ -253,7 +253,7 @@ RSpec.describe ShoppingList, type: :model do
 
           context 'when there is a shopping list called "My List <negative integer>"' do
             before do
-              create(:shopping_list, game: game, title: 'My List -4')
+              create(:shopping_list, game:, title: 'My List -4')
             end
 
             it 'ignores the list title with the negative integer' do
@@ -345,13 +345,13 @@ RSpec.describe ShoppingList, type: :model do
   describe 'after destroy hook' do
     subject(:destroy_list) { shopping_list.destroy! }
 
-    let!(:aggregate_list) { create(:aggregate_shopping_list, game: game) }
-    let!(:shopping_list)  { create(:shopping_list, game: game) }
+    let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
+    let!(:shopping_list)  { create(:shopping_list, game:) }
     let(:game)            { create(:game) }
 
     context 'when the user has additional regular lists' do
       before do
-        create(:shopping_list, game: game)
+        create(:shopping_list, game:)
       end
 
       it "doesn't destroy the aggregate list" do
@@ -394,7 +394,7 @@ RSpec.describe ShoppingList, type: :model do
       end
 
       context 'when there is a matching item on the aggregate list' do
-        let(:other_list)          { create(:shopping_list, game: aggregate_list.game, aggregate_list: aggregate_list) }
+        let(:other_list)          { create(:shopping_list, game: aggregate_list.game, aggregate_list:) }
         let!(:item_on_other_list) { create(:shopping_list_item, description: 'Dwarven metal ingot', list: other_list, unit_weight: 0.3) }
 
         context 'when both have notes' do
@@ -631,7 +631,7 @@ RSpec.describe ShoppingList, type: :model do
         let(:new_notes) { 'another thing' }
 
         before do
-          aggregate_list.list_items.create(description: description, quantity: 3, notes: old_notes)
+          aggregate_list.list_items.create(description:, quantity: 3, notes: old_notes)
         end
 
         it 'adds the negative quantity delta to the existing one' do
@@ -649,7 +649,7 @@ RSpec.describe ShoppingList, type: :model do
         subject(:update_item) { aggregate_list.update_item_from_child_list(description, 0, unit_weight, 'something', 'another thing') }
 
         before do
-          aggregate_list.list_items.create(description: description, quantity: 3, notes: 'something')
+          aggregate_list.list_items.create(description:, quantity: 3, notes: 'something')
         end
 
         it "doesn't change the quantity" do
@@ -662,7 +662,7 @@ RSpec.describe ShoppingList, type: :model do
         subject(:update_item) { aggregate_list.update_item_from_child_list(description, 1, nil, 'something', 'another thing') }
 
         before do
-          aggregate_list.list_items.create(description: description, quantity: 3, unit_weight: 1, notes: 'something')
+          aggregate_list.list_items.create(description:, quantity: 3, unit_weight: 1, notes: 'something')
         end
 
         it 'leaves the existing unit_weight as-is' do
@@ -674,12 +674,12 @@ RSpec.describe ShoppingList, type: :model do
       context 'when there is a unit_weight given' do
         subject(:update_item) { aggregate_list.update_item_from_child_list(description, 1, 2, 'something', 'another thing') }
 
-        let(:other_list) { create(:shopping_list, game: aggregate_list.game, aggregate_list: aggregate_list) }
-        let!(:item_on_other_list)  { create(:shopping_list_item, list: other_list, description: description, unit_weight: 1) }
-        let!(:aggregate_list_item) { create(:shopping_list_item, list: aggregate_list, description: description, quantity: 3, unit_weight: 1, notes: 'something') }
+        let(:other_list) { create(:shopping_list, game: aggregate_list.game, aggregate_list:) }
+        let!(:item_on_other_list)  { create(:shopping_list_item, list: other_list, description:, unit_weight: 1) }
+        let!(:aggregate_list_item) { create(:shopping_list_item, list: aggregate_list, description:, quantity: 3, unit_weight: 1, notes: 'something') }
 
         before do
-          aggregate_list.list_items.create(description: description, quantity: 3, unit_weight: 1, notes: 'something')
+          aggregate_list.list_items.create(description:, quantity: 3, unit_weight: 1, notes: 'something')
         end
 
         it 'updates the unit_weight on the aggregate list' do
@@ -699,7 +699,7 @@ RSpec.describe ShoppingList, type: :model do
         let(:new_notes) { 'something' }
 
         before do
-          aggregate_list.list_items.create(description: description, quantity: 3, notes: "#{old_notes} -- something else")
+          aggregate_list.list_items.create(description:, quantity: 3, notes: "#{old_notes} -- something else")
         end
 
         it "doesn't mess with the notes" do
@@ -713,7 +713,7 @@ RSpec.describe ShoppingList, type: :model do
         let(:existing_notes) { 'notes 1 -- notes 2 -- notes 3' }
 
         before do
-          aggregate_list.list_items.create!(description: description, quantity: 3, notes: existing_notes)
+          aggregate_list.list_items.create!(description:, quantity: 3, notes: existing_notes)
         end
 
         context 'when replacing the middle notes' do
@@ -806,7 +806,7 @@ RSpec.describe ShoppingList, type: :model do
         let(:new_notes)   { nil }
 
         before do
-          aggregate_list.list_items.create!(description: description)
+          aggregate_list.list_items.create!(description:)
         end
 
         it 'raises an error' do
@@ -822,7 +822,7 @@ RSpec.describe ShoppingList, type: :model do
         let(:new_notes)   { nil }
 
         before do
-          aggregate_list.list_items.create!(description: description, quantity: 1)
+          aggregate_list.list_items.create!(description:, quantity: 1)
         end
 
         it 'raises an error' do

--- a/spec/requests/games_spec.rb
+++ b/spec/requests/games_spec.rb
@@ -226,7 +226,7 @@ RSpec.describe 'Games', type: :request do
       end
 
       context 'when the params are invalid' do
-        let!(:game) { create(:game, user:) }
+        let!(:game)       { create(:game, user:) }
         let!(:other_game) { create(:game, user:) }
         let(:params)      { { game: { name: other_game.name } }.to_json }
 
@@ -242,7 +242,7 @@ RSpec.describe 'Games', type: :request do
       end
 
       context 'when the game does not exist' do
-        let(:game) { double(id: 829_315) }
+        let(:game)   { double(id: 829_315) }
         let(:user)   { create(:user) }
         let(:params) { { game: { name: 'New Name' } }.to_json }
 
@@ -258,7 +258,7 @@ RSpec.describe 'Games', type: :request do
       end
 
       context 'when the game does not belong to the authenticated user' do
-        let(:game) { create(:game) }
+        let(:game)   { create(:game) }
         let(:params) { { game: { description: 'New description' } }.to_json }
 
         it 'returns status 404' do
@@ -273,7 +273,7 @@ RSpec.describe 'Games', type: :request do
       end
 
       context 'when something unexpected goes wrong' do
-        let(:game) { create(:game, user:) }
+        let(:game)   { create(:game, user:) }
         let(:params) { { game: { description: 'New description' } }.to_json }
 
         before do
@@ -293,7 +293,7 @@ RSpec.describe 'Games', type: :request do
     end
 
     context 'when unauthenticated' do
-      let(:game) { create(:game) }
+      let(:game)   { create(:game) }
       let(:params) { { game: { name: 'New Name' } }.to_json }
 
       it 'returns status 401' do
@@ -328,7 +328,7 @@ RSpec.describe 'Games', type: :request do
       end
 
       context 'when all goes well' do
-        let(:game) { create(:game, user:) }
+        let(:game)   { create(:game, user:) }
         let(:params) { { game: { name: 'New Name' } }.to_json }
 
         it 'updates the game' do
@@ -355,7 +355,7 @@ RSpec.describe 'Games', type: :request do
       end
 
       context 'when the params are invalid' do
-        let!(:game) { create(:game, user:) }
+        let!(:game)       { create(:game, user:) }
         let!(:other_game) { create(:game, user:) }
         let(:params)      { { game: { name: other_game.name } }.to_json }
 
@@ -371,7 +371,7 @@ RSpec.describe 'Games', type: :request do
       end
 
       context 'when the game does not exist' do
-        let(:game) { double(id: 829_315) }
+        let(:game)   { double(id: 829_315) }
         let(:user)   { create(:user) }
         let(:params) { { game: { name: 'New Name' } }.to_json }
 
@@ -387,7 +387,7 @@ RSpec.describe 'Games', type: :request do
       end
 
       context 'when the game does not belong to the authenticated user' do
-        let(:game) { create(:game) }
+        let(:game)   { create(:game) }
         let(:params) { { game: { description: 'New description' } }.to_json }
 
         it 'returns status 404' do
@@ -402,7 +402,7 @@ RSpec.describe 'Games', type: :request do
       end
 
       context 'when something unexpected goes wrong' do
-        let(:game) { create(:game, user:) }
+        let(:game)   { create(:game, user:) }
         let(:params) { { game: { description: 'New description' } }.to_json }
 
         before do
@@ -422,7 +422,7 @@ RSpec.describe 'Games', type: :request do
     end
 
     context 'when unauthenticated' do
-      let(:game) { create(:game) }
+      let(:game)   { create(:game) }
       let(:params) { { game: { name: 'New Name' } }.to_json }
 
       it 'returns status 401' do

--- a/spec/requests/games_spec.rb
+++ b/spec/requests/games_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe 'Games', type: :request do
   end
 
   describe 'POST /games' do
-    subject(:create_game) { post '/games', headers:, params: params.to_json }
+    subject(:create_game) { post '/games', headers:, params: }
 
     context 'when authenticated' do
       let(:user) { create(:user) }
@@ -108,7 +108,7 @@ RSpec.describe 'Games', type: :request do
       end
 
       context 'when all goes well' do
-        let(:params) { { game: { name: 'My Game' } } }
+        let(:params) { { game: { name: 'My Game' } }.to_json }
 
         it 'creates a game' do
           expect { create_game }
@@ -127,7 +127,7 @@ RSpec.describe 'Games', type: :request do
       end
 
       context 'when the params are invalid' do
-        let(:params) { { game: { name: '@#*!)&' } } }
+        let(:params) { { game: { name: '@#*!)&' } }.to_json }
 
         it "doesn't create a game" do
           expect { create_game }
@@ -146,7 +146,7 @@ RSpec.describe 'Games', type: :request do
       end
 
       context 'when something unexpected goes wrong' do
-        let(:params) { { name: 'My Game' } }
+        let(:params) { { name: 'My Game' }.to_json }
 
         before do
           allow_any_instance_of(Game).to receive(:save).and_raise(StandardError, 'Something has gone horribly wrong')
@@ -165,7 +165,7 @@ RSpec.describe 'Games', type: :request do
     end
 
     context 'when unauthenticated' do
-      let(:params) { { game: { name: 'My Game' } } }
+      let(:params) { { game: { name: 'My Game' } }.to_json }
 
       it 'returns status 401' do
         create_game
@@ -180,7 +180,7 @@ RSpec.describe 'Games', type: :request do
   end
 
   describe 'PATCH /games/:id' do
-    subject(:update_game) { patch "/games/#{game.id}", headers:, params: params.to_json }
+    subject(:update_game) { patch "/games/#{game.id}", headers:, params: }
 
     context 'when authenticated' do
       let(:user) { create(:user) }
@@ -200,7 +200,7 @@ RSpec.describe 'Games', type: :request do
 
       context 'when all goes well' do
         let(:game)   { create(:game, user:) }
-        let(:params) { { game: { name: 'New Name' } } }
+        let(:params) { { game: { name: 'New Name' } }.to_json }
 
         it 'updates the game' do
           update_game
@@ -228,7 +228,7 @@ RSpec.describe 'Games', type: :request do
       context 'when the params are invalid' do
         let!(:game) { create(:game, user:) }
         let!(:other_game) { create(:game, user:) }
-        let(:params)      { { game: { name: other_game.name } } }
+        let(:params)      { { game: { name: other_game.name } }.to_json }
 
         it 'returns status 422' do
           update_game
@@ -244,7 +244,7 @@ RSpec.describe 'Games', type: :request do
       context 'when the game does not exist' do
         let(:game) { double(id: 829_315) }
         let(:user)   { create(:user) }
-        let(:params) { { game: { name: 'New Name' } } }
+        let(:params) { { game: { name: 'New Name' } }.to_json }
 
         it 'returns status 404' do
           update_game
@@ -259,7 +259,7 @@ RSpec.describe 'Games', type: :request do
 
       context 'when the game does not belong to the authenticated user' do
         let(:game) { create(:game) }
-        let(:params) { { game: { description: 'New description' } } }
+        let(:params) { { game: { description: 'New description' } }.to_json }
 
         it 'returns status 404' do
           update_game
@@ -274,7 +274,7 @@ RSpec.describe 'Games', type: :request do
 
       context 'when something unexpected goes wrong' do
         let(:game) { create(:game, user:) }
-        let(:params) { { game: { description: 'New description' } } }
+        let(:params) { { game: { description: 'New description' } }.to_json }
 
         before do
           allow_any_instance_of(Game).to receive(:update).and_raise(StandardError, 'Something went horribly wrong')
@@ -294,7 +294,7 @@ RSpec.describe 'Games', type: :request do
 
     context 'when unauthenticated' do
       let(:game) { create(:game) }
-      let(:params) { { game: { name: 'New Name' } } }
+      let(:params) { { game: { name: 'New Name' } }.to_json }
 
       it 'returns status 401' do
         update_game
@@ -309,7 +309,7 @@ RSpec.describe 'Games', type: :request do
   end
 
   describe 'PUT /games/:id' do
-    subject(:update_game) { put "/games/#{game.id}", headers:, params: params.to_json }
+    subject(:update_game) { put "/games/#{game.id}", headers:, params: }
 
     context 'when authenticated' do
       let(:user) { create(:user) }
@@ -329,7 +329,7 @@ RSpec.describe 'Games', type: :request do
 
       context 'when all goes well' do
         let(:game) { create(:game, user:) }
-        let(:params) { { game: { name: 'New Name' } } }
+        let(:params) { { game: { name: 'New Name' } }.to_json }
 
         it 'updates the game' do
           update_game
@@ -357,7 +357,7 @@ RSpec.describe 'Games', type: :request do
       context 'when the params are invalid' do
         let!(:game) { create(:game, user:) }
         let!(:other_game) { create(:game, user:) }
-        let(:params)      { { game: { name: other_game.name } } }
+        let(:params)      { { game: { name: other_game.name } }.to_json }
 
         it 'returns status 422' do
           update_game
@@ -373,7 +373,7 @@ RSpec.describe 'Games', type: :request do
       context 'when the game does not exist' do
         let(:game) { double(id: 829_315) }
         let(:user)   { create(:user) }
-        let(:params) { { game: { name: 'New Name' } } }
+        let(:params) { { game: { name: 'New Name' } }.to_json }
 
         it 'returns status 404' do
           update_game
@@ -388,7 +388,7 @@ RSpec.describe 'Games', type: :request do
 
       context 'when the game does not belong to the authenticated user' do
         let(:game) { create(:game) }
-        let(:params) { { game: { description: 'New description' } } }
+        let(:params) { { game: { description: 'New description' } }.to_json }
 
         it 'returns status 404' do
           update_game
@@ -403,7 +403,7 @@ RSpec.describe 'Games', type: :request do
 
       context 'when something unexpected goes wrong' do
         let(:game) { create(:game, user:) }
-        let(:params) { { game: { description: 'New description' } } }
+        let(:params) { { game: { description: 'New description' } }.to_json }
 
         before do
           allow_any_instance_of(Game).to receive(:update).and_raise(StandardError, 'Something went horribly wrong')
@@ -423,7 +423,7 @@ RSpec.describe 'Games', type: :request do
 
     context 'when unauthenticated' do
       let(:game) { create(:game) }
-      let(:params) { { game: { name: 'New Name' } } }
+      let(:params) { { game: { name: 'New Name' } }.to_json }
 
       it 'returns status 401' do
         update_game

--- a/spec/requests/games_spec.rb
+++ b/spec/requests/games_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'Games', type: :request do
 
       context 'when the user has games' do
         before do
-          create_list(:game, 2, user: user)
+          create_list(:game, 2, user:)
           create(:game) # for another user, shouldn't be returned
         end
 
@@ -89,7 +89,7 @@ RSpec.describe 'Games', type: :request do
   end
 
   describe 'POST /games' do
-    subject(:create_game) { post '/games', headers: headers, params: params.to_json }
+    subject(:create_game) { post '/games', headers:, params: params.to_json }
 
     context 'when authenticated' do
       let(:user) { create(:user) }
@@ -180,7 +180,7 @@ RSpec.describe 'Games', type: :request do
   end
 
   describe 'PATCH /games/:id' do
-    subject(:update_game) { patch "/games/#{game.id}", headers: headers, params: params.to_json }
+    subject(:update_game) { patch "/games/#{game.id}", headers:, params: params.to_json }
 
     context 'when authenticated' do
       let(:user) { create(:user) }
@@ -199,7 +199,7 @@ RSpec.describe 'Games', type: :request do
       end
 
       context 'when all goes well' do
-        let(:game)   { create(:game, user: user) }
+        let(:game)   { create(:game, user:) }
         let(:params) { { game: { name: 'New Name' } } }
 
         it 'updates the game' do
@@ -226,8 +226,8 @@ RSpec.describe 'Games', type: :request do
       end
 
       context 'when the params are invalid' do
-        let!(:game) { create(:game, user: user) }
-        let!(:other_game) { create(:game, user: user) }
+        let!(:game) { create(:game, user:) }
+        let!(:other_game) { create(:game, user:) }
         let(:params)      { { game: { name: other_game.name } } }
 
         it 'returns status 422' do
@@ -273,7 +273,7 @@ RSpec.describe 'Games', type: :request do
       end
 
       context 'when something unexpected goes wrong' do
-        let(:game) { create(:game, user: user) }
+        let(:game) { create(:game, user:) }
         let(:params) { { game: { description: 'New description' } } }
 
         before do
@@ -309,7 +309,7 @@ RSpec.describe 'Games', type: :request do
   end
 
   describe 'PUT /games/:id' do
-    subject(:update_game) { put "/games/#{game.id}", headers: headers, params: params.to_json }
+    subject(:update_game) { put "/games/#{game.id}", headers:, params: params.to_json }
 
     context 'when authenticated' do
       let(:user) { create(:user) }
@@ -328,7 +328,7 @@ RSpec.describe 'Games', type: :request do
       end
 
       context 'when all goes well' do
-        let(:game) { create(:game, user: user) }
+        let(:game) { create(:game, user:) }
         let(:params) { { game: { name: 'New Name' } } }
 
         it 'updates the game' do
@@ -355,8 +355,8 @@ RSpec.describe 'Games', type: :request do
       end
 
       context 'when the params are invalid' do
-        let!(:game) { create(:game, user: user) }
-        let!(:other_game) { create(:game, user: user) }
+        let!(:game) { create(:game, user:) }
+        let!(:other_game) { create(:game, user:) }
         let(:params)      { { game: { name: other_game.name } } }
 
         it 'returns status 422' do
@@ -402,7 +402,7 @@ RSpec.describe 'Games', type: :request do
       end
 
       context 'when something unexpected goes wrong' do
-        let(:game) { create(:game, user: user) }
+        let(:game) { create(:game, user:) }
         let(:params) { { game: { description: 'New description' } } }
 
         before do
@@ -438,7 +438,7 @@ RSpec.describe 'Games', type: :request do
   end
 
   describe 'DELETE /games/:id' do
-    subject(:destroy_game) { delete "/games/#{game.id}", headers: headers }
+    subject(:destroy_game) { delete "/games/#{game.id}", headers: }
 
     context 'when authenticated' do
       let(:user) { create(:user) }
@@ -457,7 +457,7 @@ RSpec.describe 'Games', type: :request do
       end
 
       context 'when all goes well' do
-        let!(:game) { create(:game, user: user) }
+        let!(:game) { create(:game, user:) }
 
         it 'destroys the game' do
           expect { destroy_game }
@@ -504,7 +504,7 @@ RSpec.describe 'Games', type: :request do
       end
 
       context 'when something unexpected goes wrong' do
-        let(:game) { create(:game, user: user) }
+        let(:game) { create(:game, user:) }
 
         before do
           allow_any_instance_of(Game).to receive(:destroy!).and_raise(StandardError, 'Something went horribly wrong')

--- a/spec/requests/inventory_items_spec.rb
+++ b/spec/requests/inventory_items_spec.rb
@@ -12,9 +12,7 @@ RSpec.describe 'InventoryItems', type: :request do
 
   describe 'POST /inventory_lists/:inventory_list_id/inventory_items' do
     subject(:create_item) do
-      post "/inventory_lists/#{inventory_list.id}/inventory_items",
-           params:  params.to_json,
-           headers:
+      post "/inventory_lists/#{inventory_list.id}/inventory_items", params:, headers:
     end
 
     let!(:aggregate_list) { create(:aggregate_inventory_list) }
@@ -37,7 +35,7 @@ RSpec.describe 'InventoryItems', type: :request do
       end
 
       context 'when all goes well' do
-        let(:params) { { inventory_item: { description: 'Corundum ingot', quantity: 5, notes: 'To make locks' } } }
+        let(:params) { { inventory_item: { description: 'Corundum ingot', quantity: 5, notes: 'To make locks' } }.to_json }
 
         context 'when there is no existing matching item on the same list' do
           context 'when there is no existing matching item on any list' do
@@ -71,7 +69,7 @@ RSpec.describe 'InventoryItems', type: :request do
             end
 
             context "when unit weight isn't set" do
-              let(:params) { { inventory_item: { description: 'Corundum ingot', quantity: 5 } } }
+              let(:params) { { inventory_item: { description: 'Corundum ingot', quantity: 5 } }.to_json }
 
               it 'creates a new item on the requested list' do
                 expect { create_item }
@@ -95,7 +93,7 @@ RSpec.describe 'InventoryItems', type: :request do
             end
 
             context 'when unit weight is set' do
-              let(:params) { { inventory_item: { description: 'Corundum ingot', quantity: 5, unit_weight: 1 } } }
+              let(:params) { { inventory_item: { description: 'Corundum ingot', quantity: 5, unit_weight: 1 } }.to_json }
 
               it 'creates a new item on the requested list' do
                 expect { create_item }
@@ -165,7 +163,7 @@ RSpec.describe 'InventoryItems', type: :request do
           end
 
           context 'when unit weight is updated' do
-            let(:params) { { inventory_item: { description: 'Corundum ingot', quantity: 2, unit_weight: 1 } } }
+            let(:params) { { inventory_item: { description: 'Corundum ingot', quantity: 2, unit_weight: 1 } }.to_json }
 
             it "doesn't create a new list item" do
               expect { create_item }
@@ -204,7 +202,7 @@ RSpec.describe 'InventoryItems', type: :request do
       end
 
       context "when the list doesn't exist" do
-        let(:params)         { { description: 'Necklace', quantity: 2, unit_weight: 0.5 } }
+        let(:params)         { { description: 'Necklace', quantity: 2, unit_weight: 0.5 }.to_json }
         let(:inventory_list) { double(id: 23_498) }
 
         it 'returns status 404' do
@@ -220,7 +218,7 @@ RSpec.describe 'InventoryItems', type: :request do
 
       context "when the list doesn't belong to the authenticated user" do
         let(:inventory_list) { create(:inventory_list) }
-        let(:params)         { { inventory_item: { description: 'Corundum ingot', quantity: 5 } } }
+        let(:params)         { { inventory_item: { description: 'Corundum ingot', quantity: 5 } }.to_json }
 
         it "doesn't create the list item" do
           expect { create_item }
@@ -239,7 +237,7 @@ RSpec.describe 'InventoryItems', type: :request do
       end
 
       context 'when the params are invalid' do
-        let(:params) { { inventory_item: { description: 'Corundum ingot', quantity: -2 } } }
+        let(:params) { { inventory_item: { description: 'Corundum ingot', quantity: -2 } }.to_json }
 
         it "doesn't create the item" do
           expect { create_item }
@@ -259,7 +257,7 @@ RSpec.describe 'InventoryItems', type: :request do
 
       context 'when the list is an aggregate list' do
         let(:inventory_list) { aggregate_list }
-        let(:params)         { { inventory_item: { description: 'Corundum ingot', quantity: 4 } } }
+        let(:params)         { { inventory_item: { description: 'Corundum ingot', quantity: 4 } }.to_json }
 
         it "doesn't create an item" do
           expect { create_item }
@@ -279,7 +277,7 @@ RSpec.describe 'InventoryItems', type: :request do
       end
 
       context 'when something unexpected goes wrong' do
-        let(:params) { { inventory_item: { description: 'Corundum ingot', quantity: 4 } } }
+        let(:params) { { inventory_item: { description: 'Corundum ingot', quantity: 4 } }.to_json }
 
         before do
           allow(InventoryList).to receive(:find).and_raise(StandardError.new('Something went horribly wrong'))
@@ -298,7 +296,7 @@ RSpec.describe 'InventoryItems', type: :request do
     end
 
     context 'when not authenticated' do
-      let(:params) { { quantity: 4 } }
+      let(:params) { { quantity: 4 }.to_json }
 
       it 'returns status 401' do
         create_item
@@ -313,7 +311,7 @@ RSpec.describe 'InventoryItems', type: :request do
   end
 
   describe 'PATCH /inventory_items/:id' do
-    subject(:update_item) { patch "/inventory_items/#{list_item.id}", headers:, params: params.to_json }
+    subject(:update_item) { patch "/inventory_items/#{list_item.id}", headers:, params: }
 
     let(:game)            { create(:game) }
     let!(:aggregate_list) { create(:aggregate_inventory_list, game:) }
@@ -339,7 +337,7 @@ RSpec.describe 'InventoryItems', type: :request do
         context 'when there is no matching item on another list' do
           let!(:list_item)          { create(:inventory_item, list: inventory_list, description: 'Dwarven metal ingot', quantity: 5) }
           let(:aggregate_list_item) { aggregate_list.list_items.first }
-          let(:params)              { { inventory_item: { description: 'Dwarven metal ingot', quantity: 10 } } }
+          let(:params)              { { inventory_item: { description: 'Dwarven metal ingot', quantity: 10 } }.to_json }
 
           before do
             aggregate_list.add_item_from_child_list(list_item)
@@ -378,7 +376,7 @@ RSpec.describe 'InventoryItems', type: :request do
           end
 
           context 'when unit_weight is not changed' do
-            let(:params) { { inventory_item: { quantity: 10 } } }
+            let(:params) { { inventory_item: { quantity: 10 } }.to_json }
 
             it 'updates the list item' do
               update_item
@@ -426,7 +424,7 @@ RSpec.describe 'InventoryItems', type: :request do
           end
 
           context 'when unit_weight is changed' do
-            let(:params) { { inventory_item: { quantity: 10, unit_weight: 2 } } }
+            let(:params) { { inventory_item: { quantity: 10, unit_weight: 2 } }.to_json }
 
             it 'updates the list item', :aggregate_failures do
               update_item
@@ -493,7 +491,7 @@ RSpec.describe 'InventoryItems', type: :request do
 
       context "when the inventory list item doesn't exist" do
         let(:list_item) { double(id: 234_567) }
-        let(:params)    { { quantity: 4, unit_weight: 0.3 } }
+        let(:params)    { { quantity: 4, unit_weight: 0.3 }.to_json }
 
         it 'returns status 404' do
           update_item
@@ -508,7 +506,7 @@ RSpec.describe 'InventoryItems', type: :request do
 
       context "when the inventory list item doesn't belong to the authenticated user" do
         let(:list_item) { create(:inventory_item) }
-        let(:params)    { { notes: 'Hello world' } }
+        let(:params)    { { notes: 'Hello world' }.to_json }
 
         it 'returns status 404' do
           update_item
@@ -523,7 +521,7 @@ RSpec.describe 'InventoryItems', type: :request do
 
       context 'when the list item is on an aggregate list' do
         let!(:list_item) { create(:inventory_item, list: aggregate_list) }
-        let(:params)     { { inventory_item: { quantity: 10 } } }
+        let(:params)     { { inventory_item: { quantity: 10 } }.to_json }
 
         it 'returns status 405' do
           update_item
@@ -541,7 +539,7 @@ RSpec.describe 'InventoryItems', type: :request do
         let(:other_list)          { create(:inventory_list, game:) }
         let!(:other_item)         { create(:inventory_item, list: other_list, description: list_item.description, quantity: 1) }
         let(:aggregate_list_item) { aggregate_list.list_items.first }
-        let(:params)              { { inventory_item: { quantity: -4, unit_weight: 2 } } }
+        let(:params)              { { inventory_item: { quantity: -4, unit_weight: 2 } }.to_json }
 
         before do
           aggregate_list.add_item_from_child_list(list_item)
@@ -572,7 +570,7 @@ RSpec.describe 'InventoryItems', type: :request do
 
       context 'when something unexpected goes wrong' do
         let!(:list_item) { create(:inventory_item, list: inventory_list) }
-        let(:params)     { { notes: 'Hello world' } }
+        let(:params)     { { notes: 'Hello world' }.to_json }
 
         before do
           aggregate_list.add_item_from_child_list(list_item)
@@ -595,7 +593,7 @@ RSpec.describe 'InventoryItems', type: :request do
 
     context 'when not authenticated' do
       let!(:list_item) { create(:inventory_item, list: inventory_list) }
-      let(:params)     { { quantity: 4 } }
+      let(:params)     { { quantity: 4 }.to_json }
 
       it 'returns status 401' do
         update_item
@@ -610,7 +608,7 @@ RSpec.describe 'InventoryItems', type: :request do
   end
 
   describe 'PUT /inventory_items/:id' do
-    subject(:update_item) { put "/inventory_items/#{list_item.id}", headers:, params: params.to_json }
+    subject(:update_item) { put "/inventory_items/#{list_item.id}", headers:, params: }
 
     let(:game)            { create(:game) }
     let!(:aggregate_list) { create(:aggregate_inventory_list, game:) }
@@ -636,7 +634,7 @@ RSpec.describe 'InventoryItems', type: :request do
         context 'when there is no matching item on another list' do
           let!(:list_item)          { create(:inventory_item, list: inventory_list, description: 'Dwarven metal ingot', quantity: 5) }
           let(:aggregate_list_item) { aggregate_list.list_items.first }
-          let(:params)              { { inventory_item: { description: 'Dwarven metal ingot', quantity: 10 } } }
+          let(:params)              { { inventory_item: { description: 'Dwarven metal ingot', quantity: 10 } }.to_json }
 
           before do
             aggregate_list.add_item_from_child_list(list_item)
@@ -675,7 +673,7 @@ RSpec.describe 'InventoryItems', type: :request do
           end
 
           context 'when unit_weight is not changed' do
-            let(:params) { { inventory_item: { quantity: 10 } } }
+            let(:params) { { inventory_item: { quantity: 10 } }.to_json }
 
             it 'updates the list item' do
               update_item
@@ -699,7 +697,7 @@ RSpec.describe 'InventoryItems', type: :request do
           end
 
           context 'when unit_weight is changed' do
-            let(:params) { { inventory_item: { quantity: 10, unit_weight: 2 } } }
+            let(:params) { { inventory_item: { quantity: 10, unit_weight: 2 } }.to_json }
 
             it 'updates the list item', :aggregate_failures do
               update_item
@@ -734,7 +732,7 @@ RSpec.describe 'InventoryItems', type: :request do
 
       context "when the inventory list item doesn't exist" do
         let(:list_item) { double(id: 234_567) }
-        let(:params)    { { quantity: 4, unit_weight: 0.3 } }
+        let(:params)    { { quantity: 4, unit_weight: 0.3 }.to_json }
 
         it 'returns status 404' do
           update_item
@@ -749,7 +747,7 @@ RSpec.describe 'InventoryItems', type: :request do
 
       context "when the inventory list item doesn't belong to the authenticated user" do
         let(:list_item) { create(:inventory_item) }
-        let(:params)    { { notes: 'Hello world' } }
+        let(:params)    { { notes: 'Hello world' }.to_json }
 
         it 'returns status 404' do
           update_item
@@ -764,7 +762,7 @@ RSpec.describe 'InventoryItems', type: :request do
 
       context 'when the list item is on an aggregate list' do
         let!(:list_item) { create(:inventory_item, list: aggregate_list) }
-        let(:params)     { { inventory_item: { quantity: 10 } } }
+        let(:params)     { { inventory_item: { quantity: 10 } }.to_json }
 
         it 'returns status 405' do
           update_item
@@ -782,7 +780,7 @@ RSpec.describe 'InventoryItems', type: :request do
         let(:other_list)          { create(:inventory_list, game:) }
         let!(:other_item)         { create(:inventory_item, list: other_list, description: list_item.description, quantity: 1) }
         let(:aggregate_list_item) { aggregate_list.list_items.first }
-        let(:params)              { { inventory_item: { quantity: -4, unit_weight: 2 } } }
+        let(:params)              { { inventory_item: { quantity: -4, unit_weight: 2 } }.to_json }
 
         before do
           aggregate_list.add_item_from_child_list(list_item)
@@ -813,7 +811,7 @@ RSpec.describe 'InventoryItems', type: :request do
 
       context 'when something unexpected goes wrong' do
         let!(:list_item) { create(:inventory_item, list: inventory_list) }
-        let(:params)     { { notes: 'Hello world' } }
+        let(:params)     { { notes: 'Hello world' }.to_json }
 
         before do
           aggregate_list.add_item_from_child_list(list_item)
@@ -836,7 +834,7 @@ RSpec.describe 'InventoryItems', type: :request do
 
     context 'when not authenticated' do
       let!(:list_item) { create(:inventory_item, list: inventory_list) }
-      let(:params)     { { notes: 'Hello world' } }
+      let(:params)     { { notes: 'Hello world' }.to_json }
 
       it 'returns status 401' do
         update_item

--- a/spec/requests/inventory_items_spec.rb
+++ b/spec/requests/inventory_items_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe 'InventoryItems', type: :request do
     subject(:create_item) do
       post "/inventory_lists/#{inventory_list.id}/inventory_items",
            params:  params.to_json,
-           headers: headers
+           headers:
     end
 
     let!(:aggregate_list) { create(:aggregate_inventory_list) }
-    let!(:inventory_list) { create(:inventory_list, aggregate_list: aggregate_list, game: aggregate_list.game) }
+    let!(:inventory_list) { create(:inventory_list, aggregate_list:, game: aggregate_list.game) }
 
     context 'when authenticated' do
       let!(:user)     { aggregate_list.user }
@@ -128,7 +128,7 @@ RSpec.describe 'InventoryItems', type: :request do
         end
 
         context 'when there is an existing matching item on the same list' do
-          let(:other_list) { create(:inventory_list, game: aggregate_list.game, aggregate_list: aggregate_list) }
+          let(:other_list) { create(:inventory_list, game: aggregate_list.game, aggregate_list:) }
           let!(:other_item) { create(:inventory_item, list: other_list, description: 'Corundum ingot', quantity: 2) }
           let!(:list_item)  { create(:inventory_item, list: inventory_list, description: 'Corundum ingot', quantity: 3) }
 
@@ -313,11 +313,11 @@ RSpec.describe 'InventoryItems', type: :request do
   end
 
   describe 'PATCH /inventory_items/:id' do
-    subject(:update_item) { patch "/inventory_items/#{list_item.id}", headers: headers, params: params.to_json }
+    subject(:update_item) { patch "/inventory_items/#{list_item.id}", headers:, params: params.to_json }
 
     let(:game)            { create(:game) }
-    let!(:aggregate_list) { create(:aggregate_inventory_list, game: game) }
-    let!(:inventory_list) { create(:inventory_list, game: game, aggregate_list: aggregate_list) }
+    let!(:aggregate_list) { create(:aggregate_inventory_list, game:) }
+    let!(:inventory_list) { create(:inventory_list, game:, aggregate_list:) }
 
     context 'when authenticated' do
       let!(:user)     { game.user }
@@ -368,7 +368,7 @@ RSpec.describe 'InventoryItems', type: :request do
 
         context 'when there is a matching item on another list' do
           let!(:list_item)          { create(:inventory_item, list: inventory_list) }
-          let!(:other_list)         { create(:inventory_list, game: game, aggregate_list: aggregate_list) }
+          let!(:other_list)         { create(:inventory_list, game:, aggregate_list:) }
           let!(:other_item)         { create(:inventory_item, list: other_list, description: list_item.description, quantity: 4) }
           let(:aggregate_list_item) { aggregate_list.list_items.first }
 
@@ -538,7 +538,7 @@ RSpec.describe 'InventoryItems', type: :request do
 
       context 'when the attributes are invalid' do
         let!(:list_item)          { create(:inventory_item, list: inventory_list, quantity: 2) }
-        let(:other_list)          { create(:inventory_list, game: game) }
+        let(:other_list)          { create(:inventory_list, game:) }
         let!(:other_item)         { create(:inventory_item, list: other_list, description: list_item.description, quantity: 1) }
         let(:aggregate_list_item) { aggregate_list.list_items.first }
         let(:params)              { { inventory_item: { quantity: -4, unit_weight: 2 } } }
@@ -610,11 +610,11 @@ RSpec.describe 'InventoryItems', type: :request do
   end
 
   describe 'PUT /inventory_items/:id' do
-    subject(:update_item) { put "/inventory_items/#{list_item.id}", headers: headers, params: params.to_json }
+    subject(:update_item) { put "/inventory_items/#{list_item.id}", headers:, params: params.to_json }
 
     let(:game)            { create(:game) }
-    let!(:aggregate_list) { create(:aggregate_inventory_list, game: game) }
-    let!(:inventory_list) { create(:inventory_list, game: game, aggregate_list: aggregate_list) }
+    let!(:aggregate_list) { create(:aggregate_inventory_list, game:) }
+    let!(:inventory_list) { create(:inventory_list, game:, aggregate_list:) }
 
     context 'when authenticated' do
       let!(:user)     { game.user }
@@ -665,7 +665,7 @@ RSpec.describe 'InventoryItems', type: :request do
 
         context 'when there is a matching item on another list' do
           let!(:list_item)          { create(:inventory_item, list: inventory_list) }
-          let!(:other_list)         { create(:inventory_list, game: game, aggregate_list: aggregate_list) }
+          let!(:other_list)         { create(:inventory_list, game:, aggregate_list:) }
           let!(:other_item)         { create(:inventory_item, list: other_list, description: list_item.description, quantity: 4) }
           let(:aggregate_list_item) { aggregate_list.list_items.first }
 
@@ -779,7 +779,7 @@ RSpec.describe 'InventoryItems', type: :request do
 
       context 'when the attributes are invalid' do
         let!(:list_item)          { create(:inventory_item, list: inventory_list, quantity: 2) }
-        let(:other_list)          { create(:inventory_list, game: game) }
+        let(:other_list)          { create(:inventory_list, game:) }
         let!(:other_item)         { create(:inventory_item, list: other_list, description: list_item.description, quantity: 1) }
         let(:aggregate_list_item) { aggregate_list.list_items.first }
         let(:params)              { { inventory_item: { quantity: -4, unit_weight: 2 } } }
@@ -851,11 +851,11 @@ RSpec.describe 'InventoryItems', type: :request do
   end
 
   describe 'DELETE /inventory_items/:id' do
-    subject(:destroy_item) { delete "/inventory_items/#{list_item.id}", headers: headers }
+    subject(:destroy_item) { delete "/inventory_items/#{list_item.id}", headers: }
 
     let(:game)            { create(:game) }
-    let!(:aggregate_list) { create(:aggregate_inventory_list, game: game) }
-    let!(:inventory_list) { create(:inventory_list, game: game, aggregate_list: aggregate_list) }
+    let!(:aggregate_list) { create(:aggregate_inventory_list, game:) }
+    let!(:inventory_list) { create(:inventory_list, game:, aggregate_list:) }
 
     context 'when authenticated' do
       let!(:user)     { game.user }
@@ -918,7 +918,7 @@ RSpec.describe 'InventoryItems', type: :request do
 
         context 'when there is a matching list item on another list' do
           let!(:list_item)  { create(:inventory_item, list: inventory_list) }
-          let(:other_list)  { create(:inventory_list, game: game) }
+          let(:other_list)  { create(:inventory_list, game:) }
           let!(:other_item) { create(:inventory_item, description: list_item.description, list: other_list) }
 
           before do

--- a/spec/requests/inventory_lists_spec.rb
+++ b/spec/requests/inventory_lists_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe 'InventoryLists', type: :request do
   end
 
   describe 'GET /games/:game_id/inventory_lists' do
-    subject(:get_index) { get "/games/#{game.id}/inventory_lists", headers: headers }
+    subject(:get_index) { get "/games/#{game.id}/inventory_lists", headers: }
 
     context 'when unauthenticated' do
       let(:game) { create(:game) }
 
       before do
         # create some data to not be returned
-        create_list(:inventory_list, 3, game: game)
+        create_list(:inventory_list, 3, game:)
       end
 
       it 'returns 401' do
@@ -107,7 +107,7 @@ RSpec.describe 'InventoryLists', type: :request do
   end
 
   describe 'POST games/:game_id/inventory_lists' do
-    subject(:create_inventory_list) { post "/games/#{game.id}/inventory_lists", params: { inventory_list: {} }.to_json, headers: headers }
+    subject(:create_inventory_list) { post "/games/#{game.id}/inventory_lists", params: { inventory_list: {} }.to_json, headers: }
 
     context 'when authenticated' do
       let!(:user) { create(:user) }
@@ -126,7 +126,7 @@ RSpec.describe 'InventoryLists', type: :request do
       end
 
       context 'when all goes well' do
-        let(:game) { create(:game, user: user) }
+        let(:game) { create(:game, user:) }
 
         context 'when an aggregate list has also been created' do
           it 'creates a new inventory list' do
@@ -146,7 +146,7 @@ RSpec.describe 'InventoryLists', type: :request do
         end
 
         context 'when only the new inventory list has been created' do
-          let!(:aggregate_list) { create(:aggregate_inventory_list, game: game, created_at: 2.seconds.ago, updated_at: 2.seconds.ago) }
+          let!(:aggregate_list) { create(:aggregate_inventory_list, game:, created_at: 2.seconds.ago, updated_at: 2.seconds.ago) }
 
           it 'creates one list' do
             expect { create_inventory_list }
@@ -160,11 +160,11 @@ RSpec.describe 'InventoryLists', type: :request do
         end
 
         context 'when the request does not include a body' do
-          subject(:create_inventory_list) { post "/games/#{game.id}/inventory_lists", headers: headers }
+          subject(:create_inventory_list) { post "/games/#{game.id}/inventory_lists", headers: }
 
           before do
             # let's not have this request create an aggregate list too
-            create(:aggregate_inventory_list, game: game)
+            create(:aggregate_inventory_list, game:)
           end
 
           it 'returns status 201' do
@@ -214,10 +214,10 @@ RSpec.describe 'InventoryLists', type: :request do
       end
 
       context 'when the params are invalid' do
-        subject(:create_inventory_list) { post "/games/#{game.id}/inventory_lists", params: { inventory_list: { title: existing_list.title } }.to_json, headers: headers }
+        subject(:create_inventory_list) { post "/games/#{game.id}/inventory_lists", params: { inventory_list: { title: existing_list.title } }.to_json, headers: }
 
-        let(:game)          { create(:game, user: user) }
-        let(:existing_list) { create(:inventory_list, game: game) }
+        let(:game)          { create(:game, user:) }
+        let(:existing_list) { create(:inventory_list, game:) }
 
         it 'returns status 422' do
           create_inventory_list
@@ -231,9 +231,9 @@ RSpec.describe 'InventoryLists', type: :request do
       end
 
       context 'when the client attempts to create an aggregate list' do
-        subject(:create_inventory_list) { post "/games/#{game.id}/inventory_lists", params: { inventory_list: { aggregate: true } }.to_json, headers: headers }
+        subject(:create_inventory_list) { post "/games/#{game.id}/inventory_lists", params: { inventory_list: { aggregate: true } }.to_json, headers: }
 
-        let(:game) { create(:game, user: user) }
+        let(:game) { create(:game, user:) }
 
         it "doesn't create a list" do
           expect { create_inventory_list }
@@ -263,7 +263,7 @@ RSpec.describe 'InventoryLists', type: :request do
   end
 
   describe 'PATCH /inventory_lists/:id' do
-    subject(:update_inventory_list) { patch "/inventory_lists/#{list_id}", params: { inventory_list: { title: 'Severin Manor' } }.to_json, headers: headers }
+    subject(:update_inventory_list) { patch "/inventory_lists/#{list_id}", params: { inventory_list: { title: 'Severin Manor' } }.to_json, headers: }
 
     context 'when authenticated' do
       let!(:user) { create(:user) }
@@ -282,8 +282,8 @@ RSpec.describe 'InventoryLists', type: :request do
       end
 
       context 'when all goes well' do
-        let!(:inventory_list) { create(:inventory_list, game: game) }
-        let(:game)            { create(:game, user: user) }
+        let!(:inventory_list) { create(:inventory_list, game:) }
+        let(:game)            { create(:game, user:) }
         let(:list_id)         { inventory_list.id }
 
         it 'updates the title' do
@@ -306,12 +306,12 @@ RSpec.describe 'InventoryLists', type: :request do
       end
 
       context 'when the params are invalid' do
-        subject(:update_inventory_list) { patch "/inventory_lists/#{list_id}", params: { inventory_list: { title: other_list.title } }.to_json, headers: headers }
+        subject(:update_inventory_list) { patch "/inventory_lists/#{list_id}", params: { inventory_list: { title: other_list.title } }.to_json, headers: }
 
-        let!(:inventory_list) { create(:inventory_list, game: game) }
-        let(:game)            { create(:game, user: user) }
+        let!(:inventory_list) { create(:inventory_list, game:) }
+        let(:game)            { create(:game, user:) }
         let(:list_id)         { inventory_list.id }
-        let(:other_list)      { create(:inventory_list, game: game) }
+        let(:other_list)      { create(:inventory_list, game:) }
 
         it 'returns status 422' do
           update_inventory_list
@@ -359,10 +359,10 @@ RSpec.describe 'InventoryLists', type: :request do
       end
 
       context 'when the client attempts to update an aggregate list' do
-        subject(:update_inventory_list) { patch "/inventory_lists/#{inventory_list.id}", params: { inventory_list: { title: 'Foo' } }.to_json, headers: headers }
+        subject(:update_inventory_list) { patch "/inventory_lists/#{inventory_list.id}", params: { inventory_list: { title: 'Foo' } }.to_json, headers: }
 
-        let!(:inventory_list) { create(:aggregate_inventory_list, game: game) }
-        let(:game)            { create(:game, user: user) }
+        let!(:inventory_list) { create(:aggregate_inventory_list, game:) }
+        let(:game)            { create(:game, user:) }
 
         it "doesn't update the list" do
           update_inventory_list
@@ -381,10 +381,10 @@ RSpec.describe 'InventoryLists', type: :request do
       end
 
       context 'when the client attempts to change a regular list to an aggregate list' do
-        subject(:update_inventory_list) { patch "/inventory_lists/#{inventory_list.id}", params: { inventory_list: { aggregate: true } }.to_json, headers: headers }
+        subject(:update_inventory_list) { patch "/inventory_lists/#{inventory_list.id}", params: { inventory_list: { aggregate: true } }.to_json, headers: }
 
-        let!(:inventory_list) { create(:inventory_list, game: game) }
-        let(:game)            { create(:game, user: user) }
+        let!(:inventory_list) { create(:inventory_list, game:) }
+        let(:game)            { create(:game, user:) }
 
         it "doesn't update the list" do
           update_inventory_list
@@ -403,10 +403,10 @@ RSpec.describe 'InventoryLists', type: :request do
       end
 
       context 'when something unexpected goes wrong' do
-        subject(:update_inventory_list) { patch "/inventory_lists/#{inventory_list.id}", params: { inventory_list: { title: 'Some New Title' } }.to_json, headers: headers }
+        subject(:update_inventory_list) { patch "/inventory_lists/#{inventory_list.id}", params: { inventory_list: { title: 'Some New Title' } }.to_json, headers: }
 
-        let!(:inventory_list) { create(:inventory_list, game: game) }
-        let(:game)            { create(:game, user: user) }
+        let!(:inventory_list) { create(:inventory_list, game:) }
+        let(:game)            { create(:game, user:) }
 
         before do
           allow_any_instance_of(User).to receive(:inventory_lists).and_raise(StandardError, 'Something went catastrophically wrong')
@@ -435,7 +435,7 @@ RSpec.describe 'InventoryLists', type: :request do
   end
 
   describe 'PUT /inventory_lists/:id' do
-    subject(:update_inventory_list) { put "/inventory_lists/#{list_id}", params: { inventory_list: { title: 'Severin Manor' } }.to_json, headers: headers }
+    subject(:update_inventory_list) { put "/inventory_lists/#{list_id}", params: { inventory_list: { title: 'Severin Manor' } }.to_json, headers: }
 
     context 'when authenticated' do
       let!(:user) { create(:user) }
@@ -454,8 +454,8 @@ RSpec.describe 'InventoryLists', type: :request do
       end
 
       context 'when all goes well' do
-        let!(:inventory_list) { create(:inventory_list, game: game) }
-        let(:game)            { create(:game, user: user) }
+        let!(:inventory_list) { create(:inventory_list, game:) }
+        let(:game)            { create(:game, user:) }
         let(:list_id)         { inventory_list.id }
 
         it 'updates the title' do
@@ -478,12 +478,12 @@ RSpec.describe 'InventoryLists', type: :request do
       end
 
       context 'when the params are invalid' do
-        subject(:update_inventory_list) { put "/inventory_lists/#{list_id}", params: { inventory_list: { title: other_list.title } }.to_json, headers: headers }
+        subject(:update_inventory_list) { put "/inventory_lists/#{list_id}", params: { inventory_list: { title: other_list.title } }.to_json, headers: }
 
-        let!(:inventory_list) { create(:inventory_list, game: game) }
-        let(:game)            { create(:game, user: user) }
+        let!(:inventory_list) { create(:inventory_list, game:) }
+        let(:game)            { create(:game, user:) }
         let(:list_id)         { inventory_list.id }
-        let(:other_list)      { create(:inventory_list, game: game) }
+        let(:other_list)      { create(:inventory_list, game:) }
 
         it 'returns status 422' do
           update_inventory_list
@@ -531,10 +531,10 @@ RSpec.describe 'InventoryLists', type: :request do
       end
 
       context 'when the client attempts to update an aggregate list' do
-        subject(:update_inventory_list) { put "/inventory_lists/#{inventory_list.id}", params: { inventory_list: { title: 'Foo' } }.to_json, headers: headers }
+        subject(:update_inventory_list) { put "/inventory_lists/#{inventory_list.id}", params: { inventory_list: { title: 'Foo' } }.to_json, headers: }
 
-        let!(:inventory_list) { create(:aggregate_inventory_list, game: game) }
-        let(:game)            { create(:game, user: user) }
+        let!(:inventory_list) { create(:aggregate_inventory_list, game:) }
+        let(:game)            { create(:game, user:) }
 
         it "doesn't update the list" do
           update_inventory_list
@@ -553,10 +553,10 @@ RSpec.describe 'InventoryLists', type: :request do
       end
 
       context 'when the client attempts to change a regular list to an aggregate list' do
-        subject(:update_inventory_list) { put "/inventory_lists/#{inventory_list.id}", params: { inventory_list: { aggregate: true } }.to_json, headers: headers }
+        subject(:update_inventory_list) { put "/inventory_lists/#{inventory_list.id}", params: { inventory_list: { aggregate: true } }.to_json, headers: }
 
-        let!(:inventory_list) { create(:inventory_list, game: game) }
-        let(:game)            { create(:game, user: user) }
+        let!(:inventory_list) { create(:inventory_list, game:) }
+        let(:game)            { create(:game, user:) }
 
         it "doesn't update the list" do
           update_inventory_list
@@ -575,10 +575,10 @@ RSpec.describe 'InventoryLists', type: :request do
       end
 
       context 'when something unexpected goes wrong' do
-        subject(:update_inventory_list) { put "/inventory_lists/#{inventory_list.id}", params: { inventory_list: { title: 'Some New Title' } }.to_json, headers: headers }
+        subject(:update_inventory_list) { put "/inventory_lists/#{inventory_list.id}", params: { inventory_list: { title: 'Some New Title' } }.to_json, headers: }
 
-        let!(:inventory_list) { create(:inventory_list, game: game) }
-        let(:game)            { create(:game, user: user) }
+        let!(:inventory_list) { create(:inventory_list, game:) }
+        let(:game)            { create(:game, user:) }
 
         before do
           allow_any_instance_of(User).to receive(:inventory_lists).and_raise(StandardError, 'Something went catastrophically wrong')
@@ -607,7 +607,7 @@ RSpec.describe 'InventoryLists', type: :request do
   end
 
   describe 'DELETE /inventory_lists/:id' do
-    subject(:delete_inventory_list) { delete "/inventory_lists/#{inventory_list.id}", headers: headers }
+    subject(:delete_inventory_list) { delete "/inventory_lists/#{inventory_list.id}", headers: }
 
     context 'when unauthenticated' do
       let!(:inventory_list) { create(:inventory_list) }
@@ -630,7 +630,7 @@ RSpec.describe 'InventoryLists', type: :request do
 
     context 'when authenticated' do
       let(:user)      { create(:user) }
-      let(:game)      { create(:game, user: user) }
+      let(:game)      { create(:game, user:) }
       let(:validator) { instance_double(GoogleIDToken::Validator, check: validation_data) }
 
       let(:validation_data) do
@@ -646,7 +646,7 @@ RSpec.describe 'InventoryLists', type: :request do
       end
 
       context 'when the inventory list exists' do
-        let!(:inventory_list) { create(:inventory_list, game: game) }
+        let!(:inventory_list) { create(:inventory_list, game:) }
 
         context "when this is the game's last regular inventory list" do
           it 'deletes the inventory list and the aggregate list' do
@@ -667,7 +667,7 @@ RSpec.describe 'InventoryLists', type: :request do
 
         context "when this is not the game's last regular inventory list" do
           before do
-            create(:inventory_list, game: game, aggregate_list: game.aggregate_inventory_list)
+            create(:inventory_list, game:, aggregate_list: game.aggregate_inventory_list)
           end
 
           it 'deletes the requested inventory list' do
@@ -721,7 +721,7 @@ RSpec.describe 'InventoryLists', type: :request do
       end
 
       context 'when attempting to delete the aggregate list' do
-        let!(:inventory_list) { create(:aggregate_inventory_list, game: game) }
+        let!(:inventory_list) { create(:aggregate_inventory_list, game:) }
 
         it "doesn't delete the list" do
           expect { delete_inventory_list }

--- a/spec/requests/shopping_list_items_spec.rb
+++ b/spec/requests/shopping_list_items_spec.rb
@@ -12,9 +12,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
   describe 'POST /shopping_lists/:shopping_list_id/shopping_list_items' do
     subject(:create_item) do
-      post "/shopping_lists/#{shopping_list.id}/shopping_list_items",
-           params:  params.to_json,
-           headers:
+      post "/shopping_lists/#{shopping_list.id}/shopping_list_items", params:, headers:
     end
 
     let!(:aggregate_list) { create(:aggregate_shopping_list) }
@@ -37,7 +35,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
       end
 
       context 'when all goes well' do
-        let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 5, notes: 'To make locks' } } }
+        let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 5, notes: 'To make locks' } }.to_json }
 
         context 'when there is no existing matching item on the same list' do
           context 'when there is no existing matching item on any list' do
@@ -71,7 +69,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
             end
 
             context "when unit weight isn't set" do
-              let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 5 } } }
+              let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 5 } }.to_json }
 
               it 'creates a new item on the requested list' do
                 expect { create_item }
@@ -95,7 +93,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
             end
 
             context 'when unit weight is set' do
-              let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 5, unit_weight: 1 } } }
+              let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 5, unit_weight: 1 } }.to_json }
 
               it 'creates a new item on the requested list' do
                 expect { create_item }
@@ -165,7 +163,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
           end
 
           context 'when unit weight is updated' do
-            let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 2, unit_weight: 1 } } }
+            let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 2, unit_weight: 1 } }.to_json }
 
             it "doesn't create a new list item" do
               expect { create_item }
@@ -204,7 +202,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
       end
 
       context "when the list doesn't exist" do
-        let(:params)         { { description: 'Necklace', quantity: 2, unit_weight: 0.5 } }
+        let(:params)         { { description: 'Necklace', quantity: 2, unit_weight: 0.5 }.to_json }
         let(:shopping_list)  { double(id: 23_498) }
 
         it 'returns status 404' do
@@ -220,7 +218,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
       context "when the list doesn't belong to the authenticated user" do
         let(:shopping_list) { create(:shopping_list) }
-        let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 5 } } }
+        let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 5 } }.to_json }
 
         it "doesn't create the list item" do
           expect { create_item }
@@ -239,7 +237,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
       end
 
       context 'when the params are invalid' do
-        let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: -2 } } }
+        let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: -2 } }.to_json }
 
         it "doesn't create the item" do
           expect { create_item }
@@ -259,7 +257,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
       context 'when the list is an aggregate list' do
         let(:shopping_list) { aggregate_list }
-        let(:params)        { { shopping_list_item: { description: 'Corundum ingot', quantity: 4 } } }
+        let(:params)        { { shopping_list_item: { description: 'Corundum ingot', quantity: 4 } }.to_json }
 
         it "doesn't create an item" do
           expect { create_item }
@@ -279,7 +277,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
       end
 
       context 'when something unexpected goes wrong' do
-        let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 4 } } }
+        let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 4 } }.to_json }
 
         before do
           allow(ShoppingList).to receive(:find).and_raise(StandardError.new('Something went horribly wrong'))
@@ -298,7 +296,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
     end
 
     context 'when not authenticated' do
-      let(:params) { { description: 'Corundum ingot', quantity: 4 } }
+      let(:params) { { description: 'Corundum ingot', quantity: 4 }.to_json }
 
       it 'returns status 401' do
         create_item
@@ -313,7 +311,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
   end
 
   describe 'PATCH /shopping_list_items/:id' do
-    subject(:update_item) { patch "/shopping_list_items/#{list_item.id}", headers:, params: params.to_json }
+    subject(:update_item) { patch "/shopping_list_items/#{list_item.id}", headers:, params: }
 
     let(:game)            { create(:game) }
     let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
@@ -339,7 +337,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
         context 'when there is no matching item on another list' do
           let!(:list_item)          { create(:shopping_list_item, list: shopping_list, description: 'Dwarven metal ingot', quantity: 5) }
           let(:aggregate_list_item) { aggregate_list.list_items.first }
-          let(:params)              { { shopping_list_item: { description: 'Dwarven metal ingot', quantity: 10 } } }
+          let(:params)              { { shopping_list_item: { description: 'Dwarven metal ingot', quantity: 10 } }.to_json }
 
           before do
             aggregate_list.add_item_from_child_list(list_item)
@@ -402,7 +400,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
           end
 
           context 'when unit_weight is not changed' do
-            let(:params) { { shopping_list_item: { quantity: 10 } } }
+            let(:params) { { shopping_list_item: { quantity: 10 } }.to_json }
 
             it 'updates the list item' do
               update_item
@@ -450,7 +448,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
           end
 
           context 'when unit_weight is changed' do
-            let(:params) { { shopping_list_item: { quantity: 10, unit_weight: 2 } } }
+            let(:params) { { shopping_list_item: { quantity: 10, unit_weight: 2 } }.to_json }
 
             it 'updates the list item', :aggregate_failures do
               update_item
@@ -517,7 +515,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
       context "when the shopping list item doesn't exist" do
         let(:list_item) { double(id: 234_567) }
-        let(:params)    { { quantity: 4, unit_weight: 0.3 } }
+        let(:params)    { { quantity: 4, unit_weight: 0.3 }.to_json }
 
         it 'returns status 404' do
           update_item
@@ -532,7 +530,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
       context "when the shopping list item doesn't belong to the authenticated user" do
         let(:list_item) { create(:shopping_list_item) }
-        let(:params)    { { notes: 'Hello world' } }
+        let(:params)    { { notes: 'Hello world' }.to_json }
 
         it 'returns status 404' do
           update_item
@@ -547,7 +545,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
       context 'when the list item is on an aggregate list' do
         let!(:list_item) { create(:shopping_list_item, list: aggregate_list) }
-        let(:params)     { { shopping_list_item: { quantity: 10 } } }
+        let(:params)     { { shopping_list_item: { quantity: 10 } }.to_json }
 
         it 'returns status 405' do
           update_item
@@ -565,7 +563,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
         let(:other_list)          { create(:shopping_list, game:) }
         let!(:other_item)         { create(:shopping_list_item, list: other_list, description: list_item.description, quantity: 1) }
         let(:aggregate_list_item) { aggregate_list.list_items.first }
-        let(:params)              { { shopping_list_item: { quantity: -4, unit_weight: 2 } } }
+        let(:params)              { { shopping_list_item: { quantity: -4, unit_weight: 2 } }.to_json }
 
         before do
           aggregate_list.add_item_from_child_list(list_item)
@@ -596,7 +594,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
       context 'when something unexpected goes wrong' do
         let!(:list_item) { create(:shopping_list_item, list: shopping_list) }
-        let(:params)     { { notes: 'Hello world' } }
+        let(:params)     { { notes: 'Hello world' }.to_json }
 
         before do
           aggregate_list.add_item_from_child_list(list_item)
@@ -619,7 +617,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
     context 'when not authenticated' do
       let!(:list_item) { create(:shopping_list_item, list: shopping_list) }
-      let(:params)     { { quantity: 6 } }
+      let(:params)     { { quantity: 6 }.to_json }
 
       it 'returns status 401' do
         update_item
@@ -634,7 +632,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
   end
 
   describe 'PUT /shopping_list_items/:id' do
-    subject(:update_item) { put "/shopping_list_items/#{list_item.id}", headers:, params: params.to_json }
+    subject(:update_item) { put "/shopping_list_items/#{list_item.id}", headers:, params: }
 
     let(:game)            { create(:game) }
     let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
@@ -660,7 +658,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
         context 'when there is no matching item on another list' do
           let!(:list_item)          { create(:shopping_list_item, list: shopping_list, description: 'Dwarven metal ingot', quantity: 5) }
           let(:aggregate_list_item) { aggregate_list.list_items.first }
-          let(:params)              { { shopping_list_item: { description: 'Dwarven metal ingot', quantity: 10 } } }
+          let(:params)              { { shopping_list_item: { description: 'Dwarven metal ingot', quantity: 10 } }.to_json }
 
           before do
             aggregate_list.add_item_from_child_list(list_item)
@@ -699,7 +697,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
           end
 
           context 'when unit_weight is not changed' do
-            let(:params) { { shopping_list_item: { quantity: 10 } } }
+            let(:params) { { shopping_list_item: { quantity: 10 } }.to_json }
 
             it 'updates the list item' do
               update_item
@@ -723,7 +721,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
           end
 
           context 'when unit_weight is changed' do
-            let(:params) { { shopping_list_item: { quantity: 10, unit_weight: 2 } } }
+            let(:params) { { shopping_list_item: { quantity: 10, unit_weight: 2 } }.to_json }
 
             it 'updates the list item', :aggregate_failures do
               update_item
@@ -758,7 +756,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
       context "when the shopping list item doesn't exist" do
         let(:list_item) { double(id: 234_567) }
-        let(:params)    { { quantity: 4, unit_weight: 0.3 } }
+        let(:params)    { { quantity: 4, unit_weight: 0.3 }.to_json }
 
         it 'returns status 404' do
           update_item
@@ -773,7 +771,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
       context "when the shopping list item doesn't belong to the authenticated user" do
         let(:list_item) { create(:shopping_list_item) }
-        let(:params)    { { notes: 'Hello world' } }
+        let(:params)    { { notes: 'Hello world' }.to_json }
 
         it 'returns status 404' do
           update_item
@@ -788,7 +786,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
       context 'when the list item is on an aggregate list' do
         let!(:list_item) { create(:shopping_list_item, list: aggregate_list) }
-        let(:params)     { { shopping_list_item: { quantity: 10 } } }
+        let(:params)     { { shopping_list_item: { quantity: 10 } }.to_json }
 
         it 'returns status 405' do
           update_item
@@ -806,7 +804,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
         let(:other_list)          { create(:shopping_list, game:) }
         let!(:other_item)         { create(:shopping_list_item, list: other_list, description: list_item.description, quantity: 1) }
         let(:aggregate_list_item) { aggregate_list.list_items.first }
-        let(:params)              { { shopping_list_item: { quantity: -4, unit_weight: 2 } } }
+        let(:params)              { { shopping_list_item: { quantity: -4, unit_weight: 2 } }.to_json }
 
         before do
           aggregate_list.add_item_from_child_list(list_item)
@@ -837,7 +835,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
       context 'when something unexpected goes wrong' do
         let!(:list_item) { create(:shopping_list_item, list: shopping_list) }
-        let(:params)     { { notes: 'Hello world' } }
+        let(:params)     { { notes: 'Hello world' }.to_json }
 
         before do
           aggregate_list.add_item_from_child_list(list_item)
@@ -860,7 +858,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
     context 'when not authenticated' do
       let!(:list_item) { create(:shopping_list_item, list: shopping_list) }
-      let(:params)     { { quantity: 12 } }
+      let(:params)     { { quantity: 12 }.to_json }
 
       it 'returns status 401' do
         update_item

--- a/spec/requests/shopping_list_items_spec.rb
+++ b/spec/requests/shopping_list_items_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe 'ShoppingListItems', type: :request do
     subject(:create_item) do
       post "/shopping_lists/#{shopping_list.id}/shopping_list_items",
            params:  params.to_json,
-           headers: headers
+           headers:
     end
 
     let!(:aggregate_list) { create(:aggregate_shopping_list) }
-    let!(:shopping_list)  { create(:shopping_list, aggregate_list: aggregate_list, game: aggregate_list.game) }
+    let!(:shopping_list)  { create(:shopping_list, aggregate_list:, game: aggregate_list.game) }
 
     context 'when authenticated' do
       let!(:user)     { aggregate_list.user }
@@ -128,7 +128,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
         end
 
         context 'when there is an existing matching item on the same list' do
-          let(:other_list) { create(:shopping_list, game: aggregate_list.game, aggregate_list: aggregate_list) }
+          let(:other_list) { create(:shopping_list, game: aggregate_list.game, aggregate_list:) }
           let!(:other_item) { create(:shopping_list_item, list: other_list, description: 'Corundum ingot', quantity: 2) }
           let!(:list_item)  { create(:shopping_list_item, list: shopping_list, description: 'Corundum ingot', quantity: 3) }
 
@@ -313,11 +313,11 @@ RSpec.describe 'ShoppingListItems', type: :request do
   end
 
   describe 'PATCH /shopping_list_items/:id' do
-    subject(:update_item) { patch "/shopping_list_items/#{list_item.id}", headers: headers, params: params.to_json }
+    subject(:update_item) { patch "/shopping_list_items/#{list_item.id}", headers:, params: params.to_json }
 
     let(:game)            { create(:game) }
-    let!(:aggregate_list) { create(:aggregate_shopping_list, game: game) }
-    let!(:shopping_list)  { create(:shopping_list, game: game, aggregate_list: aggregate_list) }
+    let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
+    let!(:shopping_list)  { create(:shopping_list, game:, aggregate_list:) }
 
     context 'when authenticated' do
       let!(:user)     { game.user }
@@ -392,7 +392,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
         context 'when there is a matching item on another list' do
           let!(:list_item)          { create(:shopping_list_item, list: shopping_list) }
-          let!(:other_list)         { create(:shopping_list, game: game, aggregate_list: aggregate_list) }
+          let!(:other_list)         { create(:shopping_list, game:, aggregate_list:) }
           let!(:other_item)         { create(:shopping_list_item, list: other_list, description: list_item.description, quantity: 4) }
           let(:aggregate_list_item) { aggregate_list.list_items.first }
 
@@ -562,7 +562,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
       context 'when the attributes are invalid' do
         let!(:list_item)          { create(:shopping_list_item, list: shopping_list, quantity: 2) }
-        let(:other_list)          { create(:shopping_list, game: game) }
+        let(:other_list)          { create(:shopping_list, game:) }
         let!(:other_item)         { create(:shopping_list_item, list: other_list, description: list_item.description, quantity: 1) }
         let(:aggregate_list_item) { aggregate_list.list_items.first }
         let(:params)              { { shopping_list_item: { quantity: -4, unit_weight: 2 } } }
@@ -634,11 +634,11 @@ RSpec.describe 'ShoppingListItems', type: :request do
   end
 
   describe 'PUT /shopping_list_items/:id' do
-    subject(:update_item) { put "/shopping_list_items/#{list_item.id}", headers: headers, params: params.to_json }
+    subject(:update_item) { put "/shopping_list_items/#{list_item.id}", headers:, params: params.to_json }
 
     let(:game)            { create(:game) }
-    let!(:aggregate_list) { create(:aggregate_shopping_list, game: game) }
-    let!(:shopping_list)  { create(:shopping_list, game: game, aggregate_list: aggregate_list) }
+    let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
+    let!(:shopping_list)  { create(:shopping_list, game:, aggregate_list:) }
 
     context 'when authenticated' do
       let!(:user)     { game.user }
@@ -689,7 +689,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
         context 'when there is a matching item on another list' do
           let!(:list_item)          { create(:shopping_list_item, list: shopping_list) }
-          let!(:other_list)         { create(:shopping_list, game: game, aggregate_list: aggregate_list) }
+          let!(:other_list)         { create(:shopping_list, game:, aggregate_list:) }
           let!(:other_item)         { create(:shopping_list_item, list: other_list, description: list_item.description, quantity: 4) }
           let(:aggregate_list_item) { aggregate_list.list_items.first }
 
@@ -803,7 +803,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
       context 'when the attributes are invalid' do
         let!(:list_item)          { create(:shopping_list_item, list: shopping_list, quantity: 2) }
-        let(:other_list)          { create(:shopping_list, game: game) }
+        let(:other_list)          { create(:shopping_list, game:) }
         let!(:other_item)         { create(:shopping_list_item, list: other_list, description: list_item.description, quantity: 1) }
         let(:aggregate_list_item) { aggregate_list.list_items.first }
         let(:params)              { { shopping_list_item: { quantity: -4, unit_weight: 2 } } }
@@ -875,11 +875,11 @@ RSpec.describe 'ShoppingListItems', type: :request do
   end
 
   describe 'DELETE /shopping_list_items/:id' do
-    subject(:destroy_item) { delete "/shopping_list_items/#{list_item.id}", headers: headers }
+    subject(:destroy_item) { delete "/shopping_list_items/#{list_item.id}", headers: }
 
     context 'when authenticated' do
-      let!(:aggregate_list) { create(:aggregate_shopping_list, game: game) }
-      let!(:shopping_list)  { create(:shopping_list, game: game, aggregate_list: aggregate_list) }
+      let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
+      let!(:shopping_list)  { create(:shopping_list, game:, aggregate_list:) }
 
       let(:game)      { create(:game) }
       let(:validator) { instance_double(GoogleIDToken::Validator, check: validation_data) }
@@ -951,7 +951,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
         end
 
         context 'when the quantity on the aggregate list exceeds that on the regular list' do
-          let(:second_list) { create(:shopping_list, game: game) }
+          let(:second_list) { create(:shopping_list, game:) }
           let(:second_item) { create(:shopping_list_item, list: second_list, description: list_item.description, quantity: 2, notes: 'bar') }
 
           before do

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'ShoppingLists', type: :request do
   end
 
   describe 'POST games/:game_id/shopping_lists' do
-    subject(:create_shopping_list) { post "/games/#{game.id}/shopping_lists", params: { shopping_list: {} }.to_json, headers: headers }
+    subject(:create_shopping_list) { post "/games/#{game.id}/shopping_lists", params: { shopping_list: {} }.to_json, headers: }
 
     context 'when authenticated' do
       let!(:user) { create(:user) }
@@ -30,7 +30,7 @@ RSpec.describe 'ShoppingLists', type: :request do
       end
 
       context 'when all goes well' do
-        let(:game) { create(:game, user: user) }
+        let(:game) { create(:game, user:) }
 
         context 'when an aggregate list has also been created' do
           it 'creates a new shopping list' do
@@ -50,7 +50,7 @@ RSpec.describe 'ShoppingLists', type: :request do
         end
 
         context 'when only the new shopping list has been created' do
-          let!(:aggregate_list) { create(:aggregate_shopping_list, game: game, created_at: 2.seconds.ago, updated_at: 2.seconds.ago) }
+          let!(:aggregate_list) { create(:aggregate_shopping_list, game:, created_at: 2.seconds.ago, updated_at: 2.seconds.ago) }
 
           it 'creates one list' do
             expect { create_shopping_list }
@@ -64,11 +64,11 @@ RSpec.describe 'ShoppingLists', type: :request do
         end
 
         context 'when the request does not include a body' do
-          subject(:create_shopping_list) { post "/games/#{game.id}/shopping_lists", headers: headers }
+          subject(:create_shopping_list) { post "/games/#{game.id}/shopping_lists", headers: }
 
           before do
             # let's not have this request create an aggregate list too
-            create(:aggregate_shopping_list, game: game)
+            create(:aggregate_shopping_list, game:)
           end
 
           it 'returns status 201' do
@@ -113,10 +113,10 @@ RSpec.describe 'ShoppingLists', type: :request do
       end
 
       context 'when the params are invalid' do
-        subject(:create_shopping_list) { post "/games/#{game.id}/shopping_lists", params: { shopping_list: { title: existing_list.title } }.to_json, headers: headers }
+        subject(:create_shopping_list) { post "/games/#{game.id}/shopping_lists", params: { shopping_list: { title: existing_list.title } }.to_json, headers: }
 
-        let(:game)          { create(:game, user: user) }
-        let(:existing_list) { create(:shopping_list, game: game) }
+        let(:game)          { create(:game, user:) }
+        let(:existing_list) { create(:shopping_list, game:) }
 
         it 'returns status 422' do
           create_shopping_list
@@ -130,9 +130,9 @@ RSpec.describe 'ShoppingLists', type: :request do
       end
 
       context 'when the client attempts to create an aggregate list' do
-        subject(:create_shopping_list) { post "/games/#{game.id}/shopping_lists", params: { shopping_list: { aggregate: true } }.to_json, headers: headers }
+        subject(:create_shopping_list) { post "/games/#{game.id}/shopping_lists", params: { shopping_list: { aggregate: true } }.to_json, headers: }
 
-        let(:game) { create(:game, user: user) }
+        let(:game) { create(:game, user:) }
 
         it "doesn't create a list" do
           expect { create_shopping_list }
@@ -162,7 +162,7 @@ RSpec.describe 'ShoppingLists', type: :request do
   end
 
   describe 'PUT /shopping_lists/:id' do
-    subject(:update_shopping_list) { put "/shopping_lists/#{list_id}", params: { shopping_list: { title: 'Severin Manor' } }.to_json, headers: headers }
+    subject(:update_shopping_list) { put "/shopping_lists/#{list_id}", params: { shopping_list: { title: 'Severin Manor' } }.to_json, headers: }
 
     context 'when authenticated' do
       let!(:user) { create(:user) }
@@ -181,8 +181,8 @@ RSpec.describe 'ShoppingLists', type: :request do
       end
 
       context 'when all goes well' do
-        let!(:shopping_list) { create(:shopping_list, game: game) }
-        let(:game)           { create(:game, user: user) }
+        let!(:shopping_list) { create(:shopping_list, game:) }
+        let(:game)           { create(:game, user:) }
         let(:list_id)        { shopping_list.id }
 
         it 'updates the title' do
@@ -205,12 +205,12 @@ RSpec.describe 'ShoppingLists', type: :request do
       end
 
       context 'when the params are invalid' do
-        subject(:update_shopping_list) { put "/shopping_lists/#{list_id}", params: { shopping_list: { title: other_list.title } }.to_json, headers: headers }
+        subject(:update_shopping_list) { put "/shopping_lists/#{list_id}", params: { shopping_list: { title: other_list.title } }.to_json, headers: }
 
-        let!(:shopping_list) { create(:shopping_list, game: game) }
-        let(:game)           { create(:game, user: user) }
+        let!(:shopping_list) { create(:shopping_list, game:) }
+        let(:game)           { create(:game, user:) }
         let(:list_id)        { shopping_list.id }
-        let(:other_list)     { create(:shopping_list, game: game) }
+        let(:other_list)     { create(:shopping_list, game:) }
 
         it 'returns status 422' do
           update_shopping_list
@@ -258,10 +258,10 @@ RSpec.describe 'ShoppingLists', type: :request do
       end
 
       context 'when the client attempts to update an aggregate list' do
-        subject(:update_shopping_list) { put "/shopping_lists/#{shopping_list.id}", params: { shopping_list: { title: 'Foo' } }.to_json, headers: headers }
+        subject(:update_shopping_list) { put "/shopping_lists/#{shopping_list.id}", params: { shopping_list: { title: 'Foo' } }.to_json, headers: }
 
-        let!(:shopping_list) { create(:aggregate_shopping_list, game: game) }
-        let(:game)           { create(:game, user: user) }
+        let!(:shopping_list) { create(:aggregate_shopping_list, game:) }
+        let(:game)           { create(:game, user:) }
 
         it "doesn't update the list" do
           update_shopping_list
@@ -280,10 +280,10 @@ RSpec.describe 'ShoppingLists', type: :request do
       end
 
       context 'when the client attempts to change a regular list to an aggregate list' do
-        subject(:update_shopping_list) { put "/shopping_lists/#{shopping_list.id}", params: { shopping_list: { aggregate: true } }.to_json, headers: headers }
+        subject(:update_shopping_list) { put "/shopping_lists/#{shopping_list.id}", params: { shopping_list: { aggregate: true } }.to_json, headers: }
 
-        let!(:shopping_list) { create(:shopping_list, game: game) }
-        let(:game)           { create(:game, user: user) }
+        let!(:shopping_list) { create(:shopping_list, game:) }
+        let(:game)           { create(:game, user:) }
 
         it "doesn't update the list" do
           update_shopping_list
@@ -302,10 +302,10 @@ RSpec.describe 'ShoppingLists', type: :request do
       end
 
       context 'when something unexpected goes wrong' do
-        subject(:update_shopping_list) { put "/shopping_lists/#{shopping_list.id}", params: { shopping_list: { title: 'Some New Title' } }.to_json, headers: headers }
+        subject(:update_shopping_list) { put "/shopping_lists/#{shopping_list.id}", params: { shopping_list: { title: 'Some New Title' } }.to_json, headers: }
 
-        let!(:shopping_list) { create(:shopping_list, game: game) }
-        let(:game)           { create(:game, user: user) }
+        let!(:shopping_list) { create(:shopping_list, game:) }
+        let(:game)           { create(:game, user:) }
 
         before do
           allow_any_instance_of(User).to receive(:shopping_lists).and_raise(StandardError, 'Something went catastrophically wrong')
@@ -334,7 +334,7 @@ RSpec.describe 'ShoppingLists', type: :request do
   end
 
   describe 'PATCH /shopping_lists/:id' do
-    subject(:update_shopping_list) { patch "/shopping_lists/#{list_id}", params: { shopping_list: { title: 'Severin Manor' } }.to_json, headers: headers }
+    subject(:update_shopping_list) { patch "/shopping_lists/#{list_id}", params: { shopping_list: { title: 'Severin Manor' } }.to_json, headers: }
 
     context 'when authenticated' do
       let!(:user) { create(:user) }
@@ -353,8 +353,8 @@ RSpec.describe 'ShoppingLists', type: :request do
       end
 
       context 'when all goes well' do
-        let!(:shopping_list) { create(:shopping_list, game: game) }
-        let(:game)           { create(:game, user: user) }
+        let!(:shopping_list) { create(:shopping_list, game:) }
+        let(:game)           { create(:game, user:) }
         let(:list_id)        { shopping_list.id }
 
         it 'updates the title' do
@@ -377,12 +377,12 @@ RSpec.describe 'ShoppingLists', type: :request do
       end
 
       context 'when the params are invalid' do
-        subject(:update_shopping_list) { patch "/shopping_lists/#{list_id}", params: { shopping_list: { title: other_list.title } }.to_json, headers: headers }
+        subject(:update_shopping_list) { patch "/shopping_lists/#{list_id}", params: { shopping_list: { title: other_list.title } }.to_json, headers: }
 
-        let!(:shopping_list) { create(:shopping_list, game: game) }
-        let(:game)           { create(:game, user: user) }
+        let!(:shopping_list) { create(:shopping_list, game:) }
+        let(:game)           { create(:game, user:) }
         let(:list_id)        { shopping_list.id }
-        let(:other_list)     { create(:shopping_list, game: game) }
+        let(:other_list)     { create(:shopping_list, game:) }
 
         it 'returns status 422' do
           update_shopping_list
@@ -430,10 +430,10 @@ RSpec.describe 'ShoppingLists', type: :request do
       end
 
       context 'when the client attempts to update an aggregate list' do
-        subject(:update_shopping_list) { patch "/shopping_lists/#{shopping_list.id}", params: { shopping_list: { title: 'Foo' } }.to_json, headers: headers }
+        subject(:update_shopping_list) { patch "/shopping_lists/#{shopping_list.id}", params: { shopping_list: { title: 'Foo' } }.to_json, headers: }
 
-        let!(:shopping_list) { create(:aggregate_shopping_list, game: game) }
-        let(:game)           { create(:game, user: user) }
+        let!(:shopping_list) { create(:aggregate_shopping_list, game:) }
+        let(:game)           { create(:game, user:) }
 
         it "doesn't update the list" do
           update_shopping_list
@@ -452,10 +452,10 @@ RSpec.describe 'ShoppingLists', type: :request do
       end
 
       context 'when the client attempts to change a regular list to an aggregate list' do
-        subject(:update_shopping_list) { patch "/shopping_lists/#{shopping_list.id}", params: { shopping_list: { aggregate: true } }.to_json, headers: headers }
+        subject(:update_shopping_list) { patch "/shopping_lists/#{shopping_list.id}", params: { shopping_list: { aggregate: true } }.to_json, headers: }
 
-        let!(:shopping_list) { create(:shopping_list, game: game) }
-        let(:game)           { create(:game, user: user) }
+        let!(:shopping_list) { create(:shopping_list, game:) }
+        let(:game)           { create(:game, user:) }
 
         it "doesn't update the list" do
           update_shopping_list
@@ -474,10 +474,10 @@ RSpec.describe 'ShoppingLists', type: :request do
       end
 
       context 'when something unexpected goes wrong' do
-        subject(:update_shopping_list) { patch "/shopping_lists/#{shopping_list.id}", params: { shopping_list: { title: 'Some New Title' } }.to_json, headers: headers }
+        subject(:update_shopping_list) { patch "/shopping_lists/#{shopping_list.id}", params: { shopping_list: { title: 'Some New Title' } }.to_json, headers: }
 
-        let!(:shopping_list) { create(:shopping_list, game: game) }
-        let(:game)           { create(:game, user: user) }
+        let!(:shopping_list) { create(:shopping_list, game:) }
+        let(:game)           { create(:game, user:) }
 
         before do
           allow_any_instance_of(User).to receive(:shopping_lists).and_raise(StandardError, 'Something went catastrophically wrong')
@@ -506,14 +506,14 @@ RSpec.describe 'ShoppingLists', type: :request do
   end
 
   describe 'GET games/:game_id/shopping_lists' do
-    subject(:get_index) { get "/games/#{game.id}/shopping_lists", headers: headers }
+    subject(:get_index) { get "/games/#{game.id}/shopping_lists", headers: }
 
     context 'when unauthenticated' do
       let(:game) { create(:game) }
 
       before do
         # create some data to not be returned
-        create_list(:shopping_list, 3, game: game)
+        create_list(:shopping_list, 3, game:)
       end
 
       it 'returns 401' do
@@ -602,7 +602,7 @@ RSpec.describe 'ShoppingLists', type: :request do
   end
 
   describe 'DELETE /shopping_lists/:id' do
-    subject(:delete_shopping_list) { delete "/shopping_lists/#{shopping_list.id}", headers: headers }
+    subject(:delete_shopping_list) { delete "/shopping_lists/#{shopping_list.id}", headers: }
 
     context 'when unauthenticated' do
       let!(:shopping_list) { create(:shopping_list) }
@@ -625,7 +625,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
     context 'when authenticated' do
       let(:user)      { create(:user) }
-      let(:game)      { create(:game, user: user) }
+      let(:game)      { create(:game, user:) }
       let(:validator) { instance_double(GoogleIDToken::Validator, check: validation_data) }
 
       let(:validation_data) do
@@ -641,7 +641,7 @@ RSpec.describe 'ShoppingLists', type: :request do
       end
 
       context 'when the shopping list exists' do
-        let!(:shopping_list) { create(:shopping_list, game: game) }
+        let!(:shopping_list) { create(:shopping_list, game:) }
 
         context "when this is the game's last regular shopping list" do
           it 'deletes the shopping list and the aggregate list' do
@@ -662,7 +662,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
         context "when this is not the game's last regular shopping list" do
           before do
-            create(:shopping_list, game: game, aggregate_list: game.aggregate_shopping_list)
+            create(:shopping_list, game:, aggregate_list: game.aggregate_shopping_list)
           end
 
           it 'deletes the requested shopping list' do
@@ -716,7 +716,7 @@ RSpec.describe 'ShoppingLists', type: :request do
       end
 
       context 'when attempting to delete the aggregate list' do
-        let!(:shopping_list) { create(:aggregate_shopping_list, game: game) }
+        let!(:shopping_list) { create(:aggregate_shopping_list, game:) }
 
         it "doesn't delete the list" do
           expect { delete_shopping_list }

--- a/spec/support/factories/games.rb
+++ b/spec/support/factories/games.rb
@@ -12,8 +12,8 @@ FactoryBot.define do
       end
 
       after(:create) do |game, evaluator|
-        create(:aggregate_shopping_list, game: game)
-        create_list(:shopping_list, evaluator.shopping_list_count, game: game)
+        create(:aggregate_shopping_list, game:)
+        create_list(:shopping_list, evaluator.shopping_list_count, game:)
       end
     end
 
@@ -23,7 +23,7 @@ FactoryBot.define do
       end
 
       after(:create) do |game, evaluator|
-        shopping_lists = create_list(:shopping_list_with_list_items, evaluator.shopping_list_count, game: game)
+        shopping_lists = create_list(:shopping_list_with_list_items, evaluator.shopping_list_count, game:)
 
         shopping_lists.each do |list|
           list.list_items.each do |item|
@@ -39,8 +39,8 @@ FactoryBot.define do
       end
 
       after(:create) do |game, evaluator|
-        create(:aggregate_inventory_list, game: game)
-        create_list(:inventory_list, evaluator.inventory_list_count, game: game)
+        create(:aggregate_inventory_list, game:)
+        create_list(:inventory_list, evaluator.inventory_list_count, game:)
       end
     end
 
@@ -50,7 +50,7 @@ FactoryBot.define do
       end
 
       after(:create) do |game, evaluator|
-        inventory_lists = create_list(:inventory_list_with_list_items, evaluator.inventory_list_count, game: game)
+        inventory_lists = create_list(:inventory_list_with_list_items, evaluator.inventory_list_count, game:)
 
         inventory_lists.each do |list|
           list.list_items.each do |item|
@@ -67,7 +67,7 @@ FactoryBot.define do
       end
 
       after(:create) do |game, evaluator|
-        inventory_lists = create_list(:inventory_list_with_list_items, evaluator.inventory_list_count, game: game)
+        inventory_lists = create_list(:inventory_list_with_list_items, evaluator.inventory_list_count, game:)
 
         inventory_lists.each do |list|
           list.list_items.each do |item|
@@ -75,7 +75,7 @@ FactoryBot.define do
           end
         end
 
-        shopping_lists = create_list(:shopping_list_with_list_items, evaluator.shopping_list_count, game: game)
+        shopping_lists = create_list(:shopping_list_with_list_items, evaluator.shopping_list_count, game:)
 
         shopping_lists.each do |list|
           list.list_items.each do |item|

--- a/spec/support/factories/inventory_lists.rb
+++ b/spec/support/factories/inventory_lists.rb
@@ -18,7 +18,7 @@ FactoryBot.define do
       end
 
       after(:create) do |list, evaluator|
-        create_list(:inventory_item, evaluator.list_item_count, list: list)
+        create_list(:inventory_item, evaluator.list_item_count, list:)
       end
     end
   end

--- a/spec/support/factories/shopping_lists.rb
+++ b/spec/support/factories/shopping_lists.rb
@@ -18,7 +18,7 @@ FactoryBot.define do
       end
 
       after(:create) do |list, evaluator|
-        create_list(:shopping_list_item, evaluator.list_item_count, list: list)
+        create_list(:shopping_list_item, evaluator.list_item_count, list:)
       end
     end
   end

--- a/spec/support/factories/users.rb
+++ b/spec/support/factories/users.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
       end
 
       after(:create) do |user, evaluator|
-        create_list(:game, evaluator.game_count, user: user)
+        create_list(:game, evaluator.game_count, user:)
       end
     end
   end


### PR DESCRIPTION
## Context

[**Update to the latest Ruby**](https://trello.com/c/RjRNHErC/192-update-to-the-latest-ruby)

We've updated Ruby to 3.1.2 in #118 but still need to make changes to make use of its features and write code in a style more suited to Ruby 3.1. This includes, at the most basic level, fixing Rubocop failures that have cropped up, but also making use of expanded functionality. This PR includes only updating hash syntax to use value omission. For example:

```ruby
# Ruby 3.0
list_id = 4
hash = { list_id: list_id }

# Ruby 3.1
hash = { list_id: }
```

## Changes

* Update hash syntax to use value omission where possible (e.g., `{ list_id: }` instead of `{ list_id: list_id }`)

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [ ] Added and updated API docs and developer docs as appropriate

## Considerations

I've created this PR to only update hash syntax because there were so many files that needed to be changed for that change alone. All corrections were done automatically using Rubocop:

```sh
bundle exec rubocop -A --only Style/HashSyntax
```

### Notes

After consideration, I've decided this will be the only PR to make use of Ruby 3.1 features. The reason is that other features are harder to implement using a simple process of grepping through the code base for key words and making changes where I find them, so instead, I'll take the approach of updating files, if appropriate, as they are touched in the course of other work.