### PR TITLE
Return all shopping lists from shopping list creation endpoint

### DIFF
--- a/app/controller_services/shopping_lists_controller/create_service.rb
+++ b/app/controller_services/shopping_lists_controller/create_service.rb
@@ -21,12 +21,9 @@ class ShoppingListsController < ApplicationController
       return Service::UnprocessableEntityResult.new(errors: [AGGREGATE_LIST_ERROR]) if params[:aggregate]
 
       shopping_list = game.shopping_lists.new(params)
-      preexisting_aggregate_list = game.aggregate_shopping_list
 
       if shopping_list.save
-        # Check if the aggregate shopping list is newly created and return it too if so
-        resource = preexisting_aggregate_list ? shopping_list : [game.aggregate_shopping_list, shopping_list]
-        Service::CreatedResult.new(resource:)
+        Service::CreatedResult.new(resource: game.shopping_lists.index_order)
       else
         Service::UnprocessableEntityResult.new(errors: shopping_list.error_array)
       end

--- a/docs/api/resources/shopping-lists.md
+++ b/docs/api/resources/shopping-lists.md
@@ -151,7 +151,7 @@ A 500 error response, which is always a result of an unforeseen problem, include
 
 ## POST /games/:game_id/shopping_lists
 
-Creates a new shopping list for the specified game if it exists and belongs to the authenticated user. If the game does not already have an aggregate list, an aggregate list will also be created automatically. The response is an array that includes the newly created shopping list(s).
+Creates a new shopping list for the specified game if it exists and belongs to the authenticated user. If the game does not already have an aggregate list, an aggregate list will also be created automatically. The response is an array that includes all shopping lists belonging to the specified game. Each shopping list also includes an array with any shopping list items on that list. The JSON schema for the shopping list items is described in the [docs for shopping list items](/docs/api/resources/shopping-list-items.md). The shopping lists are returned with the aggregate list first and subsequent lists in order of most recently updated. (Adding, removing, or updating a list item on a list counts as updating the list.)
 
 The request does not have to include a body. If it does, the body should include a `"shopping_list"` object with an optional `"title"` key, the only attribute that can be set on a shopping list via request data. If you don't include a title, your list will be titled "My List N", where _N_ is an integer equal to the highest numbered default list title you have. For example, if you have lists titled "My List 1", "My List 3", and "My List 4" and you don't specify a title for your new list, your new list will be titled "My List 5".
 
@@ -197,32 +197,29 @@ Authorization: Bearer xxxxxxxxxx
 
 * 201 Created
 
-#### Example Bodies
+#### Example Body
 
-When there hasn't been an aggregate list created:
-```json
-{
-  "id": 4,
-  "user_id": 6,
-  "aggregate": false,
-  "aggregate_list_id": 3,
-  "title": "My List 1",
-  "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-  "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-  "list_items": []
-}
-```
-
-When the aggregate list has also been created:
 ```json
 [
   {
     "id": 4,
     "user_id": 6,
     "aggregate": true,
+    "aggregate_list_id": null,
     "title": "All Items",
+    "created_at": "Tue, 15 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "updated_at": "Tue, 15 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "list_items": []
+  },
+  {
+    "id": 12,
+    "user_id": 6,
+    "aggregate": false,
+    "aggregate_list_id": 4,
+    "title": "Custom Titled List",
     "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
     "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "list_items": []
   },
   {
     "id": 5,
@@ -230,8 +227,9 @@ When the aggregate list has also been created:
     "aggregate": false,
     "aggregate_list_id": 4,
     "title": "My List 1",
-    "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+    "created_at": "Tue, 15 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "updated_at": "Tue, 15 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "list_items": []
   }
 ]
 ```
@@ -408,7 +406,7 @@ If the resource deleted was the user's last regular list, the aggregate list wil
       "created_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00",
       "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
     }
-  ] 
+  ]
 }
 ```
 

--- a/spec/controller_services/shopping_lists_controller/create_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/create_service_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe ShoppingListsController::CreateService do
         end
 
         it 'sets the resource to the created list' do
-          expect(perform.resource).to eq game.shopping_lists.last
+          expect(perform.resource).to eq game.shopping_lists.index_order
         end
 
         it 'updates the game' do
@@ -123,7 +123,7 @@ RSpec.describe ShoppingListsController::CreateService do
         end
 
         it 'sets the resource to include both lists' do
-          expect(perform.resource).to eq([game.aggregate_shopping_list, game.shopping_lists.last])
+          expect(perform.resource).to eq(game.shopping_lists.index_order)
         end
       end
     end

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -29,9 +29,9 @@ RSpec.describe 'ShoppingLists', type: :request do
               .to change(game.shopping_lists, :count).from(0).to(2) # because of the aggregate list
           end
 
-          it 'returns the aggregate list as well as the new list' do
+          it 'returns all shopping lists for that game' do
             create_shopping_list
-            expect(response.body).to eq([game.aggregate_shopping_list, game.shopping_lists.last].to_json)
+            expect(response.body).to eq(game.shopping_lists.index_order.to_json)
           end
 
           it 'returns status 201' do
@@ -48,9 +48,14 @@ RSpec.describe 'ShoppingLists', type: :request do
               .to change(game.shopping_lists, :count).from(1).to(2)
           end
 
-          it 'returns only the newly created list' do
+          it 'returns all shopping lists for that game' do
             create_shopping_list
-            expect(response.body).to eq(game.shopping_lists.last.to_json)
+            expect(response.body).to eq(game.shopping_lists.index_order.to_json)
+          end
+
+          it 'returns status 201' do
+            create_shopping_list
+            expect(response.status).to eq 201
           end
         end
 
@@ -69,8 +74,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
           it 'creates the shopping list with a default title' do
             create_shopping_list
-            list_attributes = JSON.parse(response.body)
-            expect(list_attributes['title']).to eq 'My List 1'
+            expect(game.shopping_lists.last.title).to eq 'My List 1'
           end
         end
       end


### PR DESCRIPTION
## Context

[**Return all shopping lists from POST /games/:id/shopping_lists endpoint**](https://trello.com/c/KsAdkOZI/257-return-all-shopping-lists-from-post-games-id-shoppinglists-endpoint)

Currently, when the client creates a shopping list for a particular game, what response body is returned depends on whether an aggregate list was created at the same time. However, this complicates matters on the front end, which has to then incorporate logic around what to do with different types of responses. As we are [rewriting the front end](https://trello.com/c/jx60e2Fb/220-frontend-rewrite), we would like to avoid this kind of complexity in our code.

All other logic for the `POST /games/:game_id/shopping_lists` endpoint stays the same, such as error responses and the order in which lists are returned. As before, lists are returned with their list items.

## Changes

* Return all shopping lists for the requested game when creating a new shopping list
* Update tests
* Update docs

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate
