### PR TITLE
Use Rails 7 default ActionDispatch headers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: Skyrim Inventory Management CI
 
 on:
   push:
-    branches: [ main, 192-update-to-the-latest-ruby ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, 192-update-to-the-latest-ruby ]
+    branches: [ main ]
 
 jobs:
   runner-job:

--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 #
 # This file eases your Rails 7.0 framework defaults upgrade.
@@ -108,11 +109,11 @@
 # Rails.application.config.active_support.use_rfc4122_namespaced_uuids = true
 
 # Change the default headers to disable browsers' flawed legacy XSS protection.
-# Rails.application.config.action_dispatch.default_headers = {
-#   "X-Frame-Options" => "SAMEORIGIN",
-#   "X-XSS-Protection" => "0",
-#   "X-Content-Type-Options" => "nosniff",
-#   "X-Download-Options" => "noopen",
-#   "X-Permitted-Cross-Domain-Policies" => "none",
-#   "Referrer-Policy" => "strict-origin-when-cross-origin"
-# }
+Rails.application.config.action_dispatch.default_headers = {
+                                                             'X-Frame-Options'                   => 'SAMEORIGIN',
+                                                             'X-XSS-Protection'                  => '0',
+                                                             'X-Content-Type-Options'            => 'nosniff',
+                                                             'X-Download-Options'                => 'noopen',
+                                                             'X-Permitted-Cross-Domain-Policies' => 'none',
+                                                             'Referrer-Policy'                   => 'strict-origin-when-cross-origin',
+                                                           }


### PR DESCRIPTION
## Context

[**Use Rails 7 default config**](https://trello.com/c/db2cyy3B/201-use-rails-7-default-config)

This is the first of several PRs updating config options from Rails 6 defaults to Rails 7 defaults. Though small, each of these changes is being made in a separate PR so we can easily roll back individual changes in the event production breaks.

## Changes

* Update default ActionDispatch headers to the Rails 7 defaults
* Remove now-unused feature branch from CI

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~
