### PR TITLE
Access priority of alchemical property directly from the property itself

### DIFF
--- a/app/models/canonical/ingredient.rb
+++ b/app/models/canonical/ingredient.rb
@@ -11,8 +11,11 @@ module Canonical
 
     has_many :canonical_ingredients_alchemical_properties,
              dependent:  :destroy,
-             class_name: 'Canonical::IngredientsAlchemicalProperty'
-    has_many :alchemical_properties, through: :canonical_ingredients_alchemical_properties
+             class_name: 'Canonical::IngredientsAlchemicalProperty',
+             inverse_of: :ingredient
+    has_many :alchemical_properties,
+             -> { select 'alchemical_properties.*, canonical_ingredients_alchemical_properties.priority' },
+             through: :canonical_ingredients_alchemical_properties
 
     has_many :canonical_recipes_ingredients,
              dependent:  :destroy,

--- a/app/models/canonical/ingredients_alchemical_property.rb
+++ b/app/models/canonical/ingredients_alchemical_property.rb
@@ -25,7 +25,7 @@ module Canonical
     private
 
     def ensure_max_of_four_per_ingredient
-      errors.add(:ingredient, "already has #{MAX_PER_INGREDIENT} alchemical properties") if ingredient.alchemical_properties.count >= MAX_PER_INGREDIENT
+      errors.add(:ingredient, "already has #{MAX_PER_INGREDIENT} alchemical properties") if ingredient.alchemical_properties.length >= MAX_PER_INGREDIENT
     end
   end
 end

--- a/spec/models/canonical/ingredient_spec.rb
+++ b/spec/models/canonical/ingredient_spec.rb
@@ -172,4 +172,20 @@ RSpec.describe Canonical::Ingredient, type: :model do
       end
     end
   end
+
+  describe 'associations' do
+    let!(:ingredient) { create(:canonical_ingredient, :with_alchemical_properties) }
+
+    # Ensure that a key attribute from the join model can be retrieved directly from
+    # the alchemical property
+    it 'can get the priority from its alchemical properties' do
+      expect(ingredient.reload.alchemical_properties.first.priority).to eq 1
+    end
+
+    # Ensure that a key attribute from the associated model can also be retrieved
+    # directly
+    it 'can get the name from its alchemical properties' do
+      expect(ingredient.reload.alchemical_properties.last.name).to eq AlchemicalProperty.last.name
+    end
+  end
 end

--- a/spec/models/canonical/ingredients_alchemical_property_spec.rb
+++ b/spec/models/canonical/ingredients_alchemical_property_spec.rb
@@ -5,15 +5,10 @@ require 'rails_helper'
 RSpec.describe Canonical::IngredientsAlchemicalProperty, type: :model do
   describe 'validations' do
     describe 'number of records per ingredient' do
-      let(:ingredient) { create(:canonical_ingredient) }
+      let!(:ingredient) { create(:canonical_ingredient, :with_alchemical_properties) }
 
       it 'cannot have more than 4 records corresponding to one ingredient' do
-        4.times do |n|
-          ingredient.canonical_ingredients_alchemical_properties.create!(
-            alchemical_property: create(:alchemical_property),
-            priority:            n + 1,
-          )
-        end
+        ingredient.reload
 
         new_association = build(:canonical_ingredients_alchemical_property, ingredient:)
 

--- a/spec/support/factories/canonical/ingredients.rb
+++ b/spec/support/factories/canonical/ingredients.rb
@@ -10,5 +10,13 @@ FactoryBot.define do
     purchase_requires_perk { false }
     unique_item            { false }
     rare_item              { false }
+
+    trait :with_alchemical_properties do
+      after(:create) do |ingredient, _evaluator|
+        4.times do |n|
+          create(:canonical_ingredients_alchemical_property, ingredient:, priority: n + 1)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

[**Access priority of alchemical property through the property itself**](https://trello.com/c/62ySB6vn/191-access-priority-of-alchemical-property-through-the-property-itself)

For some of our associations, we're able to access metadata stored on a join model directly from the associated model itself. For instance, we can find the strength of an enchantment:

```ruby
weapon = Canonical::Weapon.first
weapon.enchantments.first.name #=> enchantment name defined on enchantment model, e.g. "Absorb Health"
weapon.enchantments.first.strength #=> strength defined on join model, e.g. 20 [points]
```

However, we can't find the priority of an alchemical property on an ingredient in the same way. We want to be able to write code like this:

```ruby
ingredient = Canonical::Ingredient.first
ingredient.alchemical_properties.first.name #=> name defined on alchemical property model, e.g., "Weakness to Frost"
ingredient.alchemical_properties.first.priority #=> priority defined on join model, e.g., 2
```

## Changes

* Enable priority of ingredient's alchemical properties to be called on the association directly
* Add specs for new behaviour

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [ ] Added and updated API docs and developer docs as appropriate