### PR TITLE
Don't override ActiveSupport::TimeWithZone.name

### DIFF
--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -34,7 +34,7 @@
 
 # Don't override ActiveSupport::TimeWithZone.name and use the default Ruby
 # implementation.
-# Rails.application.config.active_support.remove_deprecated_time_with_zone_name = true
+Rails.application.config.active_support.remove_deprecated_time_with_zone_name = true
 
 # Change the format of the cache entry.
 # Changing this default means that all new cache entries added to the cache


### PR DESCRIPTION
## Context

[**Use Rails 7 default config**](https://trello.com/c/db2cyy3B/201-use-rails-7-default-config)

This is one of several PRs that update Rails config to use Rails 7 defaults. This PR removes deprecated `ActiveSupport::TimeWithZone.name`, replacing it with the plain Ruby implementation.

## Changes

* Don't use deprecated `ActiveSupport::TimeWithZone.name`

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~