### PR TITLE
Update Rubocop rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -58,6 +58,12 @@ Bundler/DuplicatedGem:
     - '**/Gemfile'
 Bundler/GemComment:
   Enabled: true
+Bundler/GemFilename:
+  Enabled: true
+  EnforcedStyle: Gemfile
+Bundler/OrderedGems:
+  Enabled: true
+  TreatCommentsAsGroupSeparators: false
 Bundler/GemVersion:
   Enabled: true
   EnforcedStyle: 'required'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -175,8 +175,8 @@ Layout/EndAlignment:
   EnforcedStyleAlignWith: keyword
 Layout/ExtraSpacing:
   Enabled: true
-  AllowForAlignment: true
-  ForceEqualSignAlignment: true
+  AllowBeforeTrailingComments: true
+  AllowForAlignment: false
 Layout/FirstArgumentIndentation:
   Enabled: true
   EnforcedStyle: consistent_relative_to_receiver
@@ -1389,8 +1389,6 @@ Rails/WhereNot:
 ### RSpec Requirements ###
 ##########################
 
-RSpec/AlignLeftLetBrace:
-  Enabled: true
 RSpec/AroundBlock:
   Enabled: true
 RSpec/Be:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -153,6 +153,8 @@ Layout/EmptyLinesAroundAccessModifier:
   Enabled: true
 Layout/EmptyLinesAroundArguments:
   Enabled: true
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: true
 Layout/EmptyLinesAroundBeginBody:
   Enabled: true
 Layout/EmptyLinesAroundBlockBody:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -100,8 +100,7 @@ Layout/CaseIndentation:
 Layout/ClassStructure:
   Description: 'Enforces a configured order of definitions within a class body.'
   StyleGuide: '#consistent-classes'
-  Enabled: false
-  VersionAdded: '0.52'
+  Enabled: true
   Categories:
     module_inclusion:
       - include

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -123,6 +123,7 @@ Layout/ClosingParenthesisIndentation:
 Layout/CommentIndentation:
   Description: 'Indentation of comments.'
   Enabled: true
+  AllowForAlignment: true
 Layout/ConditionPosition:
   Enabled: true
 Layout/DefEndAlignment:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -84,6 +84,8 @@ Layout/ArgumentAlignment:
 Layout/ArrayAlignment:
   Enabled: true
   EnforcedStyle: with_first_element
+Layout/AssignmentIndentation:
+  Enabled: true
 Layout/BeginEndAlignment:
   Enabled: true
   EnforcedStyleAlignWith: start_of_line

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -135,6 +135,10 @@ Layout/DotPosition:
   EnforcedStyle: leading
 Layout/ElseAlignment:
   Enabled: true
+Layout/EmptyComment:
+  Enabled: true
+  AllowBorderComment: true
+  AllowMarginComment: true
 Layout/EmptyLineAfterGuardClause:
   Enabled: true
 Layout/EmptyLineAfterMagicComment:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -143,6 +143,8 @@ Layout/EmptyLineAfterGuardClause:
   Enabled: true
 Layout/EmptyLineAfterMagicComment:
   Enabled: true
+Layout/EmptyLineAfterMultilineCondition:
+  Enabled: true
 Layout/EmptyLineBetweenDefs:
   Enabled: true
 Layout/EmptyLines:

--- a/app/controller_services/application_controller/authorization_service.rb
+++ b/app/controller_services/application_controller/authorization_service.rb
@@ -9,7 +9,7 @@ class ApplicationController < ActionController::API
     class AmbiguousUserError < StandardError; end
 
     def initialize(controller, access_token)
-      @controller   = controller
+      @controller = controller
       @access_token = access_token
     end
 

--- a/app/controller_services/games_controller/create_service.rb
+++ b/app/controller_services/games_controller/create_service.rb
@@ -7,7 +7,7 @@ require 'service/internal_server_error_result'
 class GamesController < ApplicationController
   class CreateService
     def initialize(user, params)
-      @user   = user
+      @user = user
       @params = params
     end
 

--- a/app/controller_services/games_controller/destroy_service.rb
+++ b/app/controller_services/games_controller/destroy_service.rb
@@ -7,7 +7,7 @@ require 'service/internal_server_error_result'
 class GamesController < ApplicationController
   class DestroyService
     def initialize(user, game_id)
-      @user    = user
+      @user = user
       @game_id = game_id
     end
 

--- a/app/controller_services/games_controller/update_service.rb
+++ b/app/controller_services/games_controller/update_service.rb
@@ -8,9 +8,9 @@ require 'service/internal_server_error_result'
 class GamesController < ApplicationController
   class UpdateService
     def initialize(user, game_id, params)
-      @user    = user
+      @user = user
       @game_id = game_id
-      @params  = params
+      @params = params
     end
 
     def perform

--- a/app/controller_services/inventory_items_controller/create_service.rb
+++ b/app/controller_services/inventory_items_controller/create_service.rb
@@ -12,16 +12,16 @@ class InventoryItemsController < ApplicationController
     AGGREGATE_LIST_ERROR = 'Cannot manually manage items on an aggregate inventory list'
 
     def initialize(user, list_id, params)
-      @user    = user
+      @user = user
       @list_id = list_id
-      @params  = params
+      @params = params
     end
 
     def perform
       return Service::MethodNotAllowedResult.new(errors: [AGGREGATE_LIST_ERROR]) if inventory_list.aggregate == true
 
       preexisting_item = inventory_list.list_items.find_by('description ILIKE ?', params[:description])
-      item             = InventoryItem.combine_or_new(params.merge(list_id:))
+      item = InventoryItem.combine_or_new(params.merge(list_id:))
 
       ActiveRecord::Base.transaction do
         item.save!

--- a/app/controller_services/inventory_items_controller/destroy_service.rb
+++ b/app/controller_services/inventory_items_controller/destroy_service.rb
@@ -11,7 +11,7 @@ class InventoryItemsController < ApplicationController
     AGGREGATE_LIST_ERROR = 'Cannot manually delete list item from aggregate inventory list'
 
     def initialize(user, item_id)
-      @user    = user
+      @user = user
       @item_id = item_id
     end
 

--- a/app/controller_services/inventory_items_controller/update_service.rb
+++ b/app/controller_services/inventory_items_controller/update_service.rb
@@ -11,9 +11,9 @@ class InventoryItemsController < ApplicationController
     AGGREGATE_LIST_ERROR = 'Cannot manually update list items on an aggregate inventory list'
 
     def initialize(user, item_id, params)
-      @user    = user
+      @user = user
       @item_id = item_id
-      @params  = params
+      @params = params
     end
 
     def perform

--- a/app/controller_services/inventory_lists_controller/create_service.rb
+++ b/app/controller_services/inventory_lists_controller/create_service.rb
@@ -10,15 +10,15 @@ class InventoryListsController < ApplicationController
     AGGREGATE_LIST_ERROR = 'Cannot manually create an aggregate inventory list'
 
     def initialize(user, game_id, params)
-      @user    = user
+      @user = user
       @game_id = game_id
-      @params  = params
+      @params = params
     end
 
     def perform
       return Service::UnprocessableEntityResult.new(errors: [AGGREGATE_LIST_ERROR]) if params[:aggregate]
 
-      inventory_list             = game.inventory_lists.new(params)
+      inventory_list = game.inventory_lists.new(params)
       preexisting_aggregate_list = game.aggregate_inventory_list
 
       if inventory_list.save

--- a/app/controller_services/inventory_lists_controller/destroy_service.rb
+++ b/app/controller_services/inventory_lists_controller/destroy_service.rb
@@ -11,7 +11,7 @@ class InventoryListsController < ApplicationController
     AGGREGATE_LIST_ERROR = 'Cannot manually delete an aggregate inventory list'
 
     def initialize(user, list_id)
-      @user    = user
+      @user = user
       @list_id = list_id
     end
 
@@ -33,7 +33,7 @@ class InventoryListsController < ApplicationController
 
     def destroy_and_update_aggregate_list_items
       aggregate_list = inventory_list.aggregate_list
-      list_items     = inventory_list.list_items.map(&:attributes)
+      list_items = inventory_list.list_items.map(&:attributes)
 
       ActiveRecord::Base.transaction do
         # If inventory_list is the user's last regular inventory list, this will also

--- a/app/controller_services/inventory_lists_controller/index_service.rb
+++ b/app/controller_services/inventory_lists_controller/index_service.rb
@@ -6,7 +6,7 @@ require 'service/not_found_result'
 class InventoryListsController < ApplicationController
   class IndexService
     def initialize(user, game_id)
-      @user    = user
+      @user = user
       @game_id = game_id
     end
 

--- a/app/controller_services/inventory_lists_controller/update_service.rb
+++ b/app/controller_services/inventory_lists_controller/update_service.rb
@@ -8,13 +8,13 @@ require 'service/internal_server_error_result'
 
 class InventoryListsController < ApplicationController
   class UpdateService
-    AGGREGATE_LIST_ERROR    = 'Cannot manually update an aggregate inventory list'
+    AGGREGATE_LIST_ERROR = 'Cannot manually update an aggregate inventory list'
     DISALLOWED_UPDATE_ERROR = 'Cannot make a regular inventory list an aggregate list'
 
     def initialize(user, list_id, params)
-      @user    = user
+      @user = user
       @list_id = list_id
-      @params  = params
+      @params = params
     end
 
     def perform

--- a/app/controller_services/shopping_list_items_controller/create_service.rb
+++ b/app/controller_services/shopping_list_items_controller/create_service.rb
@@ -12,16 +12,16 @@ class ShoppingListItemsController < ApplicationController
     AGGREGATE_LIST_ERROR = 'Cannot manually manage items on an aggregate shopping list'
 
     def initialize(user, list_id, params)
-      @user    = user
+      @user = user
       @list_id = list_id
-      @params  = params
+      @params = params
     end
 
     def perform
       return Service::MethodNotAllowedResult.new(errors: [AGGREGATE_LIST_ERROR]) if shopping_list.aggregate == true
 
       preexisting_item = shopping_list.list_items.find_by('description ILIKE ?', params[:description])
-      item             = ShoppingListItem.combine_or_new(params.merge(list_id:))
+      item = ShoppingListItem.combine_or_new(params.merge(list_id:))
 
       ActiveRecord::Base.transaction do
         item.save!

--- a/app/controller_services/shopping_list_items_controller/destroy_service.rb
+++ b/app/controller_services/shopping_list_items_controller/destroy_service.rb
@@ -11,7 +11,7 @@ class ShoppingListItemsController < ApplicationController
     AGGREGATE_LIST_ERROR = 'Cannot manually delete list item from aggregate shopping list'
 
     def initialize(user, item_id)
-      @user    = user
+      @user = user
       @item_id = item_id
     end
 

--- a/app/controller_services/shopping_list_items_controller/update_service.rb
+++ b/app/controller_services/shopping_list_items_controller/update_service.rb
@@ -11,9 +11,9 @@ class ShoppingListItemsController < ApplicationController
     AGGREGATE_LIST_ERROR = 'Cannot manually update list items on an aggregate shopping list'
 
     def initialize(user, item_id, params)
-      @user    = user
+      @user = user
       @item_id = item_id
-      @params  = params
+      @params = params
     end
 
     def perform

--- a/app/controller_services/shopping_lists_controller/create_service.rb
+++ b/app/controller_services/shopping_lists_controller/create_service.rb
@@ -12,15 +12,15 @@ class ShoppingListsController < ApplicationController
     AGGREGATE_LIST_ERROR = 'Cannot manually create an aggregate shopping list'
 
     def initialize(user, game_id, params)
-      @user    = user
+      @user = user
       @game_id = game_id
-      @params  = params
+      @params = params
     end
 
     def perform
       return Service::UnprocessableEntityResult.new(errors: [AGGREGATE_LIST_ERROR]) if params[:aggregate]
 
-      shopping_list              = game.shopping_lists.new(params)
+      shopping_list = game.shopping_lists.new(params)
       preexisting_aggregate_list = game.aggregate_shopping_list
 
       if shopping_list.save

--- a/app/controller_services/shopping_lists_controller/destroy_service.rb
+++ b/app/controller_services/shopping_lists_controller/destroy_service.rb
@@ -11,7 +11,7 @@ class ShoppingListsController < ApplicationController
     AGGREGATE_LIST_ERROR = 'Cannot manually delete an aggregate shopping list'
 
     def initialize(user, list_id)
-      @user    = user
+      @user = user
       @list_id = list_id
     end
 

--- a/app/controller_services/shopping_lists_controller/index_service.rb
+++ b/app/controller_services/shopping_lists_controller/index_service.rb
@@ -7,7 +7,7 @@ require 'service/internal_server_error_result'
 class ShoppingListsController < ApplicationController
   class IndexService
     def initialize(user, game_id)
-      @user    = user
+      @user = user
       @game_id = game_id
     end
 

--- a/app/controller_services/shopping_lists_controller/update_service.rb
+++ b/app/controller_services/shopping_lists_controller/update_service.rb
@@ -8,13 +8,13 @@ require 'service/internal_server_error_result'
 
 class ShoppingListsController < ApplicationController
   class UpdateService
-    AGGREGATE_LIST_ERROR    = 'Cannot manually update an aggregate shopping list'
+    AGGREGATE_LIST_ERROR = 'Cannot manually update an aggregate shopping list'
     DISALLOWED_UPDATE_ERROR = 'Cannot make a regular shopping list an aggregate list'
 
     def initialize(user, list_id, params)
-      @user    = user
+      @user = user
       @list_id = list_id
-      @params  = params
+      @params = params
     end
 
     def perform

--- a/app/controllers/utilities_controller.rb
+++ b/app/controllers/utilities_controller.rb
@@ -3,14 +3,6 @@
 class UtilitiesController < ApplicationController
   skip_before_action :authenticate_user!
 
-  def privacy
-    render plain: PRIVACY, status: :ok
-  end
-
-  def tos
-    render plain: TOS, status: :ok
-  end
-
   PRIVACY = <<~HEREDOC
     Thank you for using Skyrim Inventory Management. This app was intended
     for my personal use and offers no guarantees of security, privacy, or
@@ -31,4 +23,12 @@ class UtilitiesController < ApplicationController
     the documentation, which may be found in the README at
     https://github.com/danascheider/skyrim_inventory_management.
   HEREDOC
+
+  def privacy
+    render plain: PRIVACY, status: :ok
+  end
+
+  def tos
+    render plain: TOS, status: :ok
+  end
 end

--- a/app/models/canonical/armor.rb
+++ b/app/models/canonical/armor.rb
@@ -6,7 +6,7 @@ module Canonical
   class Armor < ApplicationRecord
     self.table_name = 'canonical_armors'
 
-    BOOLEAN_VALUES             = [true, false].freeze
+    BOOLEAN_VALUES = [true, false].freeze
     BOOLEAN_VALIDATION_MESSAGE = 'must be true or false'
 
     has_many :canonical_enchantables_enchantments,

--- a/app/models/canonical/book.rb
+++ b/app/models/canonical/book.rb
@@ -6,7 +6,7 @@ module Canonical
   class Book < ApplicationRecord
     self.table_name = 'canonical_books'
 
-    BOOLEAN_VALUES             = [true, false].freeze
+    BOOLEAN_VALUES = [true, false].freeze
     BOOLEAN_VALIDATION_MESSAGE = 'must be true or false'
 
     BOOK_TYPES = [

--- a/app/models/canonical/clothing_item.rb
+++ b/app/models/canonical/clothing_item.rb
@@ -4,8 +4,8 @@ module Canonical
   class ClothingItem < ApplicationRecord
     self.table_name = 'canonical_clothing_items'
 
-    BODY_SLOTS                 = %w[head hands body feet].freeze
-    BOOLEAN_VALUES             = [true, false].freeze
+    BODY_SLOTS = %w[head hands body feet].freeze
+    BOOLEAN_VALUES = [true, false].freeze
     BOOLEAN_VALIDATION_MESSAGE = 'must be true or false'
 
     has_many :canonical_enchantables_enchantments,

--- a/app/models/canonical/ingredient.rb
+++ b/app/models/canonical/ingredient.rb
@@ -4,9 +4,9 @@ module Canonical
   class Ingredient < ApplicationRecord
     self.table_name = 'canonical_ingredients'
 
-    VALID_TYPES                = %w[common uncommon rare Solstheim].freeze
-    TYPE_VALIDATION_MESSAGE    = 'must be "common", "uncommon", "rare", or "Solstheim"'
-    BOOLEAN_VALUES             = [true, false].freeze
+    VALID_TYPES = %w[common uncommon rare Solstheim].freeze
+    TYPE_VALIDATION_MESSAGE = 'must be "common", "uncommon", "rare", or "Solstheim"'
+    BOOLEAN_VALUES = [true, false].freeze
     BOOLEAN_VALIDATION_MESSAGE = 'must be true or false'
 
     has_many :canonical_ingredients_alchemical_properties,

--- a/app/models/canonical/jewelry_item.rb
+++ b/app/models/canonical/jewelry_item.rb
@@ -4,7 +4,7 @@ module Canonical
   class JewelryItem < ApplicationRecord
     self.table_name = 'canonical_jewelry_items'
 
-    BOOLEAN_VALUES             = [true, false].freeze
+    BOOLEAN_VALUES = [true, false].freeze
     BOOLEAN_VALIDATION_MESSAGE = 'must be true or false'
 
     has_many :canonical_enchantables_enchantments,

--- a/app/models/canonical/misc_item.rb
+++ b/app/models/canonical/misc_item.rb
@@ -4,7 +4,7 @@ module Canonical
   class MiscItem < ApplicationRecord
     self.table_name = 'canonical_misc_items'
 
-    BOOLEAN_VALUES             = [true, false].freeze
+    BOOLEAN_VALUES = [true, false].freeze
     BOOLEAN_VALIDATION_MESSAGE = 'must be true or false'
 
     VALID_ITEM_TYPES = [

--- a/app/models/canonical/potion.rb
+++ b/app/models/canonical/potion.rb
@@ -4,9 +4,9 @@ module Canonical
   class Potion < ApplicationRecord
     self.table_name = 'canonical_potions'
 
-    BOOLEAN_VALUES             = [true, false].freeze
+    BOOLEAN_VALUES = [true, false].freeze
     BOOLEAN_VALIDATION_MESSAGE = 'must be true or false'
-    VALID_POTION_TYPES         = %w[potion poison].freeze
+    VALID_POTION_TYPES = %w[potion poison].freeze
 
     has_many :canonical_potions_alchemical_properties,
              dependent:  :destroy,

--- a/app/models/canonical/staff.rb
+++ b/app/models/canonical/staff.rb
@@ -6,7 +6,7 @@ module Canonical
   class Staff < ApplicationRecord
     self.table_name = 'canonical_staves'
 
-    BOOLEAN_VALUES             = [true, false].freeze
+    BOOLEAN_VALUES = [true, false].freeze
     BOOLEAN_VALIDATION_MESSAGE = 'must be true or false'
 
     has_many :canonical_powerables_powers,

--- a/app/models/canonical/sync/association_syncer.rb
+++ b/app/models/canonical/sync/association_syncer.rb
@@ -20,16 +20,16 @@ module Canonical
             next unless associations.any?
 
             associations.each do |association|
-              reflection                   = model_class.reflect_on_association(association)
-              association_name             = reflection.through_reflection.name
-              associated_model             = reflection.source_reflection.name
-              associated_model_class       = reflection.klass
-              associated_model_identifier  = associated_model_class.unique_identifier
-              associated_fk                = reflection.foreign_key.to_sym
+              reflection = model_class.reflect_on_association(association)
+              association_name = reflection.through_reflection.name
+              associated_model = reflection.source_reflection.name
+              associated_model_class = reflection.klass
+              associated_model_identifier = associated_model_class.unique_identifier
+              associated_fk = reflection.foreign_key.to_sym
 
               if !preserve_existing_records || !preserve_associations?
                 identifiers = object[association].pluck(associated_model_identifier)
-                assn_ids    = associated_model_class.where(associated_model_identifier => identifiers).ids
+                assn_ids = associated_model_class.where(associated_model_identifier => identifiers).ids
                 model.send(association_name).where.not(associated_fk => assn_ids).destroy_all
               end
 

--- a/app/models/canonical/weapon.rb
+++ b/app/models/canonical/weapon.rb
@@ -6,28 +6,28 @@ module Canonical
   class Weapon < ApplicationRecord
     self.table_name = 'canonical_weapons'
 
-    BOOLEAN_VALUES             = [true, false].freeze
+    BOOLEAN_VALUES = [true, false].freeze
     BOOLEAN_VALIDATION_MESSAGE = 'must be true or false'
-    VALID_WEAPON_TYPES         = {
-                                   'one-handed' => [
-                                                     'dagger',
-                                                     'mace',
-                                                     'other',
-                                                     'sword',
-                                                     'war axe',
-                                                   ],
-                                   'two-handed' => %w[
-                                                     battleaxe
-                                                     greatsword
-                                                     warhammer
-                                                   ],
-                                   'archery'    => %w[
-                                                     arrow
-                                                     bolt
-                                                     bow
-                                                     crossbow
-                                                   ],
-                                 }.freeze
+    VALID_WEAPON_TYPES = {
+                           'one-handed' => [
+                                             'dagger',
+                                             'mace',
+                                             'other',
+                                             'sword',
+                                             'war axe',
+                                           ],
+                           'two-handed' => %w[
+                                             battleaxe
+                                             greatsword
+                                             warhammer
+                                           ],
+                           'archery'    => %w[
+                                             arrow
+                                             bolt
+                                             bow
+                                             crossbow
+                                           ],
+                         }.freeze
 
     has_many :canonical_enchantables_enchantments,
              dependent:  :destroy,

--- a/app/models/concerns/aggregatable.rb
+++ b/app/models/concerns/aggregatable.rb
@@ -47,17 +47,17 @@ module Aggregatable
 
     serialize :list_items, class_name: 'Array'
 
-    validate :one_aggregate_list_per_game,        if: :aggregate_list?
-    validate :not_named_all_items,                unless: :aggregate_list?
+    validate :one_aggregate_list_per_game, if: :aggregate_list?
+    validate :not_named_all_items, unless: :aggregate_list?
     validate :ensure_aggregate_list_is_aggregate, unless: :aggregate_list?
 
-    before_create :create_aggregate_list,    unless: :aggregate_list?
-    before_validation :set_aggregate_list,   unless: :aggregate_list?
+    before_create :create_aggregate_list, unless: :aggregate_list?
+    before_validation :set_aggregate_list, unless: :aggregate_list?
     before_save :abort_if_aggregate_changed
-    before_save :remove_aggregate_list_id,   if: :aggregate_list?
-    before_save :set_title_to_all_items,     if: :aggregate_list?
-    before_destroy :abort_if_aggregate,      if: :has_child_lists?
-    after_destroy :destroy_aggregate_list,   unless: -> { aggregate_list? || aggregate_has_other_children? }
+    before_save :remove_aggregate_list_id, if: :aggregate_list?
+    before_save :set_title_to_all_items, if: :aggregate_list?
+    before_destroy :abort_if_aggregate, if: :has_child_lists?
+    after_destroy :destroy_aggregate_list, unless: -> { aggregate_list? || aggregate_has_other_children? }
 
     scope :aggregate_first, -> { order(aggregate: :desc) }
     scope :includes_items, -> { includes(:list_items) }
@@ -91,7 +91,7 @@ module Aggregatable
       existing_item.destroy!
     else
       existing_item.quantity -= attrs['quantity']
-      existing_item.notes     = extract_notes(attrs['notes'], existing_item.notes)
+      existing_item.notes = extract_notes(attrs['notes'], existing_item.notes)
       existing_item.save!
     end
 
@@ -106,11 +106,11 @@ module Aggregatable
     raise AggregateListError.new('invalid data to update aggregate list item') if existing_item.nil? || delta_quantity < (-existing_item.quantity) || (unit_weight && (!unit_weight.is_a?(Numeric) || unit_weight < 0))
 
     existing_item.quantity += delta_quantity
-    existing_item.notes     = if old_notes.nil? && new_notes.present?
-                                [existing_item.notes.to_s, new_notes.to_s].join(' -- ')
-                              else
-                                existing_item.notes&.sub(/#{old_notes}/, new_notes.to_s).presence || new_notes
-                              end
+    existing_item.notes = if old_notes.nil? && new_notes.present?
+                            [existing_item.notes.to_s, new_notes.to_s].join(' -- ')
+                          else
+                            existing_item.notes&.sub(/#{old_notes}/, new_notes.to_s).presence || new_notes
+                          end
 
     unless unit_weight.nil?
       existing_item.unit_weight = unit_weight

--- a/app/models/concerns/listable.rb
+++ b/app/models/concerns/listable.rb
@@ -34,10 +34,10 @@ module Listable
       # result in problems if the key types of the attrs differ
       # (e.g., if there is a :unit_weight key and a 'unit_weight'
       # key, only the value of the second one will be preserved)
-      new_attrs                                      = {}
+      new_attrs = {}
       attrs.each {|key, value| new_attrs[key.to_sym] = value }
 
-      list          = new_attrs[:list] || list_class.find(new_attrs[:list_id])
+      list = new_attrs[:list] || list_class.find(new_attrs[:list_id])
       existing_item = list.list_items.find_by('description ILIKE ?', new_attrs[:description])
 
       if existing_item.nil?
@@ -49,13 +49,13 @@ module Listable
 
         new new_attrs
       else
-        qty        = new_attrs[:quantity] || 1
-        new_notes  = new_attrs[:notes]
+        qty = new_attrs[:quantity] || 1
+        new_notes = new_attrs[:notes]
         new_weight = new_attrs[:unit_weight] || existing_item.unit_weight
-        old_notes  = existing_item.notes
+        old_notes = existing_item.notes
 
         new_quantity = existing_item.quantity + qty
-        new_notes    = [old_notes, new_notes].compact.join(' -- ').presence
+        new_notes = [old_notes, new_notes].compact.join(' -- ').presence
 
         existing_item.assign_attributes(quantity: new_quantity, notes: new_notes, unit_weight: new_weight)
         existing_item

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -53,8 +53,8 @@ class Game < ApplicationRecord
     if name.blank?
       max_existing_number = user.games.where("name LIKE 'My Game %'").pluck(:name).map {|t| t.gsub('My Game ', '').to_i }
                               .max || 0
-      next_number         = max_existing_number >= 0 ? max_existing_number + 1 : 1
-      self.name           = "My Game #{next_number}"
+      next_number = max_existing_number >= 0 ? max_existing_number + 1 : 1
+      self.name = "My Game #{next_number}"
     else
       self.name = Titlecase.titleize(name.strip)
     end

--- a/app/models/inventory_list.rb
+++ b/app/models/inventory_list.rb
@@ -35,8 +35,8 @@ class InventoryList < ApplicationRecord
     if title.blank?
       max_existing_number = game.inventory_lists.where("title LIKE 'My List %'").pluck(:title).map {|t| t.gsub('My List ', '').to_i }
                               .max || 0
-      next_number         = max_existing_number >= 0 ? max_existing_number + 1 : 1
-      self.title          = "My List #{next_number}"
+      next_number = max_existing_number >= 0 ? max_existing_number + 1 : 1
+      self.title = "My List #{next_number}"
     else
       self.title = Titlecase.titleize(title.strip)
     end

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -27,9 +27,9 @@ class Property < ApplicationRecord
             inclusion:  { in: Canonical::Property::VALID_CITIES, message: 'must be a Skyrim city in which an ownable property is located', allow_blank: true },
             uniqueness: { scope: :game_id, message: 'must be unique per game if present', allow_blank: true }
 
-  validate :ensure_alchemy_lab_available,      if: -> { has_alchemy_lab == true && !canonical_property&.alchemy_lab_available }
+  validate :ensure_alchemy_lab_available, if: -> { has_alchemy_lab == true && !canonical_property&.alchemy_lab_available }
   validate :ensure_arcane_enchanter_available, if: -> { has_arcane_enchanter == true && !canonical_property&.arcane_enchanter_available }
-  validate :ensure_forge_available,            if: -> { has_forge == true && !canonical_property&.forge_available }
+  validate :ensure_forge_available, if: -> { has_forge == true && !canonical_property&.forge_available }
   validate :ensure_matches_canonical_property
 
   private

--- a/app/models/shopping_list.rb
+++ b/app/models/shopping_list.rb
@@ -35,8 +35,8 @@ class ShoppingList < ApplicationRecord
     if title.blank?
       max_existing_number = game.shopping_lists.where("title LIKE 'My List %'").pluck(:title).map {|t| t.gsub('My List ', '').to_i }
                               .max || 0
-      next_number         = max_existing_number >= 0 ? max_existing_number + 1 : 1
-      self.title          = "My List #{next_number}"
+      next_number = max_existing_number >= 0 ? max_existing_number + 1 : 1
+      self.title = "My List #{next_number}"
     else
       self.title = Titlecase.titleize(title.strip)
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,10 +8,10 @@ class User < ApplicationRecord
 
   def self.create_or_update_for_google(data)
     where(uid: data['localId']).first_or_initialize.tap do |user|
-      user.uid          = data['localId']
-      user.email        = data['email']
+      user.uid = data['localId']
+      user.email = data['email']
       user.display_name = data['displayName']
-      user.photo_url    = data['photoUrl']
+      user.photo_url = data['photoUrl']
       user.save!
     end
   end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -22,7 +22,7 @@ Rails.application.configure do
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
   if Rails.root.join('tmp', 'caching-dev.txt').exist?
-    config.cache_store                = :memory_store
+    config.cache_store = :memory_store
     config.public_file_server.headers = {
                                           'Cache-Control' => "public, max-age=#{2.days.to_i}",
                                         }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -70,9 +70,9 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
   if ENV['RAILS_LOG_TO_STDOUT'].present?
-    logger           = ActiveSupport::Logger.new($stdout)
+    logger = ActiveSupport::Logger.new($stdout)
     logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
+    config.logger = ActiveSupport::TaggedLogging.new(logger)
   end
 
   # Do not dump schema after migrations.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -25,9 +25,9 @@ Rails.application.configure do
                                       }
 
   # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
-  config.cache_store                       = :null_store
+  config.cache_store = :null_store
 
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false

--- a/db/migrate/20220429040232_create_canonical_enchantables_enchantments.rb
+++ b/db/migrate/20220429040232_create_canonical_enchantables_enchantments.rb
@@ -4,9 +4,9 @@ class CreateCanonicalEnchantablesEnchantments < ActiveRecord::Migration[6.1]
   def change
     create_table :canonical_enchantables_enchantments do |t|
       t.references :enchantment, null: false, foreign_key: true
-      t.bigint     :enchantable_id, null: false
-      t.string     :enchantable_type, null: false
-      t.decimal    :strength, scale: 2, precision: 5
+      t.bigint :enchantable_id, null: false
+      t.string :enchantable_type, null: false
+      t.decimal :strength, scale: 2, precision: 5
 
       t.index %i[enchantment_id enchantable_id enchantable_type], unique: true, name: 'index_enchantables_enchantments_on_enchmnt_id_enchble_id_type'
 

--- a/db/migrate/20220429060600_create_canonical_craftables_crafting_materials.rb
+++ b/db/migrate/20220429060600_create_canonical_craftables_crafting_materials.rb
@@ -7,13 +7,13 @@ class CreateCanonicalCraftablesCraftingMaterials < ActiveRecord::Migration[6.1]
                    null:        false,
                    foreign_key: { to_table: 'canonical_materials' },
                    index:       { name: :index_canonical_armors_smithing_mats_on_canonical_mat_id }
-      t.bigint     :craftable_id, null: false
-      t.string     :craftable_type, null: false
-      t.integer    :quantity,
-                   default: 1,
-                   null:    false
+      t.bigint :craftable_id, null: false
+      t.string :craftable_type, null: false
+      t.integer :quantity,
+                default: 1,
+                null:    false
 
-      t.index      %i[material_id craftable_id craftable_type], unique: true, name: 'index_can_craftables_crafting_materials_on_mat_id_and_craftable'
+      t.index %i[material_id craftable_id craftable_type], unique: true, name: 'index_can_craftables_crafting_materials_on_mat_id_and_craftable'
 
       t.timestamps
     end

--- a/db/migrate/20220429061411_create_canonical_temperables_tempering_materials.rb
+++ b/db/migrate/20220429061411_create_canonical_temperables_tempering_materials.rb
@@ -7,11 +7,11 @@ class CreateCanonicalTemperablesTemperingMaterials < ActiveRecord::Migration[6.1
                    null:        false,
                    foreign_key: { to_table: 'canonical_materials' },
                    index:       { name: :index_canonical_armors_tempering_mats_on_canonical_material_id }
-      t.bigint     :temperable_id, null: false
-      t.string     :temperable_type, null: false
-      t.integer    :quantity,
-                   default: 1,
-                   null:    false
+      t.bigint :temperable_id, null: false
+      t.string :temperable_type, null: false
+      t.integer :quantity,
+                default: 1,
+                null:    false
 
       t.index %i[material_id temperable_id temperable_type],
               unique: true,

--- a/lib/controller/response.rb
+++ b/lib/controller/response.rb
@@ -4,8 +4,8 @@ module Controller
   class Response
     def initialize(controller, result, options = {})
       @controller = controller
-      @result     = result
-      @options    = options
+      @result = result
+      @options = options
     end
 
     def execute

--- a/lib/service/result.rb
+++ b/lib/service/result.rb
@@ -2,7 +2,7 @@
 
 module Service
   class Result
-    ERROR_KEYS    = [:error, 'error', :errors, 'errors'].freeze
+    ERROR_KEYS = [:error, 'error', :errors, 'errors'].freeze
     RESOURCE_KEYS = [:resource, 'resource'].freeze
 
     attr_reader :errors, :resource

--- a/lib/tasks/export_csvs.rake
+++ b/lib/tasks/export_csvs.rake
@@ -19,7 +19,7 @@ namespace :csv do
     desc 'Export a CSV of canonical alchemical properties from JSON data'
     task alchemical_properties: :environment do
       json_path = Rails.root.join('lib', 'tasks', 'canonical_models', 'alchemical_properties.json')
-      csv_path  = Rails.root.join('lib', 'tasks', 'canonical_models', 'alchemical_properties.csv')
+      csv_path = Rails.root.join('lib', 'tasks', 'canonical_models', 'alchemical_properties.csv')
       json_data = JSON.parse(File.read(json_path), symbolize_names: true)
 
       headers = "name,description,strength_unit,effects_cumulative\n"
@@ -34,16 +34,16 @@ namespace :csv do
     desc 'Export a CSV of canonical armor items from JSON data'
     task armor: :environment do
       json_path = Rails.root.join('lib', 'tasks', 'canonical_models', 'canonical_armor.json')
-      csv_path  = Rails.root.join('lib', 'tasks', 'canonical_models', 'canonical_armor.csv')
+      csv_path = Rails.root.join('lib', 'tasks', 'canonical_models', 'canonical_armor.csv')
       json_data = JSON.parse(File.read(json_path), symbolize_names: true)
 
       own_property_headers = json_data.first[:attributes].keys.map(&:to_s).join(',')
-      headers              = "#{own_property_headers},enchantment_names,enchantment_strengths,tempering_material_codes,tempering_material_quantities,crafting_material_codes,crafting_material_quantities\n"
+      headers = "#{own_property_headers},enchantment_names,enchantment_strengths,tempering_material_codes,tempering_material_quantities,crafting_material_codes,crafting_material_quantities\n"
 
       csv_data = CSV.generate(headers) do |csv|
         json_data.each do |item|
-          enchantment_names, enchantment_strengths                = concatenate_values(item[:enchantments], :name, :strength)
-          crafting_material_codes, crafting_material_quantities   = concatenate_values(item[:crafting_materials], :item_code, :quantity)
+          enchantment_names, enchantment_strengths = concatenate_values(item[:enchantments], :name, :strength)
+          crafting_material_codes, crafting_material_quantities = concatenate_values(item[:crafting_materials], :item_code, :quantity)
           tempering_material_codes, tempering_material_quantities = concatenate_values(item[:tempering_materials], :item_code, :quantity)
 
           item[:attributes][:smithing_perks] = item[:attributes][:smithing_perks].join(',')
@@ -58,11 +58,11 @@ namespace :csv do
     desc 'Export a CSV of canonical books from JSON data'
     task books: :environment do
       json_path = Rails.root.join('lib', 'tasks', 'canonical_models', 'canonical_books.json')
-      csv_path  = Rails.root.join('lib', 'tasks', 'canonical_models', 'canonical_books.csv')
+      csv_path = Rails.root.join('lib', 'tasks', 'canonical_models', 'canonical_books.csv')
       json_data = JSON.parse(File.read(json_path), symbolize_names: true)
 
       own_property_headers = json_data.first[:attributes].keys.map(&:to_s).join(',')
-      headers              = "#{own_property_headers},canonical_ingredient_codes\n"
+      headers = "#{own_property_headers},canonical_ingredient_codes\n"
 
       csv_data = CSV.generate(headers) do |csv|
         json_data.each do |item|
@@ -91,11 +91,11 @@ namespace :csv do
     desc 'Export a CSV of canonical clothing items from JSON data'
     task clothing: :environment do
       json_path = Rails.root.join('lib', 'tasks', 'canonical_models', 'canonical_clothing.json')
-      csv_path  = Rails.root.join('lib', 'tasks', 'canonical_models', 'canonical_clothing.csv')
+      csv_path = Rails.root.join('lib', 'tasks', 'canonical_models', 'canonical_clothing.csv')
       json_data = JSON.parse(File.read(json_path), symbolize_names: true)
 
       own_property_headers = json_data.first[:attributes].keys.map(&:to_s).join(',')
-      headers              = "#{own_property_headers},enchantment_names,enchantment_strengths\n"
+      headers = "#{own_property_headers},enchantment_names,enchantment_strengths\n"
 
       csv_data = CSV.generate(headers) do |csv|
         json_data.each do |item|
@@ -109,11 +109,11 @@ namespace :csv do
     desc 'Export a CSV of canonical ingredients from JSON data'
     task ingredients: :environment do
       json_path = Rails.root.join('lib', 'tasks', 'canonical_models', 'canonical_ingredients.json')
-      csv_path  = Rails.root.join('lib', 'tasks', 'canonical_models', 'canonical_ingredients.csv')
+      csv_path = Rails.root.join('lib', 'tasks', 'canonical_models', 'canonical_ingredients.csv')
       json_data = JSON.parse(File.read(json_path), symbolize_names: true)
 
       own_property_headers = json_data.first[:attributes].keys.map(&:to_s).join(',')
-      headers              = "#{own_property_headers},alchemical_property_names,alchemical_property_priorities\n"
+      headers = "#{own_property_headers},alchemical_property_names,alchemical_property_priorities\n"
 
       csv_data = CSV.generate(headers) do |csv|
         json_data.each do |item|
@@ -127,11 +127,11 @@ namespace :csv do
     desc 'Export a CSV of canonical jewelry items from JSON data'
     task jewelry: :environment do
       json_path = Rails.root.join('lib', 'tasks', 'canonical_models', 'canonical_jewelry.json')
-      csv_path  = Rails.root.join('lib', 'tasks', 'canonical_models', 'canonical_jewelry.csv')
+      csv_path = Rails.root.join('lib', 'tasks', 'canonical_models', 'canonical_jewelry.csv')
       json_data = JSON.parse(File.read(json_path), symbolize_names: true)
 
       own_property_headers = json_data.first[:attributes].keys.map(&:to_s).join(',')
-      headers              = "#{own_property_headers},enchantment_names,enchantment_strengths,crafting_material_codes,crafting_material_quantities\n"
+      headers = "#{own_property_headers},enchantment_names,enchantment_strengths,crafting_material_codes,crafting_material_quantities\n"
 
       csv_data = CSV.generate(headers) do |csv|
         json_data.each do |item|
@@ -145,7 +145,7 @@ namespace :csv do
     desc 'Export a CSV of canonical materials from JSON data'
     task materials: :environment do
       json_path = Rails.root.join('lib', 'tasks', 'canonical_models', 'canonical_materials.json')
-      csv_path  = Rails.root.join('lib', 'tasks', 'canonical_models', 'canonical_materials.csv')
+      csv_path = Rails.root.join('lib', 'tasks', 'canonical_models', 'canonical_materials.csv')
       json_data = JSON.parse(File.read(json_path), symbolize_names: true)
 
       headers = "name,item_code,building_material,smithing_material,unit_weight\n"
@@ -160,7 +160,7 @@ namespace :csv do
     desc 'Export a CSV of canonical properties from JSON data'
     task properties: :environment do
       json_path = Rails.root.join('lib', 'tasks', 'canonical_models', 'canonical_properties.json')
-      csv_path  = Rails.root.join('lib', 'tasks', 'canonical_models', 'canonical_properties.csv')
+      csv_path = Rails.root.join('lib', 'tasks', 'canonical_models', 'canonical_properties.csv')
       json_data = JSON.parse(File.read(json_path), symbolize_names: true)
 
       headers = "name,hold,city,alchemy_lab_available,arcane_enchanter_available,forge_available\n"
@@ -175,11 +175,11 @@ namespace :csv do
     desc 'Export a CSV of canonical staves from JSON data'
     task staves: :environment do
       json_path = Rails.root.join('lib', 'tasks', 'canonical_models', 'canonical_staves.json')
-      csv_path  = Rails.root.join('lib', 'tasks', 'canonical_models', 'canonical_staves.csv')
+      csv_path = Rails.root.join('lib', 'tasks', 'canonical_models', 'canonical_staves.csv')
       json_data = JSON.parse(File.read(json_path), symbolize_names: true)
 
       own_property_headers = json_data.first[:attributes].keys.map(&:to_s).join(',')
-      headers              = "#{own_property_headers},spell_names,spell_strengths,power_names\n"
+      headers = "#{own_property_headers},spell_names,spell_strengths,power_names\n"
 
       csv_data = CSV.generate(headers) do |csv|
         json_data.each do |item|
@@ -196,18 +196,18 @@ namespace :csv do
     desc 'Export a CSV of canonical weapons from JSON data'
     task weapons: :environment do
       json_path = Rails.root.join('lib', 'tasks', 'canonical_models', 'canonical_weapons.json')
-      csv_path  = Rails.root.join('lib', 'tasks', 'canonical_models', 'canonical_weapons.csv')
+      csv_path = Rails.root.join('lib', 'tasks', 'canonical_models', 'canonical_weapons.csv')
       json_data = JSON.parse(File.read(json_path), symbolize_names: true)
 
       own_property_headers = json_data.first[:attributes].keys.map(&:to_s).join(',')
-      headers              = "#{own_property_headers},enchantment_names,enchantment_strengths,tempering_material_codes,tempering_material_quantities,crafting_material_codes,crafting_material_quantities\n"
+      headers = "#{own_property_headers},enchantment_names,enchantment_strengths,tempering_material_codes,tempering_material_quantities,crafting_material_codes,crafting_material_quantities\n"
 
       csv_data = CSV.generate(headers) do |csv|
         json_data.each do |item|
           item[:attributes][:smithing_perks] = item.dig(:attributes, :smithing_perks)&.join(',')
 
-          enchantment_names, enchantment_strengths                = concatenate_values(item[:enchantments], :name, :strength)
-          crafting_material_codes, crafting_material_quantities   = concatenate_values(item[:crafting_materials], :item_code, :quantity)
+          enchantment_names, enchantment_strengths = concatenate_values(item[:enchantments], :name, :strength)
+          crafting_material_codes, crafting_material_quantities = concatenate_values(item[:crafting_materials], :item_code, :quantity)
           tempering_material_codes, tempering_material_quantities = concatenate_values(item[:tempering_materials], :item_code, :quantity)
 
           csv << item[:attributes].values + [enchantment_names, enchantment_strengths, tempering_material_codes, tempering_material_quantities, crafting_material_codes, crafting_material_quantities]
@@ -220,7 +220,7 @@ namespace :csv do
     desc 'Export a CSV of enchantments from JSON data'
     task enchantments: :environment do
       json_path = Rails.root.join('lib', 'tasks', 'canonical_models', 'enchantments.json')
-      csv_path  = Rails.root.join('lib', 'tasks', 'canonical_models', 'enchantments.csv')
+      csv_path = Rails.root.join('lib', 'tasks', 'canonical_models', 'enchantments.csv')
       json_data = JSON.parse(File.read(json_path), symbolize_names: true)
 
       headers = "#{json_data.first[:attributes].keys.map(&:to_s).join(',')}\n"
@@ -239,7 +239,7 @@ namespace :csv do
     desc 'Export a CSV of powers from JSON data'
     task powers: :environment do
       json_path = Rails.root.join('lib', 'tasks', 'canonical_models', 'powers.json')
-      csv_path  = Rails.root.join('lib', 'tasks', 'canonical_models', 'powers.csv')
+      csv_path = Rails.root.join('lib', 'tasks', 'canonical_models', 'powers.csv')
       json_data = JSON.parse(File.read(json_path), symbolize_names: true)
 
       headers = "#{json_data.first[:attributes].keys.map(&:to_s).join(',')}\n"
@@ -254,7 +254,7 @@ namespace :csv do
     desc 'Export a CSV of spells from JSON data'
     task spells: :environment do
       json_path = Rails.root.join('lib', 'tasks', 'canonical_models', 'spells.json')
-      csv_path  = Rails.root.join('lib', 'tasks', 'canonical_models', 'spells.csv')
+      csv_path = Rails.root.join('lib', 'tasks', 'canonical_models', 'spells.csv')
       json_data = JSON.parse(File.read(json_path), symbolize_names: true)
 
       headers = "#{json_data.first[:attributes].keys.map(&:to_s).join(',')}\n"
@@ -269,7 +269,7 @@ namespace :csv do
     desc 'Export a CSV of canonical misc items from JSON data'
     task misc_items: :environment do
       json_path = Rails.root.join('lib', 'tasks', 'canonical_models', 'canonical_misc_items.json')
-      csv_path  = Rails.root.join('lib', 'tasks', 'canonical_models', 'canonical_misc_items.csv')
+      csv_path = Rails.root.join('lib', 'tasks', 'canonical_models', 'canonical_misc_items.csv')
       json_data = JSON.parse(File.read(json_path), symbolize_names: true)
 
       headers = "#{json_data.first[:attributes].keys.map(&:to_s).join(',')}\n"
@@ -288,11 +288,11 @@ namespace :csv do
     desc 'Export a CSV of canonical potions from JSON data'
     task potions: :environment do
       json_path = Rails.root.join('lib', 'tasks', 'canonical_models', 'canonical_potions.json')
-      csv_path  = Rails.root.join('lib', 'tasks', 'canonical_models', 'canonical_potions.csv')
+      csv_path = Rails.root.join('lib', 'tasks', 'canonical_models', 'canonical_potions.csv')
       json_data = JSON.parse(File.read(json_path), symbolize_names: true)
 
       own_property_headers = json_data.first[:attributes].keys.map(&:to_s).join(',')
-      headers              = "#{own_property_headers},alchemical_property_names,alchemical_property_strengths,alchemical_property_durations\n"
+      headers = "#{own_property_headers},alchemical_property_names,alchemical_property_strengths,alchemical_property_durations\n"
 
       csv_data = CSV.generate(headers) do |csv|
         json_data.each do |item|

--- a/spec/controller_services/application_controller/authorization_service_spec.rb
+++ b/spec/controller_services/application_controller/authorization_service_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe ApplicationController::AuthorizationService do
   describe '#perform' do
     subject(:perform) { described_class.new(controller, token).perform }
 
-    let(:controller)           { instance_double(ApplicationController) }
-    let(:faraday)              { instance_double(Faraday::Connection, post: google_auth_response) }
+    let(:controller) { instance_double(ApplicationController) }
+    let(:faraday) { instance_double(Faraday::Connection, post: google_auth_response) }
     let(:google_auth_response) { instance_double(Faraday::Response, status:, body:, success?: success) }
-    let(:token)                { 'xxxxxxx' }
+    let(:token) { 'xxxxxxx' }
 
     before do
       allow(Faraday).to receive(:new).and_return(faraday)
@@ -19,9 +19,9 @@ RSpec.describe ApplicationController::AuthorizationService do
 
     context 'when the token is nil' do
       let(:token) { nil }
-      let(:status)  { nil }
+      let(:status) { nil }
       let(:success) { nil }
-      let(:body)    { nil }
+      let(:body) { nil }
 
       it 'returns a Service::UnauthorizedResult' do
         expect(perform).to be_a(Service::UnauthorizedResult)
@@ -38,7 +38,7 @@ RSpec.describe ApplicationController::AuthorizationService do
     end
 
     context 'when login is successful' do
-      let(:status)  { 200 }
+      let(:status) { 200 }
       let(:success) { true }
       let(:body) do
         File.read(
@@ -110,7 +110,7 @@ RSpec.describe ApplicationController::AuthorizationService do
     end
 
     context 'when an unexpected response body is returned' do
-      let(:status)  { 200 }
+      let(:status) { 200 }
       let(:success) { true }
 
       before do
@@ -236,7 +236,7 @@ RSpec.describe ApplicationController::AuthorizationService do
     end
 
     context 'when a non-200-range response is returned' do
-      let(:status)  { 400 }
+      let(:status) { 400 }
       let(:success) { false }
 
       # Note: We don't actually know what an unsuccessful response body would look like
@@ -282,9 +282,9 @@ RSpec.describe ApplicationController::AuthorizationService do
     end
 
     context 'when an unexpected error is raised' do
-      let(:status)  { 200 }
+      let(:status) { 200 }
       let(:success) { true }
-      let(:body)    { 'oops' }
+      let(:body) { 'oops' }
 
       before do
         allow(Rails.logger).to receive(:error)

--- a/spec/controller_services/games_controller/update_service_spec.rb
+++ b/spec/controller_services/games_controller/update_service_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe GamesController::UpdateService do
     subject(:perform) { described_class.new(user, game.id, params).perform }
 
     context 'when all goes well' do
-      let!(:user)  { create(:user) }
-      let!(:game)  { create(:game, user:) }
+      let!(:user) { create(:user) }
+      let!(:game) { create(:game, user:) }
       let(:params) { { description: 'New description' } }
 
       it 'updates the game' do
@@ -30,10 +30,10 @@ RSpec.describe GamesController::UpdateService do
     end
 
     context 'when the params are invalid' do
-      let!(:user)       { create(:user) }
-      let!(:game)       { create(:game, user:) }
+      let!(:user) { create(:user) }
+      let!(:game) { create(:game, user:) }
       let!(:other_game) { create(:game, user:) }
-      let(:params)      { { name: other_game.name } }
+      let(:params) { { name: other_game.name } }
 
       it "doesn't update the game" do
         perform
@@ -50,8 +50,8 @@ RSpec.describe GamesController::UpdateService do
     end
 
     context "when the game doesn't exist" do
-      let(:user)   { create(:user) }
-      let(:game)   { double(id: 823_589) }
+      let(:user) { create(:user) }
+      let(:game) { double(id: 823_589) }
       let(:params) { { description: 'New description' } }
 
       it 'returns a Service::NotFoundResult' do
@@ -66,7 +66,7 @@ RSpec.describe GamesController::UpdateService do
 
     context 'when the game belongs to another user' do
       let!(:user) { create(:user) }
-      let!(:game)  { create(:game) }
+      let!(:game) { create(:game) }
       let(:params) { { name: 'Valid name' } }
 
       it "doesn't update the game" do
@@ -80,8 +80,8 @@ RSpec.describe GamesController::UpdateService do
     end
 
     context 'when something unexpected goes wrong' do
-      let!(:user)  { create(:user) }
-      let(:game)   { create(:game, user:) }
+      let!(:user) { create(:user) }
+      let(:game) { create(:game, user:) }
       let(:params) { { description: 'New description' } }
 
       before do

--- a/spec/controller_services/inventory_items_controller/create_service_spec.rb
+++ b/spec/controller_services/inventory_items_controller/create_service_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe InventoryItemsController::CreateService do
   describe '#perform' do
     subject(:perform) { described_class.new(user, inventory_list.id, params).perform }
 
-    let(:user)            { create(:user) }
-    let(:game)            { create(:game, user:) }
+    let(:user) { create(:user) }
+    let(:game) { create(:game, user:) }
     let!(:aggregate_list) { create(:aggregate_inventory_list, game:) }
     let!(:inventory_list) { create(:inventory_list, game:, aggregate_list:) }
 
@@ -41,7 +41,7 @@ RSpec.describe InventoryItemsController::CreateService do
         end
 
         context 'when there is an existing matching item on another list' do
-          let(:other_list)  { create(:inventory_list, game: aggregate_list.game, aggregate_list:) }
+          let(:other_list) { create(:inventory_list, game: aggregate_list.game, aggregate_list:) }
           let!(:other_item) { create(:inventory_item, list: other_list, description: 'Necklace', quantity: 1) }
 
           before do
@@ -102,9 +102,9 @@ RSpec.describe InventoryItemsController::CreateService do
       end
 
       context 'when there is an existing matching item on the same list' do
-        let(:other_list)  { create(:inventory_list, game:) }
+        let(:other_list) { create(:inventory_list, game:) }
         let!(:other_item) { create(:inventory_item, list: other_list, description: 'Necklace', quantity: 2) }
-        let!(:list_item)  { create(:inventory_item, list: inventory_list, description: 'Necklace', quantity: 1) }
+        let!(:list_item) { create(:inventory_item, list: inventory_list, description: 'Necklace', quantity: 1) }
 
         before do
           aggregate_list.add_item_from_child_list(other_item)
@@ -176,7 +176,7 @@ RSpec.describe InventoryItemsController::CreateService do
     end
 
     context "when the list doesn't exist" do
-      let(:params)         { { description: 'Necklace', quantity: 4, unit_weight: 0.5 } }
+      let(:params) { { description: 'Necklace', quantity: 4, unit_weight: 0.5 } }
       let(:inventory_list) { double(id: 234_980) }
 
       it 'returns a Service::NotFoundResult' do
@@ -190,7 +190,7 @@ RSpec.describe InventoryItemsController::CreateService do
     end
 
     context 'when the list belongs to another user' do
-      let(:params)          { { description: 'Necklace', quantity: 4, unit_weight: 0.5 } }
+      let(:params) { { description: 'Necklace', quantity: 4, unit_weight: 0.5 } }
       let!(:inventory_list) { create(:inventory_list) }
 
       it "doesn't create an inventory item" do
@@ -221,8 +221,8 @@ RSpec.describe InventoryItemsController::CreateService do
     end
 
     context 'when the list is an aggregate list' do
-      let(:inventory_list)  { aggregate_list }
-      let!(:params)         { { description: 'Necklace', quantity: 2 } }
+      let(:inventory_list) { aggregate_list }
+      let!(:params) { { description: 'Necklace', quantity: 2 } }
 
       it "doesn't create an item" do
         expect { perform }

--- a/spec/controller_services/inventory_items_controller/destroy_service_spec.rb
+++ b/spec/controller_services/inventory_items_controller/destroy_service_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe InventoryItemsController::DestroyService do
       end
 
       context 'when there is a matching item on another list' do
-        let!(:list_item)  { create(:inventory_item, list: inventory_list) }
-        let(:other_list)  { create(:inventory_list, game:) }
+        let!(:list_item) { create(:inventory_item, list: inventory_list) }
+        let(:other_list) { create(:inventory_list, game:) }
         let!(:other_item) { create(:inventory_item, description: list_item.description, list: other_list) }
 
         before do

--- a/spec/controller_services/inventory_items_controller/update_service_spec.rb
+++ b/spec/controller_services/inventory_items_controller/update_service_spec.rb
@@ -11,16 +11,16 @@ RSpec.describe InventoryItemsController::UpdateService do
   describe '#perform' do
     subject(:perform) { described_class.new(user, list_item.id, params).perform }
 
-    let(:user)            { create(:user) }
-    let(:game)            { create(:game, user:) }
+    let(:user) { create(:user) }
+    let(:game) { create(:game, user:) }
     let!(:aggregate_list) { create(:aggregate_inventory_list, game:) }
     let!(:inventory_list) { create(:inventory_list, game:, aggregate_list:) }
 
     context 'when all goes well' do
       context 'when there is no matching item on another list' do
-        let!(:list_item)          { create(:inventory_item, list: inventory_list, description: 'Dwarven metal ingot', quantity: 2) }
+        let!(:list_item) { create(:inventory_item, list: inventory_list, description: 'Dwarven metal ingot', quantity: 2) }
         let(:aggregate_list_item) { aggregate_list.list_items.first }
-        let(:params)              { { quantity: 9, notes: 'To make bolts with' } }
+        let(:params) { { quantity: 9, notes: 'To make bolts with' } }
 
         before do
           aggregate_list.add_item_from_child_list(list_item)
@@ -48,9 +48,9 @@ RSpec.describe InventoryItemsController::UpdateService do
       end
 
       context 'when there is a matching item on another list' do
-        let!(:list_item)          { create(:inventory_item, list: inventory_list, quantity: 4) }
-        let(:other_list)          { create(:inventory_list, game:, aggregate_list:) }
-        let!(:other_item)         { create(:inventory_item, description: list_item.description, list: other_list, quantity: 3) }
+        let!(:list_item) { create(:inventory_item, list: inventory_list, quantity: 4) }
+        let(:other_list) { create(:inventory_list, game:, aggregate_list:) }
+        let!(:other_item) { create(:inventory_item, description: list_item.description, list: other_list, quantity: 3) }
         let(:aggregate_list_item) { aggregate_list.list_items.first }
 
         before do
@@ -114,7 +114,7 @@ RSpec.describe InventoryItemsController::UpdateService do
 
     context "when the inventory list item doesn't exist" do
       let(:list_item) { double(id: 3_459_250) }
-      let(:params)    { { quantity: 4 } }
+      let(:params) { { quantity: 4 } }
 
       it 'returns a Service::NotFoundResult' do
         expect(perform).to be_a(Service::NotFoundResult)
@@ -128,7 +128,7 @@ RSpec.describe InventoryItemsController::UpdateService do
 
     context 'when the inventory list item belongs to another user' do
       let!(:list_item) { create(:inventory_item) }
-      let(:params)     { { quantity: 4 } }
+      let(:params) { { quantity: 4 } }
 
       it "doesn't update the item" do
         expect { perform }
@@ -147,7 +147,7 @@ RSpec.describe InventoryItemsController::UpdateService do
 
     context 'when the item is on an aggregate list' do
       let!(:list_item) { create(:inventory_item, list: aggregate_list) }
-      let(:params)     { { quantity: 5 } }
+      let(:params) { { quantity: 5 } }
 
       it 'returns a Service::MethodNotAllowedResult' do
         expect(perform).to be_a(Service::MethodNotAllowedResult)
@@ -159,11 +159,11 @@ RSpec.describe InventoryItemsController::UpdateService do
     end
 
     context 'when the attributes are invalid' do
-      let!(:list_item)          { create(:inventory_item, list: inventory_list, quantity: 2) }
-      let(:other_list)          { create(:inventory_list, game:) }
-      let!(:other_item)         { create(:inventory_item, list: other_list, description: list_item.description, quantity: 1) }
+      let!(:list_item) { create(:inventory_item, list: inventory_list, quantity: 2) }
+      let(:other_list) { create(:inventory_list, game:) }
+      let!(:other_item) { create(:inventory_item, list: other_list, description: list_item.description, quantity: 1) }
       let(:aggregate_list_item) { aggregate_list.list_items.first }
-      let(:params)              { { quantity: -4, unit_weight: 2 } }
+      let(:params) { { quantity: -4, unit_weight: 2 } }
 
       before do
         aggregate_list.add_item_from_child_list(list_item)
@@ -192,7 +192,7 @@ RSpec.describe InventoryItemsController::UpdateService do
 
     context 'when there is an unexpected error' do
       let!(:list_item) { create(:inventory_item, list: inventory_list) }
-      let(:params)     { { notes: 'Hello world' } }
+      let(:params) { { notes: 'Hello world' } }
 
       before do
         aggregate_list.add_item_from_child_list(list_item)

--- a/spec/controller_services/inventory_lists_controller/create_service_spec.rb
+++ b/spec/controller_services/inventory_lists_controller/create_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe InventoryListsController::CreateService do
     let(:user) { create(:user) }
 
     context 'when the params are valid' do
-      let!(:game)  { create(:game, user:) }
+      let!(:game) { create(:game, user:) }
       let(:params) { { title: 'Hjerim' } }
 
       context 'when the game has no aggregate inventory list' do
@@ -70,9 +70,9 @@ RSpec.describe InventoryListsController::CreateService do
     end
 
     context 'when the params are invalid' do
-      let(:game)    { create(:game, user:) }
+      let(:game) { create(:game, user:) }
       let(:game_id) { game.id }
-      let(:params)  { { title: '|nvalid Tit|e' } }
+      let(:params) { { title: '|nvalid Tit|e' } }
 
       it "doesn't create an inventory list" do
         expect { perform }
@@ -89,7 +89,7 @@ RSpec.describe InventoryListsController::CreateService do
     end
 
     context 'when the game is not found' do
-      let(:game)   { double(id: 898_243) }
+      let(:game) { double(id: 898_243) }
       let(:params) { { title: 'My Inventory List' } }
 
       it 'returns a Service::NotFoundResult' do
@@ -102,7 +102,7 @@ RSpec.describe InventoryListsController::CreateService do
     end
 
     context 'when the game belongs to another user' do
-      let!(:game)  { create(:game) }
+      let!(:game) { create(:game) }
       let(:params) { { title: 'My Inventory List' } }
 
       it "doesn't create an inventory list" do
@@ -139,7 +139,7 @@ RSpec.describe InventoryListsController::CreateService do
     end
 
     context 'when something unexpected goes wrong' do
-      let(:game)   { create(:game, user:) }
+      let(:game) { create(:game, user:) }
       let(:params) { { title: 'Foobar' } }
 
       before do

--- a/spec/controller_services/inventory_lists_controller/update_service_spec.rb
+++ b/spec/controller_services/inventory_lists_controller/update_service_spec.rb
@@ -12,12 +12,12 @@ RSpec.describe InventoryListsController::UpdateService do
     subject(:perform) { described_class.new(user, inventory_list.id, params).perform }
 
     let!(:aggregate_list) { create(:aggregate_inventory_list, game:) }
-    let(:user)            { create(:user) }
-    let(:game)            { create(:game, user:) }
+    let(:user) { create(:user) }
+    let(:game) { create(:game, user:) }
 
     context 'when all goes well' do
       let(:inventory_list) { create(:inventory_list, game:, aggregate_list:) }
-      let(:params)         { { title: 'My New Title' } }
+      let(:params) { { title: 'My New Title' } }
 
       it 'updates the inventory list' do
         perform
@@ -43,7 +43,7 @@ RSpec.describe InventoryListsController::UpdateService do
 
     context 'when the params are invalid' do
       let(:inventory_list) { create(:inventory_list, game:) }
-      let(:params)         { { title: '|nvalid Tit|e' } }
+      let(:params) { { title: '|nvalid Tit|e' } }
 
       it 'returns a Service::UnprocessableEntityResult' do
         expect(perform).to be_a(Service::UnprocessableEntityResult)
@@ -56,7 +56,7 @@ RSpec.describe InventoryListsController::UpdateService do
 
     context "when the inventory list doesn't exist" do
       let(:inventory_list) { double(id: 23_859) }
-      let(:params)         { { title: 'Valid New Title' } }
+      let(:params) { { title: 'Valid New Title' } }
 
       it 'returns a Service::NotFoundResult' do
         expect(perform).to be_a(Service::NotFoundResult)
@@ -70,7 +70,7 @@ RSpec.describe InventoryListsController::UpdateService do
 
     context 'when the inventory list belongs to another user' do
       let!(:inventory_list) { create(:inventory_list) }
-      let(:params)          { { title: 'Valid New Title' } }
+      let(:params) { { title: 'Valid New Title' } }
 
       it "doesn't update the inventory list" do
         expect { perform }
@@ -89,7 +89,7 @@ RSpec.describe InventoryListsController::UpdateService do
 
     context 'when the inventory list is an aggregate list' do
       let(:inventory_list) { aggregate_list }
-      let(:params)         { { title: 'New Title' } }
+      let(:params) { { title: 'New Title' } }
 
       it 'returns a Service::MethodNotAllowedResult' do
         expect(perform).to be_a(Service::MethodNotAllowedResult)
@@ -102,7 +102,7 @@ RSpec.describe InventoryListsController::UpdateService do
 
     context 'when the request tries to set aggregate to true' do
       let(:inventory_list) { create(:inventory_list, game:) }
-      let(:params)         { { aggregate: true } }
+      let(:params) { { aggregate: true } }
 
       it 'returns a Service::UnprocessableEntityResult' do
         expect(perform).to be_a(Service::UnprocessableEntityResult)
@@ -115,7 +115,7 @@ RSpec.describe InventoryListsController::UpdateService do
 
     context 'when something unexpected goes wrong' do
       let(:inventory_list) { create(:inventory_list, game:) }
-      let(:params)         { { title: 'New Title' } }
+      let(:params) { { title: 'New Title' } }
 
       before do
         allow_any_instance_of(InventoryList).to receive(:update).and_raise(StandardError, 'Something went horribly wrong')

--- a/spec/controller_services/shopping_list_items_controller/create_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/create_service_spec.rb
@@ -11,10 +11,10 @@ RSpec.describe ShoppingListItemsController::CreateService do
   describe '#perform' do
     subject(:perform) { described_class.new(user, shopping_list.id, params).perform }
 
-    let(:user)            { create(:user) }
-    let(:game)            { create(:game, user:) }
+    let(:user) { create(:user) }
+    let(:game) { create(:game, user:) }
     let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
-    let!(:shopping_list)  { create(:shopping_list, game:, aggregate_list:) }
+    let!(:shopping_list) { create(:shopping_list, game:, aggregate_list:) }
 
     context 'when all goes well' do
       let(:params) { { description: 'Necklace', quantity: 2, notes: 'Hello world' } }
@@ -41,7 +41,7 @@ RSpec.describe ShoppingListItemsController::CreateService do
         end
 
         context 'when there is an existing matching item on another list' do
-          let(:other_list)  { create(:shopping_list, game: aggregate_list.game, aggregate_list:) }
+          let(:other_list) { create(:shopping_list, game: aggregate_list.game, aggregate_list:) }
           let!(:other_item) { create(:shopping_list_item, list: other_list, description: 'Necklace', quantity: 1) }
 
           before do
@@ -102,9 +102,9 @@ RSpec.describe ShoppingListItemsController::CreateService do
       end
 
       context 'when there is an existing matching item on the same list' do
-        let(:other_list)  { create(:shopping_list, game:) }
+        let(:other_list) { create(:shopping_list, game:) }
         let!(:other_item) { create(:shopping_list_item, list: other_list, description: 'Necklace', quantity: 2) }
-        let!(:list_item)  { create(:shopping_list_item, list: shopping_list, description: 'Necklace', quantity: 1) }
+        let!(:list_item) { create(:shopping_list_item, list: shopping_list, description: 'Necklace', quantity: 1) }
 
         before do
           aggregate_list.add_item_from_child_list(other_item)
@@ -176,8 +176,8 @@ RSpec.describe ShoppingListItemsController::CreateService do
     end
 
     context "when the list doesn't exist" do
-      let(:params)         { { description: 'Necklace', quantity: 4, unit_weight: 0.5 } }
-      let(:shopping_list)  { double(id: 234_980) }
+      let(:params) { { description: 'Necklace', quantity: 4, unit_weight: 0.5 } }
+      let(:shopping_list) { double(id: 234_980) }
 
       it 'returns a Service::NotFoundResult' do
         expect(perform).to be_a(Service::NotFoundResult)
@@ -190,8 +190,8 @@ RSpec.describe ShoppingListItemsController::CreateService do
     end
 
     context 'when the list belongs to another user' do
-      let(:params)          { { description: 'Necklace', quantity: 4, unit_weight: 0.5 } }
-      let!(:shopping_list)  { create(:shopping_list) }
+      let(:params) { { description: 'Necklace', quantity: 4, unit_weight: 0.5 } }
+      let!(:shopping_list) { create(:shopping_list) }
 
       it "doesn't create a list item" do
         expect { perform }
@@ -221,8 +221,8 @@ RSpec.describe ShoppingListItemsController::CreateService do
     end
 
     context 'when the list is an aggregate list' do
-      let(:shopping_list)   { aggregate_list }
-      let!(:params)         { { description: 'Necklace', quantity: 2 } }
+      let(:shopping_list) { aggregate_list }
+      let!(:params) { { description: 'Necklace', quantity: 2 } }
 
       it "doesn't create an item" do
         expect { perform }

--- a/spec/controller_services/shopping_list_items_controller/destroy_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/destroy_service_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe ShoppingListItemsController::DestroyService do
   describe '#perform' do
     subject(:perform) { described_class.new(user, list_item.id).perform }
 
-    let(:game)            { create(:game) }
+    let(:game) { create(:game) }
     let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
-    let!(:shopping_list)  { create(:shopping_list, game:, aggregate_list:) }
+    let!(:shopping_list) { create(:shopping_list, game:, aggregate_list:) }
 
     context 'when all goes well' do
       let(:list_item) { create(:shopping_list_item, list: shopping_list, notes: 'some notes') }
@@ -125,7 +125,7 @@ RSpec.describe ShoppingListItemsController::DestroyService do
     end
 
     context 'when the specified list item belongs to another user' do
-      let(:user)       { game.user }
+      let(:user) { game.user }
       let!(:list_item) { create(:shopping_list_item) }
 
       it "doesn't destroy the list item" do

--- a/spec/controller_services/shopping_list_items_controller/update_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/update_service_spec.rb
@@ -11,16 +11,16 @@ RSpec.describe ShoppingListItemsController::UpdateService do
   describe '#perform' do
     subject(:perform) { described_class.new(user, list_item.id, params).perform }
 
-    let(:user)            { create(:user) }
-    let(:game)            { create(:game, user:) }
+    let(:user) { create(:user) }
+    let(:game) { create(:game, user:) }
     let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
-    let!(:shopping_list)  { create(:shopping_list, game:, aggregate_list:) }
+    let!(:shopping_list) { create(:shopping_list, game:, aggregate_list:) }
 
     context 'when all goes well' do
       context 'when there is no matching item on another list' do
-        let!(:list_item)          { create(:shopping_list_item, list: shopping_list, description: 'Dwarven metal ingot', quantity: 2) }
+        let!(:list_item) { create(:shopping_list_item, list: shopping_list, description: 'Dwarven metal ingot', quantity: 2) }
         let(:aggregate_list_item) { aggregate_list.list_items.first }
-        let(:params)              { { quantity: 9, notes: 'To make bolts with' } }
+        let(:params) { { quantity: 9, notes: 'To make bolts with' } }
 
         before do
           aggregate_list.add_item_from_child_list(list_item)
@@ -48,9 +48,9 @@ RSpec.describe ShoppingListItemsController::UpdateService do
       end
 
       context 'when there is a matching item on another list' do
-        let!(:list_item)          { create(:shopping_list_item, list: shopping_list, quantity: 4) }
-        let(:other_list)          { create(:shopping_list, game:, aggregate_list:) }
-        let!(:other_item)         { create(:shopping_list_item, description: list_item.description, list: other_list, quantity: 3) }
+        let!(:list_item) { create(:shopping_list_item, list: shopping_list, quantity: 4) }
+        let(:other_list) { create(:shopping_list, game:, aggregate_list:) }
+        let!(:other_item) { create(:shopping_list_item, description: list_item.description, list: other_list, quantity: 3) }
         let(:aggregate_list_item) { aggregate_list.list_items.first }
 
         before do
@@ -114,7 +114,7 @@ RSpec.describe ShoppingListItemsController::UpdateService do
 
     context "when the shopping list item doesn't exist" do
       let(:list_item) { double(id: 3_459_250) }
-      let(:params)    { { quantity: 4 } }
+      let(:params) { { quantity: 4 } }
 
       it 'returns a Service::NotFoundResult' do
         expect(perform).to be_a(Service::NotFoundResult)
@@ -128,7 +128,7 @@ RSpec.describe ShoppingListItemsController::UpdateService do
 
     context 'when the shopping list item belongs to another user' do
       let!(:list_item) { create(:shopping_list_item) }
-      let(:params)     { { quantity: 4 } }
+      let(:params) { { quantity: 4 } }
 
       it "doesn't update the item" do
         expect { perform }
@@ -147,7 +147,7 @@ RSpec.describe ShoppingListItemsController::UpdateService do
 
     context 'when the item is on an aggregate list' do
       let!(:list_item) { create(:shopping_list_item, list: aggregate_list) }
-      let(:params)     { { quantity: 5 } }
+      let(:params) { { quantity: 5 } }
 
       it 'returns a Service::MethodNotAllowedResult' do
         expect(perform).to be_a(Service::MethodNotAllowedResult)
@@ -159,11 +159,11 @@ RSpec.describe ShoppingListItemsController::UpdateService do
     end
 
     context 'when the attributes are invalid' do
-      let!(:list_item)          { create(:shopping_list_item, list: shopping_list, quantity: 2) }
-      let(:other_list)          { create(:shopping_list, game:) }
-      let!(:other_item)         { create(:shopping_list_item, list: other_list, description: list_item.description, quantity: 1) }
+      let!(:list_item) { create(:shopping_list_item, list: shopping_list, quantity: 2) }
+      let(:other_list) { create(:shopping_list, game:) }
+      let!(:other_item) { create(:shopping_list_item, list: other_list, description: list_item.description, quantity: 1) }
       let(:aggregate_list_item) { aggregate_list.list_items.first }
-      let(:params)              { { quantity: -4, unit_weight: 2 } }
+      let(:params) { { quantity: -4, unit_weight: 2 } }
 
       before do
         aggregate_list.add_item_from_child_list(list_item)
@@ -192,7 +192,7 @@ RSpec.describe ShoppingListItemsController::UpdateService do
 
     context 'when there is an unexpected error' do
       let!(:list_item) { create(:shopping_list_item, list: shopping_list) }
-      let(:params)     { { notes: 'Hello world' } }
+      let(:params) { { notes: 'Hello world' } }
 
       before do
         aggregate_list.add_item_from_child_list(list_item)

--- a/spec/controller_services/shopping_lists_controller/create_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/create_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ShoppingListsController::CreateService do
     let(:user) { create(:user) }
 
     context 'when the game is not found' do
-      let(:game)   { double(id: 898_243) }
+      let(:game) { double(id: 898_243) }
       let(:params) { { title: 'My Shopping List' } }
 
       it 'returns a Service::NotFoundResult' do
@@ -27,7 +27,7 @@ RSpec.describe ShoppingListsController::CreateService do
     end
 
     context 'when the game belongs to another user' do
-      let(:game)   { create(:game) }
+      let(:game) { create(:game) }
       let(:params) { { title: 'My Shopping List' } }
 
       it "doesn't create a shopping list" do
@@ -64,7 +64,7 @@ RSpec.describe ShoppingListsController::CreateService do
     end
 
     context 'when params are valid' do
-      let!(:game)  { create(:game, user:) }
+      let!(:game) { create(:game, user:) }
       let(:params) { { title: 'Proudspire Manor' } }
 
       context 'when the game has an aggregate shopping list' do
@@ -129,9 +129,9 @@ RSpec.describe ShoppingListsController::CreateService do
     end
 
     context 'when params are invalid' do
-      let(:game)    { create(:game, user:) }
+      let(:game) { create(:game, user:) }
       let(:game_id) { game.id }
-      let(:params)  { { title: '|nvalid Tit|e' } }
+      let(:params) { { title: '|nvalid Tit|e' } }
 
       it 'does not create a shopping list' do
         expect { perform }
@@ -148,7 +148,7 @@ RSpec.describe ShoppingListsController::CreateService do
     end
 
     context 'when something unexpected goes wrong' do
-      let(:game)   { create(:game, user:) }
+      let(:game) { create(:game, user:) }
       let(:params) { { title: 'Foobar' } }
 
       before do

--- a/spec/controller_services/shopping_lists_controller/destroy_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/destroy_service_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe ShoppingListsController::DestroyService do
 
     context 'when all goes well' do
       let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
-      let!(:shopping_list)  { create(:shopping_list_with_list_items, game:) }
-      let(:game)            { create(:game, user:) }
+      let!(:shopping_list) { create(:shopping_list_with_list_items, game:) }
+      let(:game) { create(:game, user:) }
 
       context 'when the game has additional regular lists' do
         let!(:third_list) { create(:shopping_list, game:, aggregate_list:) }
@@ -100,7 +100,7 @@ RSpec.describe ShoppingListsController::DestroyService do
 
     context 'when the list is an aggregate list' do
       let!(:shopping_list) { create(:aggregate_shopping_list, game:) }
-      let(:game)           { create(:game, user:) }
+      let(:game) { create(:game, user:) }
 
       it 'returns a Service::MethodNotAllowedResult' do
         expect(perform).to be_a(Service::MethodNotAllowedResult)
@@ -144,7 +144,7 @@ RSpec.describe ShoppingListsController::DestroyService do
 
     context 'when something unexpected goes wrong' do
       let!(:shopping_list) { create(:shopping_list, game:) }
-      let(:game)           { create(:game, user:) }
+      let(:game) { create(:game, user:) }
 
       before do
         allow_any_instance_of(ShoppingList).to receive(:aggregate_list).and_raise(StandardError.new('Something went horribly wrong'))

--- a/spec/controller_services/shopping_lists_controller/index_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/index_service_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe ShoppingListsController::IndexService do
     end
 
     context 'when there are no shopping lists for that game' do
-      let(:game)    { create(:game, user:) }
+      let(:game) { create(:game, user:) }
       let(:game_id) { game.id }
 
       it 'returns a Service::OKResult' do

--- a/spec/controller_services/shopping_lists_controller/update_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/update_service_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe ShoppingListsController::UpdateService do
     subject(:perform) { described_class.new(user, shopping_list.id, params).perform }
 
     let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
-    let(:user)            { create(:user) }
+    let(:user) { create(:user) }
 
     context 'when all goes well' do
       let(:shopping_list) { create(:shopping_list, game:, aggregate_list:) }
-      let(:game)   { create(:game, user:) }
+      let(:game) { create(:game, user:) }
       let(:params) { { title: 'My New Title' } }
 
       it 'updates the shopping list' do
@@ -43,8 +43,8 @@ RSpec.describe ShoppingListsController::UpdateService do
 
     context 'when the params are invalid' do
       let(:shopping_list) { create(:shopping_list, game:) }
-      let(:game)          { create(:game, user:) }
-      let(:params)        { { title: '|nvalid Tit|e' } }
+      let(:game) { create(:game, user:) }
+      let(:params) { { title: '|nvalid Tit|e' } }
 
       it 'returns a Service::UnprocessableEntityResult' do
         expect(perform).to be_a(Service::UnprocessableEntityResult)
@@ -57,8 +57,8 @@ RSpec.describe ShoppingListsController::UpdateService do
 
     context "when the shopping list doesn't exist" do
       let(:shopping_list) { double(id: 23_859) }
-      let(:game)          { create(:game) }
-      let(:params)        { { title: 'Valid New Title' } }
+      let(:game) { create(:game) }
+      let(:params) { { title: 'Valid New Title' } }
 
       it 'returns a Service::NotFoundResult' do
         expect(perform).to be_a(Service::NotFoundResult)
@@ -72,8 +72,8 @@ RSpec.describe ShoppingListsController::UpdateService do
 
     context 'when the shopping list belongs to another user' do
       let!(:shopping_list) { create(:shopping_list) }
-      let(:game)           { create(:game) }
-      let(:params)         { { title: 'Valid New Title' } }
+      let(:game) { create(:game) }
+      let(:params) { { title: 'Valid New Title' } }
 
       it "doesn't update the shopping list" do
         expect { perform }
@@ -92,8 +92,8 @@ RSpec.describe ShoppingListsController::UpdateService do
 
     context 'when the shopping list is an aggregate shopping list' do
       let(:shopping_list) { aggregate_list }
-      let(:game)          { create(:game, user:) }
-      let(:params)        { { title: 'New Title' } }
+      let(:game) { create(:game, user:) }
+      let(:params) { { title: 'New Title' } }
 
       it 'returns a Service::MethodNotAllowedResult' do
         expect(perform).to be_a(Service::MethodNotAllowedResult)
@@ -106,8 +106,8 @@ RSpec.describe ShoppingListsController::UpdateService do
 
     context 'when the request tries to set aggregate to true' do
       let(:shopping_list) { create(:shopping_list, game:) }
-      let(:game)          { create(:game, user:) }
-      let(:params)        { { aggregate: true } }
+      let(:game) { create(:game, user:) }
+      let(:params) { { aggregate: true } }
 
       it 'returns a Service::UnprocessableEntityResult' do
         expect(perform).to be_a(Service::UnprocessableEntityResult)
@@ -120,8 +120,8 @@ RSpec.describe ShoppingListsController::UpdateService do
 
     context 'when something unexpected goes wrong' do
       let!(:shopping_list) { create(:shopping_list, game:) }
-      let(:game)           { create(:game, user:) }
-      let(:params)         { { title: 'New Title' } }
+      let(:game) { create(:game, user:) }
+      let(:params) { { title: 'New Title' } }
 
       before do
         allow_any_instance_of(ShoppingList).to receive(:update).and_raise(StandardError, 'Something went horribly wrong')

--- a/spec/lib/controller/response_spec.rb
+++ b/spec/lib/controller/response_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe Controller::Response do
 
     context 'when the result has no resource and the errors are empty' do
       let(:controller) { instance_double(ShoppingListsController, head: nil) }
-      let(:options)    { {} }
-      let(:result)     { Service::NoContentResult.new(resource: nil, errors: []) }
+      let(:options) { {} }
+      let(:result) { Service::NoContentResult.new(resource: nil, errors: []) }
 
       it 'returns the status with no response body' do
         execute
@@ -24,8 +24,8 @@ RSpec.describe Controller::Response do
 
     context 'when the resource is present but empty' do
       let(:controller) { instance_double(ShoppingListsController, render: nil) }
-      let(:options)    { {} }
-      let(:result)     { Service::OKResult.new(resource: []) }
+      let(:options) { {} }
+      let(:result) { Service::OKResult.new(resource: []) }
 
       it 'returns the empty resource' do
         execute
@@ -35,8 +35,8 @@ RSpec.describe Controller::Response do
 
     context 'when there is a resource' do
       let(:controller) { instance_double(ShoppingListsController, render: nil) }
-      let(:options)    { {} }
-      let(:result)     { Service::OKResult.new(resource:) }
+      let(:options) { {} }
+      let(:result) { Service::OKResult.new(resource:) }
 
       let(:resource) do
         {
@@ -56,9 +56,9 @@ RSpec.describe Controller::Response do
 
     context 'when there are errors' do
       let(:controller) { instance_double(ShoppingListsController, render: nil) }
-      let(:errors)     { ['Cannot manually update an aggregate shopping list'] }
-      let(:options)    { {} }
-      let(:result)     { Service::MethodNotAllowedResult.new(errors:) }
+      let(:errors) { ['Cannot manually update an aggregate shopping list'] }
+      let(:options) { {} }
+      let(:result) { Service::MethodNotAllowedResult.new(errors:) }
 
       it 'renders the errors with the result status' do
         execute
@@ -69,9 +69,9 @@ RSpec.describe Controller::Response do
     describe 'unexpected cases' do
       context 'when there is a resource and errors' do
         let(:controller) { instance_double(ShoppingListsController, render: nil) }
-        let(:options)    { {} }
-        let(:errors)     { ['Title is already taken', 'Cannot manually create or update an aggregate shopping list'] }
-        let(:result)     { Service::UnprocessableEntityResult.new(errors:, resource: { foo: 'bar' }) }
+        let(:options) { {} }
+        let(:errors) { ['Title is already taken', 'Cannot manually create or update an aggregate shopping list'] }
+        let(:result) { Service::UnprocessableEntityResult.new(errors:, resource: { foo: 'bar' }) }
 
         it 'renders the errors' do
           execute

--- a/spec/models/canonical/armor_spec.rb
+++ b/spec/models/canonical/armor_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe Canonical::Armor, type: :model do
 
   describe 'associations' do
     describe 'enchantments' do
-      let(:armor)       { create(:canonical_armor) }
+      let(:armor) { create(:canonical_armor) }
       let(:enchantment) { create(:enchantment) }
 
       before do
@@ -190,7 +190,7 @@ RSpec.describe Canonical::Armor, type: :model do
     end
 
     describe 'smithing materials' do
-      let(:armor)    { create(:canonical_armor) }
+      let(:armor) { create(:canonical_armor) }
       let(:material) { create(:canonical_material) }
 
       before do

--- a/spec/models/canonical/clothing_item_spec.rb
+++ b/spec/models/canonical/clothing_item_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe Canonical::ClothingItem, type: :model do
 
   describe 'associations' do
     describe 'enchantments' do
-      let(:item)        { create(:canonical_clothing_item) }
+      let(:item) { create(:canonical_clothing_item) }
       let(:enchantment) { create(:enchantment) }
 
       before do

--- a/spec/models/canonical/craftables_crafting_material_spec.rb
+++ b/spec/models/canonical/craftables_crafting_material_spec.rb
@@ -5,27 +5,27 @@ require 'rails_helper'
 RSpec.describe Canonical::CraftablesCraftingMaterial, type: :model do
   describe 'validations' do
     it 'is valid with valid attributes' do
-      armor    = create(:canonical_armor)
+      armor = create(:canonical_armor)
       material = create(:canonical_material)
-      model    = described_class.new(quantity: 2, craftable: armor, material:)
+      model = described_class.new(quantity: 2, craftable: armor, material:)
 
       expect(model).to be_valid
     end
 
     describe 'quantity' do
       it 'must be greater than zero' do
-        weapon   = create(:canonical_weapon)
+        weapon = create(:canonical_weapon)
         material = create(:canonical_material)
-        model    = described_class.new(quantity: 0, craftable: weapon, material:)
+        model = described_class.new(quantity: 0, craftable: weapon, material:)
 
         model.validate
         expect(model.errors[:quantity]).to include 'must be greater than 0'
       end
 
       it 'must be an integer' do
-        item     = create(:canonical_jewelry_item)
+        item = create(:canonical_jewelry_item)
         material = create(:canonical_material)
-        model    = described_class.new(quantity: 1.3, craftable: item, material:)
+        model = described_class.new(quantity: 1.3, craftable: item, material:)
 
         model.validate
         expect(model.errors[:quantity]).to include 'must be an integer'
@@ -34,7 +34,7 @@ RSpec.describe Canonical::CraftablesCraftingMaterial, type: :model do
 
     describe 'canonical material and craftable item' do
       let(:material) { create(:canonical_material) }
-      let(:armor)    { create(:canonical_armor) }
+      let(:armor) { create(:canonical_armor) }
 
       it 'must form a unique combination' do
         create(:canonical_craftables_crafting_material, material:, craftable: armor)

--- a/spec/models/canonical/enchantables_enchantment_spec.rb
+++ b/spec/models/canonical/enchantables_enchantment_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Canonical::EnchantablesEnchantment, type: :model do
   describe 'validations' do
     describe 'enchantable item and enchantment' do
       let(:enchantment) { create(:enchantment) }
-      let(:armor)       { create(:canonical_armor) }
+      let(:armor) { create(:canonical_armor) }
 
       it 'must form a unique combination' do
         create(:canonical_enchantables_enchantment, :for_armor, enchantable: armor, enchantment:)

--- a/spec/models/canonical/jewelry_item_spec.rb
+++ b/spec/models/canonical/jewelry_item_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe Canonical::JewelryItem, type: :model do
 
   describe 'associations' do
     describe 'enchantments' do
-      let(:item)        { create(:canonical_jewelry_item) }
+      let(:item) { create(:canonical_jewelry_item) }
       let(:enchantment) { create(:enchantment) }
 
       before do
@@ -150,7 +150,7 @@ RSpec.describe Canonical::JewelryItem, type: :model do
     end
 
     describe 'materials' do
-      let(:item)     { create(:canonical_jewelry_item) }
+      let(:item) { create(:canonical_jewelry_item) }
       let(:material) { create(:canonical_material) }
 
       before do

--- a/spec/models/canonical/potion_spec.rb
+++ b/spec/models/canonical/potion_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe Canonical::Potion, type: :model do
 
   describe 'associations' do
     describe 'alchemical properties' do
-      let(:potion)              { create(:canonical_potion) }
+      let(:potion) { create(:canonical_potion) }
       let(:alchemical_property) { create(:alchemical_property) }
 
       before do

--- a/spec/models/canonical/recipes_ingredient_spec.rb
+++ b/spec/models/canonical/recipes_ingredient_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Canonical::RecipesIngredient, type: :model do
   describe 'validations' do
     it 'is invalid if the book is not a recipe' do
-      book  = create(:canonical_book, book_type: 'skill book', skill_name: 'Heavy Armor')
+      book = create(:canonical_book, book_type: 'skill book', skill_name: 'Heavy Armor')
       model = build(:canonical_recipes_ingredient, recipe: book)
 
       model.validate
@@ -13,7 +13,7 @@ RSpec.describe Canonical::RecipesIngredient, type: :model do
     end
 
     it 'is valid if the book is a recipe' do
-      book  = create(:canonical_recipe)
+      book = create(:canonical_recipe)
       model = build(:canonical_recipes_ingredient, recipe: book)
 
       expect(model).to be_valid

--- a/spec/models/canonical/sync/alchemical_properties_spec.rb
+++ b/spec/models/canonical/sync/alchemical_properties_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Canonical::Sync::AlchemicalProperties do
   # Use let! because if we wait to evaluate these until we've run the
   # examples, the stub in the before block will prevent `File.read` from
   # running.
-  let(:json_path)  { Rails.root.join('spec', 'support', 'fixtures', 'canonical', 'sync', 'alchemical_properties.json') }
+  let(:json_path) { Rails.root.join('spec', 'support', 'fixtures', 'canonical', 'sync', 'alchemical_properties.json') }
   let!(:json_data) { File.read(json_path) }
 
   before do
@@ -18,7 +18,7 @@ RSpec.describe Canonical::Sync::AlchemicalProperties do
 
     context 'when preserve_existing_records is false' do
       let(:preserve_existing_records) { false }
-      let(:syncer)                    { described_class.new(preserve_existing_records) }
+      let(:syncer) { described_class.new(preserve_existing_records) }
 
       before do
         allow(described_class).to receive(:new).and_return(syncer)
@@ -40,7 +40,7 @@ RSpec.describe Canonical::Sync::AlchemicalProperties do
       end
 
       context 'when there are existing records in the database' do
-        let!(:property_in_json)     { create(:alchemical_property, name: 'Cure Disease', strength_unit: 'point') }
+        let!(:property_in_json) { create(:alchemical_property, name: 'Cure Disease', strength_unit: 'point') }
         let!(:property_not_in_json) { create(:alchemical_property, name: 'Restore Health') }
 
         it 'updates models that were already in the database' do
@@ -64,9 +64,9 @@ RSpec.describe Canonical::Sync::AlchemicalProperties do
 
     context 'when preserve_existing_records is true' do
       let(:preserve_existing_records) { true }
-      let(:syncer)                    { described_class.new(preserve_existing_records) }
-      let!(:property_in_json)         { create(:alchemical_property, name: 'Cure Disease', strength_unit: 'percentage') }
-      let!(:property_not_in_json)     { create(:alchemical_property, name: 'Restore Health') }
+      let(:syncer) { described_class.new(preserve_existing_records) }
+      let!(:property_in_json) { create(:alchemical_property, name: 'Cure Disease', strength_unit: 'percentage') }
+      let!(:property_not_in_json) { create(:alchemical_property, name: 'Restore Health') }
 
       before do
         allow(described_class).to receive(:new).and_return(syncer)

--- a/spec/models/canonical/sync/armor_spec.rb
+++ b/spec/models/canonical/sync/armor_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Canonical::Sync::Armor do
   # Use let! because if we wait to evaluate these until we've run the
   # examples, the stub in the before block will prevent `File.read` from
   # running.
-  let(:json_path)  { Rails.root.join('spec', 'support', 'fixtures', 'canonical', 'sync', 'armor.json') }
+  let(:json_path) { Rails.root.join('spec', 'support', 'fixtures', 'canonical', 'sync', 'armor.json') }
   let!(:json_data) { File.read(json_path) }
 
   let(:material_codes) { %w[0005ACE5 0005AD9F 0005ACE4 000DB5D2 000800E4 0003ADA3 0003ADA4] }
@@ -66,9 +66,9 @@ RSpec.describe Canonical::Sync::Armor do
       end
 
       context 'when there are existing armor item records in the database' do
-        let!(:item_in_json)     { create(:canonical_armor, item_code: 'XX01DB97', body_slot: 'feet') }
+        let!(:item_in_json) { create(:canonical_armor, item_code: 'XX01DB97', body_slot: 'feet') }
         let!(:item_not_in_json) { create(:canonical_armor, item_code: '12345678') }
-        let(:syncer)            { described_class.new(preserve_existing_records) }
+        let(:syncer) { described_class.new(preserve_existing_records) }
 
         before do
           create(:enchantment, name: 'Fortify Block')
@@ -152,9 +152,9 @@ RSpec.describe Canonical::Sync::Armor do
 
     context 'when preserve_existing_records is true' do
       let(:preserve_existing_records) { true }
-      let(:syncer)                    { described_class.new(preserve_existing_records) }
-      let!(:item_in_json)             { create(:canonical_armor, item_code: 'XX01DB97', body_slot: 'hands') }
-      let!(:item_not_in_json)         { create(:canonical_armor, item_code: '12345678') }
+      let(:syncer) { described_class.new(preserve_existing_records) }
+      let!(:item_in_json) { create(:canonical_armor, item_code: 'XX01DB97', body_slot: 'hands') }
+      let!(:item_not_in_json) { create(:canonical_armor, item_code: '12345678') }
 
       before do
         create(:enchantment, name: 'Fortify Block')

--- a/spec/models/canonical/sync/books_spec.rb
+++ b/spec/models/canonical/sync/books_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Canonical::Sync::Books do
   # Use let! because if we wait to evaluate these until we've run the
   # examples, the stub in the before block will prevent `File.read` from
   # running.
-  let(:json_path)  { Rails.root.join('spec', 'support', 'fixtures', 'canonical', 'sync', 'books.json') }
+  let(:json_path) { Rails.root.join('spec', 'support', 'fixtures', 'canonical', 'sync', 'books.json') }
   let!(:json_data) { File.read(json_path) }
 
   before do
@@ -57,7 +57,7 @@ RSpec.describe Canonical::Sync::Books do
         end
 
         let!(:book_not_in_json) { create(:canonical_book, item_code: '12345678') }
-        let(:syncer)            { described_class.new(preserve_existing_records) }
+        let(:syncer) { described_class.new(preserve_existing_records) }
 
         before do
           create(:canonical_ingredient, item_code: '00052695')
@@ -141,9 +141,9 @@ RSpec.describe Canonical::Sync::Books do
 
     context 'when preserve_existing_records is true' do
       let(:preserve_existing_records) { true }
-      let(:syncer)                    { described_class.new(preserve_existing_records) }
-      let!(:book_in_json)             { create(:canonical_recipe, item_code: '000F5CB8', title: 'Rich Dad, Poor Dad') }
-      let!(:book_not_in_json)         { create(:canonical_book, item_code: '12345678') }
+      let(:syncer) { described_class.new(preserve_existing_records) }
+      let!(:book_in_json) { create(:canonical_recipe, item_code: '000F5CB8', title: 'Rich Dad, Poor Dad') }
+      let!(:book_not_in_json) { create(:canonical_book, item_code: '12345678') }
 
       before do
         create(:canonical_ingredient, item_code: '00052695')

--- a/spec/models/canonical/sync/clothing_items_spec.rb
+++ b/spec/models/canonical/sync/clothing_items_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Canonical::Sync::ClothingItems do
   # Use let! because if we wait to evaluate these until we've run the
   # examples, the stub in the before block will prevent `File.read` from
   # running.
-  let(:json_path)  { Rails.root.join('spec', 'support', 'fixtures', 'canonical', 'sync', 'clothing_items.json') }
+  let(:json_path) { Rails.root.join('spec', 'support', 'fixtures', 'canonical', 'sync', 'clothing_items.json') }
   let!(:json_data) { File.read(json_path) }
 
   let(:enchantment_names) { ['Fortify Magicka', 'Fortify Destruction', 'Fortify Magicka Regen'] }
@@ -50,9 +50,9 @@ RSpec.describe Canonical::Sync::ClothingItems do
       end
 
       context 'when there are existing clothing item records in the database' do
-        let!(:item_in_json)     { create(:canonical_clothing_item, item_code: '0010DD3C', body_slot: 'feet') }
+        let!(:item_in_json) { create(:canonical_clothing_item, item_code: '0010DD3C', body_slot: 'feet') }
         let!(:item_not_in_json) { create(:canonical_clothing_item, item_code: '12345678') }
-        let(:syncer)            { described_class.new(preserve_existing_records) }
+        let(:syncer) { described_class.new(preserve_existing_records) }
 
         before do
           enchantment_names.each {|name| create(:enchantment, name:) }
@@ -136,9 +136,9 @@ RSpec.describe Canonical::Sync::ClothingItems do
 
     context 'when preserve_existing_records is true' do
       let(:preserve_existing_records) { true }
-      let(:syncer)                    { described_class.new(preserve_existing_records) }
-      let!(:item_in_json)             { create(:canonical_clothing_item, item_code: '0010DD3C', body_slot: 'body') }
-      let!(:item_not_in_json)         { create(:canonical_clothing_item, item_code: '12345678') }
+      let(:syncer) { described_class.new(preserve_existing_records) }
+      let!(:item_in_json) { create(:canonical_clothing_item, item_code: '0010DD3C', body_slot: 'body') }
+      let!(:item_not_in_json) { create(:canonical_clothing_item, item_code: '12345678') }
 
       before do
         enchantment_names.each {|name| create(:enchantment, name:) }

--- a/spec/models/canonical/sync/enchantments_spec.rb
+++ b/spec/models/canonical/sync/enchantments_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Canonical::Sync::Enchantments do
   # Use let! because if we wait to evaluate these until we've run the
   # examples, the stub in the before block will prevent `File.read` from
   # running.
-  let(:json_path)  { Rails.root.join('spec', 'support', 'fixtures', 'canonical', 'sync', 'enchantments.json') }
+  let(:json_path) { Rails.root.join('spec', 'support', 'fixtures', 'canonical', 'sync', 'enchantments.json') }
   let!(:json_data) { File.read(json_path) }
 
   before do
@@ -18,7 +18,7 @@ RSpec.describe Canonical::Sync::Enchantments do
 
     context 'when preserve_existing_records is false' do
       let(:preserve_existing_records) { false }
-      let(:syncer)                    { described_class.new(preserve_existing_records) }
+      let(:syncer) { described_class.new(preserve_existing_records) }
 
       it 'instantiates itself' do
         allow(described_class).to receive(:new).and_return(syncer)
@@ -37,7 +37,7 @@ RSpec.describe Canonical::Sync::Enchantments do
       end
 
       context 'when there are existing records in the database' do
-        let!(:enchantment_in_json)     { create(:enchantment, name: 'Banish', strength_unit: 'point') }
+        let!(:enchantment_in_json) { create(:enchantment, name: 'Banish', strength_unit: 'point') }
         let!(:enchantment_not_in_json) { create(:enchantment, name: 'Shock Damage') }
 
         it 'updates models that were already in the database' do
@@ -61,9 +61,9 @@ RSpec.describe Canonical::Sync::Enchantments do
 
     context 'when preserve_existing_records is true' do
       let(:preserve_existing_records) { true }
-      let(:syncer)                    { described_class.new(preserve_existing_records) }
-      let!(:enchantment_in_json)      { create(:enchantment, name: 'Banish', strength_unit: 'percentage') }
-      let!(:enchantment_not_in_json)  { create(:enchantment, name: 'Shock Damage') }
+      let(:syncer) { described_class.new(preserve_existing_records) }
+      let!(:enchantment_in_json) { create(:enchantment, name: 'Banish', strength_unit: 'percentage') }
+      let!(:enchantment_not_in_json) { create(:enchantment, name: 'Shock Damage') }
 
       before do
         allow(described_class).to receive(:new).and_return(syncer)

--- a/spec/models/canonical/sync/ingredients_spec.rb
+++ b/spec/models/canonical/sync/ingredients_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Canonical::Sync::Ingredients do
   # Use let! because if we wait to evaluate these until we've run the
   # examples, the stub in the before block will prevent `File.read` from
   # running.
-  let(:json_path)  { Rails.root.join('spec', 'support', 'fixtures', 'canonical', 'sync', 'ingredients.json') }
+  let(:json_path) { Rails.root.join('spec', 'support', 'fixtures', 'canonical', 'sync', 'ingredients.json') }
   let!(:json_data) { File.read(json_path) }
 
   let(:alchemical_property_names) do
@@ -57,9 +57,9 @@ RSpec.describe Canonical::Sync::Ingredients do
       end
 
       context 'when there are existing canonical ingredient records in the database' do
-        let!(:item_in_json)     { create(:canonical_ingredient, item_code: '00106E1B', unit_weight: 1.2) }
+        let!(:item_in_json) { create(:canonical_ingredient, item_code: '00106E1B', unit_weight: 1.2) }
         let!(:item_not_in_json) { create(:canonical_ingredient, item_code: '12345678') }
-        let(:syncer)            { described_class.new(preserve_existing_records) }
+        let(:syncer) { described_class.new(preserve_existing_records) }
 
         before do
           alchemical_property_names.each {|name| create(:alchemical_property, name:) }
@@ -143,9 +143,9 @@ RSpec.describe Canonical::Sync::Ingredients do
 
     context 'when preserve_existing_records is true' do
       let(:preserve_existing_records) { true }
-      let(:syncer)                    { described_class.new(preserve_existing_records) }
-      let!(:item_in_json)             { create(:canonical_ingredient, item_code: '00106E1B', unit_weight: 1.2) }
-      let!(:item_not_in_json)         { create(:canonical_ingredient, item_code: '12345678') }
+      let(:syncer) { described_class.new(preserve_existing_records) }
+      let!(:item_in_json) { create(:canonical_ingredient, item_code: '00106E1B', unit_weight: 1.2) }
+      let!(:item_not_in_json) { create(:canonical_ingredient, item_code: '12345678') }
 
       before do
         alchemical_property_names.each {|name| create(:alchemical_property, name:) }

--- a/spec/models/canonical/sync/jewelry_items_spec.rb
+++ b/spec/models/canonical/sync/jewelry_items_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Canonical::Sync::JewelryItems do
   # Use let! because if we wait to evaluate these until we've run the
   # examples, the stub in the before block will prevent `File.read` from
   # running.
-  let(:json_path)  { Rails.root.join('spec', 'support', 'fixtures', 'canonical', 'sync', 'jewelry_items.json') }
+  let(:json_path) { Rails.root.join('spec', 'support', 'fixtures', 'canonical', 'sync', 'jewelry_items.json') }
   let!(:json_data) { File.read(json_path) }
 
   let(:material_codes) { %w[XX002993 XX002994 000800E4] }
@@ -58,9 +58,9 @@ RSpec.describe Canonical::Sync::JewelryItems do
       end
 
       context 'when there are existing jewelry item records in the database' do
-        let!(:item_in_json)     { create(:canonical_jewelry_item, item_code: '00094E3E', jewelry_type: 'ring') }
+        let!(:item_in_json) { create(:canonical_jewelry_item, item_code: '00094E3E', jewelry_type: 'ring') }
         let!(:item_not_in_json) { create(:canonical_jewelry_item, item_code: '12345678') }
-        let(:syncer)            { described_class.new(preserve_existing_records) }
+        let(:syncer) { described_class.new(preserve_existing_records) }
 
         before do
           create(:enchantment, name: 'Fortify Health')
@@ -146,9 +146,9 @@ RSpec.describe Canonical::Sync::JewelryItems do
 
     context 'when preserve_existing_records is true' do
       let(:preserve_existing_records) { true }
-      let(:syncer)                    { described_class.new(preserve_existing_records) }
-      let!(:item_in_json)             { create(:canonical_jewelry_item, item_code: '00094E3E', jewelry_type: 'circlet') }
-      let!(:item_not_in_json)         { create(:canonical_jewelry_item, item_code: '12345678') }
+      let(:syncer) { described_class.new(preserve_existing_records) }
+      let!(:item_in_json) { create(:canonical_jewelry_item, item_code: '00094E3E', jewelry_type: 'circlet') }
+      let!(:item_not_in_json) { create(:canonical_jewelry_item, item_code: '12345678') }
 
       before do
         create(:enchantment, name: 'Fortify Health')

--- a/spec/models/canonical/sync/materials_spec.rb
+++ b/spec/models/canonical/sync/materials_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Canonical::Sync::Materials do
   # Use let! because if we wait to evaluate these until we've run the
   # examples, the stub in the before block will prevent `File.read` from
   # running.
-  let(:json_path)  { Rails.root.join('spec', 'support', 'fixtures', 'canonical', 'sync', 'materials.json') }
+  let(:json_path) { Rails.root.join('spec', 'support', 'fixtures', 'canonical', 'sync', 'materials.json') }
   let!(:json_data) { File.read(json_path) }
 
   before do
@@ -18,7 +18,7 @@ RSpec.describe Canonical::Sync::Materials do
 
     context 'when preserve_existing_records is false' do
       let(:preserve_existing_records) { false }
-      let(:syncer)                    { described_class.new(preserve_existing_records) }
+      let(:syncer) { described_class.new(preserve_existing_records) }
 
       before do
         allow(described_class).to receive(:new).and_return(syncer)
@@ -40,9 +40,9 @@ RSpec.describe Canonical::Sync::Materials do
       end
 
       context 'when there are existing records in the database' do
-        let!(:material_in_json)     { create(:canonical_material, item_code: 'XX00300F', smithing_material: true) }
+        let!(:material_in_json) { create(:canonical_material, item_code: 'XX00300F', smithing_material: true) }
         let!(:material_not_in_json) { create(:canonical_material, item_code: '12345678') }
-        let(:syncer)                { described_class.new(preserve_existing_records) }
+        let(:syncer) { described_class.new(preserve_existing_records) }
 
         it 'instantiates itself' do
           allow(described_class).to receive(:new).and_return(syncer)
@@ -71,9 +71,9 @@ RSpec.describe Canonical::Sync::Materials do
 
     context 'when preserve_existing_records is true' do
       let(:preserve_existing_records) { true }
-      let(:syncer)                    { described_class.new(preserve_existing_records) }
-      let!(:material_in_json)         { create(:canonical_material, item_code: 'XX00300F', smithing_material: true) }
-      let!(:material_not_in_json)     { create(:canonical_material, item_code: '12345678') }
+      let(:syncer) { described_class.new(preserve_existing_records) }
+      let!(:material_in_json) { create(:canonical_material, item_code: 'XX00300F', smithing_material: true) }
+      let!(:material_not_in_json) { create(:canonical_material, item_code: '12345678') }
 
       it 'instantiates itself' do
         allow(described_class).to receive(:new).and_return(syncer)

--- a/spec/models/canonical/sync/misc_items_spec.rb
+++ b/spec/models/canonical/sync/misc_items_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Canonical::Sync::MiscItems do
   # Use let! because if we wait to evaluate these until we've run the
   # examples, the stub in the before block will prevent `File.read` from
   # running.
-  let(:json_path)  { Rails.root.join('spec', 'support', 'fixtures', 'canonical', 'sync', 'misc_items.json') }
+  let(:json_path) { Rails.root.join('spec', 'support', 'fixtures', 'canonical', 'sync', 'misc_items.json') }
   let!(:json_data) { File.read(json_path) }
 
   before do
@@ -18,7 +18,7 @@ RSpec.describe Canonical::Sync::MiscItems do
 
     context 'when preserve_existing_records is false' do
       let(:preserve_existing_records) { false }
-      let(:syncer)                    { described_class.new(preserve_existing_records) }
+      let(:syncer) { described_class.new(preserve_existing_records) }
 
       before do
         allow(described_class).to receive(:new).and_return(syncer)
@@ -37,9 +37,9 @@ RSpec.describe Canonical::Sync::MiscItems do
       end
 
       context 'when there are existing records in the database' do
-        let!(:item_in_json)     { create(:canonical_misc_item, item_code: 'XX012F97', name: 'Quartz Paragon') }
+        let!(:item_in_json) { create(:canonical_misc_item, item_code: 'XX012F97', name: 'Quartz Paragon') }
         let!(:item_not_in_json) { create(:canonical_misc_item, item_code: '12345678') }
-        let(:syncer)            { described_class.new(preserve_existing_records) }
+        let(:syncer) { described_class.new(preserve_existing_records) }
 
         it 'instantiates itself' do
           allow(described_class).to receive(:new).and_return(syncer)
@@ -68,9 +68,9 @@ RSpec.describe Canonical::Sync::MiscItems do
 
     context 'when preserve_existing_records is true' do
       let(:preserve_existing_records) { true }
-      let(:syncer)                    { described_class.new(preserve_existing_records) }
-      let!(:item_in_json)             { create(:canonical_misc_item, item_code: 'XX012F97', name: 'Quartz Paragon') }
-      let!(:item_not_in_json)         { create(:canonical_misc_item, item_code: '12345678') }
+      let(:syncer) { described_class.new(preserve_existing_records) }
+      let!(:item_in_json) { create(:canonical_misc_item, item_code: 'XX012F97', name: 'Quartz Paragon') }
+      let!(:item_not_in_json) { create(:canonical_misc_item, item_code: '12345678') }
 
       it 'instantiates itself' do
         allow(described_class).to receive(:new).and_return(syncer)

--- a/spec/models/canonical/sync/potions_spec.rb
+++ b/spec/models/canonical/sync/potions_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Canonical::Sync::Potions do
   # Use let! because if we wait to evaluate these until we've run the
   # examples, the stub in the before block will prevent `File.read` from
   # running.
-  let(:json_path)  { Rails.root.join('spec', 'support', 'fixtures', 'canonical', 'sync', 'potions.json') }
+  let(:json_path) { Rails.root.join('spec', 'support', 'fixtures', 'canonical', 'sync', 'potions.json') }
   let!(:json_data) { File.read(json_path) }
 
   let(:alchemical_property_names) do
@@ -56,9 +56,9 @@ RSpec.describe Canonical::Sync::Potions do
       end
 
       context 'when there are existing potion records in the database' do
-        let!(:item_in_json)     { create(:canonical_potion, item_code: '0003EB2E', unit_weight: 1) }
+        let!(:item_in_json) { create(:canonical_potion, item_code: '0003EB2E', unit_weight: 1) }
         let!(:item_not_in_json) { create(:canonical_potion, item_code: '12345678') }
-        let(:syncer)            { described_class.new(preserve_existing_records) }
+        let(:syncer) { described_class.new(preserve_existing_records) }
 
         before do
           alchemical_property_names.each {|name| create(:alchemical_property, name:) }
@@ -141,9 +141,9 @@ RSpec.describe Canonical::Sync::Potions do
 
     context 'when preserve_existing_records is true' do
       let(:preserve_existing_records) { true }
-      let(:syncer)                    { described_class.new(preserve_existing_records) }
-      let!(:item_in_json)             { create(:canonical_potion, item_code: '0003EB2E', unit_weight: 1) }
-      let!(:item_not_in_json)         { create(:canonical_potion, item_code: '12345678') }
+      let(:syncer) { described_class.new(preserve_existing_records) }
+      let!(:item_in_json) { create(:canonical_potion, item_code: '0003EB2E', unit_weight: 1) }
+      let!(:item_not_in_json) { create(:canonical_potion, item_code: '12345678') }
 
       before do
         alchemical_property_names.each {|name| create(:alchemical_property, name:) }

--- a/spec/models/canonical/sync/powers_spec.rb
+++ b/spec/models/canonical/sync/powers_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Canonical::Sync::Powers do
   # Use let! because if we wait to evaluate these until we've run the
   # examples, the stub in the before block will prevent `File.read` from
   # running.
-  let(:json_path)  { Rails.root.join('spec', 'support', 'fixtures', 'canonical', 'sync', 'powers.json') }
+  let(:json_path) { Rails.root.join('spec', 'support', 'fixtures', 'canonical', 'sync', 'powers.json') }
   let!(:json_data) { File.read(json_path) }
 
   before do
@@ -18,7 +18,7 @@ RSpec.describe Canonical::Sync::Powers do
 
     context 'when preserve_existing_records is false' do
       let(:preserve_existing_records) { false }
-      let(:syncer)                    { described_class.new(preserve_existing_records) }
+      let(:syncer) { described_class.new(preserve_existing_records) }
 
       before do
         allow(described_class).to receive(:new).and_return(syncer)
@@ -40,7 +40,7 @@ RSpec.describe Canonical::Sync::Powers do
       end
 
       context 'when there are existing records in the database' do
-        let!(:power_in_json)     { create(:power, name: "Ancestor's Wrath", power_type: 'lesser') }
+        let!(:power_in_json) { create(:power, name: "Ancestor's Wrath", power_type: 'lesser') }
         let!(:power_not_in_json) { create(:power, name: 'My Power') }
 
         it 'updates models that were already in the database' do
@@ -64,9 +64,9 @@ RSpec.describe Canonical::Sync::Powers do
 
     context 'when preserve_existing_records is true' do
       let(:preserve_existing_records) { true }
-      let(:syncer)                    { described_class.new(preserve_existing_records) }
-      let!(:power_in_json)            { create(:power, name: "Ancestor's Wrath", power_type: 'ability') }
-      let!(:power_not_in_json)        { create(:power, name: 'My Power') }
+      let(:syncer) { described_class.new(preserve_existing_records) }
+      let!(:power_in_json) { create(:power, name: "Ancestor's Wrath", power_type: 'ability') }
+      let!(:power_not_in_json) { create(:power, name: 'My Power') }
 
       it 'instantiates itself' do
         allow(described_class).to receive(:new).and_return(syncer)

--- a/spec/models/canonical/sync/properties_spec.rb
+++ b/spec/models/canonical/sync/properties_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Canonical::Sync::Properties do
   # Use let! because if we wait to evaluate these until we've run the
   # examples, the stub in the before block will prevent `File.read` from
   # running.
-  let(:json_path)  { Rails.root.join('spec', 'support', 'fixtures', 'canonical', 'sync', 'properties.json') }
+  let(:json_path) { Rails.root.join('spec', 'support', 'fixtures', 'canonical', 'sync', 'properties.json') }
   let!(:json_data) { File.read(json_path) }
 
   before do
@@ -18,7 +18,7 @@ RSpec.describe Canonical::Sync::Properties do
 
     context 'when preserve_existing_records is false' do
       let(:preserve_existing_records) { false }
-      let(:syncer)                    { described_class.new(preserve_existing_records) }
+      let(:syncer) { described_class.new(preserve_existing_records) }
 
       before do
         allow(described_class).to receive(:new).and_return(syncer)
@@ -37,9 +37,9 @@ RSpec.describe Canonical::Sync::Properties do
       end
 
       context 'when there are existing records in the database' do
-        let!(:property_in_json)     { create(:canonical_property, name: 'Hjerim', city: 'Windhelm', hold: 'Eastmarch', alchemy_lab_available: false) }
+        let!(:property_in_json) { create(:canonical_property, name: 'Hjerim', city: 'Windhelm', hold: 'Eastmarch', alchemy_lab_available: false) }
         let!(:property_not_in_json) { create(:canonical_property, name: 'Breezehome', city: 'Whiterun', hold: 'Whiterun') }
-        let(:syncer)                { described_class.new(preserve_existing_records) }
+        let(:syncer) { described_class.new(preserve_existing_records) }
 
         it 'instantiates itself' do
           allow(described_class).to receive(:new).and_return(syncer)
@@ -68,9 +68,9 @@ RSpec.describe Canonical::Sync::Properties do
 
     context 'when preserve_existing_records is true' do
       let(:preserve_existing_records) { true }
-      let(:syncer)                    { described_class.new(preserve_existing_records) }
-      let!(:property_in_json)         { create(:canonical_property, name: 'Hjerim', city: 'Windhelm', hold: 'Eastmarch', forge_available: true) }
-      let!(:property_not_in_json)     { create(:canonical_property, name: 'Breezehome', city: 'Whiterun', hold: 'Whiterun') }
+      let(:syncer) { described_class.new(preserve_existing_records) }
+      let!(:property_in_json) { create(:canonical_property, name: 'Hjerim', city: 'Windhelm', hold: 'Eastmarch', forge_available: true) }
+      let!(:property_not_in_json) { create(:canonical_property, name: 'Breezehome', city: 'Whiterun', hold: 'Whiterun') }
 
       before do
         allow(described_class).to receive(:new).and_return(syncer)

--- a/spec/models/canonical/sync/spells_spec.rb
+++ b/spec/models/canonical/sync/spells_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Canonical::Sync::Spells do
   # Use let! because if we wait to evaluate these until we've run the
   # examples, the stub in the before block will prevent `File.read` from
   # running.
-  let(:json_path)  { Rails.root.join('spec', 'support', 'fixtures', 'canonical', 'sync', 'spells.json') }
+  let(:json_path) { Rails.root.join('spec', 'support', 'fixtures', 'canonical', 'sync', 'spells.json') }
   let!(:json_data) { File.read(json_path) }
 
   before do
@@ -18,7 +18,7 @@ RSpec.describe Canonical::Sync::Spells do
 
     context 'when preserve_existing_records is false' do
       let(:preserve_existing_records) { false }
-      let(:syncer)                    { described_class.new(preserve_existing_records) }
+      let(:syncer) { described_class.new(preserve_existing_records) }
 
       before do
         allow(described_class).to receive(:new).and_return(syncer)
@@ -40,9 +40,9 @@ RSpec.describe Canonical::Sync::Spells do
       end
 
       context 'when there are existing records in the database' do
-        let!(:spell_in_json)     { create(:spell, name: 'Bound Battleaxe', strength_unit: 'point', strength: 50) }
+        let!(:spell_in_json) { create(:spell, name: 'Bound Battleaxe', strength_unit: 'point', strength: 50) }
         let!(:spell_not_in_json) { create(:spell, name: 'My Awesome Spell') }
-        let(:syncer)             { described_class.new(preserve_existing_records) }
+        let(:syncer) { described_class.new(preserve_existing_records) }
 
         it 'instantiates itself' do
           allow(described_class).to receive(:new).and_return(syncer)
@@ -72,9 +72,9 @@ RSpec.describe Canonical::Sync::Spells do
 
     context 'when preserve_existing_records is true' do
       let(:preserve_existing_records) { true }
-      let(:syncer)                    { described_class.new(preserve_existing_records) }
-      let!(:spell_in_json)            { create(:spell, name: 'Bound Bow', strength_unit: 'percentage', strength: 20) }
-      let!(:spell_not_in_json)        { create(:spell, name: 'My Awesome Spell') }
+      let(:syncer) { described_class.new(preserve_existing_records) }
+      let!(:spell_in_json) { create(:spell, name: 'Bound Bow', strength_unit: 'percentage', strength: 20) }
+      let!(:spell_not_in_json) { create(:spell, name: 'My Awesome Spell') }
 
       before do
         allow(described_class).to receive(:new).and_return(syncer)

--- a/spec/models/canonical/sync/staves_spec.rb
+++ b/spec/models/canonical/sync/staves_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Canonical::Sync::Staves do
   # Use let! because if we wait to evaluate these until we've run the
   # examples, the stub in the before block will prevent `File.read` from
   # running.
-  let(:json_path)  { Rails.root.join('spec', 'support', 'fixtures', 'canonical', 'sync', 'staves.json') }
+  let(:json_path) { Rails.root.join('spec', 'support', 'fixtures', 'canonical', 'sync', 'staves.json') }
   let!(:json_data) { File.read(json_path) }
 
   let(:spell_names) do
@@ -65,9 +65,9 @@ RSpec.describe Canonical::Sync::Staves do
       end
 
       context 'when there are existing staff records in the database' do
-        let!(:item_in_json)     { create(:canonical_staff, item_code: '000AB704', magical_effects: 'Fucks up the target severely') }
+        let!(:item_in_json) { create(:canonical_staff, item_code: '000AB704', magical_effects: 'Fucks up the target severely') }
         let!(:item_not_in_json) { create(:canonical_staff, item_code: '12345678') }
-        let(:syncer)            { described_class.new(preserve_existing_records) }
+        let(:syncer) { described_class.new(preserve_existing_records) }
 
         before do
           spell_names.each {|name| create(:spell, name:) }
@@ -150,9 +150,9 @@ RSpec.describe Canonical::Sync::Staves do
 
     context 'when preserve_existing_records is true' do
       let(:preserve_existing_records) { true }
-      let(:syncer)                    { described_class.new(preserve_existing_records) }
-      let!(:item_in_json)             { create(:canonical_staff, item_code: '000AB704', unit_weight: 27) }
-      let!(:item_not_in_json)         { create(:canonical_staff, item_code: '12345678') }
+      let(:syncer) { described_class.new(preserve_existing_records) }
+      let!(:item_in_json) { create(:canonical_staff, item_code: '000AB704', unit_weight: 27) }
+      let!(:item_not_in_json) { create(:canonical_staff, item_code: '12345678') }
 
       before do
         spell_names.each {|name| create(:spell, name:) }

--- a/spec/models/canonical/sync/weapons_spec.rb
+++ b/spec/models/canonical/sync/weapons_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Canonical::Sync::Weapons do
   # Use let! because if we wait to evaluate these until we've run the
   # examples, the stub in the before block will prevent `File.read` from
   # running.
-  let(:json_path)  { Rails.root.join('spec', 'support', 'fixtures', 'canonical', 'sync', 'weapons.json') }
+  let(:json_path) { Rails.root.join('spec', 'support', 'fixtures', 'canonical', 'sync', 'weapons.json') }
   let!(:json_data) { File.read(json_path) }
 
   let(:material_codes) { %w[0005ACE5 0003AD5B 000800E4 0005AD9D 0005ADA1] }
@@ -75,9 +75,9 @@ RSpec.describe Canonical::Sync::Weapons do
       end
 
       context 'when there are existing canonical weapon records in the database' do
-        let!(:item_in_json)     { create(:canonical_weapon, item_code: '0005BF06', base_damage: 13) }
+        let!(:item_in_json) { create(:canonical_weapon, item_code: '0005BF06', base_damage: 13) }
         let!(:item_not_in_json) { create(:canonical_weapon, item_code: '12345678') }
-        let(:syncer)            { described_class.new(preserve_existing_records) }
+        let(:syncer) { described_class.new(preserve_existing_records) }
 
         before do
           create(:enchantment, name: 'Frost Damage')
@@ -163,9 +163,9 @@ RSpec.describe Canonical::Sync::Weapons do
 
     context 'when preserve_existing_records is true' do
       let(:preserve_existing_records) { true }
-      let(:syncer)                    { described_class.new(preserve_existing_records) }
-      let!(:item_in_json)             { create(:canonical_weapon, item_code: '0005BF06', base_damage: 13) }
-      let!(:item_not_in_json)         { create(:canonical_weapon, item_code: '12345678') }
+      let(:syncer) { described_class.new(preserve_existing_records) }
+      let!(:item_in_json) { create(:canonical_weapon, item_code: '0005BF06', base_damage: 13) }
+      let!(:item_not_in_json) { create(:canonical_weapon, item_code: '12345678') }
 
       before do
         create(:enchantment, name: 'Frost Damage')

--- a/spec/models/canonical/temperables_tempering_material_spec.rb
+++ b/spec/models/canonical/temperables_tempering_material_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Canonical::TemperablesTemperingMaterial, type: :model do
   describe 'validations' do
     it 'is valid with valid attributes' do
       material = create(:canonical_material)
-      armor    = create(:canonical_armor)
-      model    = described_class.new(quantity: 3, material:, temperable: armor)
+      armor = create(:canonical_armor)
+      model = described_class.new(quantity: 3, material:, temperable: armor)
 
       expect(model).to be_valid
     end
@@ -30,7 +30,7 @@ RSpec.describe Canonical::TemperablesTemperingMaterial, type: :model do
 
     describe 'temperable and canonical material' do
       let(:material) { create(:canonical_material) }
-      let(:weapon)   { create(:canonical_weapon) }
+      let(:weapon) { create(:canonical_weapon) }
 
       it 'must be a unique combination' do
         create(:canonical_temperables_tempering_material, material:, temperable: weapon)

--- a/spec/models/canonical/weapon_spec.rb
+++ b/spec/models/canonical/weapon_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe Canonical::Weapon, type: :model do
 
   describe 'associations' do
     describe 'enchantments' do
-      let(:weapon)      { create(:canonical_weapon) }
+      let(:weapon) { create(:canonical_weapon) }
       let(:enchantment) { create(:enchantment) }
 
       before do
@@ -237,7 +237,7 @@ RSpec.describe Canonical::Weapon, type: :model do
 
     describe 'powers' do
       let(:weapon) { create(:canonical_weapon) }
-      let(:power)  { create(:power) }
+      let(:power) { create(:power) }
 
       before do
         weapon.canonical_powerables_powers.create!(power:)
@@ -249,7 +249,7 @@ RSpec.describe Canonical::Weapon, type: :model do
     end
 
     describe 'crafting materials' do
-      let(:weapon)   { create(:canonical_weapon) }
+      let(:weapon) { create(:canonical_weapon) }
       let(:material) { create(:canonical_material) }
 
       before do
@@ -262,7 +262,7 @@ RSpec.describe Canonical::Weapon, type: :model do
     end
 
     describe 'tempering materials' do
-      let(:weapon)   { create(:canonical_weapon) }
+      let(:weapon) { create(:canonical_weapon) }
       let(:material) { create(:canonical_material) }
 
       before do

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe Game, type: :model do
   describe '#aggregate_shopping_list' do
     subject(:aggregate_shopping_list) { game.aggregate_shopping_list }
 
-    let(:game)            { create(:game) }
+    let(:game) { create(:game) }
     let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
 
     before do
@@ -186,7 +186,7 @@ RSpec.describe Game, type: :model do
   describe '#aggregate_inventory_list' do
     subject(:aggregate_inventory_list) { game.aggregate_inventory_list }
 
-    let(:game)            { create(:game) }
+    let(:game) { create(:game) }
     let!(:aggregate_list) { create(:aggregate_inventory_list, game:) }
 
     before do

--- a/spec/models/inventory_item_spec.rb
+++ b/spec/models/inventory_item_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe InventoryItem, type: :model do
-  let!(:game)          { create(:game) }
+  let!(:game) { create(:game) }
   let(:aggregate_list) { create(:aggregate_inventory_list, game:) }
   let(:inventory_list) { create(:inventory_list, game:, aggregate_list:) }
 

--- a/spec/models/inventory_list_spec.rb
+++ b/spec/models/inventory_list_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe InventoryList, type: :model do
     describe '::index_order' do
       subject(:index_order) { game.inventory_lists.index_order.to_a }
 
-      let!(:game)            { create(:game) }
-      let!(:aggregate_list)  { create(:aggregate_inventory_list, game:) }
+      let!(:game) { create(:game) }
+      let!(:aggregate_list) { create(:aggregate_inventory_list, game:) }
       let!(:inventory_list1) { create(:inventory_list, game:) }
       let!(:inventory_list2) { create(:inventory_list, game:) }
       let!(:inventory_list3) { create(:inventory_list, game:) }
@@ -26,9 +26,9 @@ RSpec.describe InventoryList, type: :model do
     describe '::includes_items' do
       subject(:includes_items) { game.inventory_lists.includes_items }
 
-      let!(:game)           { create(:game) }
+      let!(:game) { create(:game) }
       let!(:aggregate_list) { create(:aggregate_inventory_list, game:) }
-      let!(:lists)          { create_list(:inventory_list_with_list_items, 2, game:) }
+      let!(:lists) { create_list(:inventory_list_with_list_items, 2, game:) }
 
       it 'includes the inventory list items' do
         expect(includes_items).to eq game.inventory_lists.includes(:list_items)
@@ -39,7 +39,7 @@ RSpec.describe InventoryList, type: :model do
     describe '::aggregates_first' do
       subject(:aggregate_first) { game.inventory_lists.aggregate_first.to_a }
 
-      let!(:game)           { create(:game) }
+      let!(:game) { create(:game) }
       let!(:aggregate_list) { create(:aggregate_inventory_list, game:) }
       let!(:inventory_list) { create(:inventory_list, game:) }
 
@@ -49,7 +49,7 @@ RSpec.describe InventoryList, type: :model do
     end
 
     describe '::belongs_to_user' do
-      let(:user)   { create(:user) }
+      let(:user) { create(:user) }
       let!(:game1) { create(:game_with_inventory_lists, user:) }
       let!(:game2) { create(:game_with_inventory_lists, user:) }
       let!(:game3) { create(:game_with_inventory_lists, user:) }
@@ -82,7 +82,7 @@ RSpec.describe InventoryList, type: :model do
     # Aggregatable
     describe 'aggregate lists' do
       context 'when there are no aggregate lists' do
-        let(:game)           { create(:game) }
+        let(:game) { create(:game) }
         let(:aggregate_list) { build(:aggregate_inventory_list, game:) }
 
         it 'is valid' do
@@ -91,7 +91,7 @@ RSpec.describe InventoryList, type: :model do
       end
 
       context 'when there is an existing aggregate list belonging to another user' do
-        let(:game)           { create(:game) }
+        let(:game) { create(:game) }
         let(:aggregate_list) { build(:aggregate_inventory_list, game:) }
 
         before do
@@ -104,7 +104,7 @@ RSpec.describe InventoryList, type: :model do
       end
 
       context 'when the user already has an aggregate list' do
-        let(:game)           { create(:game) }
+        let(:game) { create(:game) }
         let(:aggregate_list) { build(:aggregate_inventory_list, game:) }
 
         before do
@@ -306,10 +306,10 @@ RSpec.describe InventoryList, type: :model do
     subject(:items) { inventory_list.list_items }
 
     let!(:aggregate_list) { create(:aggregate_inventory_list) }
-    let(:inventory_list)  { create(:inventory_list, game: aggregate_list.game, aggregate_list_id: aggregate_list.id) }
-    let!(:item1)          { create(:inventory_item, list: inventory_list) }
-    let!(:item2)          { create(:inventory_item, list: inventory_list) }
-    let!(:item3)          { create(:inventory_item, list: inventory_list) }
+    let(:inventory_list) { create(:inventory_list, game: aggregate_list.game, aggregate_list_id: aggregate_list.id) }
+    let!(:item1) { create(:inventory_item, list: inventory_list) }
+    let!(:item2) { create(:inventory_item, list: inventory_list) }
+    let!(:item3) { create(:inventory_item, list: inventory_list) }
 
     before do
       item2.update!(quantity: 2)
@@ -353,7 +353,7 @@ RSpec.describe InventoryList, type: :model do
 
     let!(:aggregate_list) { create(:aggregate_inventory_list, game:) }
     let!(:inventory_list) { create(:inventory_list, game:) }
-    let(:game)            { create(:game) }
+    let(:game) { create(:game) }
 
     context 'when the game has additional regular lists' do
       before do
@@ -399,7 +399,7 @@ RSpec.describe InventoryList, type: :model do
       end
 
       context 'when there is a matching item on the aggregate list' do
-        let(:other_list)          { create(:inventory_list, game: aggregate_list.game, aggregate_list:) }
+        let(:other_list) { create(:inventory_list, game: aggregate_list.game, aggregate_list:) }
         let!(:item_on_other_list) { create(:inventory_item, description: 'Dwarven metal ingot', list: other_list, unit_weight: 0.3) }
 
         context 'when both have notes' do
@@ -415,7 +415,7 @@ RSpec.describe InventoryList, type: :model do
 
         context 'when neither have notes' do
           let!(:existing_list_item) { create(:inventory_item, list: aggregate_list, quantity: 3, notes: nil) }
-          let(:list_item)           { create(:inventory_item, description: existing_list_item.description, quantity: 2, notes: nil) }
+          let(:list_item) { create(:inventory_item, description: existing_list_item.description, quantity: 2, notes: nil) }
 
           it 'combines the quantities and leaves the notes nil', :aggregate_failures do
             add_item
@@ -468,7 +468,7 @@ RSpec.describe InventoryList, type: :model do
 
       context 'when called on a non-aggregate list' do
         let(:aggregate_list) { create(:inventory_list) }
-        let(:list_item)      { create(:inventory_item) }
+        let(:list_item) { create(:inventory_item) }
 
         it 'raises an AggregateListError' do
           expect { add_item }
@@ -482,7 +482,7 @@ RSpec.describe InventoryList, type: :model do
 
       context 'when there is no matching item on the aggregate list' do
         let(:aggregate_list) { create(:aggregate_inventory_list) }
-        let(:item_attrs)     { { description: 'Necklace', quantity: 3, notes: 'some notes' } }
+        let(:item_attrs) { { description: 'Necklace', quantity: 3, notes: 'some notes' } }
 
         it 'raises an error' do
           expect { remove_item }
@@ -492,7 +492,7 @@ RSpec.describe InventoryList, type: :model do
 
       context 'when the quantity is greater than the quantity on the aggregate list' do
         let(:aggregate_list) { create(:aggregate_inventory_list) }
-        let(:item_attrs)     { { 'description' => 'Necklace', 'quantity' => 3, 'notes' => 'some notes' } }
+        let(:item_attrs) { { 'description' => 'Necklace', 'quantity' => 3, 'notes' => 'some notes' } }
 
         before do
           aggregate_list.list_items.create(description: 'Necklace', quantity: 2)
@@ -506,7 +506,7 @@ RSpec.describe InventoryList, type: :model do
 
       context 'when the quantity is equal to the quantity on the aggregate list' do
         let(:aggregate_list) { create(:aggregate_inventory_list) }
-        let(:item_attrs)     { { 'description' => 'Necklace', 'quantity' => 3, 'notes' => 'some notes' } }
+        let(:item_attrs) { { 'description' => 'Necklace', 'quantity' => 3, 'notes' => 'some notes' } }
 
         before do
           aggregate_list.list_items.create(description: 'Necklace', quantity: 3)
@@ -593,7 +593,7 @@ RSpec.describe InventoryList, type: :model do
 
       context 'when called on a non-aggregate list' do
         let(:aggregate_list) { create(:inventory_list) }
-        let(:item_attrs)     { { description: 'Necklace', quantity: 3, notes: 'some notes' } }
+        let(:item_attrs) { { description: 'Necklace', quantity: 3, notes: 'some notes' } }
 
         it 'raises an error' do
           expect { remove_item }
@@ -606,11 +606,11 @@ RSpec.describe InventoryList, type: :model do
       subject(:update_item) { aggregate_list.update_item_from_child_list(description, delta, unit_weight, old_notes, new_notes) }
 
       let(:aggregate_list) { create(:aggregate_inventory_list) }
-      let(:description)    { 'Corundum ingot' }
-      let(:unit_weight)    { 1 }
+      let(:description) { 'Corundum ingot' }
+      let(:unit_weight) { 1 }
 
       context 'when adjusting quantity up' do
-        let(:delta)     { 2 }
+        let(:delta) { 2 }
         let(:old_notes) { 'something' }
         let(:new_notes) { 'another thing' }
 
@@ -631,7 +631,7 @@ RSpec.describe InventoryList, type: :model do
       end
 
       context 'when adjusting quantity down' do
-        let(:delta)     { -2 }
+        let(:delta) { -2 }
         let(:old_notes) { 'something' }
         let(:new_notes) { 'another thing' }
 
@@ -680,7 +680,7 @@ RSpec.describe InventoryList, type: :model do
         subject(:update_item) { aggregate_list.update_item_from_child_list(description, 1, 2, 'something', 'another thing') }
 
         let(:other_list) { create(:inventory_list, game: aggregate_list.game, aggregate_list:) }
-        let!(:item_on_other_list)  { create(:inventory_item, list: other_list, description:, unit_weight: 1) }
+        let!(:item_on_other_list) { create(:inventory_item, list: other_list, description:, unit_weight: 1) }
         let!(:aggregate_list_item) { create(:inventory_item, list: aggregate_list, description:, quantity: 3, unit_weight: 1, notes: 'something') }
 
         before do
@@ -699,7 +699,7 @@ RSpec.describe InventoryList, type: :model do
       end
 
       context 'when the notes have not changed' do
-        let(:delta)     { -2 }
+        let(:delta) { -2 }
         let(:old_notes) { 'something' }
         let(:new_notes) { 'something' }
 
@@ -714,7 +714,7 @@ RSpec.describe InventoryList, type: :model do
       end
 
       context 'when there are edge cases with the notes' do
-        let(:delta)          { 5 }
+        let(:delta) { 5 }
         let(:existing_notes) { 'notes 1 -- notes 2 -- notes 3' }
 
         before do
@@ -763,8 +763,8 @@ RSpec.describe InventoryList, type: :model do
 
         context 'when there are multiple identical note values' do
           let(:existing_notes) { 'notes 1 -- notes 1 -- notes 2' }
-          let(:old_notes)      { 'notes 1' }
-          let(:new_notes)      { 'something else' }
+          let(:old_notes) { 'notes 1' }
+          let(:new_notes) { 'something else' }
 
           it 'only replaces one instance' do
             update_item
@@ -794,7 +794,7 @@ RSpec.describe InventoryList, type: :model do
       end
 
       context 'when the delta would bring the quantity below zero' do
-        let(:delta)     { -20 }
+        let(:delta) { -20 }
         let(:old_notes) { nil }
         let(:new_notes) { 'something else' }
 
@@ -806,9 +806,9 @@ RSpec.describe InventoryList, type: :model do
 
       context 'when the unit_weight is not a number' do
         let(:unit_weight) { 'carrot' }
-        let(:delta)       { 1 }
-        let(:old_notes)   { nil }
-        let(:new_notes)   { nil }
+        let(:delta) { 1 }
+        let(:old_notes) { nil }
+        let(:new_notes) { nil }
 
         before do
           aggregate_list.list_items.create!(description:)
@@ -822,9 +822,9 @@ RSpec.describe InventoryList, type: :model do
 
       context 'when the unit_weight value is invalid' do
         let(:unit_weight) { -0.3 }
-        let(:delta)       { 1 }
-        let(:old_notes)   { nil }
-        let(:new_notes)   { nil }
+        let(:delta) { 1 }
+        let(:old_notes) { nil }
+        let(:new_notes) { nil }
 
         before do
           aggregate_list.list_items.create!(description:, quantity: 1)
@@ -838,9 +838,9 @@ RSpec.describe InventoryList, type: :model do
 
       context 'when there is no matching item on the aggregate list' do
         let(:description) { 'Iron ore' }
-        let(:delta)       { 2 }
-        let(:old_notes)   { 'something' }
-        let(:new_notes)   { 'something else' }
+        let(:delta) { 2 }
+        let(:old_notes) { 'something' }
+        let(:new_notes) { 'something else' }
 
         it 'raises an error' do
           expect { update_item }
@@ -850,10 +850,10 @@ RSpec.describe InventoryList, type: :model do
 
       context 'when called on a regular list' do
         let(:aggregate_list) { create(:inventory_list) }
-        let(:description)    { 'Corundum ingot' }
-        let(:delta)          { 2 }
-        let(:old_notes)      { 'to build things' }
-        let(:new_notes)      { 'to make locks' }
+        let(:description) { 'Corundum ingot' }
+        let(:delta) { 2 }
+        let(:old_notes) { 'to build things' }
+        let(:new_notes) { 'to make locks' }
 
         it 'raises an error' do
           expect { update_item }
@@ -872,7 +872,7 @@ RSpec.describe InventoryList, type: :model do
   end
 
   describe 'parent model' do
-    let(:game)           { create(:game) }
+    let(:game) { create(:game) }
     let(:aggregate_list) { create(:aggregate_inventory_list, game:) }
 
     it 'is invalid without a game' do

--- a/spec/models/property_spec.rb
+++ b/spec/models/property_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Property, type: :model do
       end
 
       it 'has a unique combination of game and canonical property' do
-        property.game               = game
+        property.game = game
         property.canonical_property = canonical_property
         property.validate
         expect(property.errors[:canonical_property]).to include 'must be unique per game'
@@ -114,9 +114,9 @@ RSpec.describe Property, type: :model do
 
       it 'must have the same name, hold, and city as the canonical property' do
         property.canonical_property_id = canonical_property.id
-        property.name                  = canonical_property.name
-        property.hold                  = canonical_property.hold
-        property.city                  = nil
+        property.name = canonical_property.name
+        property.hold = canonical_property.hold
+        property.city = nil
         property.validate
         expect(property.errors[:base]).to include 'property attributes must match attributes of a property that exists in Skyrim'
       end
@@ -128,7 +128,7 @@ RSpec.describe Property, type: :model do
 
         it 'cannot have an arcane enchanter' do
           property.canonical_property_id = canonical_property.id
-          property.has_arcane_enchanter  = true
+          property.has_arcane_enchanter = true
           property.validate
           expect(property.errors[:has_arcane_enchanter]).to include 'cannot be true because this property cannot have an arcane enchanter in Skyrim'
         end
@@ -139,14 +139,14 @@ RSpec.describe Property, type: :model do
 
         it 'can have an arcane enchanter' do
           property.canonical_property_id = canonical_property.id
-          property.has_arcane_enchanter  = true
+          property.has_arcane_enchanter = true
           property.validate
           expect(property.errors[:has_arcane_enchanter]).to be_blank
         end
 
         it "doesn't have to have an arcane enchanter" do
           property.canonical_property_id = canonical_property.id
-          property.has_arcane_enchanter  = false
+          property.has_arcane_enchanter = false
           property.validate
           expect(property.errors[:has_arcane_enchanter]).to be_blank
         end
@@ -159,7 +159,7 @@ RSpec.describe Property, type: :model do
 
         it 'cannot have a forge' do
           property.canonical_property_id = canonical_property.id
-          property.has_forge             = true
+          property.has_forge = true
           property.validate
           expect(property.errors[:has_forge]).to include 'cannot be true because this property cannot have a forge in Skyrim'
         end
@@ -170,14 +170,14 @@ RSpec.describe Property, type: :model do
 
         it 'can have a forge' do
           property.canonical_property_id = canonical_property.id
-          property.has_forge             = true
+          property.has_forge = true
           property.validate
           expect(property.errors[:has_forge]).to be_blank
         end
 
         it "doesn't have to have a forge" do
           property.canonical_property_id = canonical_property.id
-          property.has_forge             = false
+          property.has_forge = false
           property.validate
           expect(property.errors[:has_forge]).to be_blank
         end

--- a/spec/models/shopping_list_item_spec.rb
+++ b/spec/models/shopping_list_item_spec.rb
@@ -3,9 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe ShoppingListItem, type: :model do
-  let!(:game)          { create(:game) }
+  let!(:game) { create(:game) }
   let(:aggregate_list) { create(:aggregate_shopping_list, game:) }
-  let(:shopping_list)  { create(:shopping_list, game:, aggregate_list:) }
+  let(:shopping_list) { create(:shopping_list, game:, aggregate_list:) }
 
   describe 'delegation' do
     let(:list_item) { create(:shopping_list_item, list: shopping_list) }

--- a/spec/models/shopping_list_spec.rb
+++ b/spec/models/shopping_list_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ShoppingList, type: :model do
     describe '::index_order' do
       subject(:index_order) { game.shopping_lists.index_order.to_a }
 
-      let!(:game)           { create(:game) }
+      let!(:game) { create(:game) }
       let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
       let!(:shopping_list1) { create(:shopping_list, game:) }
       let!(:shopping_list2) { create(:shopping_list, game:) }
@@ -26,9 +26,9 @@ RSpec.describe ShoppingList, type: :model do
     describe '::includes_items' do
       subject(:includes_items) { game.shopping_lists.includes_items }
 
-      let!(:game)           { create(:game) }
+      let!(:game) { create(:game) }
       let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
-      let!(:lists)          { create_list(:shopping_list_with_list_items, 2, game:) }
+      let!(:lists) { create_list(:shopping_list_with_list_items, 2, game:) }
 
       it 'includes the shopping list items' do
         expect(includes_items).to eq game.shopping_lists.includes(:list_items)
@@ -39,9 +39,9 @@ RSpec.describe ShoppingList, type: :model do
     describe '::aggregates_first' do
       subject(:aggregate_first) { game.shopping_lists.aggregate_first.to_a }
 
-      let!(:game)           { create(:game) }
+      let!(:game) { create(:game) }
       let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
-      let!(:shopping_list)  { create(:shopping_list, game:) }
+      let!(:shopping_list) { create(:shopping_list, game:) }
 
       it 'returns the shopping lists with the aggregate list first' do
         expect(aggregate_first).to eq([aggregate_list, shopping_list])
@@ -49,7 +49,7 @@ RSpec.describe ShoppingList, type: :model do
     end
 
     describe '::belongs_to_user' do
-      let(:user)   { create(:user) }
+      let(:user) { create(:user) }
       let!(:game1) { create(:game_with_shopping_lists, user:) }
       let!(:game2) { create(:game_with_shopping_lists, user:) }
       let!(:game3) { create(:game_with_shopping_lists, user:) }
@@ -82,7 +82,7 @@ RSpec.describe ShoppingList, type: :model do
     # Aggregatable
     describe 'aggregate lists' do
       context 'when there are no aggregate lists' do
-        let(:game)           { create(:game) }
+        let(:game) { create(:game) }
         let(:aggregate_list) { build(:aggregate_shopping_list, game:) }
 
         it 'is valid' do
@@ -91,7 +91,7 @@ RSpec.describe ShoppingList, type: :model do
       end
 
       context 'when there is an existing aggregate list belonging to another user' do
-        let(:game)           { create(:game) }
+        let(:game) { create(:game) }
         let(:aggregate_list) { build(:aggregate_shopping_list, game:) }
 
         before do
@@ -104,7 +104,7 @@ RSpec.describe ShoppingList, type: :model do
       end
 
       context 'when the user already has an aggregate list' do
-        let(:game)           { create(:game) }
+        let(:game) { create(:game) }
         let(:aggregate_list) { build(:aggregate_shopping_list, game:) }
 
         before do
@@ -176,7 +176,7 @@ RSpec.describe ShoppingList, type: :model do
   # Aggregatable
   describe '#aggregate_list' do
     let!(:aggregate_list) { create(:aggregate_shopping_list) }
-    let(:shopping_list)   { create(:shopping_list, game: aggregate_list.game) }
+    let(:shopping_list) { create(:shopping_list, game: aggregate_list.game) }
 
     it 'returns the aggregate list that tracks it' do
       expect(shopping_list.aggregate_list).to eq aggregate_list
@@ -300,10 +300,10 @@ RSpec.describe ShoppingList, type: :model do
     subject(:items) { shopping_list.list_items }
 
     let!(:aggregate_list) { create(:aggregate_shopping_list) }
-    let(:shopping_list)   { create(:shopping_list, game: aggregate_list.game, aggregate_list_id: aggregate_list.id) }
-    let!(:item1)          { create(:shopping_list_item, list: shopping_list) }
-    let!(:item2)          { create(:shopping_list_item, list: shopping_list) }
-    let!(:item3)          { create(:shopping_list_item, list: shopping_list) }
+    let(:shopping_list) { create(:shopping_list, game: aggregate_list.game, aggregate_list_id: aggregate_list.id) }
+    let!(:item1) { create(:shopping_list_item, list: shopping_list) }
+    let!(:item2) { create(:shopping_list_item, list: shopping_list) }
+    let!(:item3) { create(:shopping_list_item, list: shopping_list) }
 
     before do
       item2.update!(quantity: 2)
@@ -346,8 +346,8 @@ RSpec.describe ShoppingList, type: :model do
     subject(:destroy_list) { shopping_list.destroy! }
 
     let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
-    let!(:shopping_list)  { create(:shopping_list, game:) }
-    let(:game)            { create(:game) }
+    let!(:shopping_list) { create(:shopping_list, game:) }
+    let(:game) { create(:game) }
 
     context 'when the user has additional regular lists' do
       before do
@@ -394,12 +394,12 @@ RSpec.describe ShoppingList, type: :model do
       end
 
       context 'when there is a matching item on the aggregate list' do
-        let(:other_list)          { create(:shopping_list, game: aggregate_list.game, aggregate_list:) }
+        let(:other_list) { create(:shopping_list, game: aggregate_list.game, aggregate_list:) }
         let!(:item_on_other_list) { create(:shopping_list_item, description: 'Dwarven metal ingot', list: other_list, unit_weight: 0.3) }
 
         context 'when both have notes' do
           let!(:existing_list_item) { create(:shopping_list_item, description: 'Dwarven metal ingot', notes: 'notes 1 -- notes 2', quantity: 3, unit_weight: 0.3, list: aggregate_list) }
-          let(:list_item)           { create(:shopping_list_item, description: 'Dwarven metal ingot', quantity: 2, notes: 'notes 3') }
+          let(:list_item) { create(:shopping_list_item, description: 'Dwarven metal ingot', quantity: 2, notes: 'notes 3') }
 
           it 'combines the notes and quantities', :aggregate_failures do
             add_item
@@ -410,7 +410,7 @@ RSpec.describe ShoppingList, type: :model do
 
         context 'when neither have notes' do
           let!(:existing_list_item) { create(:shopping_list_item, list: aggregate_list, quantity: 3, notes: nil) }
-          let(:list_item)           { create(:shopping_list_item, description: existing_list_item.description, quantity: 2, notes: nil) }
+          let(:list_item) { create(:shopping_list_item, description: existing_list_item.description, quantity: 2, notes: nil) }
 
           it 'combines the quantities and leaves the notes nil', :aggregate_failures do
             add_item
@@ -421,7 +421,7 @@ RSpec.describe ShoppingList, type: :model do
 
         context 'when one has notes and the other does not' do
           let!(:existing_list_item) { create(:shopping_list_item, description: 'Dwarven metal ingot', quantity: 3, unit_weight: 0.3, notes: 'notes 1 -- notes 2', list: aggregate_list) }
-          let(:list_item)           { create(:shopping_list_item, description: existing_list_item.description, quantity: 2) }
+          let(:list_item) { create(:shopping_list_item, description: existing_list_item.description, quantity: 2) }
 
           it 'combines the quantities and uses the existing notes value', :aggregate_failures do
             add_item
@@ -432,7 +432,7 @@ RSpec.describe ShoppingList, type: :model do
 
         context "when the new item doesn't have a unit weight" do
           let!(:existing_list_item) { create(:shopping_list_item, description: 'Dwarven metal ingot', list: aggregate_list, unit_weight: 0.3) }
-          let(:list_item)           { create(:shopping_list_item, description: existing_list_item.description, quantity: 2, notes: nil, unit_weight: nil) }
+          let(:list_item) { create(:shopping_list_item, description: existing_list_item.description, quantity: 2, notes: nil, unit_weight: nil) }
 
           it 'leaves the unit weight as-is on the existing item' do
             add_item
@@ -447,7 +447,7 @@ RSpec.describe ShoppingList, type: :model do
 
         context 'when the new item has a unit weight' do
           let!(:existing_list_item) { create(:shopping_list_item, description: item_on_other_list.description, list: aggregate_list) }
-          let(:list_item)           { create(:shopping_list_item, description: existing_list_item.description, quantity: 2, notes: nil, unit_weight: 0.2) }
+          let(:list_item) { create(:shopping_list_item, description: existing_list_item.description, quantity: 2, notes: nil, unit_weight: 0.2) }
 
           it 'updates the unit weight of the existing item' do
             add_item
@@ -463,7 +463,7 @@ RSpec.describe ShoppingList, type: :model do
 
       context 'when called on a non-aggregate list' do
         let(:aggregate_list) { create(:shopping_list) }
-        let(:list_item)      { create(:shopping_list_item) }
+        let(:list_item) { create(:shopping_list_item) }
 
         it 'raises an AggregateListError' do
           expect { add_item }
@@ -477,7 +477,7 @@ RSpec.describe ShoppingList, type: :model do
 
       context 'when there is no matching item on the aggregate list' do
         let(:aggregate_list) { create(:aggregate_shopping_list) }
-        let(:item_attrs)     { { description: 'Necklace', quantity: 3, notes: 'some notes' } }
+        let(:item_attrs) { { description: 'Necklace', quantity: 3, notes: 'some notes' } }
 
         it 'raises an error' do
           expect { remove_item }
@@ -487,7 +487,7 @@ RSpec.describe ShoppingList, type: :model do
 
       context 'when the quantity is greater than the quantity on the aggregate list' do
         let(:aggregate_list) { create(:aggregate_shopping_list) }
-        let(:item_attrs)     { { 'description' => 'Necklace', 'quantity' => 3, 'notes' => 'some notes' } }
+        let(:item_attrs) { { 'description' => 'Necklace', 'quantity' => 3, 'notes' => 'some notes' } }
 
         before do
           aggregate_list.list_items.create(description: 'Necklace', quantity: 2)
@@ -501,7 +501,7 @@ RSpec.describe ShoppingList, type: :model do
 
       context 'when the quantity is equal to the quantity on the aggregate list' do
         let(:aggregate_list) { create(:aggregate_shopping_list) }
-        let(:item_attrs)     { { 'description' => 'Necklace', 'quantity' => 3, 'notes' => 'some notes' } }
+        let(:item_attrs) { { 'description' => 'Necklace', 'quantity' => 3, 'notes' => 'some notes' } }
 
         before do
           aggregate_list.list_items.create(description: 'Necklace', quantity: 3)
@@ -588,7 +588,7 @@ RSpec.describe ShoppingList, type: :model do
 
       context 'when called on a non-aggregate list' do
         let(:aggregate_list) { create(:shopping_list) }
-        let(:item_attrs)     { { description: 'Necklace', quantity: 3, notes: 'some notes' } }
+        let(:item_attrs) { { description: 'Necklace', quantity: 3, notes: 'some notes' } }
 
         it 'raises an error' do
           expect { remove_item }
@@ -601,11 +601,11 @@ RSpec.describe ShoppingList, type: :model do
       subject(:update_item) { aggregate_list.update_item_from_child_list(description, delta, unit_weight, old_notes, new_notes) }
 
       let(:aggregate_list) { create(:aggregate_shopping_list) }
-      let(:description)    { 'Corundum ingot' }
-      let(:unit_weight)    { 1 }
+      let(:description) { 'Corundum ingot' }
+      let(:unit_weight) { 1 }
 
       context 'when adjusting quantity up' do
-        let(:delta)     { 2 }
+        let(:delta) { 2 }
         let(:old_notes) { 'something' }
         let(:new_notes) { 'another thing' }
 
@@ -626,7 +626,7 @@ RSpec.describe ShoppingList, type: :model do
       end
 
       context 'when adjusting quantity down' do
-        let(:delta)     { -2 }
+        let(:delta) { -2 }
         let(:old_notes) { 'something' }
         let(:new_notes) { 'another thing' }
 
@@ -675,7 +675,7 @@ RSpec.describe ShoppingList, type: :model do
         subject(:update_item) { aggregate_list.update_item_from_child_list(description, 1, 2, 'something', 'another thing') }
 
         let(:other_list) { create(:shopping_list, game: aggregate_list.game, aggregate_list:) }
-        let!(:item_on_other_list)  { create(:shopping_list_item, list: other_list, description:, unit_weight: 1) }
+        let!(:item_on_other_list) { create(:shopping_list_item, list: other_list, description:, unit_weight: 1) }
         let!(:aggregate_list_item) { create(:shopping_list_item, list: aggregate_list, description:, quantity: 3, unit_weight: 1, notes: 'something') }
 
         before do
@@ -694,7 +694,7 @@ RSpec.describe ShoppingList, type: :model do
       end
 
       context 'when the notes have not changed' do
-        let(:delta)     { -2 }
+        let(:delta) { -2 }
         let(:old_notes) { 'something' }
         let(:new_notes) { 'something' }
 
@@ -709,7 +709,7 @@ RSpec.describe ShoppingList, type: :model do
       end
 
       context 'when there are edge cases with the notes' do
-        let(:delta)          { 5 }
+        let(:delta) { 5 }
         let(:existing_notes) { 'notes 1 -- notes 2 -- notes 3' }
 
         before do
@@ -758,8 +758,8 @@ RSpec.describe ShoppingList, type: :model do
 
         context 'when there are multiple identical note values' do
           let(:existing_notes) { 'notes 1 -- notes 1 -- notes 2' }
-          let(:old_notes)      { 'notes 1' }
-          let(:new_notes)      { 'something else' }
+          let(:old_notes) { 'notes 1' }
+          let(:new_notes) { 'something else' }
 
           it 'only replaces one instance' do
             update_item
@@ -789,7 +789,7 @@ RSpec.describe ShoppingList, type: :model do
       end
 
       context 'when the delta would bring the quantity below zero' do
-        let(:delta)     { -20 }
+        let(:delta) { -20 }
         let(:old_notes) { nil }
         let(:new_notes) { 'something else' }
 
@@ -801,9 +801,9 @@ RSpec.describe ShoppingList, type: :model do
 
       context 'when the unit_weight is not a number' do
         let(:unit_weight) { 'carrot' }
-        let(:delta)       { 1 }
-        let(:old_notes)   { nil }
-        let(:new_notes)   { nil }
+        let(:delta) { 1 }
+        let(:old_notes) { nil }
+        let(:new_notes) { nil }
 
         before do
           aggregate_list.list_items.create!(description:)
@@ -817,9 +817,9 @@ RSpec.describe ShoppingList, type: :model do
 
       context 'when the unit_weight value is invalid' do
         let(:unit_weight) { -0.3 }
-        let(:delta)       { 1 }
-        let(:old_notes)   { nil }
-        let(:new_notes)   { nil }
+        let(:delta) { 1 }
+        let(:old_notes) { nil }
+        let(:new_notes) { nil }
 
         before do
           aggregate_list.list_items.create!(description:, quantity: 1)
@@ -833,9 +833,9 @@ RSpec.describe ShoppingList, type: :model do
 
       context 'when there is no matching item on the aggregate list' do
         let(:description) { 'Iron ore' }
-        let(:delta)       { 2 }
-        let(:old_notes)   { 'something' }
-        let(:new_notes)   { 'something else' }
+        let(:delta) { 2 }
+        let(:old_notes) { 'something' }
+        let(:new_notes) { 'something else' }
 
         it 'raises an error' do
           expect { update_item }
@@ -845,10 +845,10 @@ RSpec.describe ShoppingList, type: :model do
 
       context 'when called on a regular list' do
         let(:aggregate_list) { create(:shopping_list) }
-        let(:description)    { 'Corundum ingot' }
-        let(:delta)          { 2 }
-        let(:old_notes)      { 'to build things' }
-        let(:new_notes)      { 'to make locks' }
+        let(:description) { 'Corundum ingot' }
+        let(:delta) { 2 }
+        let(:old_notes) { 'to build things' }
+        let(:new_notes) { 'to make locks' }
 
         it 'raises an error' do
           expect { update_item }

--- a/spec/requests/games_spec.rb
+++ b/spec/requests/games_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe 'Games', type: :request do
 
     context 'when not authenticated' do
       let!(:user) { create(:authenticated_user) }
-      let!(:game)  { create(:game, user:) }
+      let!(:game) { create(:game, user:) }
       let(:params) { { game: { name: 'Skyrim Game 1' } } }
 
       before do
@@ -188,7 +188,7 @@ RSpec.describe 'Games', type: :request do
       end
 
       context 'when all goes well' do
-        let(:game)   { create(:game, user:) }
+        let(:game) { create(:game, user:) }
         let(:params) { { game: { name: 'New Name' } }.to_json }
 
         it 'updates the game' do
@@ -208,16 +208,16 @@ RSpec.describe 'Games', type: :request do
           # on the deserialised response body differs from those on the model by '+0000' This is
           # the only way I've found to fix the tests.
           game_attributes_without_timestamps = game.reload.attributes.except('created_at', 'updated_at')
-          response_body_without_timestamps   = JSON.parse(response.body).except('created_at', 'updated_at')
+          response_body_without_timestamps = JSON.parse(response.body).except('created_at', 'updated_at')
 
           expect(response_body_without_timestamps).to eq game_attributes_without_timestamps
         end
       end
 
       context 'when the params are invalid' do
-        let!(:game)       { create(:game, user:) }
+        let!(:game) { create(:game, user:) }
         let!(:other_game) { create(:game, user:) }
-        let(:params)      { { game: { name: other_game.name } }.to_json }
+        let(:params) { { game: { name: other_game.name } }.to_json }
 
         it 'returns status 422' do
           update_game
@@ -231,7 +231,7 @@ RSpec.describe 'Games', type: :request do
       end
 
       context 'when the game does not exist' do
-        let(:game)   { double(id: 829_315) }
+        let(:game) { double(id: 829_315) }
         let(:params) { { game: { name: 'New Name' } }.to_json }
 
         it 'returns status 404' do
@@ -246,7 +246,7 @@ RSpec.describe 'Games', type: :request do
       end
 
       context 'when the game belongs to another user' do
-        let!(:game)  { create(:game) }
+        let!(:game) { create(:game) }
         let(:params) { { game: { name: 'New Name' } }.to_json }
 
         it "doesn't update the game" do
@@ -261,7 +261,7 @@ RSpec.describe 'Games', type: :request do
       end
 
       context 'when something unexpected goes wrong' do
-        let(:game)   { create(:game, user:) }
+        let(:game) { create(:game, user:) }
         let(:params) { { game: { description: 'New description' } }.to_json }
 
         before do
@@ -282,7 +282,7 @@ RSpec.describe 'Games', type: :request do
 
     context 'when not authenticated' do
       let!(:user) { create(:authenticated_user) }
-      let!(:game)  { create(:game, user:) }
+      let!(:game) { create(:game, user:) }
       let(:params) { { game: { name: 'Changed Name' } } }
 
       before do
@@ -317,7 +317,7 @@ RSpec.describe 'Games', type: :request do
       end
 
       context 'when all goes well' do
-        let(:game)   { create(:game, user:) }
+        let(:game) { create(:game, user:) }
         let(:params) { { game: { name: 'New Name' } }.to_json }
 
         it 'updates the game' do
@@ -337,16 +337,16 @@ RSpec.describe 'Games', type: :request do
           # on the deserialised response body differs from those on the model by '+0000' This is
           # the only way I've found to fix the tests.
           game_attributes_without_timestamps = game.reload.attributes.except('created_at', 'updated_at')
-          response_body_without_timestamps   = JSON.parse(response.body).except('created_at', 'updated_at')
+          response_body_without_timestamps = JSON.parse(response.body).except('created_at', 'updated_at')
 
           expect(response_body_without_timestamps).to eq game_attributes_without_timestamps
         end
       end
 
       context 'when the params are invalid' do
-        let!(:game)       { create(:game, user:) }
+        let!(:game) { create(:game, user:) }
         let!(:other_game) { create(:game, user:) }
-        let(:params)      { { game: { name: other_game.name } }.to_json }
+        let(:params) { { game: { name: other_game.name } }.to_json }
 
         it 'returns status 422' do
           update_game
@@ -360,7 +360,7 @@ RSpec.describe 'Games', type: :request do
       end
 
       context 'when the game does not exist' do
-        let(:game)   { double(id: 829_315) }
+        let(:game) { double(id: 829_315) }
         let(:params) { { game: { name: 'New Name' } }.to_json }
 
         it 'returns status 404' do
@@ -375,7 +375,7 @@ RSpec.describe 'Games', type: :request do
       end
 
       context 'when the game belongs to another user' do
-        let!(:game)  { create(:game) }
+        let!(:game) { create(:game) }
         let(:params) { { game: { name: 'New Name' } }.to_json }
 
         it "doesn't update the game" do
@@ -390,7 +390,7 @@ RSpec.describe 'Games', type: :request do
       end
 
       context 'when something unexpected goes wrong' do
-        let(:game)   { create(:game, user:) }
+        let(:game) { create(:game, user:) }
         let(:params) { { game: { description: 'New description' } }.to_json }
 
         before do
@@ -410,8 +410,8 @@ RSpec.describe 'Games', type: :request do
     end
 
     context 'when not authenticated' do
-      let!(:game)  { create(:game, user:) }
-      let(:user)   { create(:authenticated_user) }
+      let!(:game) { create(:game, user:) }
+      let(:user) { create(:authenticated_user) }
       let(:params) { { game: { name: 'Changed Name' } } }
 
       before do

--- a/spec/requests/inventory_items_spec.rb
+++ b/spec/requests/inventory_items_spec.rb
@@ -16,9 +16,9 @@ RSpec.describe 'InventoryItems', type: :request do
       post "/inventory_lists/#{inventory_list.id}/inventory_items", params:, headers:
     end
 
-    let!(:game)            { create(:game, user:) }
-    let!(:inventory_list)  { create(:inventory_list, game:) }
-    let!(:aggregate_list)  { game.aggregate_inventory_list }
+    let!(:game) { create(:game, user:) }
+    let!(:inventory_list) { create(:inventory_list, game:) }
+    let!(:aggregate_list) { game.aggregate_inventory_list }
 
     context 'when authenticated' do
       before do
@@ -54,7 +54,7 @@ RSpec.describe 'InventoryItems', type: :request do
 
           context 'when there is an existing matching item on another list' do
             let!(:other_item) { create(:inventory_item, list: other_list, description: 'Corundum ingot', quantity: 2) }
-            let(:other_list)  { create(:inventory_list, game:) }
+            let(:other_list) { create(:inventory_list, game:) }
 
             before do
               aggregate_list.add_item_from_child_list(other_item)
@@ -120,9 +120,9 @@ RSpec.describe 'InventoryItems', type: :request do
         end
 
         context 'when there is an existing matching item on the same list' do
-          let(:other_list)  { create(:inventory_list, game:, aggregate_list:) }
+          let(:other_list) { create(:inventory_list, game:, aggregate_list:) }
           let!(:other_item) { create(:inventory_item, list: other_list, description: 'Corundum ingot', quantity: 2) }
-          let!(:list_item)  { create(:inventory_item, list: inventory_list, description: 'Corundum ingot', quantity: 3) }
+          let!(:list_item) { create(:inventory_item, list: inventory_list, description: 'Corundum ingot', quantity: 3) }
 
           before do
             aggregate_list.add_item_from_child_list(other_item)
@@ -198,7 +198,7 @@ RSpec.describe 'InventoryItems', type: :request do
       end
 
       context "when the list doesn't exist" do
-        let(:params)         { { description: 'Necklace', quantity: 2, unit_weight: 0.5 }.to_json }
+        let(:params) { { description: 'Necklace', quantity: 2, unit_weight: 0.5 }.to_json }
         let(:inventory_list) { double(id: 23_498) }
 
         it 'returns status 404' do
@@ -213,7 +213,7 @@ RSpec.describe 'InventoryItems', type: :request do
       end
 
       context 'when the list belongs to another user' do
-        let(:params)         { { description: 'Necklace', quantity: 2, unit_weight: 0.5 }.to_json }
+        let(:params) { { description: 'Necklace', quantity: 2, unit_weight: 0.5 }.to_json }
         let(:inventory_list) { create(:inventory_list) }
 
         it "doesn't create an inventory item" do
@@ -252,8 +252,8 @@ RSpec.describe 'InventoryItems', type: :request do
       end
 
       context 'when the list is an aggregate list' do
-        let(:inventory_list)  { create(:aggregate_inventory_list, game:) }
-        let(:params)          { { inventory_item: { description: 'Corundum ingot', quantity: 4 } }.to_json }
+        let(:inventory_list) { create(:aggregate_inventory_list, game:) }
+        let(:params) { { inventory_item: { description: 'Corundum ingot', quantity: 4 } }.to_json }
 
         it "doesn't create an item" do
           expect { create_item }
@@ -319,8 +319,8 @@ RSpec.describe 'InventoryItems', type: :request do
   describe 'PATCH /inventory_items/:id' do
     subject(:update_item) { patch "/inventory_items/#{list_item.id}", headers:, params: }
 
-    let!(:user)           { create(:authenticated_user) }
-    let(:game)            { create(:game, user:) }
+    let!(:user) { create(:authenticated_user) }
+    let(:game) { create(:game, user:) }
     let!(:aggregate_list) { create(:aggregate_inventory_list, game:) }
     let!(:inventory_list) { create(:inventory_list, game:, aggregate_list:) }
 
@@ -331,9 +331,9 @@ RSpec.describe 'InventoryItems', type: :request do
 
       context 'when all goes well' do
         context 'when there is no matching item on another list' do
-          let!(:list_item)          { create(:inventory_item, list: inventory_list, description: 'Dwarven metal ingot', quantity: 5) }
+          let!(:list_item) { create(:inventory_item, list: inventory_list, description: 'Dwarven metal ingot', quantity: 5) }
           let(:aggregate_list_item) { aggregate_list.list_items.first }
-          let(:params)              { { inventory_item: { description: 'Dwarven metal ingot', quantity: 10 } }.to_json }
+          let(:params) { { inventory_item: { description: 'Dwarven metal ingot', quantity: 10 } }.to_json }
 
           before do
             aggregate_list.add_item_from_child_list(list_item)
@@ -361,9 +361,9 @@ RSpec.describe 'InventoryItems', type: :request do
         end
 
         context 'when there is a matching item on another list' do
-          let!(:list_item)          { create(:inventory_item, list: inventory_list) }
-          let!(:other_list)         { create(:inventory_list, game:, aggregate_list:) }
-          let!(:other_item)         { create(:inventory_item, list: other_list, description: list_item.description, quantity: 4) }
+          let!(:list_item) { create(:inventory_item, list: inventory_list) }
+          let!(:other_list) { create(:inventory_list, game:, aggregate_list:) }
+          let!(:other_item) { create(:inventory_item, list: other_list, description: list_item.description, quantity: 4) }
           let(:aggregate_list_item) { aggregate_list.list_items.first }
 
           before do
@@ -487,7 +487,7 @@ RSpec.describe 'InventoryItems', type: :request do
 
       context "when the inventory list item doesn't exist" do
         let(:list_item) { double(id: 234_567) }
-        let(:params)    { { quantity: 4, unit_weight: 0.3 }.to_json }
+        let(:params) { { quantity: 4, unit_weight: 0.3 }.to_json }
 
         it 'returns status 404' do
           update_item
@@ -502,7 +502,7 @@ RSpec.describe 'InventoryItems', type: :request do
 
       context 'when the inventory list item belongs to another user' do
         let!(:list_item) { create(:inventory_item) }
-        let(:params)     { { quantity: 4, unit_weight: 0.3 }.to_json }
+        let(:params) { { quantity: 4, unit_weight: 0.3 }.to_json }
 
         it "doesn't update the item" do
           expect { update_item }
@@ -522,7 +522,7 @@ RSpec.describe 'InventoryItems', type: :request do
 
       context 'when the list item is on an aggregate list' do
         let!(:list_item) { create(:inventory_item, list: aggregate_list) }
-        let(:params)     { { inventory_item: { quantity: 10 } }.to_json }
+        let(:params) { { inventory_item: { quantity: 10 } }.to_json }
 
         it 'returns status 405' do
           update_item
@@ -536,11 +536,11 @@ RSpec.describe 'InventoryItems', type: :request do
       end
 
       context 'when the attributes are invalid' do
-        let!(:list_item)          { create(:inventory_item, list: inventory_list, quantity: 2) }
-        let(:other_list)          { create(:inventory_list, game:) }
-        let!(:other_item)         { create(:inventory_item, list: other_list, description: list_item.description, quantity: 1) }
+        let!(:list_item) { create(:inventory_item, list: inventory_list, quantity: 2) }
+        let(:other_list) { create(:inventory_list, game:) }
+        let!(:other_item) { create(:inventory_item, list: other_list, description: list_item.description, quantity: 1) }
         let(:aggregate_list_item) { aggregate_list.list_items.first }
-        let(:params)              { { inventory_item: { quantity: -4, unit_weight: 2 } }.to_json }
+        let(:params) { { inventory_item: { quantity: -4, unit_weight: 2 } }.to_json }
 
         before do
           aggregate_list.add_item_from_child_list(list_item)
@@ -571,7 +571,7 @@ RSpec.describe 'InventoryItems', type: :request do
 
       context 'when something unexpected goes wrong' do
         let!(:list_item) { create(:inventory_item, list: inventory_list) }
-        let(:params)     { { notes: 'Hello world' }.to_json }
+        let(:params) { { notes: 'Hello world' }.to_json }
 
         before do
           aggregate_list.add_item_from_child_list(list_item)
@@ -594,7 +594,7 @@ RSpec.describe 'InventoryItems', type: :request do
 
     context 'when not authenticated' do
       let!(:list_item) { create(:inventory_item) }
-      let(:params)     { { inventory_item: { description: 'Dwarven metal ingot' } }.to_json }
+      let(:params) { { inventory_item: { description: 'Dwarven metal ingot' } }.to_json }
 
       before do
         stub_unsuccessful_login
@@ -620,8 +620,8 @@ RSpec.describe 'InventoryItems', type: :request do
   describe 'PUT /inventory_items/:id' do
     subject(:update_item) { put "/inventory_items/#{list_item.id}", headers:, params: }
 
-    let!(:user)           { create(:authenticated_user) }
-    let(:game)            { create(:game, user:) }
+    let!(:user) { create(:authenticated_user) }
+    let(:game) { create(:game, user:) }
     let!(:aggregate_list) { create(:aggregate_inventory_list, game:) }
     let!(:inventory_list) { create(:inventory_list, game:, aggregate_list:) }
 
@@ -632,9 +632,9 @@ RSpec.describe 'InventoryItems', type: :request do
 
       context 'when all goes well' do
         context 'when there is no matching item on another list' do
-          let!(:list_item)          { create(:inventory_item, list: inventory_list, description: 'Dwarven metal ingot', quantity: 5) }
+          let!(:list_item) { create(:inventory_item, list: inventory_list, description: 'Dwarven metal ingot', quantity: 5) }
           let(:aggregate_list_item) { aggregate_list.list_items.first }
-          let(:params)              { { inventory_item: { description: 'Dwarven metal ingot', quantity: 10 } }.to_json }
+          let(:params) { { inventory_item: { description: 'Dwarven metal ingot', quantity: 10 } }.to_json }
 
           before do
             aggregate_list.add_item_from_child_list(list_item)
@@ -662,9 +662,9 @@ RSpec.describe 'InventoryItems', type: :request do
         end
 
         context 'when there is a matching item on another list' do
-          let!(:list_item)          { create(:inventory_item, list: inventory_list) }
-          let!(:other_list)         { create(:inventory_list, game:, aggregate_list:) }
-          let!(:other_item)         { create(:inventory_item, list: other_list, description: list_item.description, quantity: 4) }
+          let!(:list_item) { create(:inventory_item, list: inventory_list) }
+          let!(:other_list) { create(:inventory_list, game:, aggregate_list:) }
+          let!(:other_item) { create(:inventory_item, list: other_list, description: list_item.description, quantity: 4) }
           let(:aggregate_list_item) { aggregate_list.list_items.first }
 
           before do
@@ -788,7 +788,7 @@ RSpec.describe 'InventoryItems', type: :request do
 
       context "when the inventory list item doesn't exist" do
         let(:list_item) { double(id: 234_567) }
-        let(:params)    { { quantity: 4, unit_weight: 0.3 }.to_json }
+        let(:params) { { quantity: 4, unit_weight: 0.3 }.to_json }
 
         it 'returns status 404' do
           update_item
@@ -803,7 +803,7 @@ RSpec.describe 'InventoryItems', type: :request do
 
       context 'when the inventory list item belongs to another user' do
         let!(:list_item) { create(:inventory_item) }
-        let(:params)     { { quantity: 4, unit_weight: 0.3 }.to_json }
+        let(:params) { { quantity: 4, unit_weight: 0.3 }.to_json }
 
         it "doesn't update the item" do
           expect { update_item }
@@ -823,7 +823,7 @@ RSpec.describe 'InventoryItems', type: :request do
 
       context 'when the list item is on an aggregate list' do
         let!(:list_item) { create(:inventory_item, list: aggregate_list) }
-        let(:params)     { { inventory_item: { quantity: 10 } }.to_json }
+        let(:params) { { inventory_item: { quantity: 10 } }.to_json }
 
         it 'returns status 405' do
           update_item
@@ -837,11 +837,11 @@ RSpec.describe 'InventoryItems', type: :request do
       end
 
       context 'when the attributes are invalid' do
-        let!(:list_item)          { create(:inventory_item, list: inventory_list, quantity: 2) }
-        let(:other_list)          { create(:inventory_list, game:) }
-        let!(:other_item)         { create(:inventory_item, list: other_list, description: list_item.description, quantity: 1) }
+        let!(:list_item) { create(:inventory_item, list: inventory_list, quantity: 2) }
+        let(:other_list) { create(:inventory_list, game:) }
+        let!(:other_item) { create(:inventory_item, list: other_list, description: list_item.description, quantity: 1) }
         let(:aggregate_list_item) { aggregate_list.list_items.first }
-        let(:params)              { { inventory_item: { quantity: -4, unit_weight: 2 } }.to_json }
+        let(:params) { { inventory_item: { quantity: -4, unit_weight: 2 } }.to_json }
 
         before do
           aggregate_list.add_item_from_child_list(list_item)
@@ -872,7 +872,7 @@ RSpec.describe 'InventoryItems', type: :request do
 
       context 'when something unexpected goes wrong' do
         let!(:list_item) { create(:inventory_item, list: inventory_list) }
-        let(:params)     { { notes: 'Hello world' }.to_json }
+        let(:params) { { notes: 'Hello world' }.to_json }
 
         before do
           aggregate_list.add_item_from_child_list(list_item)
@@ -895,7 +895,7 @@ RSpec.describe 'InventoryItems', type: :request do
 
     context 'when not authenticated' do
       let!(:list_item) { create(:inventory_item) }
-      let(:params)     { { inventory_item: { description: 'Dwarven metal ingot' } }.to_json }
+      let(:params) { { inventory_item: { description: 'Dwarven metal ingot' } }.to_json }
 
       before do
         stub_unsuccessful_login
@@ -921,8 +921,8 @@ RSpec.describe 'InventoryItems', type: :request do
   describe 'DELETE /inventory_items/:id' do
     subject(:destroy_item) { delete "/inventory_items/#{list_item.id}", headers: }
 
-    let!(:user)           { create(:authenticated_user) }
-    let(:game)            { create(:game, user:) }
+    let!(:user) { create(:authenticated_user) }
+    let(:game) { create(:game, user:) }
     let!(:aggregate_list) { create(:aggregate_inventory_list, game:) }
     let!(:inventory_list) { create(:inventory_list, game:, aggregate_list:) }
 
@@ -975,8 +975,8 @@ RSpec.describe 'InventoryItems', type: :request do
         end
 
         context 'when there is a matching list item on another list' do
-          let!(:list_item)  { create(:inventory_item, list: inventory_list) }
-          let(:other_list)  { create(:inventory_list, game:) }
+          let!(:list_item) { create(:inventory_item, list: inventory_list) }
+          let(:other_list) { create(:inventory_list, game:) }
           let!(:other_item) { create(:inventory_item, description: list_item.description, list: other_list) }
 
           before do

--- a/spec/requests/inventory_lists_spec.rb
+++ b/spec/requests/inventory_lists_spec.rb
@@ -197,7 +197,7 @@ RSpec.describe 'InventoryLists', type: :request do
       context 'when the params are invalid' do
         subject(:create_inventory_list) { post "/games/#{game.id}/inventory_lists", params: { inventory_list: { title: existing_list.title } }.to_json, headers: }
 
-        let(:game)          { create(:game, user:) }
+        let(:game) { create(:game, user:) }
         let(:existing_list) { create(:inventory_list, game:) }
 
         it 'returns status 422' do
@@ -269,8 +269,8 @@ RSpec.describe 'InventoryLists', type: :request do
 
       context 'when all goes well' do
         let!(:inventory_list) { create(:inventory_list, game:) }
-        let(:game)            { create(:game, user:) }
-        let(:list_id)         { inventory_list.id }
+        let(:game) { create(:game, user:) }
+        let(:list_id) { inventory_list.id }
 
         it 'updates the title' do
           update_inventory_list
@@ -295,9 +295,9 @@ RSpec.describe 'InventoryLists', type: :request do
         subject(:update_inventory_list) { patch "/inventory_lists/#{list_id}", params: { inventory_list: { title: other_list.title } }.to_json, headers: }
 
         let!(:inventory_list) { create(:inventory_list, game:) }
-        let(:game)            { create(:game, user:) }
-        let(:list_id)         { inventory_list.id }
-        let(:other_list)      { create(:inventory_list, game:) }
+        let(:game) { create(:game, user:) }
+        let(:list_id) { inventory_list.id }
+        let(:other_list) { create(:inventory_list, game:) }
 
         it 'returns status 422' do
           update_inventory_list
@@ -326,7 +326,7 @@ RSpec.describe 'InventoryLists', type: :request do
 
       context 'when the list belongs to another user' do
         let!(:inventory_list) { create(:inventory_list) }
-        let(:list_id)         { inventory_list.id }
+        let(:list_id) { inventory_list.id }
 
         it "doesn't update the inventory list" do
           expect { update_inventory_list }
@@ -348,7 +348,7 @@ RSpec.describe 'InventoryLists', type: :request do
         subject(:update_inventory_list) { patch "/inventory_lists/#{inventory_list.id}", params: { inventory_list: { title: 'Foo' } }.to_json, headers: }
 
         let!(:inventory_list) { create(:aggregate_inventory_list, game:) }
-        let(:game)            { create(:game, user:) }
+        let(:game) { create(:game, user:) }
 
         it "doesn't update the list" do
           update_inventory_list
@@ -370,7 +370,7 @@ RSpec.describe 'InventoryLists', type: :request do
         subject(:update_inventory_list) { patch "/inventory_lists/#{inventory_list.id}", params: { inventory_list: { aggregate: true } }.to_json, headers: }
 
         let!(:inventory_list) { create(:inventory_list, game:) }
-        let(:game)            { create(:game, user:) }
+        let(:game) { create(:game, user:) }
 
         it "doesn't update the list" do
           update_inventory_list
@@ -392,7 +392,7 @@ RSpec.describe 'InventoryLists', type: :request do
         subject(:update_inventory_list) { patch "/inventory_lists/#{inventory_list.id}", params: { inventory_list: { title: 'Some New Title' } }.to_json, headers: }
 
         let!(:inventory_list) { create(:inventory_list, game:) }
-        let(:game)            { create(:game, user:) }
+        let(:game) { create(:game, user:) }
 
         before do
           allow_any_instance_of(User).to receive(:inventory_lists).and_raise(StandardError, 'Something went catastrophically wrong')
@@ -447,8 +447,8 @@ RSpec.describe 'InventoryLists', type: :request do
 
       context 'when all goes well' do
         let!(:inventory_list) { create(:inventory_list, game:) }
-        let(:game)            { create(:game, user:) }
-        let(:list_id)         { inventory_list.id }
+        let(:game) { create(:game, user:) }
+        let(:list_id) { inventory_list.id }
 
         it 'updates the title' do
           update_inventory_list
@@ -473,9 +473,9 @@ RSpec.describe 'InventoryLists', type: :request do
         subject(:update_inventory_list) { put "/inventory_lists/#{list_id}", params: { inventory_list: { title: other_list.title } }.to_json, headers: }
 
         let!(:inventory_list) { create(:inventory_list, game:) }
-        let(:game)            { create(:game, user:) }
-        let(:list_id)         { inventory_list.id }
-        let(:other_list)      { create(:inventory_list, game:) }
+        let(:game) { create(:game, user:) }
+        let(:list_id) { inventory_list.id }
+        let(:other_list) { create(:inventory_list, game:) }
 
         it 'returns status 422' do
           update_inventory_list
@@ -504,7 +504,7 @@ RSpec.describe 'InventoryLists', type: :request do
 
       context 'when the list belongs to another user' do
         let!(:inventory_list) { create(:inventory_list) }
-        let(:list_id)         { inventory_list.id }
+        let(:list_id) { inventory_list.id }
 
         it "doesn't update the inventory list" do
           expect { update_inventory_list }
@@ -526,7 +526,7 @@ RSpec.describe 'InventoryLists', type: :request do
         subject(:update_inventory_list) { put "/inventory_lists/#{inventory_list.id}", params: { inventory_list: { title: 'Foo' } }.to_json, headers: }
 
         let!(:inventory_list) { create(:aggregate_inventory_list, game:) }
-        let(:game)            { create(:game, user:) }
+        let(:game) { create(:game, user:) }
 
         it "doesn't update the list" do
           update_inventory_list
@@ -548,7 +548,7 @@ RSpec.describe 'InventoryLists', type: :request do
         subject(:update_inventory_list) { put "/inventory_lists/#{inventory_list.id}", params: { inventory_list: { aggregate: true } }.to_json, headers: }
 
         let!(:inventory_list) { create(:inventory_list, game:) }
-        let(:game)            { create(:game, user:) }
+        let(:game) { create(:game, user:) }
 
         it "doesn't update the list" do
           update_inventory_list
@@ -570,7 +570,7 @@ RSpec.describe 'InventoryLists', type: :request do
         subject(:update_inventory_list) { put "/inventory_lists/#{inventory_list.id}", params: { inventory_list: { title: 'Some New Title' } }.to_json, headers: }
 
         let!(:inventory_list) { create(:inventory_list, game:) }
-        let(:game)            { create(:game, user:) }
+        let(:game) { create(:game, user:) }
 
         before do
           allow_any_instance_of(User).to receive(:inventory_lists).and_raise(StandardError, 'Something went catastrophically wrong')
@@ -617,8 +617,8 @@ RSpec.describe 'InventoryLists', type: :request do
     subject(:delete_inventory_list) { delete "/inventory_lists/#{inventory_list.id}", headers: }
 
     context 'when authenticated' do
-      let!(:user)     { create(:authenticated_user) }
-      let(:game)      { create(:game, user:) }
+      let!(:user) { create(:authenticated_user) }
+      let(:game) { create(:game, user:) }
 
       before do
         stub_successful_login

--- a/spec/requests/shopping_list_items_spec.rb
+++ b/spec/requests/shopping_list_items_spec.rb
@@ -15,10 +15,10 @@ RSpec.describe 'ShoppingListItems', type: :request do
       post "/shopping_lists/#{shopping_list.id}/shopping_list_items", params:, headers:
     end
 
-    let!(:user)           { create(:authenticated_user) }
-    let(:game)            { create(:game, user:) }
+    let!(:user) { create(:authenticated_user) }
+    let(:game) { create(:game, user:) }
     let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
-    let!(:shopping_list)  { create(:shopping_list, aggregate_list:, game:) }
+    let!(:shopping_list) { create(:shopping_list, aggregate_list:, game:) }
 
     context 'when authenticated' do
       before do
@@ -52,7 +52,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
           end
 
           context 'when there is an existing matching item on another list' do
-            let(:other_list)  { create(:shopping_list, game: aggregate_list.game) }
+            let(:other_list) { create(:shopping_list, game: aggregate_list.game) }
             let!(:other_item) { create(:shopping_list_item, list: other_list, description: 'Corundum ingot', quantity: 2) }
 
             before do
@@ -119,7 +119,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
         context 'when there is an existing matching item on the same list' do
           let(:other_list) { create(:shopping_list, game: aggregate_list.game, aggregate_list:) }
           let!(:other_item) { create(:shopping_list_item, list: other_list, description: 'Corundum ingot', quantity: 2) }
-          let!(:list_item)  { create(:shopping_list_item, list: shopping_list, description: 'Corundum ingot', quantity: 3) }
+          let!(:list_item) { create(:shopping_list_item, list: shopping_list, description: 'Corundum ingot', quantity: 3) }
 
           before do
             aggregate_list.add_item_from_child_list(other_item)
@@ -193,8 +193,8 @@ RSpec.describe 'ShoppingListItems', type: :request do
       end
 
       context "when the list doesn't exist" do
-        let(:params)         { { description: 'Necklace', quantity: 2, unit_weight: 0.5 }.to_json }
-        let(:shopping_list)  { double(id: 23_498) }
+        let(:params) { { description: 'Necklace', quantity: 2, unit_weight: 0.5 }.to_json }
+        let(:shopping_list) { double(id: 23_498) }
 
         it 'returns status 404' do
           create_item
@@ -208,7 +208,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
       end
 
       context 'when the list belongs to another user' do
-        let(:params)         { { description: 'Necklace', quantity: 2, unit_weight: 0.5 }.to_json }
+        let(:params) { { description: 'Necklace', quantity: 2, unit_weight: 0.5 }.to_json }
         let!(:shopping_list) { create(:shopping_list) }
 
         it "doesn't create a list item" do
@@ -248,7 +248,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
       context 'when the list is an aggregate list' do
         let(:shopping_list) { aggregate_list }
-        let(:params)        { { shopping_list_item: { description: 'Corundum ingot', quantity: 4 } }.to_json }
+        let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 4 } }.to_json }
 
         it "doesn't create an item" do
           expect { create_item }
@@ -313,10 +313,10 @@ RSpec.describe 'ShoppingListItems', type: :request do
   describe 'PATCH /shopping_list_items/:id' do
     subject(:update_item) { patch "/shopping_list_items/#{list_item.id}", headers:, params: }
 
-    let!(:user)           { create(:authenticated_user) }
-    let(:game)            { create(:game, user:) }
+    let!(:user) { create(:authenticated_user) }
+    let(:game) { create(:game, user:) }
     let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
-    let!(:shopping_list)  { create(:shopping_list, game:, aggregate_list:) }
+    let!(:shopping_list) { create(:shopping_list, game:, aggregate_list:) }
 
     context 'when authenticated' do
       before do
@@ -325,9 +325,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
       context 'when all goes well' do
         context 'when there is no matching item on another list' do
-          let!(:list_item)          { create(:shopping_list_item, list: shopping_list, description: 'Dwarven metal ingot', quantity: 5) }
+          let!(:list_item) { create(:shopping_list_item, list: shopping_list, description: 'Dwarven metal ingot', quantity: 5) }
           let(:aggregate_list_item) { aggregate_list.list_items.first }
-          let(:params)              { { shopping_list_item: { description: 'Dwarven metal ingot', quantity: 10 } }.to_json }
+          let(:params) { { shopping_list_item: { description: 'Dwarven metal ingot', quantity: 10 } }.to_json }
 
           before do
             aggregate_list.add_item_from_child_list(list_item)
@@ -379,9 +379,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
         end
 
         context 'when there is a matching item on another list' do
-          let!(:list_item)          { create(:shopping_list_item, list: shopping_list) }
-          let!(:other_list)         { create(:shopping_list, game:, aggregate_list:) }
-          let!(:other_item)         { create(:shopping_list_item, list: other_list, description: list_item.description, quantity: 4) }
+          let!(:list_item) { create(:shopping_list_item, list: shopping_list) }
+          let!(:other_list) { create(:shopping_list, game:, aggregate_list:) }
+          let!(:other_item) { create(:shopping_list_item, list: other_list, description: list_item.description, quantity: 4) }
           let(:aggregate_list_item) { aggregate_list.list_items.first }
 
           before do
@@ -505,7 +505,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
       context "when the shopping list item doesn't exist" do
         let(:list_item) { double(id: 234_567) }
-        let(:params)    { { quantity: 4, unit_weight: 0.3 }.to_json }
+        let(:params) { { quantity: 4, unit_weight: 0.3 }.to_json }
 
         it 'returns status 404' do
           update_item
@@ -520,7 +520,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
       context 'when the shopping list item belongs to another user' do
         let!(:list_item) { create(:shopping_list_item) }
-        let(:params)     { { quantity: 4, unit_weight: 0.3 }.to_json }
+        let(:params) { { quantity: 4, unit_weight: 0.3 }.to_json }
 
         it "doesn't update the item" do
           expect { update_item }
@@ -540,7 +540,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
       context 'when the list item is on an aggregate list' do
         let!(:list_item) { create(:shopping_list_item, list: aggregate_list) }
-        let(:params)     { { shopping_list_item: { quantity: 10 } }.to_json }
+        let(:params) { { shopping_list_item: { quantity: 10 } }.to_json }
 
         it 'returns status 405' do
           update_item
@@ -554,11 +554,11 @@ RSpec.describe 'ShoppingListItems', type: :request do
       end
 
       context 'when the attributes are invalid' do
-        let!(:list_item)          { create(:shopping_list_item, list: shopping_list, quantity: 2) }
-        let(:other_list)          { create(:shopping_list, game:) }
-        let!(:other_item)         { create(:shopping_list_item, list: other_list, description: list_item.description, quantity: 1) }
+        let!(:list_item) { create(:shopping_list_item, list: shopping_list, quantity: 2) }
+        let(:other_list) { create(:shopping_list, game:) }
+        let!(:other_item) { create(:shopping_list_item, list: other_list, description: list_item.description, quantity: 1) }
         let(:aggregate_list_item) { aggregate_list.list_items.first }
-        let(:params)              { { shopping_list_item: { quantity: -4, unit_weight: 2 } }.to_json }
+        let(:params) { { shopping_list_item: { quantity: -4, unit_weight: 2 } }.to_json }
 
         before do
           aggregate_list.add_item_from_child_list(list_item)
@@ -589,7 +589,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
       context 'when something unexpected goes wrong' do
         let!(:list_item) { create(:shopping_list_item, list: shopping_list) }
-        let(:params)     { { notes: 'Hello world' }.to_json }
+        let(:params) { { notes: 'Hello world' }.to_json }
 
         before do
           aggregate_list.add_item_from_child_list(list_item)
@@ -638,10 +638,10 @@ RSpec.describe 'ShoppingListItems', type: :request do
   describe 'PUT /shopping_list_items/:id' do
     subject(:update_item) { put "/shopping_list_items/#{list_item.id}", headers:, params: }
 
-    let!(:user)           { create(:authenticated_user) }
-    let(:game)            { create(:game, user:) }
+    let!(:user) { create(:authenticated_user) }
+    let(:game) { create(:game, user:) }
     let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
-    let!(:shopping_list)  { create(:shopping_list, game:, aggregate_list:) }
+    let!(:shopping_list) { create(:shopping_list, game:, aggregate_list:) }
 
     context 'when authenticated' do
       before do
@@ -650,9 +650,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
       context 'when all goes well' do
         context 'when there is no matching item on another list' do
-          let!(:list_item)          { create(:shopping_list_item, list: shopping_list, description: 'Dwarven metal ingot', quantity: 5) }
+          let!(:list_item) { create(:shopping_list_item, list: shopping_list, description: 'Dwarven metal ingot', quantity: 5) }
           let(:aggregate_list_item) { aggregate_list.list_items.first }
-          let(:params)              { { shopping_list_item: { description: 'Dwarven metal ingot', quantity: 10 } }.to_json }
+          let(:params) { { shopping_list_item: { description: 'Dwarven metal ingot', quantity: 10 } }.to_json }
 
           before do
             aggregate_list.add_item_from_child_list(list_item)
@@ -680,9 +680,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
         end
 
         context 'when there is a matching item on another list' do
-          let!(:list_item)          { create(:shopping_list_item, list: shopping_list) }
-          let!(:other_list)         { create(:shopping_list, game:, aggregate_list:) }
-          let!(:other_item)         { create(:shopping_list_item, list: other_list, description: list_item.description, quantity: 4) }
+          let!(:list_item) { create(:shopping_list_item, list: shopping_list) }
+          let!(:other_list) { create(:shopping_list, game:, aggregate_list:) }
+          let!(:other_item) { create(:shopping_list_item, list: other_list, description: list_item.description, quantity: 4) }
           let(:aggregate_list_item) { aggregate_list.list_items.first }
 
           before do
@@ -750,7 +750,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
       context "when the shopping list item doesn't exist" do
         let(:list_item) { double(id: 234_567) }
-        let(:params)    { { quantity: 4, unit_weight: 0.3 }.to_json }
+        let(:params) { { quantity: 4, unit_weight: 0.3 }.to_json }
 
         it 'returns status 404' do
           update_item
@@ -765,7 +765,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
       context 'when the shopping list item belongs to another user' do
         let!(:list_item) { create(:shopping_list_item) }
-        let(:params)     { { quantity: 4, unit_weight: 0.3 }.to_json }
+        let(:params) { { quantity: 4, unit_weight: 0.3 }.to_json }
 
         it "doesn't update the item" do
           expect { update_item }
@@ -785,7 +785,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
       context 'when the list item is on an aggregate list' do
         let!(:list_item) { create(:shopping_list_item, list: aggregate_list) }
-        let(:params)     { { shopping_list_item: { quantity: 10 } }.to_json }
+        let(:params) { { shopping_list_item: { quantity: 10 } }.to_json }
 
         it 'returns status 405' do
           update_item
@@ -799,11 +799,11 @@ RSpec.describe 'ShoppingListItems', type: :request do
       end
 
       context 'when the attributes are invalid' do
-        let!(:list_item)          { create(:shopping_list_item, list: shopping_list, quantity: 2) }
-        let(:other_list)          { create(:shopping_list, game:) }
-        let!(:other_item)         { create(:shopping_list_item, list: other_list, description: list_item.description, quantity: 1) }
+        let!(:list_item) { create(:shopping_list_item, list: shopping_list, quantity: 2) }
+        let(:other_list) { create(:shopping_list, game:) }
+        let!(:other_item) { create(:shopping_list_item, list: other_list, description: list_item.description, quantity: 1) }
         let(:aggregate_list_item) { aggregate_list.list_items.first }
-        let(:params)              { { shopping_list_item: { quantity: -4, unit_weight: 2 } }.to_json }
+        let(:params) { { shopping_list_item: { quantity: -4, unit_weight: 2 } }.to_json }
 
         before do
           aggregate_list.add_item_from_child_list(list_item)
@@ -834,7 +834,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
       context 'when something unexpected goes wrong' do
         let!(:list_item) { create(:shopping_list_item, list: shopping_list) }
-        let(:params)     { { notes: 'Hello world' }.to_json }
+        let(:params) { { notes: 'Hello world' }.to_json }
 
         before do
           aggregate_list.add_item_from_child_list(list_item)
@@ -884,10 +884,10 @@ RSpec.describe 'ShoppingListItems', type: :request do
     subject(:destroy_item) { delete "/shopping_list_items/#{list_item.id}", headers: }
 
     context 'when authenticated' do
-      let!(:user)           { create(:authenticated_user) }
+      let!(:user) { create(:authenticated_user) }
       let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
-      let!(:shopping_list)  { create(:shopping_list, game:, aggregate_list:) }
-      let(:game)            { create(:game, user:) }
+      let!(:shopping_list) { create(:shopping_list, game:, aggregate_list:) }
+      let(:game) { create(:game, user:) }
 
       before do
         stub_successful_login

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe 'ShoppingLists', type: :request do
       context 'when the params are invalid' do
         subject(:create_shopping_list) { post "/games/#{game.id}/shopping_lists", params: { shopping_list: { title: existing_list.title } }.to_json, headers: }
 
-        let(:game)          { create(:game, user:) }
+        let(:game) { create(:game, user:) }
         let(:existing_list) { create(:shopping_list, game:) }
 
         it 'returns status 422' do
@@ -183,8 +183,8 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       context 'when all goes well' do
         let!(:shopping_list) { create(:shopping_list, game:) }
-        let(:game)           { create(:game, user:) }
-        let(:list_id)        { shopping_list.id }
+        let(:game) { create(:game, user:) }
+        let(:list_id) { shopping_list.id }
 
         it 'updates the title' do
           update_shopping_list
@@ -209,9 +209,9 @@ RSpec.describe 'ShoppingLists', type: :request do
         subject(:update_shopping_list) { put "/shopping_lists/#{list_id}", params: { shopping_list: { title: other_list.title } }.to_json, headers: }
 
         let!(:shopping_list) { create(:shopping_list, game:) }
-        let(:game)           { create(:game, user:) }
-        let(:list_id)        { shopping_list.id }
-        let(:other_list)     { create(:shopping_list, game:) }
+        let(:game) { create(:game, user:) }
+        let(:list_id) { shopping_list.id }
+        let(:other_list) { create(:shopping_list, game:) }
 
         it 'returns status 422' do
           update_shopping_list
@@ -240,7 +240,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       context 'when the list belongs to another user' do
         let!(:shopping_list) { create(:shopping_list) }
-        let(:list_id)        { shopping_list.id }
+        let(:list_id) { shopping_list.id }
 
         it "doesn't update the shopping list" do
           expect { update_shopping_list }
@@ -262,7 +262,7 @@ RSpec.describe 'ShoppingLists', type: :request do
         subject(:update_shopping_list) { put "/shopping_lists/#{shopping_list.id}", params: { shopping_list: { title: 'Foo' } }.to_json, headers: }
 
         let!(:shopping_list) { create(:aggregate_shopping_list, game:) }
-        let(:game)           { create(:game, user:) }
+        let(:game) { create(:game, user:) }
 
         it "doesn't update the list" do
           update_shopping_list
@@ -284,7 +284,7 @@ RSpec.describe 'ShoppingLists', type: :request do
         subject(:update_shopping_list) { put "/shopping_lists/#{shopping_list.id}", params: { shopping_list: { aggregate: true } }.to_json, headers: }
 
         let!(:shopping_list) { create(:shopping_list, game:) }
-        let(:game)           { create(:game, user:) }
+        let(:game) { create(:game, user:) }
 
         it "doesn't update the list" do
           update_shopping_list
@@ -306,7 +306,7 @@ RSpec.describe 'ShoppingLists', type: :request do
         subject(:update_shopping_list) { put "/shopping_lists/#{shopping_list.id}", params: { shopping_list: { title: 'Some New Title' } }.to_json, headers: }
 
         let!(:shopping_list) { create(:shopping_list, game:) }
-        let(:game)           { create(:game, user:) }
+        let(:game) { create(:game, user:) }
 
         before do
           allow_any_instance_of(User).to receive(:shopping_lists).and_raise(StandardError, 'Something went catastrophically wrong')
@@ -326,7 +326,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
     context 'when unauthenticated' do
       let!(:shopping_list) { create(:shopping_list) }
-      let(:list_id)        { shopping_list.id }
+      let(:list_id) { shopping_list.id }
 
       before do
         stub_unsuccessful_login
@@ -361,8 +361,8 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       context 'when all goes well' do
         let!(:shopping_list) { create(:shopping_list, game:) }
-        let(:game)           { create(:game, user:) }
-        let(:list_id)        { shopping_list.id }
+        let(:game) { create(:game, user:) }
+        let(:list_id) { shopping_list.id }
 
         it 'updates the title' do
           update_shopping_list
@@ -387,9 +387,9 @@ RSpec.describe 'ShoppingLists', type: :request do
         subject(:update_shopping_list) { patch "/shopping_lists/#{list_id}", params: { shopping_list: { title: other_list.title } }.to_json, headers: }
 
         let!(:shopping_list) { create(:shopping_list, game:) }
-        let(:game)           { create(:game, user:) }
-        let(:list_id)        { shopping_list.id }
-        let(:other_list)     { create(:shopping_list, game:) }
+        let(:game) { create(:game, user:) }
+        let(:list_id) { shopping_list.id }
+        let(:other_list) { create(:shopping_list, game:) }
 
         it 'returns status 422' do
           update_shopping_list
@@ -418,7 +418,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       context 'when the list belongs to another user' do
         let!(:shopping_list) { create(:shopping_list) }
-        let(:list_id)        { shopping_list.id }
+        let(:list_id) { shopping_list.id }
 
         it "doesn't update the shopping list" do
           expect { update_shopping_list }
@@ -440,7 +440,7 @@ RSpec.describe 'ShoppingLists', type: :request do
         subject(:update_shopping_list) { patch "/shopping_lists/#{shopping_list.id}", params: { shopping_list: { title: 'Foo' } }.to_json, headers: }
 
         let!(:shopping_list) { create(:aggregate_shopping_list, game:) }
-        let(:game)           { create(:game, user:) }
+        let(:game) { create(:game, user:) }
 
         it "doesn't update the list" do
           update_shopping_list
@@ -462,7 +462,7 @@ RSpec.describe 'ShoppingLists', type: :request do
         subject(:update_shopping_list) { patch "/shopping_lists/#{shopping_list.id}", params: { shopping_list: { aggregate: true } }.to_json, headers: }
 
         let!(:shopping_list) { create(:shopping_list, game:) }
-        let(:game)           { create(:game, user:) }
+        let(:game) { create(:game, user:) }
 
         it "doesn't update the list" do
           update_shopping_list
@@ -484,7 +484,7 @@ RSpec.describe 'ShoppingLists', type: :request do
         subject(:update_shopping_list) { patch "/shopping_lists/#{shopping_list.id}", params: { shopping_list: { title: 'Some New Title' } }.to_json, headers: }
 
         let!(:shopping_list) { create(:shopping_list, game:) }
-        let(:game)           { create(:game, user:) }
+        let(:game) { create(:game, user:) }
 
         before do
           allow_any_instance_of(User).to receive(:shopping_lists).and_raise(StandardError, 'Something went catastrophically wrong')
@@ -504,7 +504,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
     context 'when unauthenticated' do
       let!(:shopping_list) { create(:shopping_list) }
-      let(:list_id)        { shopping_list.id }
+      let(:list_id) { shopping_list.id }
 
       before do
         stub_unsuccessful_login
@@ -618,7 +618,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
     context 'when authenticated' do
       let!(:user) { create(:authenticated_user) }
-      let(:game)  { create(:game, user:) }
+      let(:game) { create(:game, user:) }
 
       before do
         stub_successful_login

--- a/spec/support/factories/alchemical_properties.rb
+++ b/spec/support/factories/alchemical_properties.rb
@@ -3,6 +3,6 @@
 FactoryBot.define do
   factory :alchemical_property do
     sequence(:name) {|n| "Alchemical Property #{n}" }
-    description     { 'Something magical' }
+    description { 'Something magical' }
   end
 end

--- a/spec/support/factories/canonical/armors.rb
+++ b/spec/support/factories/canonical/armors.rb
@@ -2,15 +2,15 @@
 
 FactoryBot.define do
   factory :canonical_armor, class: Canonical::Armor do
-    name                 { 'Steel Plate Armor' }
+    name { 'Steel Plate Armor' }
     sequence(:item_code) {|n| "123abc#{n}" }
-    weight               { 'heavy armor' }
-    body_slot            { 'body' }
-    unit_weight          { 1.0 }
-    smithing_perks       { ['Steel Smithing'] }
-    purchasable          { true }
-    unique_item          { false }
-    rare_item            { false }
-    quest_item           { false }
+    weight { 'heavy armor' }
+    body_slot { 'body' }
+    unit_weight { 1.0 }
+    smithing_perks { ['Steel Smithing'] }
+    purchasable { true }
+    unique_item { false }
+    rare_item { false }
+    quest_item { false }
   end
 end

--- a/spec/support/factories/canonical/books.rb
+++ b/spec/support/factories/canonical/books.rb
@@ -2,15 +2,15 @@
 
 FactoryBot.define do
   factory :canonical_book, class: Canonical::Book do
-    title                { 'My Book' }
+    title { 'My Book' }
     sequence(:item_code) {|n| "123xxx#{n}" }
-    unit_weight          { 1.0 }
-    book_type            { 'lore book' }
-    purchasable          { true }
-    unique_item          { false }
-    rare_item            { false }
-    solstheim_only       { false }
-    quest_item           { false }
+    unit_weight { 1.0 }
+    book_type { 'lore book' }
+    purchasable { true }
+    unique_item { false }
+    rare_item { false }
+    solstheim_only { false }
+    quest_item { false }
 
     factory :canonical_recipe do
       book_type { 'recipe' }

--- a/spec/support/factories/canonical/clothing_items.rb
+++ b/spec/support/factories/canonical/clothing_items.rb
@@ -2,13 +2,13 @@
 
 FactoryBot.define do
   factory :canonical_clothing_item, class: Canonical::ClothingItem do
-    name                 { 'Fine Clothes' }
+    name { 'Fine Clothes' }
     sequence(:item_code) {|n| "123xxx#{n}" }
-    unit_weight          { 9.9 }
-    body_slot            { 'body' }
-    purchasable          { true }
-    unique_item          { false }
-    rare_item            { false }
-    quest_item           { false }
+    unit_weight { 9.9 }
+    body_slot { 'body' }
+    purchasable { true }
+    unique_item { false }
+    rare_item { false }
+    quest_item { false }
   end
 end

--- a/spec/support/factories/canonical/ingredients.rb
+++ b/spec/support/factories/canonical/ingredients.rb
@@ -2,14 +2,14 @@
 
 FactoryBot.define do
   factory :canonical_ingredient, class: Canonical::Ingredient do
-    name                   { 'Blue Mountain Flower' }
-    sequence(:item_code)   {|n| "xx123xx#{n}" }
-    ingredient_type        { 'common' }
-    unit_weight            { 0.5 }
-    purchasable            { true }
+    name { 'Blue Mountain Flower' }
+    sequence(:item_code) {|n| "xx123xx#{n}" }
+    ingredient_type { 'common' }
+    unit_weight { 0.5 }
+    purchasable { true }
     purchase_requires_perk { false }
-    unique_item            { false }
-    rare_item              { false }
+    unique_item { false }
+    rare_item { false }
 
     trait :with_alchemical_properties do
       after(:create) do |ingredient, _evaluator|

--- a/spec/support/factories/canonical/jewelry_items.rb
+++ b/spec/support/factories/canonical/jewelry_items.rb
@@ -2,13 +2,13 @@
 
 FactoryBot.define do
   factory :canonical_jewelry_item, class: Canonical::JewelryItem do
-    name                 { 'Gold Diamond Ring' }
+    name { 'Gold Diamond Ring' }
     sequence(:item_code) {|n| "xxx123#{n}" }
-    jewelry_type         { 'ring' }
-    unit_weight          { 37.0 }
-    purchasable          { true }
-    unique_item          { false }
-    rare_item            { false }
-    quest_item           { false }
+    jewelry_type { 'ring' }
+    unit_weight { 37.0 }
+    purchasable { true }
+    unique_item { false }
+    rare_item { false }
+    quest_item { false }
   end
 end

--- a/spec/support/factories/canonical/materials.rb
+++ b/spec/support/factories/canonical/materials.rb
@@ -2,8 +2,8 @@
 
 FactoryBot.define do
   factory :canonical_material, class: Canonical::Material do
-    name                 { 'iron ingot' }
+    name { 'iron ingot' }
     sequence(:item_code) {|n| "xxx000#{n}" }
-    unit_weight          { 2.4 }
+    unit_weight { 2.4 }
   end
 end

--- a/spec/support/factories/canonical/misc_items.rb
+++ b/spec/support/factories/canonical/misc_items.rb
@@ -2,13 +2,13 @@
 
 FactoryBot.define do
   factory :canonical_misc_item, class: Canonical::MiscItem do
-    name                 { 'My Misc Item' }
+    name { 'My Misc Item' }
     sequence(:item_code) {|n| "xx123x#{n}" }
-    unit_weight          { 1.0 }
-    item_types           { %w[miscellaneous] }
-    purchasable          { true }
-    unique_item          { false }
-    rare_item            { false }
-    quest_item           { false }
+    unit_weight { 1.0 }
+    item_types { %w[miscellaneous] }
+    purchasable { true }
+    unique_item { false }
+    rare_item { false }
+    quest_item { false }
   end
 end

--- a/spec/support/factories/canonical/potions.rb
+++ b/spec/support/factories/canonical/potions.rb
@@ -2,13 +2,13 @@
 
 FactoryBot.define do
   factory :canonical_potion, class: Canonical::Potion do
-    name                 { 'My Potion' }
+    name { 'My Potion' }
     sequence(:item_code) {|n| "xx123x#{n}" }
-    unit_weight          { 0.5 }
-    potion_type          { 'potion' }
-    purchasable          { true }
-    unique_item          { false }
-    rare_item            { false }
-    quest_item           { false }
+    unit_weight { 0.5 }
+    potion_type { 'potion' }
+    purchasable { true }
+    unique_item { false }
+    rare_item { false }
+    quest_item { false }
   end
 end

--- a/spec/support/factories/canonical/properties.rb
+++ b/spec/support/factories/canonical/properties.rb
@@ -2,8 +2,8 @@
 
 FactoryBot.define do
   factory :canonical_property, class: Canonical::Property do
-    alchemy_lab_available      { true }
+    alchemy_lab_available { true }
     arcane_enchanter_available { true }
-    forge_available            { false }
+    forge_available { false }
   end
 end

--- a/spec/support/factories/canonical/staves.rb
+++ b/spec/support/factories/canonical/staves.rb
@@ -3,14 +3,14 @@
 FactoryBot.define do
   factory :canonical_staff, class: 'Canonical::Staff' do
     sequence(:item_code) {|n| "XX222#{n}" }
-    name                 { 'Staff of Chain Lightning' }
-    unit_weight          { 8 }
-    base_damage          { 0 }
-    daedric              { false }
-    purchasable          { true }
-    unique_item          { false }
-    rare_item            { false }
-    quest_item           { false }
-    leveled              { false }
+    name { 'Staff of Chain Lightning' }
+    unit_weight { 8 }
+    base_damage { 0 }
+    daedric { false }
+    purchasable { true }
+    unique_item { false }
+    rare_item { false }
+    quest_item { false }
+    leveled { false }
   end
 end

--- a/spec/support/factories/canonical/weapons.rb
+++ b/spec/support/factories/canonical/weapons.rb
@@ -2,18 +2,18 @@
 
 FactoryBot.define do
   factory :canonical_weapon, class: Canonical::Weapon do
-    name                 { 'Dwarven War Axe' }
+    name { 'Dwarven War Axe' }
     sequence(:item_code) {|n| "123xxx#{n}" }
-    category             { 'one-handed' }
-    weapon_type          { 'war axe' }
-    base_damage          { 12 }
-    smithing_perks       { ['Dwarven Smithing'] }
-    unit_weight          { 14 }
-    purchasable          { true }
-    unique_item          { false }
-    rare_item            { false }
-    quest_item           { false }
-    leveled              { false }
-    enchantable          { true }
+    category { 'one-handed' }
+    weapon_type { 'war axe' }
+    base_damage { 12 }
+    smithing_perks { ['Dwarven Smithing'] }
+    unit_weight { 14 }
+    purchasable { true }
+    unique_item { false }
+    rare_item { false }
+    quest_item { false }
+    leveled { false }
+    enchantable { true }
   end
 end

--- a/spec/support/factories/enchantments.rb
+++ b/spec/support/factories/enchantments.rb
@@ -3,6 +3,6 @@
 FactoryBot.define do
   factory :enchantment do
     sequence(:name) {|n| "Enchantment #{n}" }
-    strength_unit   { 'point' }
+    strength_unit { 'point' }
   end
 end

--- a/spec/support/factories/inventory_items.rb
+++ b/spec/support/factories/inventory_items.rb
@@ -5,6 +5,6 @@ FactoryBot.define do
     association :list, factory: :inventory_list
 
     sequence(:description) {|n| "Item #{n}" }
-    quantity               { 1 }
+    quantity { 1 }
   end
 end

--- a/spec/support/factories/inventory_lists.rb
+++ b/spec/support/factories/inventory_lists.rb
@@ -7,8 +7,8 @@ FactoryBot.define do
     sequence(:title) {|n| "Inventory List #{n}" }
 
     factory :aggregate_inventory_list do
-      aggregate         { true }
-      title             { 'All Items' }
+      aggregate { true }
+      title { 'All Items' }
       aggregate_list_id { nil }
     end
 

--- a/spec/support/factories/powers.rb
+++ b/spec/support/factories/powers.rb
@@ -3,8 +3,8 @@
 FactoryBot.define do
   factory :power do
     sequence(:name) {|n| "My Power #{n}" }
-    power_type      { 'lesser' }
-    source          { 'Black Book: Epistolary Acumen' }
-    description     { 'Something cool' }
+    power_type { 'lesser' }
+    source { 'Black Book: Epistolary Acumen' }
+    description { 'Something cool' }
   end
 end

--- a/spec/support/factories/shopping_list_items.rb
+++ b/spec/support/factories/shopping_list_items.rb
@@ -5,6 +5,6 @@ FactoryBot.define do
     association :list, factory: :shopping_list
 
     sequence(:description) {|n| "Item #{n}" }
-    quantity               { 1 }
+    quantity { 1 }
   end
 end

--- a/spec/support/factories/shopping_lists.rb
+++ b/spec/support/factories/shopping_lists.rb
@@ -7,8 +7,8 @@ FactoryBot.define do
     sequence(:title) {|n| "Shopping List #{n}" }
 
     factory :aggregate_shopping_list do
-      aggregate         { true }
-      title             { 'All Items' }
+      aggregate { true }
+      title { 'All Items' }
       aggregate_list_id { nil }
     end
 

--- a/spec/support/factories/spells.rb
+++ b/spec/support/factories/spells.rb
@@ -3,9 +3,9 @@
 FactoryBot.define do
   factory :spell do
     sequence(:name) {|n| "Awesome Spell #{n}" }
-    school          { 'Conjuration' }
-    level           { 'Adept' }
-    description     { 'Destroys enemies on sight' }
-    base_duration   { 5 }
+    school { 'Conjuration' }
+    level { 'Adept' }
+    description { 'Destroys enemies on sight' }
+    base_duration { 5 }
   end
 end

--- a/spec/support/factories/users.rb
+++ b/spec/support/factories/users.rb
@@ -2,9 +2,9 @@
 
 FactoryBot.define do
   factory(:user) do
-    sequence(:uid)   {|n| "foobar#{n}" }
+    sequence(:uid) {|n| "foobar#{n}" }
     sequence(:email) { 'foo@example.com' }
-    display_name     { 'Jane Doe' }
+    display_name { 'Jane Doe' }
 
     # This factory uses data from /spec/support/fixtures/auth/success.json
     # to mock an existing user to authenticate with WebMock.


### PR DESCRIPTION
## Context

Certain Rubocop rules that seemed like a good idea before no longer seem like such a good idea. In particular, the rule requiring assignment operators and `let` block braces to be aligned has mainly resulted in messy code with longer lines. Since we are avoiding enabling the line length cop (since this often comes down to developer judgment, contrary to our Rubocop policy), it makes sense to set other rules to enable lines to be as short as possible.

## Changes

* Enable new Bundler cops (`Bundler/GemFilename`, `Bundler/OrderedGems`)
* Enable `Layout/AssignmentIndentation` cop (no code changes)
* Enable `Layout/ClassStructure` cop (safe autocorrect changed one class)
* Add `AllowForAlignment` configuration option to `Layout/CommentAlignment` cop
* Enable `Layout/EmptyComment` cop (no code changes)
* Enable `Layout/EmptyLineAfterMultilineCondition` cop (no code changes)
* Enable `Layout/EmptyLineAroundAttributeAccessor` cop (no code changes)
* Reverse earlier rule of forcing assignment operators and left `let` braces to be aligned with those around them

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~

## Considerations

The vast majority of the code changes in this PR (> 90%) are a result of the last change listed above. This is a safe autocorrect but I've still decided to make that the last change in this PR since it touches so many files. Certain things may look weird because of this change - they will be fixed in future PRs.

I'm realising it's weird to piggyback this onto the `frontend-rewrite-feature-branch`, since it'll make it harder to conduct a final review on that branch. But there are just a few things that were bothering me about Rubocop rules and I felt like, as I was writing the code changes for the rewrite, I was taking pains to adhere to formatting rules that I don't even like on my own project.
