### PR TITLE
Verify foreign keys in test fixtures

### DIFF
--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -67,7 +67,7 @@
 # Rails.application.config.active_record.automatic_scope_inversing = true
 
 # Raise when running tests if fixtures contained foreign key violations
-# Rails.application.config.active_record.verify_foreign_keys_for_fixtures = true
+Rails.application.config.active_record.verify_foreign_keys_for_fixtures = true
 
 # Disable partial inserts.
 # This default means that all columns will be referenced in INSERT queries


### PR DESCRIPTION
## Context

[**Use Rails 7 default config**](https://trello.com/c/db2cyy3B/201-use-rails-7-default-config)

This is one of several PRs making final config changes for the upgrade to Rails 7. It is recommended to do these like we are, after Rails 7 has been running successfully in production. This PR causes ActiveRecord to raise an error if there are foreign key violations in test fixtures.

## Changes

* Raise on foreign key violations in test fixtures

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~

## Considerations

I'm not sure if this change will actually affect anything given we are not using Rails' built-in testing apparatus. RSpec tests all pass locally.
