### PR TITLE
Raise on open redirects by default

### DIFF
--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -75,7 +75,7 @@
 # Rails.application.config.active_record.partial_inserts = false
 #
 # Protect from open redirect attacks in `redirect_back_or_to` and `redirect_to`.
-# Rails.application.config.action_controller.raise_on_open_redirects = true
+Rails.application.config.action_controller.raise_on_open_redirects = true
 
 # Change the variant processor for Active Storage.
 # Changing this default means updating all places in your code that


### PR DESCRIPTION
## Context

[**Use Rails 7 default config**](https://trello.com/c/db2cyy3B/201-use-rails-7-default-config)

We've upgraded to Rails 7, however, the Rails maintainers recommend waiting until Rails 7 is successfully running before updating several config options to the Rails 7 defaults. This is one of several PRs that make those changes.

## Changes

* Raise error on open redirects by default

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~

## Considerations

Currently, there are no redirects in SIM, so this will be difficult to test. We'll have to just click around the app and see that everything is working as expected as much as possible.