### PR TITLE
Add missing docs on canonical ingredients

### DIFF
--- a/docs/canonical_models/canonical-ingredient.md
+++ b/docs/canonical_models/canonical-ingredient.md
@@ -47,3 +47,13 @@ Because purchasability can be determined based on the `ingredient_type` field, t
 #### Merchant Perk
 
 Some ingredients are purchasable only with the Merchant perk (which requires a Speech level of 50). These ingredients are designated by the `purchase_requires_perk` boolean column. This column will be `NULL` if the ingredient is not purchasable at all. Purchasable ingredients will have this column set to `true` (if the ingredient can only be purchased with the perk) or `false` (if they are always purchasable).
+
+## Accessing Alchemical Properties
+
+Alchemical properties are accessible using `ingredient.alchemical_properties`. It is possible to retrieve the attributes of a given alchemical property, along with its priority on a particular ingredient, using code like this:
+
+```ruby
+ingredient = Canonical::Ingredient.first
+ingredient.alchemical_properties.first.name #=> name of alchemical property, defined on AlchemicalProperty model
+ingredient.alchemical_properties.first.priority #=> priority of property on this ingredient, defined on join model
+```

--- a/docs/canonical_models/canonical-ingredients-alchemical-property.md
+++ b/docs/canonical_models/canonical-ingredients-alchemical-property.md
@@ -43,7 +43,14 @@ Say you have four `Canonical::IngredientsAlchemicalProperty` models:
 ```
 If you want to change switch the priority of the model with ID `22` to `3`, you will first need to clear priorities from that model and the one whose priority is currently 3 (the one with ID of `23`) and then change both. If you aren't simply swapping values on two models, you may have to set the priority on three or even all four of the models to `nil` before you can update the values.
 
-Note that, because of the possible necessity of changing priorities, there is no `presence` validation on the `priority` attribute - it is allowed to be blank.
+**Note that, because of the possible necessity of changing priorities, there is no `presence` validation on the `priority` attribute - it is allowed to be blank.**
+
+The priority of an alchemical property on a given ingredient can be accessed from the ingredient:
+
+```ruby
+ingredient = Canonical::Ingredient.first
+ingredient.alchemical_properties.first.priority #=> the priority defined on the join model
+```
 
 ## `strength_modifier` and `duration_modifier`
 


### PR DESCRIPTION
## Context

[**Access priority of alchemical property from the property itself**](https://trello.com/c/62ySB6vn/191-access-priority-of-alchemical-property-through-the-property-itself)

In #138 I enabled the priority of an alchemical property on a particular canonical ingredient to be accessed through the alchemical property association:

```ruby
ingredient.alchemical_properties.first.priority
```

However, I didn't update the docs to include this information.

## Changes

* Update docs to describe accessing the priority of an alchemical property on a particular ingredient

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [x] Added and updated API docs and developer docs as appropriate
