### PR TITLE
Set Active Support's hash digest class to OpenSSL::Digest::SHA256

### DIFF
--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -30,7 +30,7 @@
 # Change the digest class for ActiveSupport::Digest.
 # Changing this default means that for example Etags change and
 # various cache keys leading to cache invalidation.
-# Rails.application.config.active_support.hash_digest_class = OpenSSL::Digest::SHA256
+Rails.application.config.active_support.hash_digest_class = OpenSSL::Digest::SHA256
 
 # Don't override ActiveSupport::TimeWithZone.name and use the default Ruby
 # implementation.


### PR DESCRIPTION
## Context

[**Use Rails 7 default config**](https://trello.com/c/db2cyy3B/201-use-rails-7-default-config)

This PR is one of several updating SIM's Rails configuration to use Rails 7 defaults. It is recommended to do this after Rails 7 has been running in production successfully. This PR sets Active Support's hash digest class to `OpenSSL::Digest::SHA256`. (The default in Rails 6 is [`OpenSSL::Digest::SHA1`](https://guides.rubyonrails.org/configuring.html#config-active-support-hash-digest-class).)

## Changes

* Set Active Support's `hash_digest_class` to `OpenSSL::Digest::SHA256`

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~