### PR TITLE
More Rubocop updates

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -179,7 +179,7 @@ Layout/ExtraSpacing:
   AllowForAlignment: false
 Layout/FirstArgumentIndentation:
   Enabled: true
-  EnforcedStyle: consistent_relative_to_receiver
+  EnforcedStyle: special_for_inner_method_call_in_parentheses
 Layout/FirstArrayElementIndentation:
   Enabled: true
   EnforcedStyle: align_brackets

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -187,7 +187,7 @@ Layout/FirstArrayElementLineBreak:
   Enabled: true
 Layout/FirstHashElementIndentation:
   Enabled: true
-  EnforcedStyle: align_braces
+  EnforcedStyle: consistent
 Layout/FirstHashElementLineBreak:
   Enabled: true
 Layout/FirstParameterIndentation:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -192,12 +192,12 @@ Layout/FirstHashElementLineBreak:
   Enabled: true
 Layout/FirstParameterIndentation:
   Enabled: true
-  EnforcedStyle: align_parentheses
+  EnforcedStyle: consistent
 Layout/HashAlignment:
   Enabled: true
   AllowMultipleStyles: false
-  EnforcedHashRocketStyle: table
-  EnforcedColonStyle: table
+  EnforcedHashRocketStyle: key
+  EnforcedColonStyle: key
   EnforcedLastArgumentHashStyle: always_inspect
 Layout/HeredocArgumentClosingParenthesis:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -182,7 +182,7 @@ Layout/FirstArgumentIndentation:
   EnforcedStyle: special_for_inner_method_call_in_parentheses
 Layout/FirstArrayElementIndentation:
   Enabled: true
-  EnforcedStyle: align_brackets
+  EnforcedStyle: consistent
 Layout/FirstArrayElementLineBreak:
   Enabled: true
 Layout/FirstHashElementIndentation:

--- a/app/controller_services/application_controller/authorization_service.rb
+++ b/app/controller_services/application_controller/authorization_service.rb
@@ -42,10 +42,10 @@ class ApplicationController < ActionController::API
 
     def connection
       @connection ||= Faraday.new(
-                        url:     FIREBASE_VERIFICATION_URI,
-                        params:  { key: Rails.application.credentials[:google][:firebase_web_api_key] },
-                        headers: { 'Content-Type' => 'application/json' },
-                      )
+        url:     FIREBASE_VERIFICATION_URI,
+        params:  { key: Rails.application.credentials[:google][:firebase_web_api_key] },
+        headers: { 'Content-Type' => 'application/json' },
+      )
     end
   end
 end

--- a/app/controller_services/application_controller/authorization_service.rb
+++ b/app/controller_services/application_controller/authorization_service.rb
@@ -42,8 +42,8 @@ class ApplicationController < ActionController::API
 
     def connection
       @connection ||= Faraday.new(
-        url:     FIREBASE_VERIFICATION_URI,
-        params:  { key: Rails.application.credentials[:google][:firebase_web_api_key] },
+        url: FIREBASE_VERIFICATION_URI,
+        params: { key: Rails.application.credentials[:google][:firebase_web_api_key] },
         headers: { 'Content-Type' => 'application/json' },
       )
     end

--- a/app/models/alchemical_property.rb
+++ b/app/models/alchemical_property.rb
@@ -4,12 +4,12 @@ class AlchemicalProperty < ApplicationRecord
   VALID_STRENGTH_UNITS = %w[point percentage level].freeze
 
   has_many :canonical_ingredients_alchemical_properties,
-           dependent:  :destroy,
+           dependent: :destroy,
            class_name: 'Canonical::IngredientsAlchemicalProperty'
   has_many :canonical_ingredients, through: :canonical_ingredients_alchemical_properties
 
   has_many :canonical_potions_alchemical_properties,
-           dependent:  :destroy,
+           dependent: :destroy,
            class_name: 'Canonical::PotionsAlchemicalProperty'
   has_many :canonical_potions, through: :canonical_potions_alchemical_properties, source: :potion
 

--- a/app/models/canonical/armor.rb
+++ b/app/models/canonical/armor.rb
@@ -40,15 +40,15 @@ module Canonical
     validates :weight,
               presence:  true,
               inclusion: {
-                           in:      ['light armor', 'heavy armor'],
-                           message: 'must be "light armor" or "heavy armor"',
-                         }
+                in:      ['light armor', 'heavy armor'],
+                message: 'must be "light armor" or "heavy armor"',
+              }
     validates :body_slot,
               presence:  true,
               inclusion: {
-                           in:      %w[head body hands feet hair shield],
-                           message: 'must be "head", "body", "hands", "feet", "hair", or "shield"',
-                         }
+                in:      %w[head body hands feet hair shield],
+                message: 'must be "head", "body", "hands", "feet", "hair", or "shield"',
+              }
     validates :unit_weight, presence: true, numericality: { greater_than_or_equal_to: 0 }
     validates :purchasable, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }
     validates :enchantable, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }

--- a/app/models/canonical/armor.rb
+++ b/app/models/canonical/armor.rb
@@ -10,43 +10,43 @@ module Canonical
     BOOLEAN_VALIDATION_MESSAGE = 'must be true or false'
 
     has_many :canonical_enchantables_enchantments,
-             dependent:  :destroy,
+             dependent: :destroy,
              class_name: 'Canonical::EnchantablesEnchantment',
-             as:         :enchantable
+             as: :enchantable
     has_many :enchantments,
              -> { select 'enchantments.*, canonical_enchantables_enchantments.strength as strength' },
              through: :canonical_enchantables_enchantments
 
     has_many :canonical_craftables_crafting_materials,
-             dependent:  :destroy,
+             dependent: :destroy,
              class_name: 'Canonical::CraftablesCraftingMaterial',
-             as:         :craftable
+             as: :craftable
     has_many :crafting_materials,
              -> { select 'canonical_materials.*, canonical_craftables_crafting_materials.quantity as quantity_needed' },
              through: :canonical_craftables_crafting_materials,
-             source:  :material
+             source: :material
 
     has_many :canonical_temperables_tempering_materials,
-             dependent:  :destroy,
+             dependent: :destroy,
              class_name: 'Canonical::TemperablesTemperingMaterial',
-             as:         :temperable
+             as: :temperable
     has_many :tempering_materials,
              -> { select 'canonical_materials.*, canonical_temperables_tempering_materials.quantity as quantity_needed' },
              through: :canonical_temperables_tempering_materials,
-             source:  :material
+             source: :material
 
     validates :name, presence: true
     validates :item_code, presence: true, uniqueness: { message: 'must be unique' }
     validates :weight,
-              presence:  true,
+              presence: true,
               inclusion: {
-                in:      ['light armor', 'heavy armor'],
+                in: ['light armor', 'heavy armor'],
                 message: 'must be "light armor" or "heavy armor"',
               }
     validates :body_slot,
-              presence:  true,
+              presence: true,
               inclusion: {
-                in:      %w[head body hands feet hair shield],
+                in: %w[head body hands feet hair shield],
                 message: 'must be "head", "body", "hands", "feet", "hair", or "shield"',
               }
     validates :unit_weight, presence: true, numericality: { greater_than_or_equal_to: 0 }

--- a/app/models/canonical/book.rb
+++ b/app/models/canonical/book.rb
@@ -10,17 +10,17 @@ module Canonical
     BOOLEAN_VALIDATION_MESSAGE = 'must be true or false'
 
     BOOK_TYPES = [
-                   'Black Book',
-                   'document',
-                   'Elder Scroll',
-                   'journal',
-                   'letter',
-                   'lore book',
-                   'quest book',
-                   'recipe',
-                   'skill book',
-                   'treasure map',
-                 ].freeze
+      'Black Book',
+      'document',
+      'Elder Scroll',
+      'journal',
+      'letter',
+      'lore book',
+      'quest book',
+      'recipe',
+      'skill book',
+      'treasure map',
+    ].freeze
 
     has_many :canonical_recipes_ingredients,
              dependent:   :destroy,

--- a/app/models/canonical/book.rb
+++ b/app/models/canonical/book.rb
@@ -23,9 +23,9 @@ module Canonical
     ].freeze
 
     has_many :canonical_recipes_ingredients,
-             dependent:   :destroy,
-             class_name:  'Canonical::RecipesIngredient',
-             inverse_of:  :recipe,
+             dependent: :destroy,
+             class_name: 'Canonical::RecipesIngredient',
+             inverse_of: :recipe,
              foreign_key: :recipe_id
     has_many :canonical_ingredients, through: :canonical_recipes_ingredients, class_name: 'Canonical::Ingredient', source: :ingredient
 

--- a/app/models/canonical/clothing_item.rb
+++ b/app/models/canonical/clothing_item.rb
@@ -9,9 +9,9 @@ module Canonical
     BOOLEAN_VALIDATION_MESSAGE = 'must be true or false'
 
     has_many :canonical_enchantables_enchantments,
-             dependent:  :destroy,
+             dependent: :destroy,
              class_name: 'Canonical::EnchantablesEnchantment',
-             as:         :enchantable
+             as: :enchantable
     has_many :enchantments,
              -> { select 'enchantments.*, canonical_enchantables_enchantments.strength as strength' },
              through: :canonical_enchantables_enchantments
@@ -20,7 +20,7 @@ module Canonical
     validates :item_code, presence: true, uniqueness: { message: 'must be unique' }
     validates :unit_weight, presence: true, numericality: { greater_than_or_equal_to: 0 }
     validates :body_slot,
-              presence:  true,
+              presence: true,
               inclusion: { in: BODY_SLOTS, message: 'must be "head", "hands", "body", or "feet"' }
     validates :purchasable, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }
     validates :unique_item, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }

--- a/app/models/canonical/ingredient.rb
+++ b/app/models/canonical/ingredient.rb
@@ -30,9 +30,9 @@ module Canonical
     validates :purchasable, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }
     validates :purchase_requires_perk,
               inclusion: {
-                           in:      BOOLEAN_VALUES,
-                           message: "#{BOOLEAN_VALIDATION_MESSAGE} if purchasable is true",
-                         },
+                in:      BOOLEAN_VALUES,
+                message: "#{BOOLEAN_VALIDATION_MESSAGE} if purchasable is true",
+              },
               if:        -> { purchasable == true }
     validates :unique_item, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }
     validates :rare_item, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }

--- a/app/models/canonical/ingredient.rb
+++ b/app/models/canonical/ingredient.rb
@@ -10,7 +10,7 @@ module Canonical
     BOOLEAN_VALIDATION_MESSAGE = 'must be true or false'
 
     has_many :canonical_ingredients_alchemical_properties,
-             dependent:  :destroy,
+             dependent: :destroy,
              class_name: 'Canonical::IngredientsAlchemicalProperty',
              inverse_of: :ingredient
     has_many :alchemical_properties,
@@ -18,7 +18,7 @@ module Canonical
              through: :canonical_ingredients_alchemical_properties
 
     has_many :canonical_recipes_ingredients,
-             dependent:  :destroy,
+             dependent: :destroy,
              class_name: 'Canonical::RecipesIngredient',
              inverse_of: :ingredient
     has_many :recipes, through: :canonical_recipes_ingredients, class_name: 'Canonical::Book', source: :recipe
@@ -30,10 +30,10 @@ module Canonical
     validates :purchasable, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }
     validates :purchase_requires_perk,
               inclusion: {
-                in:      BOOLEAN_VALUES,
+                in: BOOLEAN_VALUES,
                 message: "#{BOOLEAN_VALIDATION_MESSAGE} if purchasable is true",
               },
-              if:        -> { purchasable == true }
+              if: -> { purchasable == true }
     validates :unique_item, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }
     validates :rare_item, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }
     validates :quest_item, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }

--- a/app/models/canonical/ingredients_alchemical_property.rb
+++ b/app/models/canonical/ingredients_alchemical_property.rb
@@ -12,10 +12,10 @@ module Canonical
               allow_blank:  true,
               uniqueness:   { scope: :ingredient_id, message: 'must be unique per ingredient' },
               numericality: {
-                              greater_than_or_equal_to: 1,
-                              less_than_or_equal_to:    4,
-                              only_integer:             true,
-                            }
+                greater_than_or_equal_to: 1,
+                less_than_or_equal_to:    4,
+                only_integer:             true,
+              }
     validates :strength_modifier, allow_blank: true, numericality: { greater_than: 0 }
     validates :duration_modifier, allow_blank: true, numericality: { greater_than: 0 }
     validate :ensure_max_of_four_per_ingredient, on: :create

--- a/app/models/canonical/ingredients_alchemical_property.rb
+++ b/app/models/canonical/ingredients_alchemical_property.rb
@@ -9,12 +9,12 @@ module Canonical
 
     validates :alchemical_property_id, uniqueness: { scope: :ingredient_id, message: 'must form a unique combination with canonical ingredient' }
     validates :priority,
-              allow_blank:  true,
-              uniqueness:   { scope: :ingredient_id, message: 'must be unique per ingredient' },
+              allow_blank: true,
+              uniqueness: { scope: :ingredient_id, message: 'must be unique per ingredient' },
               numericality: {
                 greater_than_or_equal_to: 1,
-                less_than_or_equal_to:    4,
-                only_integer:             true,
+                less_than_or_equal_to: 4,
+                only_integer: true,
               }
     validates :strength_modifier, allow_blank: true, numericality: { greater_than: 0 }
     validates :duration_modifier, allow_blank: true, numericality: { greater_than: 0 }

--- a/app/models/canonical/jewelry_item.rb
+++ b/app/models/canonical/jewelry_item.rb
@@ -8,26 +8,26 @@ module Canonical
     BOOLEAN_VALIDATION_MESSAGE = 'must be true or false'
 
     has_many :canonical_enchantables_enchantments,
-             dependent:  :destroy,
+             dependent: :destroy,
              class_name: 'Canonical::EnchantablesEnchantment',
-             as:         :enchantable
+             as: :enchantable
     has_many :enchantments,
              -> { select 'enchantments.*, canonical_enchantables_enchantments.strength as strength' },
              through: :canonical_enchantables_enchantments
 
     has_many :canonical_craftables_crafting_materials,
-             dependent:  :destroy,
+             dependent: :destroy,
              class_name: 'Canonical::CraftablesCraftingMaterial',
-             as:         :craftable
+             as: :craftable
     has_many :crafting_materials,
              -> { select 'canonical_materials.*, canonical_craftables_crafting_materials.quantity as quantity_needed' },
              through: :canonical_craftables_crafting_materials,
-             source:  :material
+             source: :material
 
     validates :name, presence: true
     validates :item_code, presence: true, uniqueness: { message: 'must be unique' }
     validates :jewelry_type,
-              presence:  true,
+              presence: true,
               inclusion: { in: %w[ring circlet amulet], message: 'must be "ring", "circlet", or "amulet"' }
     validates :unit_weight, presence: true, numericality: { greater_than_or_equal_to: 0 }
     validates :purchasable, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }

--- a/app/models/canonical/material.rb
+++ b/app/models/canonical/material.rb
@@ -5,13 +5,13 @@ module Canonical
     self.table_name = 'canonical_materials'
 
     has_many :canonical_craftables_crafting_materials,
-             dependent:  :destroy,
+             dependent: :destroy,
              class_name: 'Canonical::CraftablesCraftingMaterial',
              inverse_of: :material
     has_many :craftables, through: :canonical_craftables_crafting_materials
 
     has_many :canonical_temperables_tempering_materials,
-             dependent:  :destroy,
+             dependent: :destroy,
              class_name: 'Canonical::TemperablesTemperingMaterial',
              inverse_of: :material
     has_many :temperables, through: :canonical_temperables_tempering_materials

--- a/app/models/canonical/misc_item.rb
+++ b/app/models/canonical/misc_item.rb
@@ -8,19 +8,19 @@ module Canonical
     BOOLEAN_VALIDATION_MESSAGE = 'must be true or false'
 
     VALID_ITEM_TYPES = [
-                         'animal part',
-                         'book',
-                         'daedric artifact',
-                         'dragon claw',
-                         'Dwemer artifact',
-                         'gemstone',
-                         'key',
-                         'larceny trophy',
-                         'map',
-                         'miscellaneous',
-                         'paragon',
-                         'pelt',
-                       ].freeze
+      'animal part',
+      'book',
+      'daedric artifact',
+      'dragon claw',
+      'Dwemer artifact',
+      'gemstone',
+      'key',
+      'larceny trophy',
+      'map',
+      'miscellaneous',
+      'paragon',
+      'pelt',
+    ].freeze
 
     validates :name, presence: true
     validates :item_code, presence: true, uniqueness: { message: 'must be unique' }

--- a/app/models/canonical/potion.rb
+++ b/app/models/canonical/potion.rb
@@ -9,7 +9,7 @@ module Canonical
     VALID_POTION_TYPES = %w[potion poison].freeze
 
     has_many :canonical_potions_alchemical_properties,
-             dependent:  :destroy,
+             dependent: :destroy,
              class_name: 'Canonical::PotionsAlchemicalProperty',
              inverse_of: :potion
     has_many :alchemical_properties, through: :canonical_potions_alchemical_properties

--- a/app/models/canonical/property.rb
+++ b/app/models/canonical/property.rb
@@ -7,9 +7,9 @@ module Canonical
     self.table_name = 'canonical_properties'
 
     has_many :properties,
-             dependent:   :destroy,
-             class_name:  '::Property',
-             inverse_of:  :canonical_property,
+             dependent: :destroy,
+             class_name: '::Property',
+             inverse_of: :canonical_property,
              foreign_key: :canonical_property_id
 
     TOTAL_PROPERTY_COUNT = 10
@@ -40,17 +40,17 @@ module Canonical
     validate :ensure_max, on: :create, if: :count_is_max
 
     validates :name,
-              presence:   true,
-              inclusion:  { in: VALID_NAMES, message: "must be an ownable property in Skyrim, or the Arch-Mage's Quarters" },
+              presence: true,
+              inclusion: { in: VALID_NAMES, message: "must be an ownable property in Skyrim, or the Arch-Mage's Quarters" },
               uniqueness: { message: 'must be unique' }
 
     validates :hold,
-              presence:   true,
-              inclusion:  { in: Skyrim::HOLDS, message: 'must be one of the nine Skyrim holds, or Solstheim' },
+              presence: true,
+              inclusion: { in: Skyrim::HOLDS, message: 'must be one of the nine Skyrim holds, or Solstheim' },
               uniqueness: { message: 'must be unique' }
 
     validates :city,
-              inclusion:  { in: VALID_CITIES, message: 'must be a Skyrim city in which an ownable property is located', allow_blank: true },
+              inclusion: { in: VALID_CITIES, message: 'must be a Skyrim city in which an ownable property is located', allow_blank: true },
               uniqueness: { message: 'must be unique if present', allow_blank: true }
 
     def self.unique_identifier

--- a/app/models/canonical/property.rb
+++ b/app/models/canonical/property.rb
@@ -15,27 +15,27 @@ module Canonical
     TOTAL_PROPERTY_COUNT = 10
 
     VALID_NAMES = [
-                    "Arch-Mage's Quarters",
-                    'Breezehome',
-                    'Heljarchen Hall',
-                    'Hjerim',
-                    'Honeyside',
-                    'Lakeview Manor',
-                    'Proudspire Manor',
-                    'Severin Manor',
-                    'Vlindrel Hall',
-                    'Windstad Manor',
-                  ].freeze
+      "Arch-Mage's Quarters",
+      'Breezehome',
+      'Heljarchen Hall',
+      'Hjerim',
+      'Honeyside',
+      'Lakeview Manor',
+      'Proudspire Manor',
+      'Severin Manor',
+      'Vlindrel Hall',
+      'Windstad Manor',
+    ].freeze
 
     VALID_CITIES = [
-                     'Markarth',
-                     'Raven Rock',
-                     'Riften',
-                     'Solitude',
-                     'Whiterun',
-                     'Windhelm',
-                     'Winterhold',
-                   ].freeze
+      'Markarth',
+      'Raven Rock',
+      'Riften',
+      'Solitude',
+      'Whiterun',
+      'Windhelm',
+      'Winterhold',
+    ].freeze
 
     validate :ensure_max, on: :create, if: :count_is_max
 

--- a/app/models/canonical/staff.rb
+++ b/app/models/canonical/staff.rb
@@ -10,13 +10,13 @@ module Canonical
     BOOLEAN_VALIDATION_MESSAGE = 'must be true or false'
 
     has_many :canonical_powerables_powers,
-             dependent:  :destroy,
+             dependent: :destroy,
              class_name: 'Canonical::PowerablesPower',
-             as:         :powerable
+             as: :powerable
     has_many :powers, through: :canonical_powerables_powers
 
     has_many :canonical_staves_spells,
-             dependent:  :destroy,
+             dependent: :destroy,
              class_name: 'Canonical::StavesSpell',
              inverse_of: :staff
     has_many :spells, through: :canonical_staves_spells
@@ -25,10 +25,10 @@ module Canonical
     validates :item_code, presence: true, uniqueness: { message: 'must be unique' }
     validates :unit_weight, presence: true, numericality: { greater_than_or_equal_to: 0 }
     validates :base_damage,
-              presence:     true,
+              presence: true,
               numericality: {
                 greater_than_or_equal_to: 0,
-                only_integer:             true,
+                only_integer: true,
               }
     validates :school, inclusion: { in: Skyrim::MAGIC_SCHOOLS, message: 'must be a valid school of magic', allow_blank: true }
     validates :daedric, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }

--- a/app/models/canonical/staff.rb
+++ b/app/models/canonical/staff.rb
@@ -27,9 +27,9 @@ module Canonical
     validates :base_damage,
               presence:     true,
               numericality: {
-                              greater_than_or_equal_to: 0,
-                              only_integer:             true,
-                            }
+                greater_than_or_equal_to: 0,
+                only_integer:             true,
+              }
     validates :school, inclusion: { in: Skyrim::MAGIC_SCHOOLS, message: 'must be a valid school of magic', allow_blank: true }
     validates :daedric, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }
     validates :purchasable, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }

--- a/app/models/canonical/sync.rb
+++ b/app/models/canonical/sync.rb
@@ -7,21 +7,21 @@ module Canonical
     SYNCERS = {
       # Syncers that are prerequisites for other syncers
       alchemical_property: Canonical::Sync::AlchemicalProperties,
-      enchantment:         Canonical::Sync::Enchantments,
-      material:            Canonical::Sync::Materials,
-      power:               Canonical::Sync::Powers,
-      spell:               Canonical::Sync::Spells,
-      ingredient:          Canonical::Sync::Ingredients,
+      enchantment: Canonical::Sync::Enchantments,
+      material: Canonical::Sync::Materials,
+      power: Canonical::Sync::Powers,
+      spell: Canonical::Sync::Spells,
+      ingredient: Canonical::Sync::Ingredients,
       # Syncers that are not prerequisites for other syncers
-      armor:               Canonical::Sync::Armor,
-      book:                Canonical::Sync::Books,
-      clothing:            Canonical::Sync::ClothingItems,
-      jewelry:             Canonical::Sync::JewelryItems,
-      misc_item:           Canonical::Sync::MiscItems,
-      potion:              Canonical::Sync::Potions,
-      property:            Canonical::Sync::Properties,
-      staff:               Canonical::Sync::Staves,
-      weapon:              Canonical::Sync::Weapons,
+      armor: Canonical::Sync::Armor,
+      book: Canonical::Sync::Books,
+      clothing: Canonical::Sync::ClothingItems,
+      jewelry: Canonical::Sync::JewelryItems,
+      misc_item: Canonical::Sync::MiscItems,
+      potion: Canonical::Sync::Potions,
+      property: Canonical::Sync::Properties,
+      staff: Canonical::Sync::Staves,
+      weapon: Canonical::Sync::Weapons,
     }.freeze
 
     module_function

--- a/app/models/canonical/sync.rb
+++ b/app/models/canonical/sync.rb
@@ -5,24 +5,24 @@ module Canonical
     class PrerequisiteNotMetError < StandardError; end
 
     SYNCERS = {
-                # Syncers that are prerequisites for other syncers
-                alchemical_property: Canonical::Sync::AlchemicalProperties,
-                enchantment:         Canonical::Sync::Enchantments,
-                material:            Canonical::Sync::Materials,
-                power:               Canonical::Sync::Powers,
-                spell:               Canonical::Sync::Spells,
-                ingredient:          Canonical::Sync::Ingredients,
-                # Syncers that are not prerequisites for other syncers
-                armor:               Canonical::Sync::Armor,
-                book:                Canonical::Sync::Books,
-                clothing:            Canonical::Sync::ClothingItems,
-                jewelry:             Canonical::Sync::JewelryItems,
-                misc_item:           Canonical::Sync::MiscItems,
-                potion:              Canonical::Sync::Potions,
-                property:            Canonical::Sync::Properties,
-                staff:               Canonical::Sync::Staves,
-                weapon:              Canonical::Sync::Weapons,
-              }.freeze
+      # Syncers that are prerequisites for other syncers
+      alchemical_property: Canonical::Sync::AlchemicalProperties,
+      enchantment:         Canonical::Sync::Enchantments,
+      material:            Canonical::Sync::Materials,
+      power:               Canonical::Sync::Powers,
+      spell:               Canonical::Sync::Spells,
+      ingredient:          Canonical::Sync::Ingredients,
+      # Syncers that are not prerequisites for other syncers
+      armor:               Canonical::Sync::Armor,
+      book:                Canonical::Sync::Books,
+      clothing:            Canonical::Sync::ClothingItems,
+      jewelry:             Canonical::Sync::JewelryItems,
+      misc_item:           Canonical::Sync::MiscItems,
+      potion:              Canonical::Sync::Potions,
+      property:            Canonical::Sync::Properties,
+      staff:               Canonical::Sync::Staves,
+      weapon:              Canonical::Sync::Weapons,
+    }.freeze
 
     module_function
 

--- a/app/models/canonical/weapon.rb
+++ b/app/models/canonical/weapon.rb
@@ -10,23 +10,23 @@ module Canonical
     BOOLEAN_VALIDATION_MESSAGE = 'must be true or false'
     VALID_WEAPON_TYPES = {
                            'one-handed' => [
-                                             'dagger',
-                                             'mace',
-                                             'other',
-                                             'sword',
-                                             'war axe',
-                                           ],
+                             'dagger',
+                             'mace',
+                             'other',
+                             'sword',
+                             'war axe',
+                           ],
                            'two-handed' => %w[
-                                             battleaxe
-                                             greatsword
-                                             warhammer
-                                           ],
+                             battleaxe
+                             greatsword
+                             warhammer
+                           ],
                            'archery'    => %w[
-                                             arrow
-                                             bolt
-                                             bow
-                                             crossbow
-                                           ],
+                             arrow
+                             bolt
+                             bow
+                             crossbow
+                           ],
                          }.freeze
 
     has_many :canonical_enchantables_enchantments,

--- a/app/models/canonical/weapon.rb
+++ b/app/models/canonical/weapon.rb
@@ -21,7 +21,7 @@ module Canonical
         greatsword
         warhammer
       ],
-      'archery'    => %w[
+      'archery' => %w[
         arrow
         bolt
         bow
@@ -30,49 +30,49 @@ module Canonical
     }.freeze
 
     has_many :canonical_enchantables_enchantments,
-             dependent:  :destroy,
+             dependent: :destroy,
              class_name: 'Canonical::EnchantablesEnchantment',
-             as:         :enchantable
+             as: :enchantable
     has_many :enchantments,
              -> { select 'enchantments.*, canonical_enchantables_enchantments.strength as strength' },
              through: :canonical_enchantables_enchantments
 
     has_many :canonical_powerables_powers,
-             dependent:  :destroy,
+             dependent: :destroy,
              class_name: 'Canonical::PowerablesPower',
-             as:         :powerable
+             as: :powerable
     has_many :powers, through: :canonical_powerables_powers
 
     has_many :canonical_craftables_crafting_materials,
-             dependent:  :destroy,
+             dependent: :destroy,
              class_name: 'Canonical::CraftablesCraftingMaterial',
-             as:         :craftable
+             as: :craftable
     has_many :crafting_materials,
              -> { select 'canonical_materials.*, canonical_craftables_crafting_materials.quantity as quantity_needed' },
              through: :canonical_craftables_crafting_materials,
-             source:  :material
+             source: :material
 
     has_many :canonical_temperables_tempering_materials,
-             dependent:  :destroy,
+             dependent: :destroy,
              class_name: 'Canonical::TemperablesTemperingMaterial',
-             as:         :temperable
+             as: :temperable
     has_many :tempering_materials,
              -> { select 'canonical_materials.*, canonical_temperables_tempering_materials.quantity as quantity_needed' },
              through: :canonical_temperables_tempering_materials,
-             source:  :material
+             source: :material
 
     validates :name, presence: true
     validates :item_code, presence: true, uniqueness: { message: 'must be unique' }
     validates :category,
-              presence:  true,
+              presence: true,
               inclusion: {
-                in:      VALID_WEAPON_TYPES.keys,
+                in: VALID_WEAPON_TYPES.keys,
                 message: 'must be "one-handed", "two-handed", or "archery"',
               }
     validates :weapon_type,
-              presence:  true,
+              presence: true,
               inclusion: {
-                in:      VALID_WEAPON_TYPES.values.flatten,
+                in: VALID_WEAPON_TYPES.values.flatten,
                 message: 'must be a valid type of weapon that occurs in Skyrim',
               }
     validates :base_damage, presence: true, numericality: { greater_than_or_equal_to: 0, only_integer: true }

--- a/app/models/canonical/weapon.rb
+++ b/app/models/canonical/weapon.rb
@@ -9,25 +9,25 @@ module Canonical
     BOOLEAN_VALUES = [true, false].freeze
     BOOLEAN_VALIDATION_MESSAGE = 'must be true or false'
     VALID_WEAPON_TYPES = {
-                           'one-handed' => [
-                             'dagger',
-                             'mace',
-                             'other',
-                             'sword',
-                             'war axe',
-                           ],
-                           'two-handed' => %w[
-                             battleaxe
-                             greatsword
-                             warhammer
-                           ],
-                           'archery'    => %w[
-                             arrow
-                             bolt
-                             bow
-                             crossbow
-                           ],
-                         }.freeze
+      'one-handed' => [
+        'dagger',
+        'mace',
+        'other',
+        'sword',
+        'war axe',
+      ],
+      'two-handed' => %w[
+        battleaxe
+        greatsword
+        warhammer
+      ],
+      'archery'    => %w[
+        arrow
+        bolt
+        bow
+        crossbow
+      ],
+    }.freeze
 
     has_many :canonical_enchantables_enchantments,
              dependent:  :destroy,
@@ -66,15 +66,15 @@ module Canonical
     validates :category,
               presence:  true,
               inclusion: {
-                           in:      VALID_WEAPON_TYPES.keys,
-                           message: 'must be "one-handed", "two-handed", or "archery"',
-                         }
+                in:      VALID_WEAPON_TYPES.keys,
+                message: 'must be "one-handed", "two-handed", or "archery"',
+              }
     validates :weapon_type,
               presence:  true,
               inclusion: {
-                           in:      VALID_WEAPON_TYPES.values.flatten,
-                           message: 'must be a valid type of weapon that occurs in Skyrim',
-                         }
+                in:      VALID_WEAPON_TYPES.values.flatten,
+                message: 'must be a valid type of weapon that occurs in Skyrim',
+              }
     validates :base_damage, presence: true, numericality: { greater_than_or_equal_to: 0, only_integer: true }
     validates :unit_weight, presence: true, numericality: { greater_than_or_equal_to: 0 }
     validates :purchasable, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }

--- a/app/models/concerns/aggregatable.rb
+++ b/app/models/concerns/aggregatable.rb
@@ -37,10 +37,10 @@ module Aggregatable
     belongs_to :game, touch: true
     has_many :list_items,
              -> { index_order },
-             class_name:  list_item_class_name,
-             dependent:   :destroy,
+             class_name: list_item_class_name,
+             dependent: :destroy,
              foreign_key: :list_id,
-             inverse_of:  :list
+             inverse_of: :list
     belongs_to :aggregate_list, class_name: to_s, optional: true
 
     has_many :child_lists, class_name: to_s, foreign_key: :aggregate_list_id, inverse_of: :aggregate_list

--- a/app/models/enchantment.rb
+++ b/app/models/enchantment.rb
@@ -38,8 +38,8 @@ class Enchantment < ApplicationRecord
   validates :name, presence: true, uniqueness: { message: 'must be unique' }
   validates :strength_unit,
             inclusion: {
-              in:          STRENGTH_UNITS,
-              message:     'must be "point", "percentage", "second", or the "level" of affected targets',
+              in: STRENGTH_UNITS,
+              message: 'must be "point", "percentage", "second", or the "level" of affected targets',
               allow_blank: true,
             }
   validates :school, inclusion: { in: Skyrim::MAGIC_SCHOOLS, message: 'must be a valid school of magic', allow_blank: true }

--- a/app/models/enchantment.rb
+++ b/app/models/enchantment.rb
@@ -38,10 +38,10 @@ class Enchantment < ApplicationRecord
   validates :name, presence: true, uniqueness: { message: 'must be unique' }
   validates :strength_unit,
             inclusion: {
-                         in:          STRENGTH_UNITS,
-                         message:     'must be "point", "percentage", "second", or the "level" of affected targets',
-                         allow_blank: true,
-                       }
+              in:          STRENGTH_UNITS,
+              message:     'must be "point", "percentage", "second", or the "level" of affected targets',
+              allow_blank: true,
+            }
   validates :school, inclusion: { in: Skyrim::MAGIC_SCHOOLS, message: 'must be a valid school of magic', allow_blank: true }
   validate :validate_enchantable_items
 

--- a/app/models/enchantment.rb
+++ b/app/models/enchantment.rb
@@ -4,29 +4,29 @@ require 'skyrim'
 
 class Enchantment < ApplicationRecord
   ENCHANTABLE_WEAPONS = [
-                          'sword',
-                          'mace',
-                          'war axe',
-                          'greatsword',
-                          'warhammer',
-                          'battleaxe',
-                          'dagger',
-                          'bow',
-                          'crossbow',
-                          'staff',
-                          'other',
-                        ].freeze
+    'sword',
+    'mace',
+    'war axe',
+    'greatsword',
+    'warhammer',
+    'battleaxe',
+    'dagger',
+    'bow',
+    'crossbow',
+    'staff',
+    'other',
+  ].freeze
 
   ENCHANTABLE_APPAREL_ITEMS = %w[
-                                head
-                                chest
-                                hands
-                                feet
-                                shield
-                                circlet
-                                amulet
-                                ring
-                              ].freeze
+    head
+    chest
+    hands
+    feet
+    shield
+    circlet
+    amulet
+    ring
+  ].freeze
 
   ENCHANTABLE_ITEMS = (ENCHANTABLE_WEAPONS + ENCHANTABLE_APPAREL_ITEMS).freeze
 

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -25,9 +25,9 @@ class Game < ApplicationRecord
   validates :name,
             uniqueness: { scope: :user_id, message: 'must be unique', case_sensitive: false },
             format:     {
-                          with:    /\A\s*[a-z0-9 \-',]*\s*\z/i,
-                          message: "can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')",
-                        }
+              with:    /\A\s*[a-z0-9 \-',]*\s*\z/i,
+              message: "can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')",
+            }
 
   scope :index_order, -> { order(updated_at: :desc) }
 

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -24,8 +24,8 @@ class Game < ApplicationRecord
 
   validates :name,
             uniqueness: { scope: :user_id, message: 'must be unique', case_sensitive: false },
-            format:     {
-              with:    /\A\s*[a-z0-9 \-',]*\s*\z/i,
+            format: {
+              with: /\A\s*[a-z0-9 \-',]*\s*\z/i,
               message: "can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')",
             }
 

--- a/app/models/inventory_list.rb
+++ b/app/models/inventory_list.rb
@@ -10,9 +10,9 @@ class InventoryList < ApplicationRecord
   validates :title,
             uniqueness: { scope: :game_id, message: 'must be unique per game', case_sensitive: false },
             format:     {
-                          with:    /\A\s*[a-z0-9 \-',]*\s*\z/i,
-                          message: "can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')",
-                        }
+              with:    /\A\s*[a-z0-9 \-',]*\s*\z/i,
+              message: "can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')",
+            }
 
   before_save :format_title
 

--- a/app/models/inventory_list.rb
+++ b/app/models/inventory_list.rb
@@ -9,8 +9,8 @@ class InventoryList < ApplicationRecord
   # ignores any leading or trailing whitespace characters.
   validates :title,
             uniqueness: { scope: :game_id, message: 'must be unique per game', case_sensitive: false },
-            format:     {
-              with:    /\A\s*[a-z0-9 \-',]*\s*\z/i,
+            format: {
+              with: /\A\s*[a-z0-9 \-',]*\s*\z/i,
               message: "can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')",
             }
 

--- a/app/models/power.rb
+++ b/app/models/power.rb
@@ -10,9 +10,9 @@ class Power < ApplicationRecord
   validates :power_type,
             presence:  true,
             inclusion: {
-                         in:      %w[greater lesser ability],
-                         message: 'must be "greater", "lesser", or "ability"',
-                       }
+              in:      %w[greater lesser ability],
+              message: 'must be "greater", "lesser", or "ability"',
+            }
   validates :source, presence: true
   validates :description, presence: true
 

--- a/app/models/power.rb
+++ b/app/models/power.rb
@@ -2,15 +2,15 @@
 
 class Power < ApplicationRecord
   has_many :canonical_powerables_powers,
-           dependent:  :destroy,
+           dependent: :destroy,
            class_name: 'Canonical::PowerablesPower'
   has_many :powerables, through: :canonical_powerables_powers
 
   validates :name, presence: true, uniqueness: { message: 'must be unique' }
   validates :power_type,
-            presence:  true,
+            presence: true,
             inclusion: {
-              in:      %w[greater lesser ability],
+              in: %w[greater lesser ability],
               message: 'must be "greater", "lesser", or "ability"',
             }
   validates :source, presence: true

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -14,17 +14,17 @@ class Property < ApplicationRecord
   validates :canonical_property, uniqueness: { scope: :game_id, message: 'must be unique per game' }
 
   validates :name,
-            presence:   true,
-            inclusion:  { in: Canonical::Property::VALID_NAMES, message: "must be an ownable property in Skyrim, or the Arch-Mage's Quarters" },
+            presence: true,
+            inclusion: { in: Canonical::Property::VALID_NAMES, message: "must be an ownable property in Skyrim, or the Arch-Mage's Quarters" },
             uniqueness: { scope: :game_id, message: 'must be unique per game' }
 
   validates :hold,
-            presence:   true,
-            inclusion:  { in: Skyrim::HOLDS, message: 'must be one of the nine Skyrim holds, or Solstheim' },
+            presence: true,
+            inclusion: { in: Skyrim::HOLDS, message: 'must be one of the nine Skyrim holds, or Solstheim' },
             uniqueness: { scope: :game_id, message: 'must be unique per game' }
 
   validates :city,
-            inclusion:  { in: Canonical::Property::VALID_CITIES, message: 'must be a Skyrim city in which an ownable property is located', allow_blank: true },
+            inclusion: { in: Canonical::Property::VALID_CITIES, message: 'must be a Skyrim city in which an ownable property is located', allow_blank: true },
             uniqueness: { scope: :game_id, message: 'must be unique per game if present', allow_blank: true }
 
   validate :ensure_alchemy_lab_available, if: -> { has_alchemy_lab == true && !canonical_property&.alchemy_lab_available }

--- a/app/models/shopping_list.rb
+++ b/app/models/shopping_list.rb
@@ -10,9 +10,9 @@ class ShoppingList < ApplicationRecord
   validates :title,
             uniqueness: { scope: :game_id, message: 'must be unique per game', case_sensitive: false },
             format:     {
-                          with:    /\A\s*[a-z0-9 \-',]*\s*\z/i,
-                          message: "can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')",
-                        }
+              with:    /\A\s*[a-z0-9 \-',]*\s*\z/i,
+              message: "can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')",
+            }
 
   before_save :format_title
 

--- a/app/models/shopping_list.rb
+++ b/app/models/shopping_list.rb
@@ -9,8 +9,8 @@ class ShoppingList < ApplicationRecord
   # ignores any leading or trailing whitespace characters.
   validates :title,
             uniqueness: { scope: :game_id, message: 'must be unique per game', case_sensitive: false },
-            format:     {
-              with:    /\A\s*[a-z0-9 \-',]*\s*\z/i,
+            format: {
+              with: /\A\s*[a-z0-9 \-',]*\s*\z/i,
               message: "can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')",
             }
 

--- a/app/models/spell.rb
+++ b/app/models/spell.rb
@@ -4,7 +4,7 @@ require 'skyrim'
 
 class Spell < ApplicationRecord
   has_many :canonical_staves_spells,
-           dependent:  :destroy,
+           dependent: :destroy,
            class_name: 'Canonical::StavesSpell',
            inverse_of: :spell
   has_many :staves, through: :canonical_staves_spells
@@ -14,8 +14,8 @@ class Spell < ApplicationRecord
   validates :level, presence: true, inclusion: { in: Skyrim::DIFFICULTY_LEVELS, message: 'must be "Novice", "Apprentice", "Adept", "Expert", or "Master"' }
   validates :strength_unit,
             inclusion: {
-              in:          %w[point percentage level],
-              message:     'must be "point", "percentage", or the "level" of affected targets',
+              in: %w[point percentage level],
+              message: 'must be "point", "percentage", or the "level" of affected targets',
               allow_blank: true,
             }
   validates :description, presence: true

--- a/app/models/spell.rb
+++ b/app/models/spell.rb
@@ -14,10 +14,10 @@ class Spell < ApplicationRecord
   validates :level, presence: true, inclusion: { in: Skyrim::DIFFICULTY_LEVELS, message: 'must be "Novice", "Apprentice", "Adept", "Expert", or "Master"' }
   validates :strength_unit,
             inclusion: {
-                         in:          %w[point percentage level],
-                         message:     'must be "point", "percentage", or the "level" of affected targets',
-                         allow_blank: true,
-                       }
+              in:          %w[point percentage level],
+              message:     'must be "point", "percentage", or the "level" of affected targets',
+              allow_blank: true,
+            }
   validates :description, presence: true
   validate :strength_and_strength_unit_both_or_neither_present
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -24,8 +24,8 @@ Rails.application.configure do
   if Rails.root.join('tmp', 'caching-dev.txt').exist?
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-                                          'Cache-Control' => "public, max-age=#{2.days.to_i}",
-                                        }
+      'Cache-Control' => "public, max-age=#{2.days.to_i}",
+    }
   else
     config.action_controller.perform_caching = false
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -21,8 +21,8 @@ Rails.application.configure do
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-                                        'Cache-Control' => "public, max-age=#{1.hour.to_i}",
-                                      }
+    'Cache-Control' => "public, max-age=#{1.hour.to_i}",
+  }
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local = true

--- a/db/migrate/20220429060600_create_canonical_craftables_crafting_materials.rb
+++ b/db/migrate/20220429060600_create_canonical_craftables_crafting_materials.rb
@@ -4,14 +4,14 @@ class CreateCanonicalCraftablesCraftingMaterials < ActiveRecord::Migration[6.1]
   def change
     create_table :canonical_craftables_crafting_materials do |t|
       t.references :material,
-                   null:        false,
+                   null: false,
                    foreign_key: { to_table: 'canonical_materials' },
-                   index:       { name: :index_canonical_armors_smithing_mats_on_canonical_mat_id }
+                   index: { name: :index_canonical_armors_smithing_mats_on_canonical_mat_id }
       t.bigint :craftable_id, null: false
       t.string :craftable_type, null: false
       t.integer :quantity,
                 default: 1,
-                null:    false
+                null: false
 
       t.index %i[material_id craftable_id craftable_type], unique: true, name: 'index_can_craftables_crafting_materials_on_mat_id_and_craftable'
 

--- a/db/migrate/20220429061411_create_canonical_temperables_tempering_materials.rb
+++ b/db/migrate/20220429061411_create_canonical_temperables_tempering_materials.rb
@@ -4,18 +4,18 @@ class CreateCanonicalTemperablesTemperingMaterials < ActiveRecord::Migration[6.1
   def change
     create_table :canonical_temperables_tempering_materials do |t|
       t.references :material,
-                   null:        false,
+                   null: false,
                    foreign_key: { to_table: 'canonical_materials' },
-                   index:       { name: :index_canonical_armors_tempering_mats_on_canonical_material_id }
+                   index: { name: :index_canonical_armors_tempering_mats_on_canonical_material_id }
       t.bigint :temperable_id, null: false
       t.string :temperable_type, null: false
       t.integer :quantity,
                 default: 1,
-                null:    false
+                null: false
 
       t.index %i[material_id temperable_id temperable_type],
               unique: true,
-              name:   'index_temperables_tempering_mats_on_mat_id_and_temperable'
+              name: 'index_temperables_tempering_mats_on_mat_id_and_temperable'
 
       t.timestamps
     end

--- a/db/migrate/20220504045733_create_canonical_ingredients_alchemical_properties.rb
+++ b/db/migrate/20220504045733_create_canonical_ingredients_alchemical_properties.rb
@@ -4,13 +4,13 @@ class CreateCanonicalIngredientsAlchemicalProperties < ActiveRecord::Migration[6
   def change
     create_table :canonical_ingredients_alchemical_properties do |t|
       t.references :alchemical_property,
-                   null:        false,
+                   null: false,
                    foreign_key: true,
-                   index:       { name: 'index_can_ingredients_alc_properties_on_alc_property_id' }
+                   index: { name: 'index_can_ingredients_alc_properties_on_alc_property_id' }
       t.references :ingredient,
-                   null:        false,
+                   null: false,
                    foreign_key: { to_table: 'canonical_ingredients' },
-                   index:       { name: 'index_can_ingredients_alc_properties_on_can_ingredient_id' }
+                   index: { name: 'index_can_ingredients_alc_properties_on_can_ingredient_id' }
 
       t.index %i[alchemical_property_id ingredient_id], unique: true, name: 'index_can_ingredients_alc_properties_on_property_and_ingr_ids'
 

--- a/db/migrate/20220504232656_add_priority_and_strength_multiplier_to_alchemical_properties_canonical_ingredients.rb
+++ b/db/migrate/20220504232656_add_priority_and_strength_multiplier_to_alchemical_properties_canonical_ingredients.rb
@@ -15,6 +15,6 @@ class AddPriorityAndStrengthMultiplierToAlchemicalPropertiesCanonicalIngredients
     add_index :canonical_ingredients_alchemical_properties,
               %i[priority ingredient_id],
               unique: true,
-              name:   :index_can_ingrs_alc_props_on_priority_and_ingr_id
+              name: :index_can_ingrs_alc_props_on_priority_and_ingr_id
   end
 end

--- a/db/migrate/20220516035227_create_canonical_powerables_powers.rb
+++ b/db/migrate/20220516035227_create_canonical_powerables_powers.rb
@@ -9,7 +9,7 @@ class CreateCanonicalPowerablesPowers < ActiveRecord::Migration[6.1]
 
       t.index %i[power_id powerable_id powerable_type],
               unique: true,
-              name:   'index_powerables_powers_on_power_id_and_powerable'
+              name: 'index_powerables_powers_on_power_id_and_powerable'
 
       t.timestamps
     end

--- a/db/migrate/20220525023945_create_canonical_potions_alchemical_properties.rb
+++ b/db/migrate/20220525023945_create_canonical_potions_alchemical_properties.rb
@@ -5,15 +5,15 @@ class CreateCanonicalPotionsAlchemicalProperties < ActiveRecord::Migration[6.1]
     create_table :canonical_potions_alchemical_properties do |t|
       t.references :potion, null: false, foreign_key: { to_table: 'canonical_potions' }
       t.references :alchemical_property,
-                   null:        false,
+                   null: false,
                    foreign_key: true,
-                   index:       { name: 'index_can_potions_properties_on_alc_property_id' }
+                   index: { name: 'index_can_potions_properties_on_alc_property_id' }
       t.integer :strength
       t.integer :duration
 
       t.index %i[potion_id alchemical_property_id],
               unique: true,
-              name:   'index_can_potions_properties_on_potion_and_property'
+              name: 'index_can_potions_properties_on_potion_and_property'
 
       t.timestamps
     end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,10 +2,10 @@
 
 module Seeds
   USER_DATA = {
-                uid:   'uruser',
-                email: 'uruser@gmail.com',
-                name:  'Uruser',
-              }.freeze
+    uid:   'uruser',
+    email: 'uruser@gmail.com',
+    name:  'Uruser',
+  }.freeze
 
   module_function
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,9 +2,9 @@
 
 module Seeds
   USER_DATA = {
-    uid:   'uruser',
+    uid: 'uruser',
     email: 'uruser@gmail.com',
-    name:  'Uruser',
+    name: 'Uruser',
   }.freeze
 
   module_function

--- a/lib/skyrim.rb
+++ b/lib/skyrim.rb
@@ -2,65 +2,65 @@
 
 module Skyrim
   SKILLS = [
-             'Alchemy',
-             'Alteration',
-             'Archery',
-             'Block',
-             'Conjuration',
-             'Destruction',
-             'Enchanting',
-             'Heavy Armor',
-             'Illusion',
-             'Light Armor',
-             'Lockpicking',
-             'One-Handed',
-             'Pickpocket',
-             'Restoration',
-             'Smithing',
-             'Sneak',
-             'Speech',
-             'Two-Handed',
-           ].freeze
+    'Alchemy',
+    'Alteration',
+    'Archery',
+    'Block',
+    'Conjuration',
+    'Destruction',
+    'Enchanting',
+    'Heavy Armor',
+    'Illusion',
+    'Light Armor',
+    'Lockpicking',
+    'One-Handed',
+    'Pickpocket',
+    'Restoration',
+    'Smithing',
+    'Sneak',
+    'Speech',
+    'Two-Handed',
+  ].freeze
 
   HOLDS = [
-            'Eastmarch',
-            'Falkreath',
-            'Haafingar',
-            'Hjaalmarch',
-            'Solstheim',
-            'The Pale',
-            'The Reach',
-            'The Rift',
-            'Whiterun',
-            'Winterhold',
-          ].freeze
+    'Eastmarch',
+    'Falkreath',
+    'Haafingar',
+    'Hjaalmarch',
+    'Solstheim',
+    'The Pale',
+    'The Reach',
+    'The Rift',
+    'Whiterun',
+    'Winterhold',
+  ].freeze
 
   MAGIC_SCHOOLS = %w[
-                    Alteration
-                    Conjuration
-                    Destruction
-                    Illusion
-                    Restoration
-                  ].freeze
+    Alteration
+    Conjuration
+    Destruction
+    Illusion
+    Restoration
+  ].freeze
 
   SMITHING_PERKS = [
-                     'Steel Smithing',
-                     'Elven Smithing',
-                     'Advanced Armors',
-                     'Glass Smithing',
-                     'Dragon Armor',
-                     'Arcane Blacksmith',
-                     'Dwarven Smithing',
-                     'Orcish Smithing',
-                     'Ebony Smithing',
-                     'Daedric Smithing',
-                   ].freeze
+    'Steel Smithing',
+    'Elven Smithing',
+    'Advanced Armors',
+    'Glass Smithing',
+    'Dragon Armor',
+    'Arcane Blacksmith',
+    'Dwarven Smithing',
+    'Orcish Smithing',
+    'Ebony Smithing',
+    'Daedric Smithing',
+  ].freeze
 
   DIFFICULTY_LEVELS = %w[
-                        Novice
-                        Apprentice
-                        Adept
-                        Expert
-                        Master
-                      ].freeze
+    Novice
+    Apprentice
+    Adept
+    Expert
+    Master
+  ].freeze
 end

--- a/lib/tasks/export_csvs.rake
+++ b/lib/tasks/export_csvs.rake
@@ -69,19 +69,19 @@ namespace :csv do
           ingredients = item[:canonical_ingredients].pluck(:item_code)
                           .join(',')
           csv << [
-                   item.dig(:attributes, :title),
-                   item.dig(:attributes, :title_variants)&.join(';'),
-                   item.dig(:attributes, :item_code),
-                   item.dig(:attributes, :unit_weight),
-                   item.dig(:attributes, :book_type),
-                   item.dig(:attributes, :skill_name),
-                   item.dig(:attributes, :purchasable),
-                   item.dig(:attributes, :unique_item),
-                   item.dig(:attributes, :rare_item),
-                   item.dig(:attributes, :solstheim_only),
-                   item.dig(:attributes, :quest_item),
-                   ingredients.empty? ? nil : ingredients,
-                 ]
+            item.dig(:attributes, :title),
+            item.dig(:attributes, :title_variants)&.join(';'),
+            item.dig(:attributes, :item_code),
+            item.dig(:attributes, :unit_weight),
+            item.dig(:attributes, :book_type),
+            item.dig(:attributes, :skill_name),
+            item.dig(:attributes, :purchasable),
+            item.dig(:attributes, :unique_item),
+            item.dig(:attributes, :rare_item),
+            item.dig(:attributes, :solstheim_only),
+            item.dig(:attributes, :quest_item),
+            ingredients.empty? ? nil : ingredients,
+          ]
         end
       end
 

--- a/lib/tasks/sync_canonical_models.rake
+++ b/lib/tasks/sync_canonical_models.rake
@@ -52,10 +52,10 @@ namespace :canonical_models do
     # rubocop:disable Layout/BlockAlignment
     task :jewelry,
          %i[preserve_existing_records] => %w[
-                                            environment
-                                            canonical_models:sync:materials
-                                            canonical_models:sync:enchantments
-                                          ] do |_t, args|
+           environment
+           canonical_models:sync:materials
+           canonical_models:sync:enchantments
+         ] do |_t, args|
       args.with_defaults(preserve_existing_records: false)
 
       Canonical::Sync.perform(:jewelry, FALSEY_VALUES.exclude?(args[:preserve_existing_records]))
@@ -64,10 +64,10 @@ namespace :canonical_models do
     desc 'Sync canonical clothing items in the database with JSON data'
     task :clothing,
          %i[preserve_existing_records] => %w[
-                                            environment
-                                            canonical_models:sync:materials
-                                            canonical_models:sync:enchantments
-                                          ] do |_t, args|
+           environment
+           canonical_models:sync:materials
+           canonical_models:sync:enchantments
+         ] do |_t, args|
       args.with_defaults(preserve_existing_records: false)
 
       Canonical::Sync.perform(:clothing, FALSEY_VALUES.exclude?(args[:preserve_existing_records]))
@@ -76,10 +76,10 @@ namespace :canonical_models do
     desc 'Sync canonical armor models in the database with JSON data'
     task :armor,
          %i[preserve_existing_records] => %w[
-                                            environment
-                                            canonical_models:sync:materials
-                                            canonical_models:sync:enchantments
-                                          ] do |_t, args|
+           environment
+           canonical_models:sync:materials
+           canonical_models:sync:enchantments
+         ] do |_t, args|
       args.with_defaults(preserve_existing_records: false)
 
       Canonical::Sync.perform(:armor, FALSEY_VALUES.exclude?(args[:preserve_existing_records]))
@@ -88,9 +88,9 @@ namespace :canonical_models do
     desc 'Sync canonical ingredient models in the database with JSON data'
     task :ingredients,
          %i[preserve_existing_records] => %w[
-                                            environment
-                                            canonical_models:sync:alchemical_properties
-                                          ] do |_t, args|
+           environment
+           canonical_models:sync:alchemical_properties
+         ] do |_t, args|
       args.with_defaults(preserve_existing_records: false)
 
       Canonical::Sync.perform(:ingredient, FALSEY_VALUES.exclude?(args[:preserve_existing_records]))
@@ -99,11 +99,11 @@ namespace :canonical_models do
     desc 'Sync canonical weapon models in the database with JSON data'
     task :weapons,
          %i[preserve_existing_records] => %w[
-                                            environment
-                                            canonical_models:sync:enchantments
-                                            canonical_models:sync:powers
-                                            canonical_models:sync:materials
-                                          ] do |_t, args|
+           environment
+           canonical_models:sync:enchantments
+           canonical_models:sync:powers
+           canonical_models:sync:materials
+         ] do |_t, args|
       args.with_defaults(preserve_existing_records: false)
 
       Canonical::Sync.perform(:weapon, FALSEY_VALUES.exclude?(args[:preserve_existing_records]))
@@ -112,10 +112,10 @@ namespace :canonical_models do
     desc 'Sync canonical staff models in the database with JSON data'
     task :staves,
          %i[preserve_existing_records] => %w[
-                                            environment
-                                            canonical_models:sync:spells
-                                            canonical_models:sync:powers
-                                          ] do |_t, args|
+           environment
+           canonical_models:sync:spells
+           canonical_models:sync:powers
+         ] do |_t, args|
       args.with_defaults(preserve_existing_records: false)
 
       Canonical::Sync.perform(:staff, FALSEY_VALUES.exclude?(args[:preserve_existing_records]))
@@ -124,9 +124,9 @@ namespace :canonical_models do
     desc 'Sync canonical book models in the database with JSON data'
     task :books,
          %i[preserve_existing_records] => %w[
-                                            environment
-                                            canonical_models:sync:ingredients
-                                          ] do |_t, args|
+           environment
+           canonical_models:sync:ingredients
+         ] do |_t, args|
       args.with_defaults(preserve_existing_records: false)
 
       Canonical::Sync.perform(:book, FALSEY_VALUES.exclude?(args[:preserve_existing_records]))
@@ -135,9 +135,9 @@ namespace :canonical_models do
     desc 'Sync canonical potion models in the database with JSON data'
     task :potions,
          %i[preserve_existing_records] => %w[
-                                            environment
-                                            canonical_models:sync:alchemical_properties
-                                          ] do |_t, args|
+           environment
+           canonical_models:sync:alchemical_properties
+         ] do |_t, args|
       args.with_defaults(preserve_existing_records: false)
 
       Canonical::Sync.perform(:potion, FALSEY_VALUES.exclude?(args[:preserve_existing_records]))

--- a/lib/titlecase.rb
+++ b/lib/titlecase.rb
@@ -53,25 +53,25 @@
 
 module Titlecase
   LOWERCASE_WORDS = %w[
-                      a
-                      an
-                      the
-                      and
-                      but
-                      for
-                      at
-                      by
-                      from
-                      with
-                      to
-                      in
-                      of
-                      into
-                      onto
-                      on
-                      without
-                      within
-                    ].freeze
+    a
+    an
+    the
+    and
+    but
+    for
+    at
+    by
+    from
+    with
+    to
+    in
+    of
+    into
+    onto
+    on
+    without
+    within
+  ].freeze
 
   module_function
 

--- a/spec/controller_services/application_controller/authorization_service_spec.rb
+++ b/spec/controller_services/application_controller/authorization_service_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe ApplicationController::AuthorizationService do
           create(
             :user,
             display_name: 'Jane Doe',
-            email:        'someuser@gmail.com',
-            uid:          'somestring',
+            email: 'someuser@gmail.com',
+            uid: 'somestring',
           )
         end
 

--- a/spec/controller_services/application_controller/authorization_service_spec.rb
+++ b/spec/controller_services/application_controller/authorization_service_spec.rb
@@ -53,14 +53,7 @@ RSpec.describe ApplicationController::AuthorizationService do
       end
 
       context 'when a matching user exists' do
-        let!(:user) do
-          create(
-            :user,
-            display_name: 'Jane Doe',
-            email: 'someuser@gmail.com',
-            uid: 'somestring',
-          )
-        end
+        let!(:user) { create(:authenticated_user) }
 
         it 'sets the current user' do
           perform

--- a/spec/controller_services/inventory_lists_controller/create_service_spec.rb
+++ b/spec/controller_services/inventory_lists_controller/create_service_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe InventoryListsController::CreateService do
       let(:game) { create(:game, user:) }
       let(:params) do
         {
-          title:     'All Items',
+          title: 'All Items',
           aggregate: true,
         }
       end

--- a/spec/controller_services/shopping_list_items_controller/destroy_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/destroy_service_spec.rb
@@ -61,10 +61,10 @@ RSpec.describe ShoppingListItemsController::DestroyService do
         let(:second_list) { create(:shopping_list, game:, aggregate_list:) }
         let(:second_list_item) do
           create(:shopping_list_item,
-                 list:        second_list,
+                 list: second_list,
                  description: list_item.description.upcase, # make sure comparison is case insensitive
-                 quantity:    2,
-                 notes:       'some other notes',)
+                 quantity: 2,
+                 notes: 'some other notes',)
         end
 
         before do

--- a/spec/controller_services/shopping_lists_controller/create_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/create_service_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe ShoppingListsController::CreateService do
       let(:game) { create(:game, user:) }
       let(:params) do
         {
-          title:     'All Items',
+          title: 'All Items',
           aggregate: true,
         }
       end

--- a/spec/lib/controller/response_spec.rb
+++ b/spec/lib/controller/response_spec.rb
@@ -40,9 +40,9 @@ RSpec.describe Controller::Response do
 
       let(:resource) do
         {
-          id:         927,
-          user_id:    72,
-          title:      'My List 2',
+          id: 927,
+          user_id: 72,
+          title: 'My List 2',
           created_at: Time.zone.now - 2.days,
           updated_at: Time.zone.now,
         }

--- a/spec/lib/service/result_spec.rb
+++ b/spec/lib/service/result_spec.rb
@@ -19,23 +19,23 @@ RSpec.describe Service::Result do
       let(:options) do
         {
           resource: {
-                      id:           32,
-                      uid:          'foobar',
-                      email:        'jane.doe@gmail.com',
-                      display_name: 'Jane Doe',
-                      photo_url:    nil,
-                    },
+            id:           32,
+            uid:          'foobar',
+            email:        'jane.doe@gmail.com',
+            display_name: 'Jane Doe',
+            photo_url:    nil,
+          },
         }
       end
 
       it 'sets the resource if one is given' do
         expect(result.resource).to eq({
-                                        id:           32,
-                                        uid:          'foobar',
-                                        email:        'jane.doe@gmail.com',
-                                        display_name: 'Jane Doe',
-                                        photo_url:    nil,
-                                      })
+          id:           32,
+          uid:          'foobar',
+          email:        'jane.doe@gmail.com',
+          display_name: 'Jane Doe',
+          photo_url:    nil,
+        })
       end
     end
 

--- a/spec/lib/service/result_spec.rb
+++ b/spec/lib/service/result_spec.rb
@@ -19,22 +19,22 @@ RSpec.describe Service::Result do
       let(:options) do
         {
           resource: {
-            id:           32,
-            uid:          'foobar',
-            email:        'jane.doe@gmail.com',
+            id: 32,
+            uid: 'foobar',
+            email: 'jane.doe@gmail.com',
             display_name: 'Jane Doe',
-            photo_url:    nil,
+            photo_url: nil,
           },
         }
       end
 
       it 'sets the resource if one is given' do
         expect(result.resource).to eq({
-          id:           32,
-          uid:          'foobar',
-          email:        'jane.doe@gmail.com',
+          id: 32,
+          uid: 'foobar',
+          email: 'jane.doe@gmail.com',
           display_name: 'Jane Doe',
-          photo_url:    nil,
+          photo_url: nil,
         })
       end
     end

--- a/spec/models/canonical/clothing_item_spec.rb
+++ b/spec/models/canonical/clothing_item_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe Canonical::ClothingItem, type: :model do
   describe 'validations' do
     it 'is valid with valid attributes' do
       model = described_class.new(
-                name:        'Clothes',
-                item_code:   'foo',
-                unit_weight: 1,
-                body_slot:   'body',
-                purchasable: true,
-                unique_item: false,
-                rare_item:   false,
-              )
+        name:        'Clothes',
+        item_code:   'foo',
+        unit_weight: 1,
+        body_slot:   'body',
+        purchasable: true,
+        unique_item: false,
+        rare_item:   false,
+      )
 
       expect(model).to be_valid
     end

--- a/spec/models/canonical/clothing_item_spec.rb
+++ b/spec/models/canonical/clothing_item_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe Canonical::ClothingItem, type: :model do
   describe 'validations' do
     it 'is valid with valid attributes' do
       model = described_class.new(
-        name:        'Clothes',
-        item_code:   'foo',
+        name: 'Clothes',
+        item_code: 'foo',
         unit_weight: 1,
-        body_slot:   'body',
+        body_slot: 'body',
         purchasable: true,
         unique_item: false,
-        rare_item:   false,
+        rare_item: false,
       )
 
       expect(model).to be_valid

--- a/spec/models/canonical/ingredient_spec.rb
+++ b/spec/models/canonical/ingredient_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe Canonical::Ingredient, type: :model do
   describe 'validations' do
     it 'is valid with valid attributes' do
       ingredient = described_class.new(
-        name:                   'Skeever Tail',
-        item_code:              'foo',
-        ingredient_type:        'common',
-        unit_weight:            1,
-        purchasable:            true,
+        name: 'Skeever Tail',
+        item_code: 'foo',
+        ingredient_type: 'common',
+        unit_weight: 1,
+        purchasable: true,
         purchase_requires_perk: false,
-        unique_item:            false,
-        rare_item:              true,
+        unique_item: false,
+        rare_item: true,
       )
 
       expect(ingredient).to be_valid

--- a/spec/models/canonical/ingredient_spec.rb
+++ b/spec/models/canonical/ingredient_spec.rb
@@ -6,15 +6,15 @@ RSpec.describe Canonical::Ingredient, type: :model do
   describe 'validations' do
     it 'is valid with valid attributes' do
       ingredient = described_class.new(
-                     name:                   'Skeever Tail',
-                     item_code:              'foo',
-                     ingredient_type:        'common',
-                     unit_weight:            1,
-                     purchasable:            true,
-                     purchase_requires_perk: false,
-                     unique_item:            false,
-                     rare_item:              true,
-                   )
+        name:                   'Skeever Tail',
+        item_code:              'foo',
+        ingredient_type:        'common',
+        unit_weight:            1,
+        purchasable:            true,
+        purchase_requires_perk: false,
+        unique_item:            false,
+        rare_item:              true,
+      )
 
       expect(ingredient).to be_valid
     end

--- a/spec/models/canonical/ingredients_alchemical_property_spec.rb
+++ b/spec/models/canonical/ingredients_alchemical_property_spec.rb
@@ -31,10 +31,10 @@ RSpec.describe Canonical::IngredientsAlchemicalProperty, type: :model do
 
         it 'must be unique per ingredient' do
           model = build(
-                    :canonical_ingredients_alchemical_property,
-                    priority:   1,
-                    ingredient:,
-                  )
+            :canonical_ingredients_alchemical_property,
+            priority:   1,
+            ingredient:,
+          )
 
           model.validate
           expect(model.errors[:priority]).to include 'must be unique per ingredient'

--- a/spec/models/canonical/ingredients_alchemical_property_spec.rb
+++ b/spec/models/canonical/ingredients_alchemical_property_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Canonical::IngredientsAlchemicalProperty, type: :model do
         before do
           create(
             :canonical_ingredients_alchemical_property,
-            priority:   1,
+            priority: 1,
             ingredient:,
           )
         end
@@ -32,7 +32,7 @@ RSpec.describe Canonical::IngredientsAlchemicalProperty, type: :model do
         it 'must be unique per ingredient' do
           model = build(
             :canonical_ingredients_alchemical_property,
-            priority:   1,
+            priority: 1,
             ingredient:,
           )
 

--- a/spec/models/canonical/sync/alchemical_properties_spec.rb
+++ b/spec/models/canonical/sync/alchemical_properties_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Canonical::Sync::AlchemicalProperties do
         let(:errored_model) do
           instance_double AlchemicalProperty,
                           errors:,
-                          class:  class_double(AlchemicalProperty, i18n_scope: :activerecord)
+                          class: class_double(AlchemicalProperty, i18n_scope: :activerecord)
         end
 
         let(:errors) { double('errors', full_messages: ["Name can't be blank"]) }

--- a/spec/models/canonical/sync/armor_spec.rb
+++ b/spec/models/canonical/sync/armor_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe Canonical::Sync::Armor do
         create(
           :canonical_temperables_tempering_material,
           temperable: item_in_json,
-          material:   create(:canonical_material, name: 'Onyx Ore'),
+          material: create(:canonical_material, name: 'Onyx Ore'),
         )
       end
 
@@ -208,7 +208,7 @@ RSpec.describe Canonical::Sync::Armor do
         let(:errored_model) do
           instance_double Canonical::Armor,
                           errors:,
-                          class:  class_double(Canonical::Armor, i18n_scope: :activerecord)
+                          class: class_double(Canonical::Armor, i18n_scope: :activerecord)
         end
 
         let(:errors) { double('errors', full_messages: ["Name can't be blank"]) }

--- a/spec/models/canonical/sync/books_spec.rb
+++ b/spec/models/canonical/sync/books_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Canonical::Sync::Books do
           create(
             :canonical_recipe,
             item_code: '000F5CB8',
-            title:     'The Seven Habits of Highly Successful People',
+            title: 'The Seven Habits of Highly Successful People',
           )
         end
 
@@ -187,7 +187,7 @@ RSpec.describe Canonical::Sync::Books do
         let(:errored_model) do
           instance_double Canonical::Book,
                           errors:,
-                          class:  class_double(Canonical::Book, i18n_scope: :activerecord)
+                          class: class_double(Canonical::Book, i18n_scope: :activerecord)
         end
 
         let(:errors) { double('errors', full_messages: ["Title can't be blank"]) }

--- a/spec/models/canonical/sync/clothing_items_spec.rb
+++ b/spec/models/canonical/sync/clothing_items_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Canonical::Sync::ClothingItems do
         it "removes enchantments that don't exist in the JSON data" do
           item_in_json.canonical_enchantables_enchantments.create!(
             enchantment: Enchantment.find_by(name: 'Fortify Destruction'),
-            strength:    2,
+            strength: 2,
           )
           perform
           expect(item_in_json.enchantments.find_by(name: 'Fortify Destruction')).to be_nil
@@ -191,7 +191,7 @@ RSpec.describe Canonical::Sync::ClothingItems do
         let(:errored_model) do
           instance_double Canonical::ClothingItem,
                           errors:,
-                          class:  class_double(Canonical::ClothingItem, i18n_scope: :activerecord)
+                          class: class_double(Canonical::ClothingItem, i18n_scope: :activerecord)
         end
 
         let(:errors) { double('errors', full_messages: ["Name can't be blank"]) }

--- a/spec/models/canonical/sync/enchantments_spec.rb
+++ b/spec/models/canonical/sync/enchantments_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Canonical::Sync::Enchantments do
         let(:errored_model) do
           instance_double Enchantment,
                           errors:,
-                          class:  class_double(Enchantment, i18n_scope: :activerecord)
+                          class: class_double(Enchantment, i18n_scope: :activerecord)
         end
 
         let(:errors) { double('errors', full_messages: ["Name can't be blank"]) }

--- a/spec/models/canonical/sync/ingredients_spec.rb
+++ b/spec/models/canonical/sync/ingredients_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Canonical::Sync::Ingredients do
         it "removes alchemical properties that don't exist in the JSON data" do
           item_in_json.canonical_ingredients_alchemical_properties.create!(
             alchemical_property: create(:alchemical_property, name: 'Fortify Awesomeness'),
-            priority:            1,
+            priority: 1,
           )
 
           perform
@@ -152,9 +152,9 @@ RSpec.describe Canonical::Sync::Ingredients do
 
         create(
           :canonical_ingredients_alchemical_property,
-          ingredient:          item_in_json,
+          ingredient: item_in_json,
           alchemical_property: create(:alchemical_property, name: 'Fortify Awesomeness'),
-          priority:            1,
+          priority: 1,
         )
 
         allow(Rails.logger).to receive(:warn)
@@ -204,7 +204,7 @@ RSpec.describe Canonical::Sync::Ingredients do
         let(:errored_model) do
           instance_double Canonical::Ingredient,
                           errors:,
-                          class:  class_double(Canonical::Ingredient, i18n_scope: :activerecord)
+                          class: class_double(Canonical::Ingredient, i18n_scope: :activerecord)
         end
 
         let(:errors) { double('errors', full_messages: ["Name can't be blank"]) }

--- a/spec/models/canonical/sync/jewelry_items_spec.rb
+++ b/spec/models/canonical/sync/jewelry_items_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe Canonical::Sync::JewelryItems do
         let(:errored_model) do
           instance_double Canonical::JewelryItem,
                           errors:,
-                          class:  class_double(Canonical::JewelryItem, i18n_scope: :activerecord)
+                          class: class_double(Canonical::JewelryItem, i18n_scope: :activerecord)
         end
 
         let(:errors) { double('errors', full_messages: ["Name can't be blank"]) }

--- a/spec/models/canonical/sync/materials_spec.rb
+++ b/spec/models/canonical/sync/materials_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Canonical::Sync::Materials do
         let(:errored_model) do
           instance_double Canonical::Material,
                           errors:,
-                          class:  class_double(Canonical::Material, i18n_scope: :activerecord)
+                          class: class_double(Canonical::Material, i18n_scope: :activerecord)
         end
 
         let(:errors) { double('errors', full_messages: ["Name can't be blank"]) }

--- a/spec/models/canonical/sync/misc_items_spec.rb
+++ b/spec/models/canonical/sync/misc_items_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Canonical::Sync::MiscItems do
         let(:errored_model) do
           instance_double Canonical::MiscItem,
                           errors:,
-                          class:  class_double(Canonical::MiscItem, i18n_scope: :activerecord)
+                          class: class_double(Canonical::MiscItem, i18n_scope: :activerecord)
         end
 
         let(:errors) { double('errors', full_messages: ["Name can't be blank"]) }

--- a/spec/models/canonical/sync/potions_spec.rb
+++ b/spec/models/canonical/sync/potions_spec.rb
@@ -90,8 +90,8 @@ RSpec.describe Canonical::Sync::Potions do
         it "removes alchemical properties that don't exist in the JSON data" do
           item_in_json.canonical_potions_alchemical_properties.create!(
             alchemical_property: AlchemicalProperty.find_by(name: 'Fortify Lockpicking'),
-            strength:            20,
-            duration:            30,
+            strength: 20,
+            duration: 30,
           )
           perform
           expect(item_in_json.alchemical_properties.find_by(name: 'Fortify Destruction')).to be_nil
@@ -187,7 +187,7 @@ RSpec.describe Canonical::Sync::Potions do
         let(:errored_model) do
           instance_double Canonical::Potion,
                           errors:,
-                          class:  class_double(Canonical::Potion, i18n_scope: :activerecord)
+                          class: class_double(Canonical::Potion, i18n_scope: :activerecord)
         end
 
         let(:errors) { double('errors', full_messages: ["Name can't be blank"]) }

--- a/spec/models/canonical/sync/powers_spec.rb
+++ b/spec/models/canonical/sync/powers_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Canonical::Sync::Powers do
         let(:errored_model) do
           instance_double Power,
                           errors:,
-                          class:  class_double(Power, i18n_scope: :activerecord)
+                          class: class_double(Power, i18n_scope: :activerecord)
         end
 
         let(:errors) { double('errors', full_messages: ["Name can't be blank"]) }

--- a/spec/models/canonical/sync/properties_spec.rb
+++ b/spec/models/canonical/sync/properties_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Canonical::Sync::Properties do
         let(:errored_model) do
           instance_double Canonical::Property,
                           errors:,
-                          class:  class_double(Spell, i18n_scope: :activerecord)
+                          class: class_double(Spell, i18n_scope: :activerecord)
         end
 
         let(:errors) { double('errors', full_messages: ["Name can't be blank"]) }

--- a/spec/models/canonical/sync/spells_spec.rb
+++ b/spec/models/canonical/sync/spells_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Canonical::Sync::Spells do
         let(:errored_model) do
           instance_double Spell,
                           errors:,
-                          class:  class_double(Spell, i18n_scope: :activerecord)
+                          class: class_double(Spell, i18n_scope: :activerecord)
         end
 
         let(:errors) { double('errors', full_messages: ["Name can't be blank"]) }

--- a/spec/models/canonical/sync/staves_spec.rb
+++ b/spec/models/canonical/sync/staves_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe Canonical::Sync::Staves do
         let(:errored_model) do
           instance_double Canonical::Staff,
                           errors:,
-                          class:  class_double(Canonical::Staff, i18n_scope: :activerecord)
+                          class: class_double(Canonical::Staff, i18n_scope: :activerecord)
         end
 
         let(:errors) { double('errors', full_messages: ["Name can't be blank"]) }

--- a/spec/models/canonical/sync/weapons_spec.rb
+++ b/spec/models/canonical/sync/weapons_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe Canonical::Sync::Weapons do
         create(
           :canonical_temperables_tempering_material,
           temperable: item_in_json,
-          material:   create(:canonical_material, name: 'Aluminum Ingot'),
+          material: create(:canonical_material, name: 'Aluminum Ingot'),
         )
       end
 
@@ -216,7 +216,7 @@ RSpec.describe Canonical::Sync::Weapons do
         let(:errored_model) do
           instance_double Canonical::Weapon,
                           errors:,
-                          class:  class_double(Canonical::Weapon, i18n_scope: :activerecord)
+                          class: class_double(Canonical::Weapon, i18n_scope: :activerecord)
         end
 
         let(:errors) { double('errors', full_messages: ["Name can't be blank"]) }

--- a/spec/models/canonical/weapon_spec.rb
+++ b/spec/models/canonical/weapon_spec.rb
@@ -6,20 +6,20 @@ RSpec.describe Canonical::Weapon, type: :model do
   describe 'validations' do
     it 'is valid with valid attributes' do
       weapon = described_class.new(
-                 name:           'Ebony Battleaxe',
-                 item_code:      '123xxx',
-                 category:       'two-handed',
-                 weapon_type:    'battleaxe',
-                 smithing_perks: ['Ebony Smithing'],
-                 base_damage:    18,
-                 unit_weight:    22,
-                 purchasable:    true,
-                 unique_item:    false,
-                 rare_item:      false,
-                 quest_item:     false,
-                 leveled:        false,
-                 enchantable:    true,
-               )
+        name:           'Ebony Battleaxe',
+        item_code:      '123xxx',
+        category:       'two-handed',
+        weapon_type:    'battleaxe',
+        smithing_perks: ['Ebony Smithing'],
+        base_damage:    18,
+        unit_weight:    22,
+        purchasable:    true,
+        unique_item:    false,
+        rare_item:      false,
+        quest_item:     false,
+        leveled:        false,
+        enchantable:    true,
+      )
 
       expect(weapon).to be_valid
     end

--- a/spec/models/canonical/weapon_spec.rb
+++ b/spec/models/canonical/weapon_spec.rb
@@ -6,19 +6,19 @@ RSpec.describe Canonical::Weapon, type: :model do
   describe 'validations' do
     it 'is valid with valid attributes' do
       weapon = described_class.new(
-        name:           'Ebony Battleaxe',
-        item_code:      '123xxx',
-        category:       'two-handed',
-        weapon_type:    'battleaxe',
+        name: 'Ebony Battleaxe',
+        item_code: '123xxx',
+        category: 'two-handed',
+        weapon_type: 'battleaxe',
         smithing_perks: ['Ebony Smithing'],
-        base_damage:    18,
-        unit_weight:    22,
-        purchasable:    true,
-        unique_item:    false,
-        rare_item:      false,
-        quest_item:     false,
-        leveled:        false,
-        enchantable:    true,
+        base_damage: 18,
+        unit_weight: 22,
+        purchasable: true,
+        unique_item: false,
+        rare_item: false,
+        quest_item: false,
+        leveled: false,
+        enchantable: true,
       )
 
       expect(weapon).to be_valid

--- a/spec/models/inventory_item_spec.rb
+++ b/spec/models/inventory_item_spec.rb
@@ -55,10 +55,10 @@ RSpec.describe InventoryItem, type: :model do
         # We don't actually care what order these are in since we currently only use this
         # scope to determine whether a given item belongs to a particular game
         items = [
-                  list1.list_items.to_a,
-                  list2.list_items.to_a,
-                  list3.list_items.to_a,
-                ].flatten!
+          list1.list_items.to_a,
+          list2.list_items.to_a,
+          list3.list_items.to_a,
+        ].flatten!
 
         expect(described_class.belonging_to_game(game).to_a.sort).to eq(items.sort)
       end

--- a/spec/models/inventory_list_spec.rb
+++ b/spec/models/inventory_list_spec.rb
@@ -392,8 +392,8 @@ RSpec.describe InventoryList, type: :model do
           add_item
           expect(aggregate_list.list_items.last.attributes).to include(
             'description' => list_item.description,
-            'quantity'    => list_item.quantity,
-            'notes'       => list_item.notes,
+            'quantity' => list_item.quantity,
+            'notes' => list_item.notes,
           )
         end
       end

--- a/spec/models/inventory_list_spec.rb
+++ b/spec/models/inventory_list_spec.rb
@@ -64,16 +64,16 @@ RSpec.describe InventoryList, type: :model do
         agg_list3, game3_list1, game3_list2 = game3.inventory_lists.to_a
 
         expect(described_class.belonging_to_user(user).to_a).to eq([
-                                                                     game3_list1,
-                                                                     game3_list2,
-                                                                     agg_list3,
-                                                                     game2_list1,
-                                                                     game2_list2,
-                                                                     agg_list2,
-                                                                     game1_list1,
-                                                                     game1_list2,
-                                                                     agg_list1,
-                                                                   ])
+          game3_list1,
+          game3_list2,
+          agg_list3,
+          game2_list1,
+          game2_list2,
+          agg_list2,
+          game1_list1,
+          game1_list2,
+          agg_list1,
+        ])
       end
     end
   end

--- a/spec/models/inventory_list_spec.rb
+++ b/spec/models/inventory_list_spec.rb
@@ -391,10 +391,10 @@ RSpec.describe InventoryList, type: :model do
         it 'sets the correct attributes' do
           add_item
           expect(aggregate_list.list_items.last.attributes).to include(
-                                                                 'description' => list_item.description,
-                                                                 'quantity'    => list_item.quantity,
-                                                                 'notes'       => list_item.notes,
-                                                               )
+            'description' => list_item.description,
+            'quantity'    => list_item.quantity,
+            'notes'       => list_item.notes,
+          )
         end
       end
 

--- a/spec/models/property_spec.rb
+++ b/spec/models/property_spec.rb
@@ -61,9 +61,9 @@ RSpec.describe Property, type: :model do
       Canonical::Property.all.each do |canonical_property|
         game.properties.create!(
           canonical_property:,
-          name:               canonical_property.name,
-          hold:               canonical_property.hold,
-          city:               canonical_property.city,
+          name: canonical_property.name,
+          hold: canonical_property.hold,
+          city: canonical_property.city,
         )
       end
 
@@ -81,9 +81,9 @@ RSpec.describe Property, type: :model do
       before do
         game.properties.create!(
           canonical_property:,
-          name:               canonical_property.name,
-          hold:               canonical_property.hold,
-          city:               canonical_property.city,
+          name: canonical_property.name,
+          hold: canonical_property.hold,
+          city: canonical_property.city,
         )
       end
 

--- a/spec/models/shopping_list_item_spec.rb
+++ b/spec/models/shopping_list_item_spec.rb
@@ -55,10 +55,10 @@ RSpec.describe ShoppingListItem, type: :model do
         # We don't actually care what order these are in since we currently only use this
         # scope to determine whether a given item belongs to a particular game
         items = [
-                  list1.list_items.to_a,
-                  list2.list_items.to_a,
-                  list3.list_items.to_a,
-                ].flatten!
+          list1.list_items.to_a,
+          list2.list_items.to_a,
+          list3.list_items.to_a,
+        ].flatten!
 
         expect(described_class.belonging_to_game(game).to_a.sort).to eq(items.sort)
       end

--- a/spec/models/shopping_list_spec.rb
+++ b/spec/models/shopping_list_spec.rb
@@ -385,11 +385,11 @@ RSpec.describe ShoppingList, type: :model do
         it 'sets the correct attributes' do
           add_item
           expect(aggregate_list.list_items.last.attributes).to include(
-                                                                 'description' => list_item.description,
-                                                                 'quantity'    => list_item.quantity,
-                                                                 'notes'       => list_item.notes,
-                                                                 'unit_weight' => list_item.unit_weight,
-                                                               )
+            'description' => list_item.description,
+            'quantity'    => list_item.quantity,
+            'notes'       => list_item.notes,
+            'unit_weight' => list_item.unit_weight,
+          )
         end
       end
 

--- a/spec/models/shopping_list_spec.rb
+++ b/spec/models/shopping_list_spec.rb
@@ -64,16 +64,16 @@ RSpec.describe ShoppingList, type: :model do
         agg_list3, game3_list1, game3_list2 = game3.shopping_lists.to_a
 
         expect(described_class.belonging_to_user(user).to_a).to eq([
-                                                                     game3_list1,
-                                                                     game3_list2,
-                                                                     agg_list3,
-                                                                     game2_list1,
-                                                                     game2_list2,
-                                                                     agg_list2,
-                                                                     game1_list1,
-                                                                     game1_list2,
-                                                                     agg_list1,
-                                                                   ])
+          game3_list1,
+          game3_list2,
+          agg_list3,
+          game2_list1,
+          game2_list2,
+          agg_list2,
+          game1_list1,
+          game1_list2,
+          agg_list1,
+        ])
       end
     end
   end

--- a/spec/models/shopping_list_spec.rb
+++ b/spec/models/shopping_list_spec.rb
@@ -386,8 +386,8 @@ RSpec.describe ShoppingList, type: :model do
           add_item
           expect(aggregate_list.list_items.last.attributes).to include(
             'description' => list_item.description,
-            'quantity'    => list_item.quantity,
-            'notes'       => list_item.notes,
+            'quantity' => list_item.quantity,
+            'notes' => list_item.notes,
             'unit_weight' => list_item.unit_weight,
           )
         end

--- a/spec/models/spell_spec.rb
+++ b/spec/models/spell_spec.rb
@@ -65,12 +65,12 @@ RSpec.describe Spell, type: :model do
     describe 'strength and strength_unit' do
       it 'is valid with both a strength and a strength_unit' do
         spell = described_class.new(
-          strength:      50,
+          strength: 50,
           strength_unit: 'point',
-          name:          'Fire Rune',
-          level:         'Adept',
-          school:        'Destruction',
-          description:   'Hello world',
+          name: 'Fire Rune',
+          level: 'Adept',
+          school: 'Destruction',
+          description: 'Hello world',
         )
 
         expect(spell).to be_valid

--- a/spec/models/spell_spec.rb
+++ b/spec/models/spell_spec.rb
@@ -65,13 +65,13 @@ RSpec.describe Spell, type: :model do
     describe 'strength and strength_unit' do
       it 'is valid with both a strength and a strength_unit' do
         spell = described_class.new(
-                  strength:      50,
-                  strength_unit: 'point',
-                  name:          'Fire Rune',
-                  level:         'Adept',
-                  school:        'Destruction',
-                  description:   'Hello world',
-                )
+          strength:      50,
+          strength_unit: 'point',
+          name:          'Fire Rune',
+          level:         'Adept',
+          school:        'Destruction',
+          description:   'Hello world',
+        )
 
         expect(spell).to be_valid
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -62,11 +62,11 @@ RSpec.describe User, type: :model do
 
     it "returns all the shopping lists for the user's games" do
       expect(user1.shopping_lists).to eq([
-                                           shopping_list4,
-                                           shopping_list3,
-                                           shopping_list2,
-                                           shopping_list1,
-                                         ])
+        shopping_list4,
+        shopping_list3,
+        shopping_list2,
+        shopping_list1,
+      ])
     end
   end
 
@@ -85,11 +85,11 @@ RSpec.describe User, type: :model do
 
     it "returns all the inventory lists for the user's games" do
       expect(user1.inventory_lists).to eq([
-                                            inventory_list4,
-                                            inventory_list3,
-                                            inventory_list2,
-                                            inventory_list1,
-                                          ])
+        inventory_list4,
+        inventory_list3,
+        inventory_list2,
+        inventory_list1,
+      ])
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe User, type: :model do
 
     let(:payload) do
       {
-        'localId'     => 'foobar',
-        'email'       => 'jane.doe@gmail.com',
+        'localId' => 'foobar',
+        'email' => 'jane.doe@gmail.com',
         'displayName' => 'Jane Doe',
-        'photoUrl'    => 'https://example.com/user_images/89',
+        'photoUrl' => 'https://example.com/user_images/89',
       }
     end
 
@@ -24,10 +24,10 @@ RSpec.describe User, type: :model do
       it 'sets the attributes' do
         create_or_update
         expect(described_class.last.attributes).to include(
-          'uid'          => 'foobar',
-          'email'        => 'jane.doe@gmail.com',
+          'uid' => 'foobar',
+          'email' => 'jane.doe@gmail.com',
           'display_name' => 'Jane Doe',
-          'photo_url'    => 'https://example.com/user_images/89',
+          'photo_url' => 'https://example.com/user_images/89',
         )
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -24,11 +24,11 @@ RSpec.describe User, type: :model do
       it 'sets the attributes' do
         create_or_update
         expect(described_class.last.attributes).to include(
-                                                     'uid'          => 'foobar',
-                                                     'email'        => 'jane.doe@gmail.com',
-                                                     'display_name' => 'Jane Doe',
-                                                     'photo_url'    => 'https://example.com/user_images/89',
-                                                   )
+          'uid'          => 'foobar',
+          'email'        => 'jane.doe@gmail.com',
+          'display_name' => 'Jane Doe',
+          'photo_url'    => 'https://example.com/user_images/89',
+        )
       end
     end
 

--- a/spec/requests/games_spec.rb
+++ b/spec/requests/games_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Games', type: :request do
   let(:headers) do
     {
-      'Content-Type'  => 'application/json',
+      'Content-Type' => 'application/json',
       'Authorization' => 'Bearer xxxxxxx',
     }
   end

--- a/spec/requests/inventory_items_spec.rb
+++ b/spec/requests/inventory_items_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'InventoryItems', type: :request do
   let!(:user) { create(:authenticated_user) }
   let(:headers) do
     {
-      'Content-Type'  => 'application/json',
+      'Content-Type' => 'application/json',
       'Authorization' => 'Bearer xxxxxxxxx',
     }
   end

--- a/spec/requests/inventory_lists_spec.rb
+++ b/spec/requests/inventory_lists_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'InventoryLists', type: :request do
   let(:headers) do
     {
-      'Content-Type'  => 'application/json',
+      'Content-Type' => 'application/json',
       'Authorization' => 'Bearer xxxxxxx',
     }
   end

--- a/spec/requests/shopping_list_items_spec.rb
+++ b/spec/requests/shopping_list_items_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'ShoppingListItems', type: :request do
   let(:headers) do
     {
-      'Content-Type'  => 'application/json',
+      'Content-Type' => 'application/json',
       'Authorization' => 'Bearer xxxxxxx',
     }
   end

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'ShoppingLists', type: :request do
   let(:headers) do
     {
-      'Content-Type'  => 'application/json',
+      'Content-Type' => 'application/json',
       'Authorization' => 'Bearer xxxxxxx',
     }
   end

--- a/spec/support/auth_helper.rb
+++ b/spec/support/auth_helper.rb
@@ -9,7 +9,7 @@ module AuthHelper
     stub_request(:post, auth_uri)
       .to_return(
         status: 200,
-        body:   File.read(Rails.root.join('spec', 'support', 'fixtures', 'auth', 'success.json')),
+        body: File.read(Rails.root.join('spec', 'support', 'fixtures', 'auth', 'success.json')),
       )
   end
 
@@ -17,7 +17,7 @@ module AuthHelper
     stub_request(:post, auth_uri)
       .to_return(
         status: 200,
-        body:   File.read(Rails.root.join('spec', 'support', 'fixtures', 'auth', 'empty_users_array.json')),
+        body: File.read(Rails.root.join('spec', 'support', 'fixtures', 'auth', 'empty_users_array.json')),
       )
   end
 


### PR DESCRIPTION
## Context

In #145, I updated some Rubocop rules that looked better on paper than they worked out in reality. In particular, certain rules around alignment of hash elements, array elements, method arguments, assignment operators, and `let` block braces were resulting in code that ended up being harder to read as well as longer line lengths. The previous PR took care of the assignment operators and `let` block braces, and this PR handles the rest.

All the changes in this PR are safe Rubocop autocorrects and are not expected to affect functionality in any way.

## Changes

* Change enforced styles for alignment of multiline arrays, hashes, and method arguments

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~

## Considerations

Although I debated the merits of including these changes on the `frontend-rewrite-feature-branch`, I realised as I was writing the code for that epic that I was spending a lot of effort adhering to formatting rules that I didn't even like. Waiting until after this epic was merged to make these changes would just result in me doing more of that.
