### PR TITLE
Disable partial inserts in ActiveRecord

### DIFF
--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -72,7 +72,7 @@
 # Disable partial inserts.
 # This default means that all columns will be referenced in INSERT queries
 # regardless of whether they have a default or not.
-# Rails.application.config.active_record.partial_inserts = false
+Rails.application.config.active_record.partial_inserts             = false
 #
 # Protect from open redirect attacks in `redirect_back_or_to` and `redirect_to`.
 Rails.application.config.action_controller.raise_on_open_redirects = true


### PR DESCRIPTION
## Context

[**Use Rails 7 default config**](https://trello.com/c/db2cyy3B/201-use-rails-7-default-config)

This is one of several PRs with atomic config changes updating our config to use Rails 7 defaults. Although Rails 7 is already running in production, config changes are recommended to be made after the upgrade, one at a time, since they can be breaking changes.

## Changes

* Disable partial inserts in ActiveRecord

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~