### PR TITLE
Use :thread as ActiveSupport isolation level

### DIFF
--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -52,7 +52,7 @@
 # Define the isolation level of most of Rails internal state.
 # If you use a fiber based server or job processor, you should set it to `:fiber`.
 # Otherwise the default of `:thread` if preferable.
-# Rails.application.config.active_support.isolation_level = :thread
+Rails.application.config.active_support.isolation_level = :thread
 
 # Set both the `:open_timeout` and `:read_timeout` values for `:smtp` delivery method.
 # Rails.application.config.action_mailer.smtp_timeout = 5


### PR DESCRIPTION
## Context

[**Use Rails 7 default config**](https://trello.com/c/db2cyy3B/201-use-rails-7-default-config)

This is one of several PRs that incrementally change SIM's default config to match Rails 7 defaults. The two possible values of `config.active_support.isolation_level` are `:thread` and `:fiber`. In Rails 7, `:thread` is the default and should be used unless using a fibre-based server.

## Changes

* Use `:thread` as the ActiveSupport `isolation_level`

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~

## Considerations

Explain any design or implementation decisions you've made here, as well as any alternatives you considered or tried. Justify your approach. Include links to any blog posts, documentation, or other materials readers may find useful to understand your implementation or the alternatives.
