### PR TITLE
Force SSL in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -33,7 +33,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).


### PR DESCRIPTION
## Context

[**Force SSL in production**](https://trello.com/c/DyFferUD/200-force-ssl-in-production)

In production, all traffic should be over HTTPS, not HTTP. However, I realised we don't have `config.force_ssl` set to `true` in our production environment (or any other environment for that matter). This means that, theoretically, somebody could access an HTTP version of the site. This is a big oversight.

## Changes

* Set `config.force_ssl` to `true` in production

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~

## Considerations

This will be a risky PR to test; since we can't use HTTPS locally, we will need to test in production.
