### PR TITLE
Update port for frontend in CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Note that the setup script installs a Git pre-commit hook that runs [Rubocop](#r
 
 To run the server, simply run `bundle exec rails s` and your server will start on `localhost:3000`.
 
-Note that if you are also running the [SIM front end](https://github.com/danascheider/skyrim_inventory_management_frontend), it will expect the backend to run on localhost:3000 in development. CORS settings on the API require the front end to run on `localhost:3001`.
+Note that if you are also running the [SIM front end](https://github.com/danascheider/skyrim_inventory_management_frontend), it will expect the backend to run on `localhost:3000` in development. CORS settings on the API require the front end to run on `localhost:5173`.
 
 ### Testing
 

--- a/config/configatron/defaults.rb
+++ b/config/configatron/defaults.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-configatron.client_origin          = ENV['CLIENT_ORIGIN'] || 'http://localhost:3001'
+configatron.client_origin          = ENV['CLIENT_ORIGIN'] || 'http://localhost:5173'
 configatron.google_oauth_client_id = ENV['GOOGLE_OAUTH_CLIENT_ID']

--- a/config/configatron/defaults.rb
+++ b/config/configatron/defaults.rb
@@ -1,4 +1,3 @@
 # frozen_string_literal: true
 
-configatron.client_origin          = ENV['CLIENT_ORIGIN'] || 'http://localhost:5173'
-configatron.google_oauth_client_id = ENV['GOOGLE_OAUTH_CLIENT_ID']
+configatron.client_origin = ENV['CLIENT_ORIGIN'] || 'http://localhost:5173'

--- a/config/configatron/development.rb
+++ b/config/configatron/development.rb
@@ -2,4 +2,4 @@
 
 # Override your default settings for the Development environment here.
 #
-configatron.client_origin = 'http://localhost:3001'
+configatron.client_origin = 'http://localhost:5173'


### PR DESCRIPTION
## Context

[**Create stock Vite app**](https://trello.com/c/UF2WLo0M/237-create-stock-vite-app)

We are porting the front end to [Vite](https://vitejs.dev). By default, Vite uses port 5173 for local development, however our backend has CORS configured to only accept requests from port 3001.

## Changes

* Changed port for front end to 5173
* Remove Google OAuth client ID configuration option, which for now we won't be using

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] Added and updated API docs and developer docs as appropriate

## Considerations

I could (should?) have made a separate PR to remove the Google OAuth client ID, but I did it in a separate commit so yay compromise.
