### PR TITLE
Update key generator hash digest class

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         run: bundle exec rails rubocop
       - name: Run RSpec
         run: |
-          bundle exec rails db:prepare
+          bundle exec rails db:test:prepare
           bundle exec rails spec
         env:
           PGHOST: localhost

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,12 @@ jobs:
           cp config/database.github-actions.yml config/database.yml
           bundle exec rails db:create
           bundle exec rails db:migrate
+        env:
+          RAILS_ENV: test
       - name: Run Rubocop
         run: bundle exec rails rubocop
       - name: Run RSpec
         run: |
-          bundle exec rails db:environment:set RAILS_ENV=test
           bundle exec rails db:prepare
           bundle exec rails spec
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
         run: bundle exec rails rubocop
       - name: Run RSpec
         run: |
+          bundle exec rails db:environment:set RAILS_ENV=test
           bundle exec rails db:prepare
           bundle exec rails spec
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,6 @@ jobs:
           cp config/database.github-actions.yml config/database.yml
           bundle exec rails db:create
           bundle exec rails db:migrate
-        env:
-          RAILS_ENV: test
       - name: Run Rubocop
         run: bundle exec rails rubocop
       - name: Run RSpec

--- a/config/database.github-actions.yml
+++ b/config/database.github-actions.yml
@@ -10,7 +10,3 @@ default: &default
 test:
   <<: *default
   database: skyrim_inventory_management_test
-
-development:
-  <<: *default
-  database: skyrim_inventory_management_development

--- a/config/database.github-actions.yml
+++ b/config/database.github-actions.yml
@@ -10,3 +10,7 @@ default: &default
 test:
   <<: *default
   database: skyrim_inventory_management_test
+
+development:
+  <<: *default
+  database: skyrim_inventory_management_development

--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -25,7 +25,7 @@
 #
 # See upgrading guide for more information on how to build a rotator.
 # https://guides.rubyonrails.org/v7.0/upgrading_ruby_on_rails.html
-# Rails.application.config.active_support.key_generator_hash_digest_class = OpenSSL::Digest::SHA256
+Rails.application.config.active_support.key_generator_hash_digest_class = OpenSSL::Digest::SHA256
 
 # Change the digest class for ActiveSupport::Digest.
 # Changing this default means that for example Etags change and


### PR DESCRIPTION
## Context

* [**Use Rails 7 default config**](https://trello.com/c/db2cyy3B/201-use-rails-7-default-config)
* [**Fix Active Record EnvironmentMismatchError in CI**](https://trello.com/c/egW7FijU/203-investigate-active-record-environmentmismatcherror-in-ci)

This is the last of several PRs updating SIM's Rails config to use the new Rails 7 defaults. This PR updates Active Support's key generator hash digest class to `OpenSSL::Digest::SHA256` (the [Rails 6 default](https://edgeguides.rubyonrails.org/configuring.html#config-active-support-key-generator-hash-digest-class) was `OpenSSL::Digest::SHA1`).

## Changes

* Set Active Support's key generator hash digest class to `OpenSSL::Digest::SHA256`
* Use `db:test:prepare` instead of `db:prepare` in the RSpec CI step to prevent `ActiveRecord::EnvironmentMismatchError`

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~