### PR TITLE
Wrap parameters by default (standard for Rails 7)

### DIFF
--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -99,7 +99,7 @@
 # Enable parameter wrapping for JSON.
 # Previously this was set in an initializer. It's fine to keep using that initializer if you've customized it.
 # To disable parameter wrapping entirely, set this config to `false`.
-# Rails.application.config.action_controller.wrap_parameters_by_default = true
+Rails.application.config.action_controller.wrap_parameters_by_default = true
 
 # Specifies whether generated namespaced UUIDs follow the RFC 4122 standard for namespace IDs provided as a
 # `String` to `Digest::UUID.uuid_v3` or `Digest::UUID.uuid_v5` method calls.


### PR DESCRIPTION
## Context

[**Use Rails 7 default config**](https://trello.com/c/db2cyy3B/201-use-rails-7-default-config)

As part of our Rails 7 upgrade, we need to update several config options to use the Rails 7 defaults. Each of these changes, while small, is being made in a separate PR to make rollback easy in the event one of the changes breaks prod. This PR sets Rails to wrap parameters by default.

## Changes

* Wrap parameters by default as is standard in Rails 7

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~