### PR TITLE
Upcase item codes whenever they are changed in models that have them

### DIFF
--- a/app/models/canonical/armor.rb
+++ b/app/models/canonical/armor.rb
@@ -60,6 +60,8 @@ module Canonical
     validate :verify_all_smithing_perks_valid
     validate :validate_unique_item_also_rare, if: -> { unique_item == true }
 
+    before_validation :upcase_item_code, if: -> { item_code_changed? }
+
     def self.unique_identifier
       :item_code
     end
@@ -74,6 +76,10 @@ module Canonical
 
     def validate_unique_item_also_rare
       errors.add(:rare_item, 'must be true if item is unique') unless rare_item == true
+    end
+
+    def upcase_item_code
+      item_code.upcase!
     end
   end
 end

--- a/app/models/canonical/book.rb
+++ b/app/models/canonical/book.rb
@@ -43,6 +43,8 @@ module Canonical
     validate :validate_skill_name_presence
     validate :verify_unique_item_rare, if: -> { unique_item == true }
 
+    before_validation :upcase_item_code, if: -> { item_code_changed? }
+
     def self.unique_identifier
       :item_code
     end
@@ -59,6 +61,10 @@ module Canonical
 
     def verify_unique_item_rare
       errors.add(:rare_item, 'must be true if item is unique') unless rare_item == true
+    end
+
+    def upcase_item_code
+      item_code.upcase!
     end
   end
 end

--- a/app/models/canonical/clothing_item.rb
+++ b/app/models/canonical/clothing_item.rb
@@ -30,6 +30,8 @@ module Canonical
 
     validate :validate_unique_item_also_rare, if: -> { unique_item == true }
 
+    before_validation :upcase_item_code, if: -> { item_code_changed? }
+
     def self.unique_identifier
       :item_code
     end
@@ -38,6 +40,10 @@ module Canonical
 
     def validate_unique_item_also_rare
       errors.add(:rare_item, 'must be true if item is unique') unless rare_item == true
+    end
+
+    def upcase_item_code
+      item_code.upcase!
     end
   end
 end

--- a/app/models/canonical/ingredient.rb
+++ b/app/models/canonical/ingredient.rb
@@ -43,6 +43,8 @@ module Canonical
     validate :validate_purchase_requires_perk
     validate :validate_unique_item_also_rare, if: -> { unique_item == true }
 
+    before_validation :upcase_item_code, if: -> { item_code_changed? }
+
     def self.unique_identifier
       :item_code
     end
@@ -63,6 +65,10 @@ module Canonical
 
     def validate_unique_item_also_rare
       errors.add(:rare_item, 'must be true if item is unique') unless rare_item == true
+    end
+
+    def upcase_item_code
+      item_code.upcase!
     end
   end
 end

--- a/app/models/canonical/jewelry_item.rb
+++ b/app/models/canonical/jewelry_item.rb
@@ -38,6 +38,8 @@ module Canonical
 
     validate :validate_unique_item_also_rare, if: -> { unique_item == true }
 
+    before_validation :upcase_item_code, if: -> { item_code_changed? }
+
     def self.unique_identifier
       :item_code
     end
@@ -46,6 +48,10 @@ module Canonical
 
     def validate_unique_item_also_rare
       errors.add(:rare_item, 'must be true if item is unique') unless rare_item == true
+    end
+
+    def upcase_item_code
+      item_code.upcase!
     end
   end
 end

--- a/app/models/canonical/material.rb
+++ b/app/models/canonical/material.rb
@@ -20,8 +20,16 @@ module Canonical
     validates :item_code, presence: true, uniqueness: { message: 'must be unique' }
     validates :unit_weight, presence: true, numericality: { greater_than_or_equal_to: 0 }
 
+    before_validation :upcase_item_code, if: -> { item_code_changed? }
+
     def self.unique_identifier
       :item_code
+    end
+
+    private
+
+    def upcase_item_code
+      item_code.upcase!
     end
   end
 end

--- a/app/models/canonical/misc_item.rb
+++ b/app/models/canonical/misc_item.rb
@@ -31,6 +31,8 @@ module Canonical
     validate :validate_boolean_values
     validate :verify_unique_item_also_rare, if: -> { unique_item == true }
 
+    before_validation :upcase_item_code, if: -> { item_code_changed? }
+
     def self.unique_identifier
       :item_code
     end
@@ -51,6 +53,10 @@ module Canonical
 
     def verify_unique_item_also_rare
       errors.add(:rare_item, 'must be true if item is unique') unless rare_item == true
+    end
+
+    def upcase_item_code
+      item_code.upcase!
     end
   end
 end

--- a/app/models/canonical/potion.rb
+++ b/app/models/canonical/potion.rb
@@ -22,6 +22,8 @@ module Canonical
     validate :validate_boolean_values
     validate :validate_unique_item_also_rare, if: -> { unique_item == true }
 
+    before_validation :upcase_item_code, if: -> { item_code_changed? }
+
     def self.unique_identifier
       :item_code
     end
@@ -37,6 +39,10 @@ module Canonical
 
     def validate_unique_item_also_rare
       errors.add(:rare_item, 'must be true if item is unique') unless rare_item == true
+    end
+
+    def upcase_item_code
+      item_code.upcase!
     end
   end
 end

--- a/app/models/canonical/staff.rb
+++ b/app/models/canonical/staff.rb
@@ -40,6 +40,8 @@ module Canonical
 
     validate :validate_unique_item_also_rare, if: -> { unique_item == true }
 
+    before_validation :upcase_item_code, if: -> { item_code_changed? }
+
     def self.unique_identifier
       :item_code
     end
@@ -48,6 +50,10 @@ module Canonical
 
     def validate_unique_item_also_rare
       errors.add(:rare_item, 'must be true if item is unique') unless rare_item == true
+    end
+
+    def upcase_item_code
+      item_code.upcase!
     end
   end
 end

--- a/app/models/canonical/weapon.rb
+++ b/app/models/canonical/weapon.rb
@@ -88,6 +88,8 @@ module Canonical
     validate :verify_all_smithing_perks_valid
     validate :validate_unique_item_also_rare, if: -> { unique_item == true }
 
+    before_validation :upcase_item_code, if: -> { item_code_changed? }
+
     def self.unique_identifier
       :item_code
     end
@@ -106,6 +108,10 @@ module Canonical
 
     def validate_unique_item_also_rare
       errors.add(:rare_item, 'must be true if item is unique') unless rare_item == true
+    end
+
+    def upcase_item_code
+      item_code.upcase!
     end
   end
 end

--- a/docs/canonical_models/canonical-data.md
+++ b/docs/canonical_models/canonical-data.md
@@ -29,7 +29,7 @@ Since associated models are not created or updated as part of each sync, it is i
 
 ### Important Note on Item Codes
 
-Codes representing particular items are not case sensitive in-game and are therefore listed using different casing (or inconsistent casing) in different sources. **Item codes in SIM are always upper-case.** Since items are generally looked up by unique identifier rather than primary key, it is critical that these codes be meticulously upcased when generating and cleansing JSON data. Failing to do can will result in duplicate item codes or failure to return a model that exists in the database but whose item code contains lower-case characters.
+Codes representing particular items are not case sensitive in-game and are therefore listed using different casing (or inconsistent casing) in different sources. **Item codes in SIM are always upper-case.** Having mixed-case codes could be problematic due to the fact that item code is the unique identifier for all classes that have them, and mixed cases could mean they were not actually unique. Previously, we relied on data cleansing to ensure all codes in SIM were upcased, however, now model classes that have item codes also automatically upcase them prior to doing the uniqueness validation.
 
 ### Example
 

--- a/spec/models/canonical/armor_spec.rb
+++ b/spec/models/canonical/armor_spec.rb
@@ -168,6 +168,13 @@ RSpec.describe Canonical::Armor, type: :model do
     end
   end
 
+  describe 'default behavior' do
+    it 'upcases item codes' do
+      armor = create(:canonical_armor, item_code: 'abc123')
+      expect(armor.reload.item_code).to eq 'ABC123'
+    end
+  end
+
   describe 'associations' do
     describe 'enchantments' do
       let(:armor)       { create(:canonical_armor) }

--- a/spec/models/canonical/book_spec.rb
+++ b/spec/models/canonical/book_spec.rb
@@ -148,6 +148,13 @@ RSpec.describe Canonical::Book, type: :model do
     end
   end
 
+  describe 'default behavior' do
+    it 'upcases item codes' do
+      book = create(:canonical_book, item_code: 'abc123')
+      expect(book.reload.item_code).to eq 'ABC123'
+    end
+  end
+
   describe '::unique_identifier' do
     it 'returns ":item_code"' do
       expect(described_class.unique_identifier).to eq :item_code

--- a/spec/models/canonical/clothing_item_spec.rb
+++ b/spec/models/canonical/clothing_item_spec.rb
@@ -136,6 +136,13 @@ RSpec.describe Canonical::ClothingItem, type: :model do
     end
   end
 
+  describe 'default behavior' do
+    it 'upcases item codes' do
+      item = create(:canonical_clothing_item, item_code: 'abc123')
+      expect(item.reload.item_code).to eq 'ABC123'
+    end
+  end
+
   describe 'associations' do
     describe 'enchantments' do
       let(:item)        { create(:canonical_clothing_item) }

--- a/spec/models/canonical/ingredient_spec.rb
+++ b/spec/models/canonical/ingredient_spec.rb
@@ -165,6 +165,13 @@ RSpec.describe Canonical::Ingredient, type: :model do
     end
   end
 
+  describe 'default behavior' do
+    it 'upcases item codes' do
+      ingredient = create(:canonical_ingredient, item_code: 'abc123')
+      expect(ingredient.reload.item_code).to eq 'ABC123'
+    end
+  end
+
   describe 'class methods' do
     describe '::unique_identifier' do
       it 'returns :item_code' do

--- a/spec/models/canonical/jewelry_item_spec.rb
+++ b/spec/models/canonical/jewelry_item_spec.rb
@@ -128,6 +128,13 @@ RSpec.describe Canonical::JewelryItem, type: :model do
     end
   end
 
+  describe 'default behavior' do
+    it 'upcases item codes' do
+      item = create(:canonical_jewelry_item, item_code: 'abc123')
+      expect(item.reload.item_code).to eq 'ABC123'
+    end
+  end
+
   describe 'associations' do
     describe 'enchantments' do
       let(:item)        { create(:canonical_jewelry_item) }

--- a/spec/models/canonical/material_spec.rb
+++ b/spec/models/canonical/material_spec.rb
@@ -60,6 +60,13 @@ RSpec.describe Canonical::Material, type: :model do
     end
   end
 
+  describe 'default behavior' do
+    it 'upcases item codes' do
+      material = create(:canonical_material, item_code: 'abc123')
+      expect(material.reload.item_code).to eq 'ABC123'
+    end
+  end
+
   describe 'class methods' do
     describe '::unique_identifier' do
       it 'returns :item_code' do

--- a/spec/models/canonical/misc_item_spec.rb
+++ b/spec/models/canonical/misc_item_spec.rb
@@ -120,6 +120,13 @@ RSpec.describe Canonical::MiscItem, type: :model do
     end
   end
 
+  describe 'default behavior' do
+    it 'upcases the item code' do
+      item = create(:canonical_misc_item, item_code: 'abc123')
+      expect(item.reload.item_code).to eq 'ABC123'
+    end
+  end
+
   describe 'class methods' do
     describe '::unique_identifier' do
       it 'returns ":item_code"' do

--- a/spec/models/canonical/potion_spec.rb
+++ b/spec/models/canonical/potion_spec.rb
@@ -113,6 +113,13 @@ RSpec.describe Canonical::Potion, type: :model do
     end
   end
 
+  describe 'default behavior' do
+    it 'upcases item codes' do
+      potion = create(:canonical_potion, item_code: 'abc123')
+      expect(potion.reload.item_code).to eq 'ABC123'
+    end
+  end
+
   describe 'associations' do
     describe 'alchemical properties' do
       let(:potion)              { create(:canonical_potion) }

--- a/spec/models/canonical/staff_spec.rb
+++ b/spec/models/canonical/staff_spec.rb
@@ -160,6 +160,13 @@ RSpec.describe Canonical::Staff, type: :model do
     end
   end
 
+  describe 'default behavior' do
+    it 'upcases item codes' do
+      staff = create(:canonical_staff, item_code: 'abc123')
+      expect(staff.reload.item_code).to eq 'ABC123'
+    end
+  end
+
   describe 'associations' do
     describe 'powers' do
       let(:staff) { create(:canonical_staff) }

--- a/spec/models/canonical/weapon_spec.rb
+++ b/spec/models/canonical/weapon_spec.rb
@@ -214,6 +214,13 @@ RSpec.describe Canonical::Weapon, type: :model do
     end
   end
 
+  describe 'default behavior' do
+    it 'upcases item codes' do
+      weapon = create(:canonical_weapon, item_code: 'abc123')
+      expect(weapon.reload.item_code).to eq 'ABC123'
+    end
+  end
+
   describe 'associations' do
     describe 'enchantments' do
       let(:weapon)      { create(:canonical_weapon) }


### PR DESCRIPTION
## Context

[**Automatically upcase item codes for models that have them**](https://trello.com/c/6gl3V31O/187-automatically-upcase-item-codes-for-models-that-have-them)

Many canonical models in SIM are uniquely identified by an `item_code`. These codes, where they exist, are taken from the game's IDs for different items. These IDs are case-insensitive, however, this can cause issues in SIM if multiple items with the same item code end up in the database with different casing. So far, the solution has been data cleansing, but this is not particularly robust.

## Changes

* Upcase item codes before validation in models that have them
* Update specs

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [ ] Added and updated API docs and developer docs as appropriate

## Considerations

It was tempting to create a concern or extract code into a shared module to enable multiple canonical models to have the same `before_validation` hook. However, in this case I thought it would be better to repeat the code in each class in order to avoid some of the awkwardness that a concern often brings. Since there are only two shared elements between these classes - this and the `::unique_identifier` class method - and the latter is shared by other classes that don't have item codes, I didn't want to extract a module just for this one thing that doesn't even apply to all canonical models.