### PR TITLE
Use RFC 4122 namespaced UUIDs

### DIFF
--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -106,7 +106,7 @@
 #
 # See https://guides.rubyonrails.org/configuring.html#config-active-support-use-rfc4122-namespaced-uuids for
 # more information.
-# Rails.application.config.active_support.use_rfc4122_namespaced_uuids = true
+Rails.application.config.active_support.use_rfc4122_namespaced_uuids = true
 
 # Change the default headers to disable browsers' flawed legacy XSS protection.
 Rails.application.config.action_dispatch.default_headers = {


### PR DESCRIPTION
## Context

[**Use Rails 7 default config**](https://trello.com/c/db2cyy3B/201-use-rails-7-default-config)

As part of our Rails 7 upgrade, we need to change our config to match Rails 7 defaults. We are doing these changes one at a time to make sure they're easy to individually roll back should problems come up in production.

This change likely doesn't change SIM behaviour unless it does something under the hood, since we don't really use UUIDs in here.

## Changes

* Use RFC 4122 namespaced UUIDs

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~