### PR TITLE
Update cache format version to 7.0

### DIFF
--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -41,7 +41,7 @@
 # will have a different format that is not supported by Rails 6.1 applications.
 # Only change this value after your application is fully deployed to Rails 7.0
 # and you have no plans to rollback.
-# Rails.application.config.active_support.cache_format_version = 7.0
+Rails.application.config.active_support.cache_format_version = 7.0
 
 # Calls `Rails.application.executor.wrap` around test cases.
 # This makes test cases behave closer to an actual request or job.


### PR DESCRIPTION
## Context

[**Use Rails 7 default config**](https://trello.com/c/db2cyy3B/201-use-rails-7-default-config)

This is one of several PRs updating config settings to Rails 7 defaults. This PR updates the cache format version to 7.0. This cache format is incompatible with the Rails 6.1 format.

## Changes

* Set Active Support cache format version to 7.0

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~