### PR TITLE
Set ActiveSupport executor_around_test_case to true

### DIFF
--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -72,7 +72,8 @@ Rails.application.config.active_record.verify_foreign_keys_for_fixtures = true
 # Disable partial inserts.
 # This default means that all columns will be referenced in INSERT queries
 # regardless of whether they have a default or not.
-Rails.application.config.active_record.partial_inserts             = false
+Rails.application.config.active_record.partial_inserts = false
+
 #
 # Protect from open redirect attacks in `redirect_back_or_to` and `redirect_to`.
 Rails.application.config.action_controller.raise_on_open_redirects = true

--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -47,7 +47,7 @@
 # This makes test cases behave closer to an actual request or job.
 # Several features that are normally disabled in test, such as Active Record query cache
 # and asynchronous queries will then be enabled.
-# Rails.application.config.active_support.executor_around_test_case = true
+Rails.application.config.active_support.executor_around_test_case = true
 
 # Define the isolation level of most of Rails internal state.
 # If you use a fiber based server or job processor, you should set it to `:fiber`.


### PR DESCRIPTION
## Context

[**Use Rails 7 default config**](https://trello.com/c/db2cyy3B/201-use-rails-7-default-config)

This is one of several PRs updating SIM's config to use Rails 7 defaults. This change only affects the test environment, where `Rails.application.executor.wrap` is now called around test cases, enabling features like Active Record query cache that are normally disabled in test.

## Changes

* Set ActiveSupport `executor_around_test_case` to `true`

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~

## Considerations

It's unclear whether this change will affect anything since we aren't using Test::Unit.