### PR TITLE
Use hybrid cookie serializer by default

### DIFF
--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -94,7 +94,7 @@
 # If you have configured the serializer elsewhere, you can remove this.
 #
 # See https://guides.rubyonrails.org/action_controller_overview.html#cookies for more information.
-# Rails.application.config.action_dispatch.cookies_serializer = :hybrid
+Rails.application.config.action_dispatch.cookies_serializer = :hybrid
 
 # Enable parameter wrapping for JSON.
 # Previously this was set in an initializer. It's fine to keep using that initializer if you've customized it.


### PR DESCRIPTION
<!-- These are basic changes that should be included in all PRs. Your PR may benefit -->

## Context

[**Use Rails 7 default config**](https://trello.com/c/db2cyy3B/201-use-rails-7-default-config)

This is one of several PRs updating SIM's config to match the defaults for Rails 7 in the wake of our upgrade. Each of these changes is being made in a separate PR in case production breaks and we need to roll back.

## Changes

* Use ActionDispatch's hybrid cookie serializer by default

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~