### PR TITLE
Shopping lists page feature branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: Skyrim Inventory Management CI
 
 on:
   push:
-    branches: [ main, shopping-lists-page-feature-branch ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, shopping-lists-page-feature-branch ]
+    branches: [ main ]
 
 jobs:
   runner-job:

--- a/app/controller_services/shopping_list_items_controller/create_service.rb
+++ b/app/controller_services/shopping_list_items_controller/create_service.rb
@@ -74,7 +74,7 @@ class ShoppingListItemsController < ApplicationController
     end
 
     def lists_to_be_changed
-      list_ids = if params[:unit_weight] && params[:unit_weight] != aggregate_list_item&.unit_weight
+      list_ids = if all_matching_list_items.count > 0 && params[:unit_weight] && params[:unit_weight] != aggregate_list_item&.unit_weight
                    all_matching_list_items.pluck(:list_id).push(shopping_list.id)
                  else
                    [aggregate_list.id, shopping_list.id]

--- a/app/controller_services/shopping_list_items_controller/create_service.rb
+++ b/app/controller_services/shopping_list_items_controller/create_service.rb
@@ -27,17 +27,13 @@ class ShoppingListItemsController < ApplicationController
         item.save!
 
         if preexisting_item.blank?
-          aggregate_list_item = aggregate_list.add_item_from_child_list(item)
+          aggregate_list.add_item_from_child_list(item)
 
-          resource = params[:unit_weight] ? all_matching_list_items : [aggregate_list_item, item]
-
-          Service::CreatedResult.new(resource:)
+          Service::CreatedResult.new(resource: shopping_list.game.shopping_lists.index_order)
         else
-          aggregate_list_item = aggregate_list.update_item_from_child_list(params[:description], params[:quantity], params[:unit_weight], nil, params[:notes])
+          aggregate_list.update_item_from_child_list(params[:description], params[:quantity], params[:unit_weight], nil, params[:notes])
 
-          resource = params[:unit_weight] ? all_matching_list_items : [aggregate_list_item, item]
-
-          Service::OKResult.new(resource:)
+          Service::OKResult.new(resource: shopping_list.game.shopping_lists.index_order)
         end
       end
     rescue ActiveRecord::RecordInvalid

--- a/app/controller_services/shopping_list_items_controller/destroy_service.rb
+++ b/app/controller_services/shopping_list_items_controller/destroy_service.rb
@@ -22,7 +22,7 @@ class ShoppingListItemsController < ApplicationController
         aggregate_list.remove_item_from_child_list(shopping_list_item.attributes)
       end
 
-      Service::OKResult.new(resource: game.shopping_lists.index_order)
+      Service::OKResult.new(resource: [aggregate_list.reload, shopping_list.reload])
     rescue ActiveRecord::RecordNotFound
       Service::NotFoundResult.new
     rescue StandardError => e

--- a/app/controller_services/shopping_list_items_controller/update_service.rb
+++ b/app/controller_services/shopping_list_items_controller/update_service.rb
@@ -28,7 +28,7 @@ class ShoppingListItemsController < ApplicationController
         aggregate_list.update_item_from_child_list(list_item.description, delta_qty, params[:unit_weight], old_notes, params[:notes])
       end
 
-      Service::OKResult.new(resource: game.shopping_lists.index_order)
+      Service::OKResult.new(resource: params[:unit_weight] ? all_matching_items : [aggregate_list_item, list_item.reload])
     rescue ActiveRecord::RecordInvalid
       Service::UnprocessableEntityResult.new(errors: list_item.error_array)
     rescue ActiveRecord::RecordNotFound
@@ -56,6 +56,10 @@ class ShoppingListItemsController < ApplicationController
 
     def game
       @game ||= shopping_list.game
+    end
+
+    def aggregate_list_item
+      aggregate_list.list_items.find_by('description ILIKE ?', list_item.description)
     end
 
     def all_matching_items

--- a/app/controller_services/shopping_list_items_controller/update_service.rb
+++ b/app/controller_services/shopping_list_items_controller/update_service.rb
@@ -22,16 +22,13 @@ class ShoppingListItemsController < ApplicationController
       delta_qty = params[:quantity] ? params[:quantity].to_i - list_item.quantity : 0
       old_notes = list_item.notes
 
-      aggregate_list_item = nil
       ActiveRecord::Base.transaction do
         list_item.update!(params)
 
-        aggregate_list_item = aggregate_list.update_item_from_child_list(list_item.description, delta_qty, params[:unit_weight], old_notes, params[:notes])
+        aggregate_list.update_item_from_child_list(list_item.description, delta_qty, params[:unit_weight], old_notes, params[:notes])
       end
 
-      resource = params[:unit_weight] ? all_matching_items : [aggregate_list_item, list_item]
-
-      Service::OKResult.new(resource:)
+      Service::OKResult.new(resource: game.shopping_lists.index_order)
     rescue ActiveRecord::RecordInvalid
       Service::UnprocessableEntityResult.new(errors: list_item.error_array)
     rescue ActiveRecord::RecordNotFound
@@ -55,6 +52,10 @@ class ShoppingListItemsController < ApplicationController
 
     def list_item
       @list_item ||= user.shopping_list_items.find(item_id)
+    end
+
+    def game
+      @game ||= shopping_list.game
     end
 
     def all_matching_items

--- a/app/controller_services/shopping_lists_controller/create_service.rb
+++ b/app/controller_services/shopping_lists_controller/create_service.rb
@@ -23,7 +23,8 @@ class ShoppingListsController < ApplicationController
       shopping_list = game.shopping_lists.new(params)
 
       if shopping_list.save
-        Service::CreatedResult.new(resource: game.shopping_lists.index_order)
+        resource = game_has_other_lists? ? Array.wrap(shopping_list) : game.shopping_lists.index_order
+        Service::CreatedResult.new(resource:)
       else
         Service::UnprocessableEntityResult.new(errors: shopping_list.error_array)
       end
@@ -39,7 +40,11 @@ class ShoppingListsController < ApplicationController
     attr_reader :user, :game_id, :params
 
     def game
-      user.games.find(game_id)
+      @game ||= user.games.find(game_id)
+    end
+
+    def game_has_other_lists?
+      game.shopping_lists.count > 2
     end
   end
 end

--- a/app/controller_services/shopping_lists_controller/create_service.rb
+++ b/app/controller_services/shopping_lists_controller/create_service.rb
@@ -21,12 +21,9 @@ class ShoppingListsController < ApplicationController
       return Service::UnprocessableEntityResult.new(errors: [AGGREGATE_LIST_ERROR]) if params[:aggregate]
 
       shopping_list = game.shopping_lists.new(params)
-      preexisting_aggregate_list = game.aggregate_shopping_list
 
       if shopping_list.save
-        # Check if the aggregate shopping list is newly created and return it too if so
-        resource = preexisting_aggregate_list ? shopping_list : [game.aggregate_shopping_list, shopping_list]
-        Service::CreatedResult.new(resource:)
+        Service::CreatedResult.new(resource: game.shopping_lists.index_order)
       else
         Service::UnprocessableEntityResult.new(errors: shopping_list.error_array)
       end

--- a/app/controller_services/shopping_lists_controller/destroy_service.rb
+++ b/app/controller_services/shopping_lists_controller/destroy_service.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'service/no_content_result'
 require 'service/method_not_allowed_result'
 require 'service/not_found_result'
 require 'service/ok_result'

--- a/app/models/concerns/aggregatable.rb
+++ b/app/models/concerns/aggregatable.rb
@@ -98,7 +98,7 @@ module Aggregatable
     existing_item&.persisted? ? existing_item : nil
   end
 
-  def update_item_from_child_list(description, delta_quantity, unit_weight, old_notes, new_notes)
+  def update_item_from_child_list(description, delta_quantity, unit_weight, old_notes, new_notes, unit_weight_changed = false)
     raise AggregateListError.new('update_item_from_child_list method only available on aggregate lists') unless aggregate_list?
 
     existing_item = list_items.find_by('description ILIKE ?', description)
@@ -112,7 +112,7 @@ module Aggregatable
                             existing_item.notes&.sub(/#{old_notes}/, new_notes.to_s).presence || new_notes
                           end
 
-    unless unit_weight.nil?
+    if unit_weight.present? || unit_weight_changed
       existing_item.unit_weight = unit_weight
 
       other_items = child_lists.all.map(&:list_items)

--- a/app/models/concerns/aggregatable.rb
+++ b/app/models/concerns/aggregatable.rb
@@ -103,7 +103,7 @@ module Aggregatable
 
     existing_item = list_items.find_by('description ILIKE ?', description)
 
-    raise AggregateListError.new('invalid data to update aggregate list item') if existing_item.nil? || delta_quantity < (-existing_item.quantity) || (unit_weight && (!unit_weight.is_a?(Numeric) || unit_weight < 0))
+    raise AggregateListError.new('Invalid data to update aggregate list item') if existing_item.nil? || delta_quantity < (-existing_item.quantity) || (unit_weight && (!unit_weight.is_a?(Numeric) || unit_weight < 0))
 
     existing_item.quantity += delta_quantity
     existing_item.notes = if old_notes.nil? && new_notes.present?

--- a/docs/aggregate-lists.md
+++ b/docs/aggregate-lists.md
@@ -203,7 +203,7 @@ Before including the `Listable` module in your class, you will need to define th
 
 ## Aggregatable
 
-The `Aggregatable` module provides aggregate list functionality to a list model. 
+The `Aggregatable` module provides aggregate list functionality to a list model.
 
 ### Associations
 
@@ -261,7 +261,7 @@ Should be called on an aggregate list any time an item is added to one of its ch
 
 Should be called on an aggregate list any time an item is removed/destroyed from one of its child lists. Handles logic for removing or updating list items on the aggregate list. Raises an `Aggregatable::AggregateListError` if called on a regular list. Returns the updated item from the aggregate list if its quantity is higher than that of the item removed and  otherwise `nil`.
 
-#### `update_item_from_child_list(description, delta_quantity, old_notes, new_notes)`
+#### `update_item_from_child_list(description, delta_quantity, unit_weight, old_notes, new_notes, unit_weight_changed)`
 
 Should be called on an aggregate list any time an item is updated on a child list. Raises an `Aggregatable::AggregateListError` if called on a regular list. Handles logic for updating items that already exist on a child list. Returns the updated list item from the aggregate list.
 
@@ -269,8 +269,10 @@ Arguments:
 
 * `description`: The `description` of the item that has been changed (descriptions are not editable).
 * `delta_quantity`: The difference between the new and old quantity on the updated item. Should be negative if the new quantity is lower and positive if it is higher.
+* `unit_weight`: The new `unit_weight` value of the item that has been changed
 * `old_notes`: The previous `notes` value of the item that has been changed
-* `new_notes`: Thee updated `notes` value of the item that has been changed
+* `new_notes`: The updated `notes` value of the item that has been changed
+* `unit_weight_changed`: If `unit_weight` param is `nil`, whether it was changed to `nil` (as opposed to just not being specified)
 
 #### `aggregate_list`
 

--- a/docs/api/resources/shopping-list-items.md
+++ b/docs/api/resources/shopping-list-items.md
@@ -232,6 +232,7 @@ Updates a given shopping list item provided the list the item is on:
 When this happens, the corresponding list item on the aggregate list is also automatically updated to stay synced with the other lists. When the aggregate list is synced, the `notes` value may be shortened, changed, or concatenated with notes from matching items on other lists, depending on which changes were requested.
 
 Requests may specify up to three fields to update:
+
 * `quantity` (integer, greater than zero)
 * `notes` (any string)
 * `unit_weight` (decimal, 1 decimal place, greater than or equal to zero)
@@ -240,17 +241,20 @@ Requests attempting to update `description` will result in a validation error.
 
 When updating `unit_weight`, the `unit_weight` value will be updated for all shopping list items belonging to the same game and matching the description. This is to prevent the aggregate list from getting out of sync with the values on its child list items.
 
-This route supports both `PATCH` and `PUT` requests. The only difference between these requests is the HTTP method; requests are handled by the same code regardless of the method.
+This route supports both `PATCH` and `PUT` requests. Application behaviour does not differ depending on which method is used.
 
 ### Example Requests
 
-Request bodies must contain a `"shopping_list_item"` key containing attributes to be changed. Attributes that can be changed include:
+Request bodies must contain a `"shopping_list_item"` key containing attributes to be changed. Request bodies lacking this key may result in an error or unexpected behaviour. If the `"shopping_list_item"` object is empty, the item will not be changed. Attributes that can be changed include:
 
 * `quantity` (integer greater than zero)
 * `notes` (string)
 * `unit_weight` (decimal greater than or equal to zero with up to one decimal place)
 
-Using a `PATCH` request:
+Note that, while `unit_weight` is an editable value, it cannot be reset to `null` once it is set to a numeric value; it can only be changed to another value.
+
+#### PATCH Requests
+
 ```
 PATCH /shopping_list_items/72
 Authorization: Bearer xxxxxxxxxxx
@@ -263,7 +267,8 @@ Content-Type: application/json
 }
 ```
 
-Using a `PUT` request:
+#### PUT Requests
+
 ```
 PUT /shopping_list_items/72
 Authorization: Bearer xxxxxxxxxxx
@@ -284,38 +289,87 @@ Content-Type: application/json
 
 #### Example Body
 
-The body is a JSON array containing all list items that were updated while handling the request, including the requested item, the corresponding aggregate list item, and, if setting `unit_weight`, any other list items with the same description belonging to the same game. (This is because, when `unit_weight` is set on any list item, all matching list items belonging to the same game are updated with the same value.)
+The body is a JSON array containing all shopping lists belonging to the same game, including the items on each list. This is because items on any of the lists may have been changed and it is easier for clients to receive the relevant data in its context.
+
 ```json
 [
   {
-    "id": 87,
-    "list_id": 236,
-    "description": "Ebony sword",
-    "quantity": 9,
-    "unit_weight": 14.0,
-    "notes": "To sell -- To enchant with 'Absorb Health'",
+    "id": 43,
+    "game_id": 8234,
+    "aggregate": true,
+    "aggregate_list_id": null,
+    "title": "All Items",
     "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "updated_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00"
+    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "list_items": [
+      {
+        "list_id": 43,
+        "description": "Unenchanted ebony sword",
+        "quantity": 1,
+        "notes": "Need an unenchanted sword to start Companions questline",
+        "unit_weight": null,
+        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      },
+      {
+        "list_id": 43,
+        "description": "Iron ingot",
+        "quantity": 4,
+        "notes": "3 locks -- 2 hinges",
+        "unit_weight": 1.0,
+        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      }
+    ]
   },
   {
-    "id": 126,
-    "list_id": 237,
-    "description": "Ebony sword",
-    "quantity": 7,
-    "unit_weight": 14.0,
-    "notes": "To enchant with 'Absorb Health'",
-    "created_at": "Fri, 18 Jun 2021 02:32:31.762797000 UTC +00:00",
-    "updated_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00"
+    "id": 46,
+    "game_id": 8234,
+    "aggregate": false,
+    "aggregate_list_id": 43,
+    "title": "Lakeview Manor",
+    "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "list_items": [
+      {
+        "list_id": 46,
+        "description": "Unenchanted ebony sword",
+        "quantity": 1,
+        "notes": "Need an unenchanted sword to start Companions questline",
+        "unit_weight": null,
+        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      },
+      {
+        "list_id": 46,
+        "description": "Iron ingot",
+        "quantity": 3,
+        "notes": "3 locks",
+        "unit_weight": 1.0,
+        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      }
+    ]
   },
   {
-    "id": 102,
-    "list_id": 238,
-    "description": "Ebony sword",
-    "quantity": 7,
-    "unit_weight": 14.0,
-    "notes": "To sell",
+    "id": 52,
+    "game_id": 8234,
+    "aggregate": false,
+    "aggregate_list_id": 43,
+    "title": "Severin Manor",
     "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "updated_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00"
+    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "list_items": [
+      {
+        "list_id": 52,
+        "description": "Iron ingot",
+        "quantity": 1,
+        "notes": "2 hinges",
+        "unit_weight": 1.0,
+        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      }
+    ]
   }
 ]
 ```
@@ -336,15 +390,15 @@ Four error responses are possible.
 No body will be returned with a 404 error, which is returned if the specified shopping list item doesn't exist or doesn't belong to the authenticated user.
 
 A 405 error, which is returned if the specified shopping list item is on an aggregate shopping list, comes with the following body:
+
 ```json
 {
-  "errors": [
-    "Cannot manually update list items on an aggregate shopping list"
-  ]
+  "errors": ["Cannot manually update list items on an aggregate shopping list"]
 }
 ```
 
 A 422 error, returned as a result of a validation error, includes whichever errors prevented the list item from being created:
+
 ```json
 {
   "errors": [

--- a/docs/api/resources/shopping-list-items.md
+++ b/docs/api/resources/shopping-list-items.md
@@ -436,24 +436,92 @@ Authorization: Bearer xxxxxxxxxxx
 #### Statuses
 
 * 200 OK
-* 204 No Content
 
 #### Example Body
 
-The API will return a 204 response if the list item has been destroyed along with the corresponding item on the aggregate list. This response does not include a body. On the other hand, if the aggregate list item has been updated rather than destroyed, it will be returned and the status code will be 200.
+The response body will be an array of all shopping lists belonging to the game to which the deleted list item ultimately belongs. This object also includes the shopping list items on each list.
 
-Example 200 response body containing the updated aggregate list item:
 ```json
-{
-  "id": 87,
-  "list_id": 238,
-  "description": "Ebony sword",
-  "quantity": 9,
-  "unit_weight": 14.0,
-  "notes": "To sell -- To enchant with 'Absorb Health'",
-  "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-  "updated_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00"
-}
+[
+  {
+    "id": 43,
+    "game_id": 8234,
+    "aggregate": true,
+    "aggregate_list_id": null,
+    "title": "All Items",
+    "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "list_items": [
+      {
+        "list_id": 43,
+        "description": "Unenchanted ebony sword",
+        "quantity": 1,
+        "notes": "Need an unenchanted sword to start Companions questline",
+        "unit_weight": null,
+        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      },
+      {
+        "list_id": 43,
+        "description": "Iron ingot",
+        "quantity": 4,
+        "notes": "3 locks -- 2 hinges",
+        "unit_weight": 1.0,
+        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      }
+    ]
+  },
+  {
+    "id": 46,
+    "game_id": 8234,
+    "aggregate": false,
+    "aggregate_list_id": 43,
+    "title": "Lakeview Manor",
+    "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "list_items": [
+      {
+        "list_id": 46,
+        "description": "Unenchanted ebony sword",
+        "quantity": 1,
+        "notes": "Need an unenchanted sword to start Companions questline",
+        "unit_weight": null,
+        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      },
+      {
+        "list_id": 46,
+        "description": "Iron ingot",
+        "quantity": 3,
+        "notes": "3 locks",
+        "unit_weight": 1.0,
+        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      }
+    ]
+  },
+  {
+    "id": 52,
+    "game_id": 8234,
+    "aggregate": false,
+    "aggregate_list_id": 43,
+    "title": "Severin Manor",
+    "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "list_items": [
+      {
+        "list_id": 52,
+        "description": "Iron ingot",
+        "quantity": 1,
+        "notes": "2 hinges",
+        "unit_weight": 1.0,
+        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      }
+    ]
+  }
+]
 ```
 
 ### Error Responses
@@ -471,15 +539,15 @@ Three error responses are possible.
 No body will be returned with a 404 error, which is returned if the specified shopping list item doesn't exist or doesn't belong to the authenticated user.
 
 A 405 error, which is returned if the specified shopping list item is on an aggregate shopping list, comes with the following body:
+
 ```json
 {
-  "errors": [
-    "Cannot manually delete an item from an aggregate shopping list"
-  ]
+  "errors": ["Cannot manually delete an item from an aggregate shopping list"]
 }
 ```
 
 A 500 error response, which is always a result of an unforeseen problem, includes the error message:
+
 ```json
 {
   "errors": ["Something went horribly wrong"]

--- a/docs/api/resources/shopping-list-items.md
+++ b/docs/api/resources/shopping-list-items.md
@@ -269,87 +269,28 @@ Content-Type: application/json
 
 #### Example Body
 
-The body is a JSON array containing all shopping lists belonging to the same game, including the items on each list. This is because items on any of the lists may have been changed and it is easier for clients to receive the relevant data in its context.
+The body is a JSON array containing all shopping list items modified in the course of handling the request. Clients should take note of each item's `list_id` value to associate the item to a shopping list. Note that, if an item's unit weight is updated, this weight will be updated on any lists with a corresponding list item, so there may be more than two list items included in the response.
 
 ```json
 [
   {
-    "id": 43,
-    "game_id": 8234,
-    "aggregate": true,
-    "aggregate_list_id": null,
-    "title": "All Items",
+    "list_id": 43,
+    "description": "Unenchanted ebony sword",
+    "quantity": 1,
+    "notes": "Need an unenchanted sword to start Companions questline",
+    "unit_weight": null,
     "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "list_items": [
-      {
-        "list_id": 43,
-        "description": "Unenchanted ebony sword",
-        "quantity": 1,
-        "notes": "Need an unenchanted sword to start Companions questline",
-        "unit_weight": null,
-        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
-      },
-      {
-        "list_id": 43,
-        "description": "Iron ingot",
-        "quantity": 4,
-        "notes": "3 locks -- 2 hinges",
-        "unit_weight": 1.0,
-        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
-      }
-    ]
+    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
   },
   {
-    "id": 46,
-    "game_id": 8234,
-    "aggregate": false,
-    "aggregate_list_id": 43,
-    "title": "Lakeview Manor",
+    "list_id": 46,
+    "description": "Unenchanted ebony sword",
+    "quantity": 1,
+    "notes": "Need an unenchanted sword to start Companions questline",
+    "unit_weight": null,
     "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "list_items": [
-      {
-        "list_id": 46,
-        "description": "Unenchanted ebony sword",
-        "quantity": 1,
-        "notes": "Need an unenchanted sword to start Companions questline",
-        "unit_weight": null,
-        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
-      },
-      {
-        "list_id": 46,
-        "description": "Iron ingot",
-        "quantity": 3,
-        "notes": "3 locks",
-        "unit_weight": 1.0,
-        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
-      }
-    ]
-  },
-  {
-    "id": 52,
-    "game_id": 8234,
-    "aggregate": false,
-    "aggregate_list_id": 43,
-    "title": "Severin Manor",
-    "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "list_items": [
-      {
-        "list_id": 52,
-        "description": "Iron ingot",
-        "quantity": 1,
-        "notes": "2 hinges",
-        "unit_weight": 1.0,
-        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
-      }
-    ]
+    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+  }
   }
 ]
 ```

--- a/docs/api/resources/shopping-list-items.md
+++ b/docs/api/resources/shopping-list-items.md
@@ -1,6 +1,6 @@
 # Shopping List Items
 
-Shopping list items represent the items on a [shopping list](/docs/api/resources/shopping-lists.md). Shopping list items on regular lists can be created, updated, and destroyed through the API. Shopping list items on aggregate shopping lists are managed automatically as the items on their other lists change. Each shopping list item belongs to a particular list and will be destroyed if the list is destroyed.
+Shopping list items represent the items on a [shopping list](/docs/api/resources/shopping-lists.md). Shopping list items on regular lists can be created, updated, and destroyed through the API. Shopping list items on aggregate shopping lists are managed automatically as the items on their child lists change. Each shopping list item belongs to a particular list and will be destroyed if the list is destroyed.
 
 There are no read routes (`GET /shopping_list_items`, `GET /shopping_list/:shopping_list_id/shopping_list_items`, or `GET /shopping_list_items/:id`) for shopping list items since all shopping list items are returned with the lists they are on when requests are made to the list routes. There are, however, routes to create, update, and destroy shopping list items.
 
@@ -8,7 +8,7 @@ All requests to shopping list item endpoints must be [authenticated](/docs/api/r
 
 ## Automatically Managed Aggregate Lists
 
-Skyrim Inventory Management makes use of automatically managed aggregate lists to help users track an aggregate of what items they need for different properties in each game. The aggregate list is created automatically when the client creates a the first regular shopping list for a game, and is destroyed automatically when the client deletes the game's last regular shopping list. When items are added, updated, or destroyed from any of a game's regular lists, aggregate list items are updated as described in this section.
+Skyrim Inventory Management makes use of automatically managed aggregate lists to help users track an aggregate of what items they need for different properties or purposes in each game. The aggregate list is created automatically when the client creates a the first regular shopping list for a game, and is destroyed automatically when the client deletes the game's last regular shopping list. When items are added, updated, or destroyed from any of a game's regular lists, aggregate list items are updated as described in this section.
 
 (Ensuring automatic management of aggregate lists does require some work on the part of SIM developers. If you are working on lists in SIM and would like information on how to keep them synced, head over to the [`Aggregatable` docs](/docs/aggregate-lists.md).)
 
@@ -70,7 +70,7 @@ Allowed fields are:
 * `notes` (string, optional): Any notes about the item or what it is for
 * `unit_weight` (decimal, optional): The unit weight of the item as given in the game, precise to one decimal place
 
-A successful response will return a JSON array of any items created or updated while handling the request. These may come in any order and will include the item requested, the aggregate list item, and, if `unit_weight` is given in the request, any other items with the same description belonging to the same game that have had their `unit_weight` changed.
+A successful response will return a JSON array of all shopping lists for the game to which the created or updated list item ultimately belongs, including all the list items on each list.
 
 ### Example Request
 
@@ -96,28 +96,87 @@ Content-Type: application/json
 
 If there is no item with a matching description on the requested shopping list, a new item will be created and the server will return a 201 response. If there is an item with a matching description, its notes and quantity will be combined with the notes and quantity in the client request and a 200 response will be returned.
 
-The body for both responses is a JSON array containing all list items that were created or updated while handling the request, including the requested item, the corresponding aggregate list item, and, if setting `unit_weight`, any other list items with the same description belonging to the same game.
+The body for both responses is a JSON array containing all shopping lists for the game to which the created or updated list item ultimately belongs. Each shopping list includes its list items.
+
 ```json
 [
   {
-    "id": 87,
-    "list_id": 238,
-    "description": "Ebony sword",
-    "quantity": 9,
-    "unit_weight": 14.0,
-    "notes": "To sell -- To enchant with 'Absorb Health'",
+    "id": 43,
+    "game_id": 8234,
+    "aggregate": true,
+    "aggregate_list_id": null,
+    "title": "All Items",
     "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "updated_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00"
+    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "list_items": [
+      {
+        "list_id": 43,
+        "description": "Unenchanted ebony sword",
+        "quantity": 1,
+        "notes": "Need an unenchanted sword to start Companions questline",
+        "unit_weight": null,
+        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      },
+      {
+        "list_id": 43,
+        "description": "Iron ingot",
+        "quantity": 4,
+        "notes": "3 locks -- 2 hinges",
+        "unit_weight": 1.0,
+        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      }
+    ]
   },
   {
-    "id": 126,
-    "list_id": 237,
-    "description": "Ebony sword",
-    "quantity": 7,
-    "unit_weight": 14.0,
-    "notes": "To enchant with 'Absorb Health'",
-    "created_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00",
-    "updated_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00"
+    "id": 46,
+    "game_id": 8234,
+    "aggregate": false,
+    "aggregate_list_id": 43,
+    "title": "Lakeview Manor",
+    "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "list_items": [
+      {
+        "list_id": 46,
+        "description": "Unenchanted ebony sword",
+        "quantity": 1,
+        "notes": "Need an unenchanted sword to start Companions questline",
+        "unit_weight": null,
+        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      },
+      {
+        "list_id": 46,
+        "description": "Iron ingot",
+        "quantity": 3,
+        "notes": "3 locks",
+        "unit_weight": 1.0,
+        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      }
+    ]
+  },
+  {
+    "id": 52,
+    "game_id": 8234,
+    "aggregate": false,
+    "aggregate_list_id": 43,
+    "title": "Severin Manor",
+    "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "list_items": [
+      {
+        "list_id": 52,
+        "description": "Iron ingot",
+        "quantity": 1,
+        "notes": "2 hinges",
+        "unit_weight": 1.0,
+        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      }
+    ]
   }
 ]
 ```
@@ -140,9 +199,7 @@ No body will be returned with a 404 error, which is returned if the specified sh
 A 405 error, which is returned if the specified shopping list is an aggregate shopping list, comes with the following body:
 ```json
 {
-  "errors": [
-    "Cannot manually manage items on an aggregate shopping list"
-  ]
+  "errors": ["Cannot manually manage items on an aggregate shopping list"]
 }
 ```
 

--- a/docs/api/resources/shopping-list-items.md
+++ b/docs/api/resources/shopping-list-items.md
@@ -419,7 +419,7 @@ Authorization: Bearer xxxxxxxxxxx
 
 #### Example Body
 
-The response body will be an array of all shopping lists belonging to the game to which the deleted list item ultimately belongs. This object also includes the shopping list items on each list.
+The response body includes the shopping list from which the item was deleted as well as the aggregate list, with the aggregate list first.
 
 ```json
 [
@@ -444,8 +444,8 @@ The response body will be an array of all shopping lists belonging to the game t
       {
         "list_id": 43,
         "description": "Iron ingot",
-        "quantity": 4,
-        "notes": "3 locks -- 2 hinges",
+        "quantity": 3,
+        "notes": "3 locks",
         "unit_weight": 1.0,
         "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
         "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
@@ -475,26 +475,6 @@ The response body will be an array of all shopping lists belonging to the game t
         "description": "Iron ingot",
         "quantity": 3,
         "notes": "3 locks",
-        "unit_weight": 1.0,
-        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
-      }
-    ]
-  },
-  {
-    "id": 52,
-    "game_id": 8234,
-    "aggregate": false,
-    "aggregate_list_id": 43,
-    "title": "Severin Manor",
-    "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "list_items": [
-      {
-        "list_id": 52,
-        "description": "Iron ingot",
-        "quantity": 1,
-        "notes": "2 hinges",
         "unit_weight": 1.0,
         "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
         "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"

--- a/docs/api/resources/shopping-list-items.md
+++ b/docs/api/resources/shopping-list-items.md
@@ -70,7 +70,7 @@ Allowed fields are:
 * `notes` (string, optional): Any notes about the item or what it is for
 * `unit_weight` (decimal, optional): The unit weight of the item as given in the game, precise to one decimal place
 
-A successful response will return a JSON array of all shopping lists for the game to which the created or updated list item ultimately belongs, including all the list items on each list.
+A successful response will return a JSON array of all changed shopping lists for the game to which the created or updated list item ultimately belongs, including all the list items on each list.
 
 ### Example Request
 
@@ -96,7 +96,7 @@ Content-Type: application/json
 
 If there is no item with a matching description on the requested shopping list, a new item will be created and the server will return a 201 response. If there is an item with a matching description, its notes and quantity will be combined with the notes and quantity in the client request and a 200 response will be returned.
 
-The body for both responses is a JSON array containing all shopping lists for the game to which the created or updated list item ultimately belongs. Each shopping list includes its list items.
+The body for both responses is a JSON array containing all _changed_ shopping lists for the game to which the created or updated list item ultimately belongs, i.e., those that have had items added, updated, or removed. Each shopping list includes its list items.
 
 ```json
 [
@@ -152,26 +152,6 @@ The body for both responses is a JSON array containing all shopping lists for th
         "description": "Iron ingot",
         "quantity": 3,
         "notes": "3 locks",
-        "unit_weight": 1.0,
-        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
-      }
-    ]
-  },
-  {
-    "id": 52,
-    "game_id": 8234,
-    "aggregate": false,
-    "aggregate_list_id": 43,
-    "title": "Severin Manor",
-    "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "list_items": [
-      {
-        "list_id": 52,
-        "description": "Iron ingot",
-        "quantity": 1,
-        "notes": "2 hinges",
         "unit_weight": 1.0,
         "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
         "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"

--- a/docs/api/resources/shopping-lists.md
+++ b/docs/api/resources/shopping-lists.md
@@ -60,6 +60,7 @@ For a game with multiple lists:
     "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
     "list_items": [
       {
+        "id": 689
         "list_id": 43,
         "description": "Unenchanted ebony sword",
         "quantity": 1,
@@ -69,6 +70,7 @@ For a game with multiple lists:
         "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
       },
       {
+        "id": 134,
         "list_id": 43,
         "description": "Iron ingot",
         "quantity": 4,
@@ -89,6 +91,7 @@ For a game with multiple lists:
     "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
     "list_items": [
       {
+        "id": 845,
         "list_id": 46,
         "description": "Unenchanted ebony sword",
         "quantity": 1,
@@ -98,6 +101,7 @@ For a game with multiple lists:
         "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
       },
       {
+        "id": 76,
         "list_id": 46,
         "description": "Iron ingot",
         "quantity": 3,
@@ -118,6 +122,7 @@ For a game with multiple lists:
     "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
     "list_items": [
       {
+        "id": 11,
         "list_id": 52,
         "description": "Iron ingot",
         "quantity": 1,
@@ -153,7 +158,7 @@ A 500 error response, which is always a result of an unforeseen problem, include
 
 ## POST /games/:game_id/shopping_lists
 
-Creates a new shopping list for the specified game if it exists and belongs to the authenticated user. If the game does not already have an aggregate list, an aggregate list will also be created automatically. The response is an array that includes all shopping lists belonging to the specified game. Each shopping list also includes an array with any shopping list items on that list. The JSON schema for the shopping list items is described in the [docs for shopping list items](/docs/api/resources/shopping-list-items.md). The shopping lists are returned with the aggregate list first and subsequent lists in order of most recently updated. (Adding, removing, or updating a list item on a list counts as updating the list.)
+Creates a new shopping list for the specified game if it exists and belongs to the authenticated user. If the game does not already have an aggregate list, an aggregate list will also be created automatically. The response is an array that includes all shopping lists that were created. The shopping lists are returned with the aggregate list first, if one was created while handling this request, and the regular list the user requested.
 
 The request does not have to include a body. If it does, the body should include a `"shopping_list"` object with an optional `"title"` key, the only attribute that can be set on a shopping list via this or any endpoint. If you don't include a title, your list will be titled "My List N", where _N_ is an integer equal to one plus the highest numbered default list title you have. For example, if you have lists titled "My List 1", "My List 3", and "My List 4" and you don't specify a title for your new list, your new list will be titled "My List 5".
 
@@ -201,6 +206,8 @@ Authorization: Bearer xxxxxxxxxx
 
 #### Example Body
 
+##### When an Aggregate List Is Created
+
 ```json
 [
   {
@@ -211,27 +218,6 @@ Authorization: Bearer xxxxxxxxxx
     "title": "All Items",
     "created_at": "Tue, 15 Jun 2021 11:59:16.891338000 UTC +00:00",
     "updated_at": "Tue, 15 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "list_items": [
-      {
-        "id": 33,
-        "list_id": 4,
-        "description": "Ebony sword",
-        "quantity": 1,
-        "notes": "To enchant with Soul Trap",
-        "unit_weight": 14.0,
-        "created_at": "Tue, 15 Jun 2021 12:34:32.713458000 UTC +00:00",
-        "updated_at": "Tue, 15 Jun 2021 12:34:32.713458000 UTC +00:00"
-      }
-    ]
-  },
-  {
-    "id": 12,
-    "user_id": 6,
-    "aggregate": false,
-    "aggregate_list_id": 4,
-    "title": "Custom Titled List",
-    "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
     "list_items": []
   },
   {
@@ -242,18 +228,24 @@ Authorization: Bearer xxxxxxxxxx
     "title": "My List 1",
     "created_at": "Tue, 15 Jun 2021 11:59:16.891338000 UTC +00:00",
     "updated_at": "Tue, 15 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "list_items": [
-      {
-        "id": 32,
-        "list_id": 5,
-        "description": "Ebony sword",
-        "quantity": 1,
-        "notes": "To enchant with Soul Trap",
-        "unit_weight": 14.0,
-        "created_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00",
-        "updated_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00"
-      }
-    ]
+    "list_items": []
+  }
+]
+```
+
+##### When Only a Regular List Is Created
+
+```json
+[
+  {
+    "id": 5,
+    "user_id": 6,
+    "aggregate": false,
+    "aggregate_list_id": 4,
+    "title": "My List 1",
+    "created_at": "Tue, 15 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "updated_at": "Tue, 15 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "list_items": []
   }
 ]
 ```

--- a/docs/api/resources/shopping-lists.md
+++ b/docs/api/resources/shopping-lists.md
@@ -151,7 +151,7 @@ A 500 error response, which is always a result of an unforeseen problem, include
 
 ## POST /games/:game_id/shopping_lists
 
-Creates a new shopping list for the specified game if it exists and belongs to the authenticated user. If the game does not already have an aggregate list, an aggregate list will also be created automatically. The response is an array that includes the newly created shopping list(s).
+Creates a new shopping list for the specified game if it exists and belongs to the authenticated user. If the game does not already have an aggregate list, an aggregate list will also be created automatically. The response is an array that includes all shopping lists belonging to the specified game. Each shopping list also includes an array with any shopping list items on that list. The JSON schema for the shopping list items is described in the [docs for shopping list items](/docs/api/resources/shopping-list-items.md). The shopping lists are returned with the aggregate list first and subsequent lists in order of most recently updated. (Adding, removing, or updating a list item on a list counts as updating the list.)
 
 The request does not have to include a body. If it does, the body should include a `"shopping_list"` object with an optional `"title"` key, the only attribute that can be set on a shopping list via request data. If you don't include a title, your list will be titled "My List N", where _N_ is an integer equal to the highest numbered default list title you have. For example, if you have lists titled "My List 1", "My List 3", and "My List 4" and you don't specify a title for your new list, your new list will be titled "My List 5".
 
@@ -197,32 +197,29 @@ Authorization: Bearer xxxxxxxxxx
 
 * 201 Created
 
-#### Example Bodies
+#### Example Body
 
-When there hasn't been an aggregate list created:
-```json
-{
-  "id": 4,
-  "user_id": 6,
-  "aggregate": false,
-  "aggregate_list_id": 3,
-  "title": "My List 1",
-  "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-  "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-  "list_items": []
-}
-```
-
-When the aggregate list has also been created:
 ```json
 [
   {
     "id": 4,
     "user_id": 6,
     "aggregate": true,
+    "aggregate_list_id": null,
     "title": "All Items",
+    "created_at": "Tue, 15 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "updated_at": "Tue, 15 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "list_items": []
+  },
+  {
+    "id": 12,
+    "user_id": 6,
+    "aggregate": false,
+    "aggregate_list_id": 4,
+    "title": "Custom Titled List",
     "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
     "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "list_items": []
   },
   {
     "id": 5,
@@ -230,8 +227,9 @@ When the aggregate list has also been created:
     "aggregate": false,
     "aggregate_list_id": 4,
     "title": "My List 1",
-    "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+    "created_at": "Tue, 15 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "updated_at": "Tue, 15 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "list_items": []
   }
 ]
 ```
@@ -408,7 +406,7 @@ If the resource deleted was the user's last regular list, the aggregate list wil
       "created_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00",
       "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
     }
-  ] 
+  ]
 }
 ```
 

--- a/docs/api/resources/shopping-lists.md
+++ b/docs/api/resources/shopping-lists.md
@@ -47,12 +47,14 @@ For a game with no lists:
 []
 ```
 For a game with multiple lists:
+
 ```json
 [
   {
     "id": 43,
     "game_id": 8234,
     "aggregate": true,
+    "aggregate_list_id": null,
     "title": "All Items",
     "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
     "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",

--- a/docs/api/resources/shopping-lists.md
+++ b/docs/api/resources/shopping-lists.md
@@ -446,7 +446,7 @@ A 500 error response, which is always a result of an unforeseen problem, include
 
 ## DELETE /shopping_lists/:id
 
-Destroys the given shopping list, and any shopping list items on it, if it exists and belongs to the authenticated user. If the list to be destroyed is the user's only regular (non-aggregate) shopping list, the aggregate list will also be destroyed.
+Destroys the given shopping list, and any shopping list items on it, if it exists and belongs to the authenticated user. If the list to be destroyed is the user's only regular (non-aggregate) shopping list, the aggregate list will also be destroyed. The response body will include any remaining shopping lists belonging to the game to which the requested list belongs.
 
 ### Example Request
 
@@ -459,34 +459,65 @@ Authorization: Bearer xxxxxxxxxxxx
 
 #### Statuses
 
-* 204 No Content
 * 200 OK
 
-#### Example Body
+#### Example Bodies
 
-If the resource deleted was the user's last regular list, the aggregate list will also be destroyed and no content will be returned in the response. If the user had at least one other regular list (as well as an aggregate list), then the aggregate list will be returned with its values updated to reflect removal of the items on the list that was deleted.
+The response body will be an array of any remaining shopping lists belonging to the same game as the destroyed list(s).
+
+Body including an aggregate list and an additional list that was not destroyed:
 
 ```json
-{
-  "id": 834,
-  "user_id": 16,
-  "aggregate": true,
-  "title": "All Items",
-  "created_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00",
-  "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-  "list_items": [
-    {
-      "id": 32,
-      "list_id": 834,
-      "description": "Ebony sword",
-      "quantity": 1,
-      "notes": "To enchant with Soul Trap",
-      "unit_weight": 14.0,
-      "created_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00",
-      "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
-    }
-  ]
-}
+[
+  {
+    "id": 834,
+    "user_id": 16,
+    "aggregate": true,
+    "aggregate_list_id": null,
+    "title": "All Items",
+    "created_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00",
+    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "list_items": [
+      {
+        "id": 32,
+        "list_id": 834,
+        "description": "Ebony sword",
+        "quantity": 1,
+        "notes": "To enchant with Soul Trap",
+        "unit_weight": 14.0,
+        "created_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      }
+    ]
+  },
+  {
+    "id": 835,
+    "user_id": 16,
+    "aggregate": false,
+    "aggregate_list_id": 834,
+    "title": "Vlindrel Hall",
+    "created_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00",
+    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "list_items": [
+      {
+        "id": 31,
+        "list_id": 835,
+        "description": "Ebony sword",
+        "quantity": 1,
+        "notes": "To enchant with Soul Trap",
+        "unit_weight": 14.0,
+        "created_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      }
+    ]
+  }
+]
+```
+
+Empty body indicating aggregate list was also destroyed:
+
+```json
+[]
 ```
 
 ### Error Responses
@@ -504,6 +535,7 @@ If the specified list does not exist or does not belong to the authenticated use
 For a 404 response, no response body will be returned.
 
 For a 405 response:
+
 ```json
 {
   "errors": ["Cannot manually delete an aggregate shopping list"]
@@ -511,6 +543,7 @@ For a 405 response:
 ```
 
 A 500 error response, which is always a result of an unforeseen problem, includes the error message:
+
 ```json
 {
   "errors": ["Something went horribly wrong"]

--- a/docs/api/resources/shopping-lists.md
+++ b/docs/api/resources/shopping-lists.md
@@ -440,7 +440,7 @@ A 500 error response, which is always a result of an unforeseen problem, include
 
 ## DELETE /shopping_lists/:id
 
-Destroys the given shopping list, and any shopping list items on it, if it exists and belongs to the authenticated user. If the list to be destroyed is the user's only regular (non-aggregate) shopping list, the aggregate list will also be destroyed. The response body will include any remaining shopping lists belonging to the game to which the requested list belongs.
+Destroys the given shopping list, and any shopping list items on it, if it exists and belongs to the authenticated user. If the list to be destroyed is the user's only regular (non-aggregate) shopping list, the aggregate list will also be destroyed. The body of a successful response includes an array of deleted list IDs and the updated aggregate list (unless it was also deleted).
 
 ### Example Request
 
@@ -457,13 +457,14 @@ Authorization: Bearer xxxxxxxxxxxx
 
 #### Example Bodies
 
-The response body will be an array of any remaining shopping lists belonging to the same game as the destroyed list(s).
+The response body will be a JSON object with a `"deleted"` key pointing to an array of deleted lists. If only the target list was destroyed, this array will include one member. If the target list was the game's last regular shopping list and the aggregate list was therefore also destroyed, the array will include two members. If the aggregate list was not destroyed, it will be returned as well, with its updated list items, under the `"aggregate"` key.
 
-Body including an aggregate list and an additional list that was not destroyed:
+Body including an aggregate list that was not destroyed:
 
 ```json
-[
-  {
+{
+  "deleted": [835],
+  "aggregate": {
     "id": 834,
     "user_id": 16,
     "aggregate": true,
@@ -483,35 +484,16 @@ Body including an aggregate list and an additional list that was not destroyed:
         "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
       }
     ]
-  },
-  {
-    "id": 835,
-    "user_id": 16,
-    "aggregate": false,
-    "aggregate_list_id": 834,
-    "title": "Vlindrel Hall",
-    "created_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00",
-    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "list_items": [
-      {
-        "id": 31,
-        "list_id": 835,
-        "description": "Ebony sword",
-        "quantity": 1,
-        "notes": "To enchant with Soul Trap",
-        "unit_weight": 14.0,
-        "created_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00",
-        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
-      }
-    ]
   }
-]
+}
 ```
 
-Empty body indicating aggregate list was also destroyed:
+Body when the aggregate list was also destroyed:
 
 ```json
-[]
+{
+  "deleted": [834, 835]
+}
 ```
 
 ### Error Responses

--- a/docs/api/resources/shopping-lists.md
+++ b/docs/api/resources/shopping-lists.md
@@ -153,7 +153,7 @@ A 500 error response, which is always a result of an unforeseen problem, include
 
 Creates a new shopping list for the specified game if it exists and belongs to the authenticated user. If the game does not already have an aggregate list, an aggregate list will also be created automatically. The response is an array that includes all shopping lists belonging to the specified game. Each shopping list also includes an array with any shopping list items on that list. The JSON schema for the shopping list items is described in the [docs for shopping list items](/docs/api/resources/shopping-list-items.md). The shopping lists are returned with the aggregate list first and subsequent lists in order of most recently updated. (Adding, removing, or updating a list item on a list counts as updating the list.)
 
-The request does not have to include a body. If it does, the body should include a `"shopping_list"` object with an optional `"title"` key, the only attribute that can be set on a shopping list via request data. If you don't include a title, your list will be titled "My List N", where _N_ is an integer equal to the highest numbered default list title you have. For example, if you have lists titled "My List 1", "My List 3", and "My List 4" and you don't specify a title for your new list, your new list will be titled "My List 5".
+The request does not have to include a body. If it does, the body should include a `"shopping_list"` object with an optional `"title"` key, the only attribute that can be set on a shopping list via this or any endpoint. If you don't include a title, your list will be titled "My List N", where _N_ is an integer equal to one plus the highest numbered default list title you have. For example, if you have lists titled "My List 1", "My List 3", and "My List 4" and you don't specify a title for your new list, your new list will be titled "My List 5".
 
 There are a few validations and automatic changes made to titles:
 
@@ -209,7 +209,18 @@ Authorization: Bearer xxxxxxxxxx
     "title": "All Items",
     "created_at": "Tue, 15 Jun 2021 11:59:16.891338000 UTC +00:00",
     "updated_at": "Tue, 15 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "list_items": []
+    "list_items": [
+      {
+        "id": 33,
+        "list_id": 4,
+        "description": "Ebony sword",
+        "quantity": 1,
+        "notes": "To enchant with Soul Trap",
+        "unit_weight": 14.0,
+        "created_at": "Tue, 15 Jun 2021 12:34:32.713458000 UTC +00:00",
+        "updated_at": "Tue, 15 Jun 2021 12:34:32.713458000 UTC +00:00"
+      }
+    ]
   },
   {
     "id": 12,
@@ -229,7 +240,18 @@ Authorization: Bearer xxxxxxxxxx
     "title": "My List 1",
     "created_at": "Tue, 15 Jun 2021 11:59:16.891338000 UTC +00:00",
     "updated_at": "Tue, 15 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "list_items": []
+    "list_items": [
+      {
+        "id": 32,
+        "list_id": 5,
+        "description": "Ebony sword",
+        "quantity": 1,
+        "notes": "To enchant with Soul Trap",
+        "unit_weight": 14.0,
+        "created_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00",
+        "updated_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00"
+      }
+    ]
   }
 ]
 ```
@@ -269,13 +291,16 @@ A 500 error response, which is always a result of an unforeseen problem, include
 
 ## PATCH|PUT /shopping_lists/:id
 
-If the specified shopping list exists, belongs to the authenticated user, and is not an aggregate list, updates the title and returns the shopping list. Title is the only shopping list attribute that can be modified using this endpoint. This endpoint also supports the `PUT` method.
+If the specified shopping list exists, belongs to the authenticated user, and is not an aggregate list, updates the title and returns the shopping list. Title is the only shopping list attribute that can be modified using this endpoint. This endpoint also supports the `PUT` method. There is no  difference in application behaviour whether `PATCH` or `PUT` is used.
 
 ### Example Requests
 
-Requests must include a `"shopping_list"` object with a `"title"` key.
+Requests should include a `"shopping_list"` object with a `"title"` key. The `"title"` may be `null`; in this case, a default title will be assigned as described [above](#post-gamesgame_idshopping_lists). If the `"shopping_list"` object is empty or nonexistent, or if no request body is given, the list will not be updated but will be returned as-is. `"title"` is the only attribute that may be set on shopping lists via the SIM API.
 
-Using a `PATCH` request:
+#### PATCH Requests
+
+Normal usage:
+
 ```
 PATCH /shopping_lists/3
 Authorization: Bearer xxxxxxxxxx
@@ -287,15 +312,66 @@ Content-Type: application/json
 }
 ```
 
-Using a `PUT` request:
+Null title (will result in a default title being assigned):
+
+```
+PATCH /shopping_lists/3
+Authorization: Bearer xxxxxxxxxx
+Content-Type: application/json
+{
+  "shopping_list": {
+    "title": null
+  }
+}
+```
+
+Empty `"shopping_list"` object (shopping list will be returned as-is):
+
+```
+PATCH /shopping_lists/3
+Authorization: Bearer xxxxxxxxxx
+Content-Type: application/json
+{
+  "shopping_list": {}
+}
+```
+
+#### PUT Requests
+
+Normal usage:
+
 ```
 PUT /shopping_lists/3
-Authorization: Bearer xxxxxxxxxxx
+Authorization: Bearer xxxxxxxxxx
 Content-Type: application/json
 {
   "shopping_list": {
     "title": "New List Title"
   }
+}
+```
+
+Null title (will result in a default title being assigned):
+
+```
+PUT /shopping_lists/3
+Authorization: Bearer xxxxxxxxxx
+Content-Type: application/json
+{
+  "shopping_list": {
+    "title": null
+  }
+}
+```
+
+Empty `"shopping_list"` object (shopping list will be returned as-is):
+
+```
+PUT /shopping_lists/3
+Authorization: Bearer xxxxxxxxxx
+Content-Type: application/json
+{
+  "shopping_list": {}
 }
 ```
 
@@ -345,6 +421,7 @@ Content-Type: application/json
 For a 404 response, no response body is returned.
 
 For a 422 response due to title uniqueness constraint:
+
 ```json
 {
   "errors": ["Title must be unique per game"]
@@ -352,6 +429,7 @@ For a 422 response due to title uniqueness constraint:
 ```
 
 For a 405 response due to attempting to update an aggregate list or convert a regular list to an aggregate list:
+
 ```json
 {
   "errors": ["Cannot manually update an aggregate shopping list"]
@@ -359,6 +437,7 @@ For a 405 response due to attempting to update an aggregate list or convert a re
 ```
 
 A 500 error response, which is always a result of an unforeseen problem, includes the error message:
+
 ```json
 {
   "errors": ["Something went horribly wrong"]

--- a/spec/controller_services/shopping_list_items_controller/create_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/create_service_spec.rb
@@ -21,22 +21,46 @@ RSpec.describe ShoppingListItemsController::CreateService do
 
       context 'when there is no existing matching item on the same list' do
         context 'when there is no existing matching item on any list' do
-          it 'creates a new item on the list' do
-            expect { perform }
-              .to change(shopping_list.list_items, :count).from(0).to(1)
+          context 'when unit weight is not set' do
+            it 'creates a new item on the list' do
+              expect { perform }
+                .to change(shopping_list.list_items, :count).from(0).to(1)
+            end
+
+            it 'creates a new item on the aggregate list' do
+              expect { perform }
+                .to change(aggregate_list.list_items, :count).from(0).to(1)
+            end
+
+            it 'returns a Service::CreatedResult' do
+              expect(perform).to be_a(Service::CreatedResult)
+            end
+
+            it 'sets the resource to all the changed shopping lists' do
+              expect(perform.resource).to eq [aggregate_list, shopping_list]
+            end
           end
 
-          it 'creates a new item on the aggregate list' do
-            expect { perform }
-              .to change(aggregate_list.list_items, :count).from(0).to(1)
-          end
+          context 'when unit weight is set' do
+            let(:params) { { description: 'Necklace', quantity: 2, unit_weight: 0.3, notes: 'Hello world' } }
 
-          it 'returns a Service::CreatedResult' do
-            expect(perform).to be_a(Service::CreatedResult)
-          end
+            it 'creates a new item on the list' do
+              expect { perform }
+                .to change(shopping_list.list_items, :count).from(0).to(1)
+            end
 
-          it 'sets the resource to all the changed shopping lists' do
-            expect(perform.resource).to eq [aggregate_list, shopping_list]
+            it 'creates a new item on the aggregate list' do
+              expect { perform }
+                .to change(aggregate_list.list_items, :count).from(0).to(1)
+            end
+
+            it 'returns a Service::CreatedResult' do
+              expect(perform).to be_a(Service::CreatedResult)
+            end
+
+            it 'sets the resource to all the changed shopping lists' do
+              expect(perform.resource).to eq [aggregate_list, shopping_list]
+            end
           end
         end
 

--- a/spec/controller_services/shopping_list_items_controller/create_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/create_service_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe ShoppingListItemsController::CreateService do
             expect(perform).to be_a(Service::CreatedResult)
           end
 
-          it 'sets the new and aggregate list items as the resource' do
-            expect(perform.resource).to eq [aggregate_list.list_items.last, shopping_list.list_items.last]
+          it "sets the resource to all the game's shopping lists" do
+            expect(perform.resource).to eq game.shopping_lists.reload.index_order
           end
         end
 
@@ -64,8 +64,8 @@ RSpec.describe ShoppingListItemsController::CreateService do
               expect(perform).to be_a(Service::CreatedResult)
             end
 
-            it 'sets the resource as the aggregate list item and the regular list item' do
-              expect(perform.resource).to eq([aggregate_list.list_items.first, shopping_list.list_items.first])
+            it "sets all the game's shopping lists as the resource" do
+              expect(perform.resource).to eq(game.shopping_lists.reload.index_order)
             end
           end
 
@@ -94,8 +94,8 @@ RSpec.describe ShoppingListItemsController::CreateService do
               expect(perform).to be_a(Service::CreatedResult)
             end
 
-            it 'sets the resource as the all created or changed list items' do
-              expect(perform.resource).to eq([aggregate_list.list_items.first, other_item, shopping_list.list_items.first])
+            it "sets all the game's shopping lists as the resource" do
+              expect(perform.resource).to eq(game.shopping_lists.reload.index_order)
             end
           end
         end
@@ -133,8 +133,8 @@ RSpec.describe ShoppingListItemsController::CreateService do
             expect(perform).to be_a(Service::OKResult)
           end
 
-          it 'returns the requested item and the aggregate list item' do
-            expect(perform.resource).to eq([aggregate_list.list_items.first, list_item.reload])
+          it "sets all the game's shopping lists as the resource" do
+            expect(perform.resource).to eq(game.shopping_lists.reload.index_order)
           end
         end
 
@@ -168,8 +168,8 @@ RSpec.describe ShoppingListItemsController::CreateService do
             expect(perform).to be_a(Service::OKResult)
           end
 
-          it 'returns all the items that have been updated' do
-            expect(perform.resource).to eq [aggregate_list.list_items.first, other_item.reload, list_item.reload]
+          it "sets all the game's shopping lists as the resource" do
+            expect(perform.resource).to eq(game.shopping_lists.reload.index_order)
           end
         end
       end

--- a/spec/controller_services/shopping_list_items_controller/destroy_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/destroy_service_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'service/no_content_result'
 require 'service/ok_result'
 require 'service/not_found_result'
 require 'service/method_not_allowed_result'
@@ -35,12 +34,12 @@ RSpec.describe ShoppingListItemsController::DestroyService do
             .to change(aggregate_list.list_items, :count).from(1).to(0)
         end
 
-        it 'returns a Service::NoContentResult' do
-          expect(perform).to be_a Service::NoContentResult
+        it 'returns a Service::OKResult' do
+          expect(perform).to be_a Service::OKResult
         end
 
-        it 'does not return data' do
-          expect(perform.resource).to be nil
+        it "sets all the game's shopping lists as the resource" do
+          expect(perform.resource).to eq(game.shopping_lists.reload.index_order)
         end
 
         it 'sets the updated_at timestamp on the shopping list' do
@@ -104,8 +103,8 @@ RSpec.describe ShoppingListItemsController::DestroyService do
           expect(perform).to be_a Service::OKResult
         end
 
-        it 'returns the updated aggregate list item' do
-          expect(perform.resource).to eq aggregate_list.list_items.first
+        it "returns all the game's shopping lists as the resource" do
+          expect(perform.resource).to eq(game.shopping_lists.reload.index_order)
         end
       end
     end

--- a/spec/controller_services/shopping_list_items_controller/destroy_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/destroy_service_spec.rb
@@ -38,8 +38,8 @@ RSpec.describe ShoppingListItemsController::DestroyService do
           expect(perform).to be_a Service::OKResult
         end
 
-        it "sets all the game's shopping lists as the resource" do
-          expect(perform.resource).to eq(game.shopping_lists.reload.index_order)
+        it 'sets the aggregate list and the regular list as the resource' do
+          expect(perform.resource).to eq([aggregate_list, shopping_list])
         end
 
         it 'sets the updated_at timestamp on the shopping list' do
@@ -103,8 +103,8 @@ RSpec.describe ShoppingListItemsController::DestroyService do
           expect(perform).to be_a Service::OKResult
         end
 
-        it "returns all the game's shopping lists as the resource" do
-          expect(perform.resource).to eq(game.shopping_lists.reload.index_order)
+        it 'sets the aggregate list and the regular list as the resource' do
+          expect(perform.resource).to eq([aggregate_list, shopping_list])
         end
       end
     end

--- a/spec/controller_services/shopping_list_items_controller/update_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/update_service_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe ShoppingListItemsController::UpdateService do
           expect(perform).to be_a(Service::OKResult)
         end
 
-        it "returns all the game's shopping lists as the resource" do
-          expect(perform.resource).to eq(game.shopping_lists.reload.index_order)
+        it 'returns the modified shopping list items as the resource' do
+          expect(perform.resource).to eq [aggregate_list_item, list_item.reload]
         end
       end
 
@@ -75,8 +75,8 @@ RSpec.describe ShoppingListItemsController::UpdateService do
             expect(perform).to be_a(Service::OKResult)
           end
 
-          it "returns all the game's shopping lists as the resource" do
-            expect(perform.resource).to eq(game.shopping_lists.reload.index_order)
+          it 'returns the two modified list items as the resource' do
+            expect(perform.resource).to eq([aggregate_list_item, list_item.reload])
           end
         end
 
@@ -105,8 +105,8 @@ RSpec.describe ShoppingListItemsController::UpdateService do
             expect(perform).to be_a(Service::OKResult)
           end
 
-          it "returns all the game's shopping lists as the resource" do
-            expect(perform.resource).to eq(game.shopping_lists.reload.index_order)
+          it 'returns all modified list items as the resource' do
+            expect(perform.resource).to eq([aggregate_list_item, other_item.reload, list_item.reload])
           end
         end
       end

--- a/spec/controller_services/shopping_list_items_controller/update_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/update_service_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe ShoppingListItemsController::UpdateService do
           expect(perform).to be_a(Service::OKResult)
         end
 
-        it 'returns the list item and aggregate list item as the resource' do
-          expect(perform.resource).to eq [aggregate_list_item, list_item.reload]
+        it "returns all the game's shopping lists as the resource" do
+          expect(perform.resource).to eq(game.shopping_lists.reload.index_order)
         end
       end
 
@@ -75,8 +75,8 @@ RSpec.describe ShoppingListItemsController::UpdateService do
             expect(perform).to be_a(Service::OKResult)
           end
 
-          it 'sets the resource to the aggregate list item and the regular list item' do
-            expect(perform.resource).to eq [aggregate_list_item, list_item.reload]
+          it "returns all the game's shopping lists as the resource" do
+            expect(perform.resource).to eq(game.shopping_lists.reload.index_order)
           end
         end
 
@@ -105,8 +105,8 @@ RSpec.describe ShoppingListItemsController::UpdateService do
             expect(perform).to be_a(Service::OKResult)
           end
 
-          it 'returns all the list items that were changed' do
-            expect(perform.resource).to eq [aggregate_list_item, other_item.reload, list_item.reload]
+          it "returns all the game's shopping lists as the resource" do
+            expect(perform.resource).to eq(game.shopping_lists.reload.index_order)
           end
         end
       end

--- a/spec/controller_services/shopping_lists_controller/create_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/create_service_spec.rb
@@ -67,14 +67,14 @@ RSpec.describe ShoppingListsController::CreateService do
       let!(:game) { create(:game, user:) }
       let(:params) { { title: 'Proudspire Manor' } }
 
-      context 'when the game has an aggregate shopping list' do
+      context 'when the game has other shopping lists' do
         before do
-          create(:aggregate_shopping_list, game:)
+          create(:shopping_list, game:)
         end
 
         it 'creates a shopping list for the given game' do
           expect { perform }
-            .to change(game.shopping_lists, :count).from(1).to(2)
+            .to change(game.shopping_lists, :count).from(2).to(3)
         end
 
         it 'returns a Service::CreatedResult' do
@@ -82,7 +82,7 @@ RSpec.describe ShoppingListsController::CreateService do
         end
 
         it 'sets the resource to the created list' do
-          expect(perform.resource).to eq game.shopping_lists.index_order
+          expect(perform.resource).to eq [game.shopping_lists.find_by(title: 'Proudspire Manor')]
         end
 
         it 'updates the game' do

--- a/spec/controller_services/shopping_lists_controller/create_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/create_service_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe ShoppingListsController::CreateService do
         end
 
         it 'sets the resource to the created list' do
-          expect(perform.resource).to eq game.shopping_lists.last
+          expect(perform.resource).to eq game.shopping_lists.index_order
         end
 
         it 'updates the game' do
@@ -123,7 +123,7 @@ RSpec.describe ShoppingListsController::CreateService do
         end
 
         it 'sets the resource to include both lists' do
-          expect(perform.resource).to eq([game.aggregate_shopping_list, game.shopping_lists.last])
+          expect(perform.resource).to eq(game.shopping_lists.index_order)
         end
       end
     end

--- a/spec/controller_services/shopping_lists_controller/destroy_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/destroy_service_spec.rb
@@ -18,10 +18,14 @@ RSpec.describe ShoppingListsController::DestroyService do
       let(:game) { create(:game, user:) }
 
       context 'when the game has additional regular lists' do
-        let!(:third_list) { create(:shopping_list, game:, aggregate_list:) }
+        let!(:third_list) { create(:shopping_list_with_list_items, game:, aggregate_list:) }
 
         before do
           shopping_list.list_items.each do |list_item|
+            aggregate_list.add_item_from_child_list(list_item)
+          end
+
+          third_list.list_items.each do |list_item|
             aggregate_list.add_item_from_child_list(list_item)
           end
         end
@@ -43,8 +47,8 @@ RSpec.describe ShoppingListsController::DestroyService do
           expect(perform).to be_a(Service::OKResult)
         end
 
-        it 'sets the resource as the aggregate list' do
-          expect(perform.resource).to eq aggregate_list
+        it "sets the resource as the game's remaining lists" do
+          expect(perform.resource).to eq game.shopping_lists.index_order
         end
 
         describe 'updating the aggregate list' do
@@ -92,8 +96,12 @@ RSpec.describe ShoppingListsController::DestroyService do
           end
         end
 
-        it 'returns a Service::NoContentResult' do
-          expect(perform).to be_a(Service::NoContentResult)
+        it 'returns a Service::OKResult' do
+          expect(perform).to be_a(Service::OKResult)
+        end
+
+        it 'returns an empty resource body' do
+          expect(perform.resource).to eq []
         end
       end
     end

--- a/spec/controller_services/shopping_lists_controller/destroy_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/destroy_service_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'service/no_content_result'
 require 'service/method_not_allowed_result'
 require 'service/not_found_result'
 require 'service/ok_result'
@@ -13,20 +12,26 @@ RSpec.describe ShoppingListsController::DestroyService do
     let(:user) { create(:user) }
 
     context 'when all goes well' do
-      let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
       let!(:shopping_list) { create(:shopping_list_with_list_items, game:) }
       let(:game) { create(:game, user:) }
 
       context 'when the game has additional regular lists' do
-        let!(:third_list) { create(:shopping_list_with_list_items, game:, aggregate_list:) }
+        let!(:third_list) { create(:shopping_list_with_list_items, game:) }
+
+        let(:expected_resource) do
+          {
+            deleted: [shopping_list.id],
+            aggregate: game.aggregate_shopping_list,
+          }
+        end
 
         before do
           shopping_list.list_items.each do |list_item|
-            aggregate_list.add_item_from_child_list(list_item)
+            game.aggregate_shopping_list.add_item_from_child_list(list_item)
           end
 
           third_list.list_items.each do |list_item|
-            aggregate_list.add_item_from_child_list(list_item)
+            game.aggregate_shopping_list.add_item_from_child_list(list_item)
           end
         end
 
@@ -47,14 +52,14 @@ RSpec.describe ShoppingListsController::DestroyService do
           expect(perform).to be_a(Service::OKResult)
         end
 
-        it "sets the resource as the game's remaining lists" do
-          expect(perform.resource).to eq game.shopping_lists.index_order
+        it 'includes the deleted list ID and the aggregate list as the resource' do
+          expect(perform.resource).to eq expected_resource
         end
 
         describe 'updating the aggregate list' do
           before do
             items = create_list(:shopping_list_item, 2, list: third_list)
-            items.each {|item| aggregate_list.add_item_from_child_list(item) }
+            items.each {|item| shopping_list.aggregate_list.add_item_from_child_list(item) }
 
             # Because in the code it finds the shopping list by ID and then gets the aggregate list
             # off that instance, the tests don't have access to the instance of the aggregate list that
@@ -62,8 +67,8 @@ RSpec.describe ShoppingListsController::DestroyService do
             user_lists = user.shopping_lists
             allow(user).to receive(:shopping_lists).and_return(user_lists)
             allow(user_lists).to receive(:find).and_return(shopping_list)
-            allow(shopping_list).to receive(:aggregate_list).and_return(aggregate_list)
-            allow(aggregate_list).to receive(:remove_item_from_child_list).twice
+            allow(shopping_list).to receive(:aggregate_list).and_return(shopping_list.aggregate_list)
+            allow(shopping_list.aggregate_list).to receive(:remove_item_from_child_list).twice
           end
 
           it 'calls #remove_item_from_child_list for each item', :aggregate_failures do
@@ -77,9 +82,15 @@ RSpec.describe ShoppingListsController::DestroyService do
       end
 
       context "when this is the game's last regular list" do
+        let(:expected_resource) do
+          {
+            deleted: [shopping_list.aggregate_list_id, shopping_list.id],
+          }
+        end
+
         before do
           shopping_list.list_items.each do |item|
-            shopping_list.aggregate_list.add_item_from_child_list(item)
+            game.aggregate_shopping_list.add_item_from_child_list(item)
           end
         end
 
@@ -100,8 +111,8 @@ RSpec.describe ShoppingListsController::DestroyService do
           expect(perform).to be_a(Service::OKResult)
         end
 
-        it 'returns an empty resource body' do
-          expect(perform.resource).to eq []
+        it 'returns an array of deleted list IDs as the resource' do
+          expect(perform.resource).to eq expected_resource
         end
       end
     end

--- a/spec/models/inventory_list_spec.rb
+++ b/spec/models/inventory_list_spec.rb
@@ -663,16 +663,36 @@ RSpec.describe InventoryList, type: :model do
         end
       end
 
-      context 'when there is no unit_weight given' do
-        subject(:update_item) { aggregate_list.update_item_from_child_list(description, 1, nil, 'something', 'another thing') }
+      context 'when unit_weight is nil' do
+        context 'when the unit weight is being unset' do
+          subject(:update_item) { aggregate_list.update_item_from_child_list(description, 1, nil, 'something', 'something', true) }
 
-        before do
-          aggregate_list.list_items.create(description:, quantity: 3, unit_weight: 1, notes: 'something')
+          let(:other_list) { create(:inventory_list, game: aggregate_list.game, aggregate_list:) }
+          let!(:item_on_other_list) { create(:inventory_item, list: other_list, description:, unit_weight: 1) }
+          let!(:aggregate_list_item) { create(:inventory_item, list: aggregate_list, description:, quantity: 3, unit_weight: 1, notes: 'something') }
+
+          it 'updates the aggregate list item unit weight' do
+            update_item
+            expect(aggregate_list_item.reload.unit_weight).to be_nil
+          end
+
+          it 'updates the item on the other list' do
+            update_item
+            expect(item_on_other_list.reload.unit_weight).to be_nil
+          end
         end
 
-        it 'leaves the existing unit_weight as-is' do
-          update_item
-          expect(aggregate_list.list_items.first.unit_weight).to eq 1
+        context 'when the unit weight is not being updated' do
+          subject(:update_item) { aggregate_list.update_item_from_child_list(description, 1, nil, 'something', 'another thing', false) }
+
+          before do
+            aggregate_list.list_items.create(description:, quantity: 3, unit_weight: 1, notes: 'something')
+          end
+
+          it 'leaves the existing unit_weight as-is' do
+            update_item
+            expect(aggregate_list.reload.list_items.first.unit_weight).to eq 1
+          end
         end
       end
 

--- a/spec/requests/shopping_list_items_spec.rb
+++ b/spec/requests/shopping_list_items_spec.rb
@@ -1065,9 +1065,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
             expect(response.status).to eq 200
           end
 
-          it 'returns an empty response' do
+          it 'returns the aggregate list and the regular list' do
             destroy_item
-            expect(response.body).to eq(game.shopping_lists.to_json)
+            expect(response.body).to eq([aggregate_list.reload, shopping_list.reload].to_json)
           end
         end
 
@@ -1125,9 +1125,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
             expect(response.status).to eq 200
           end
 
-          it "returns all the game's shopping lists" do
+          it 'returns the aggregate list and the regular list' do
             destroy_item
-            expect(response.body).to eq(game.shopping_lists.to_json)
+            expect(response.body).to eq([aggregate_list.reload, shopping_list.reload].to_json)
           end
         end
       end

--- a/spec/requests/shopping_list_items_spec.rb
+++ b/spec/requests/shopping_list_items_spec.rb
@@ -30,24 +30,50 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
         context 'when there is no existing matching item on the same list' do
           context 'when there is no existing matching item on any list' do
-            it 'creates a new item on the requested list' do
-              expect { create_item }
-                .to change(shopping_list.list_items, :count).from(0).to(1)
+            context 'when unit weight is not set' do
+              it 'creates a new item on the requested list' do
+                expect { create_item }
+                  .to change(shopping_list.list_items, :count).from(0).to(1)
+              end
+
+              it 'creates a new item on the aggregate list' do
+                expect { create_item }
+                  .to change(aggregate_list.list_items, :count).from(0).to(1)
+              end
+
+              it 'returns status 201' do
+                create_item
+                expect(response.status).to eq 201
+              end
+
+              it 'returns all changed shopping lists for the same game' do
+                create_item
+                expect(response.body).to eq(game.shopping_lists.to_json)
+              end
             end
 
-            it 'creates a new item on the aggregate list' do
-              expect { create_item }
-                .to change(aggregate_list.list_items, :count).from(0).to(1)
-            end
+            context 'when unit weight is set' do
+              let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 5, notes: 'To make locks' } }.to_json }
 
-            it 'returns status 201' do
-              create_item
-              expect(response.status).to eq 201
-            end
+              it 'creates a new item on the requested list' do
+                expect { create_item }
+                  .to change(shopping_list.list_items, :count).from(0).to(1)
+              end
 
-            it 'returns all changed shopping lists for the same game' do
-              create_item
-              expect(response.body).to eq(game.shopping_lists.to_json)
+              it 'creates a new item on the aggregate list' do
+                expect { create_item }
+                  .to change(aggregate_list.list_items, :count).from(0).to(1)
+              end
+
+              it 'returns status 201' do
+                create_item
+                expect(response.status).to eq 201
+              end
+
+              it 'returns all changed shopping lists for the same game' do
+                create_item
+                expect(response.body).to eq(game.shopping_lists.to_json)
+              end
             end
           end
 

--- a/spec/requests/shopping_list_items_spec.rb
+++ b/spec/requests/shopping_list_items_spec.rb
@@ -1016,14 +1016,14 @@ RSpec.describe 'ShoppingListItems', type: :request do
             end
           end
 
-          it 'returns status 204' do
+          it 'returns status 200' do
             destroy_item
-            expect(response.status).to eq 204
+            expect(response.status).to eq 200
           end
 
           it 'returns an empty response' do
             destroy_item
-            expect(response.body).to be_empty
+            expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
           end
         end
 
@@ -1081,9 +1081,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
             expect(response.status).to eq 200
           end
 
-          it 'returns the aggregate list item' do
+          it "returns all the game's shopping lists" do
             destroy_item
-            expect(JSON.parse(response.body)).to eq(JSON.parse(aggregate_list.list_items.first.to_json))
+            expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
           end
         end
       end

--- a/spec/requests/shopping_list_items_spec.rb
+++ b/spec/requests/shopping_list_items_spec.rb
@@ -45,9 +45,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
               expect(response.status).to eq 201
             end
 
-            it 'returns the regular list item and the aggregate list item' do
+            it 'returns all shopping lists for the same game' do
               create_item
-              expect(JSON.parse(response.body)).to eq(JSON.parse([aggregate_list.list_items.last, shopping_list.list_items.last].to_json))
+              expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
             end
           end
 
@@ -77,9 +77,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
                 expect(response.status).to eq 201
               end
 
-              it 'returns the aggregate list item and the regular list item' do
+              it 'returns all shopping lists from the same game' do
                 create_item
-                expect(JSON.parse(response.body)).to eq(JSON.parse([aggregate_list.list_items.first, shopping_list.list_items.first].to_json))
+                expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
               end
             end
 
@@ -108,9 +108,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
                 expect(response.status).to eq 201
               end
 
-              it 'returns all items that were created or updated' do
+              it 'returns all shopping lists for the same game' do
                 create_item
-                expect(JSON.parse(response.body)).to eq(JSON.parse([aggregate_list.list_items.first, other_item.reload, shopping_list.list_items.first].to_json))
+                expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
               end
             end
           end
@@ -147,9 +147,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
               expect(response.status).to eq 200
             end
 
-            it 'returns the requested item and the aggregate list item' do
+            it 'returns all shopping lists for the same game' do
               create_item
-              expect(JSON.parse(response.body)).to eq(JSON.parse([aggregate_list.list_items.first, list_item.reload].to_json))
+              expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
             end
           end
 
@@ -184,9 +184,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
               expect(response.status).to eq 200
             end
 
-            it 'returns all items that have been updated' do
+            it 'returns all shopping lists for the same game' do
               create_item
-              expect(JSON.parse(response.body)).to eq(JSON.parse([aggregate_list.list_items.first, other_item.reload, list_item.reload].to_json))
+              expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
             end
           end
         end

--- a/spec/requests/shopping_list_items_spec.rb
+++ b/spec/requests/shopping_list_items_spec.rb
@@ -423,9 +423,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
         end
 
         context 'when there is a matching item on another list' do
-          let!(:list_item) { create(:shopping_list_item, list: shopping_list) }
+          let!(:list_item) { create(:shopping_list_item, list: shopping_list, unit_weight: 1) }
           let!(:other_list) { create(:shopping_list, game:, aggregate_list:) }
-          let!(:other_item) { create(:shopping_list_item, list: other_list, description: list_item.description, quantity: 4) }
+          let!(:other_item) { create(:shopping_list_item, list: other_list, description: list_item.description, quantity: 4, unit_weight: 1) }
           let(:aggregate_list_item) { aggregate_list.list_items.first }
 
           before do
@@ -500,6 +500,70 @@ RSpec.describe 'ShoppingListItems', type: :request do
               update_item
               expect(other_item.reload.quantity).to eq 4
               expect(other_item.unit_weight).to eq 2
+            end
+
+            it 'updates the regular list' do
+              t = Time.zone.now + 3.days
+              Timecop.freeze(t) do
+                update_item
+                expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+              end
+            end
+
+            it 'updates the aggregate list' do
+              t = Time.zone.now + 3.days
+              Timecop.freeze(t) do
+                update_item
+                expect(aggregate_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+              end
+            end
+
+            it 'updates the other list' do
+              t = Time.zone.now + 3.days
+              Timecop.freeze(t) do
+                update_item
+                expect(other_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+              end
+            end
+
+            it 'updates the game' do
+              t = Time.zone.now + 3.days
+              Timecop.freeze(t) do
+                update_item
+                expect(game.reload.updated_at).to be_within(0.005.seconds).of(t)
+              end
+            end
+
+            it 'returns status 200' do
+              update_item
+              expect(response.status).to eq 200
+            end
+
+            it 'returns all the modified list items' do
+              update_item
+              expect(response.body).to eq([aggregate_list_item, other_item.reload, list_item.reload].to_json)
+            end
+          end
+
+          context 'when unit_weight is set to nil' do
+            let(:params) { { shopping_list_item: { quantity: 10, unit_weight: nil } }.to_json }
+
+            it 'updates the list item', :aggregate_failures do
+              update_item
+              expect(list_item.reload.quantity).to eq 10
+              expect(list_item.unit_weight).to be_nil
+            end
+
+            it 'updates the aggregate list item', :aggregate_failures do
+              update_item
+              expect(aggregate_list_item.quantity).to eq 14
+              expect(aggregate_list_item.unit_weight).to be_nil
+            end
+
+            it 'updates only the unit weight of the other list item', :aggregate_failures do
+              update_item
+              expect(other_item.reload.quantity).to eq 4
+              expect(other_item.unit_weight).to be_nil
             end
 
             it 'updates the regular list' do
@@ -748,9 +812,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
         end
 
         context 'when there is a matching item on another list' do
-          let!(:list_item) { create(:shopping_list_item, list: shopping_list) }
+          let!(:list_item) { create(:shopping_list_item, list: shopping_list, unit_weight: 1) }
           let!(:other_list) { create(:shopping_list, game:, aggregate_list:) }
-          let!(:other_item) { create(:shopping_list_item, list: other_list, description: list_item.description, quantity: 4) }
+          let!(:other_item) { create(:shopping_list_item, list: other_list, description: list_item.description, quantity: 4, unit_weight: 1) }
           let(:aggregate_list_item) { aggregate_list.list_items.first }
 
           before do
@@ -825,6 +889,70 @@ RSpec.describe 'ShoppingListItems', type: :request do
               update_item
               expect(other_item.reload.quantity).to eq 4
               expect(other_item.unit_weight).to eq 2
+            end
+
+            it 'updates the regular list' do
+              t = Time.zone.now + 3.days
+              Timecop.freeze(t) do
+                update_item
+                expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+              end
+            end
+
+            it 'updates the aggregate list' do
+              t = Time.zone.now + 3.days
+              Timecop.freeze(t) do
+                update_item
+                expect(aggregate_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+              end
+            end
+
+            it 'updates the other list' do
+              t = Time.zone.now + 3.days
+              Timecop.freeze(t) do
+                update_item
+                expect(other_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+              end
+            end
+
+            it 'updates the game' do
+              t = Time.zone.now + 3.days
+              Timecop.freeze(t) do
+                update_item
+                expect(game.reload.updated_at).to be_within(0.005.seconds).of(t)
+              end
+            end
+
+            it 'returns status 200' do
+              update_item
+              expect(response.status).to eq 200
+            end
+
+            it 'returns all the modified list items' do
+              update_item
+              expect(response.body).to eq([aggregate_list_item, other_item.reload, list_item.reload].to_json)
+            end
+          end
+
+          context 'when unit_weight is set to nil' do
+            let(:params) { { shopping_list_item: { quantity: 10, unit_weight: nil } }.to_json }
+
+            it 'updates the list item', :aggregate_failures do
+              update_item
+              expect(list_item.reload.quantity).to eq 10
+              expect(list_item.unit_weight).to be_nil
+            end
+
+            it 'updates the aggregate list item', :aggregate_failures do
+              update_item
+              expect(aggregate_list_item.quantity).to eq 14
+              expect(aggregate_list_item.unit_weight).to be_nil
+            end
+
+            it 'updates only the unit weight of the other list item', :aggregate_failures do
+              update_item
+              expect(other_item.reload.quantity).to eq 4
+              expect(other_item.unit_weight).to be_nil
             end
 
             it 'updates the regular list' do

--- a/spec/requests/shopping_list_items_spec.rb
+++ b/spec/requests/shopping_list_items_spec.rb
@@ -372,9 +372,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
             expect(response.status).to eq 200
           end
 
-          it 'returns the regular list item and the aggregate list item' do
+          it "returns all the game's shopping lists" do
             update_item
-            expect(JSON.parse(response.body)).to eq(JSON.parse([aggregate_list_item, list_item.reload].to_json))
+            expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
           end
         end
 
@@ -431,9 +431,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
               expect(response.status).to eq 200
             end
 
-            it 'returns the list item and the aggregate list item' do
+            it "returns all the game's shopping lists" do
               update_item
-              expect(JSON.parse(response.body)).to eq(JSON.parse([aggregate_list_item, list_item.reload].to_json))
+              expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
             end
           end
 
@@ -495,9 +495,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
               expect(response.status).to eq 200
             end
 
-            it 'returns all items that were changed' do
+            it "returns all the game's shopping lists" do
               update_item
-              expect(JSON.parse(response.body)).to eq(JSON.parse([aggregate_list_item, other_item.reload, list_item.reload].to_json))
+              expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
             end
           end
         end
@@ -668,14 +668,38 @@ RSpec.describe 'ShoppingListItems', type: :request do
             expect(aggregate_list_item.quantity).to eq 10
           end
 
+          it 'updates the regular list' do
+            t = Time.zone.now + 3.days
+            Timecop.freeze(t) do
+              update_item
+              expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+            end
+          end
+
+          it 'updates the aggregate list' do
+            t = Time.zone.now + 3.days
+            Timecop.freeze(t) do
+              update_item
+              expect(aggregate_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+            end
+          end
+
+          it 'updates the game' do
+            t = Time.zone.now + 3.days
+            Timecop.freeze(t) do
+              update_item
+              expect(game.reload.updated_at).to be_within(0.005.seconds).of(t)
+            end
+          end
+
           it 'returns status 200' do
             update_item
             expect(response.status).to eq 200
           end
 
-          it 'returns the regular list item and the aggregate list item' do
+          it "returns all the game's shopping lists" do
             update_item
-            expect(JSON.parse(response.body)).to eq(JSON.parse([aggregate_list_item, list_item.reload].to_json))
+            expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
           end
         end
 
@@ -703,14 +727,38 @@ RSpec.describe 'ShoppingListItems', type: :request do
               expect(aggregate_list_item.quantity).to eq 14
             end
 
+            it 'updates the regular list' do
+              t = Time.zone.now + 3.days
+              Timecop.freeze(t) do
+                update_item
+                expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+              end
+            end
+
+            it 'updates the aggregate list' do
+              t = Time.zone.now + 3.days
+              Timecop.freeze(t) do
+                update_item
+                expect(aggregate_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+              end
+            end
+
+            it 'updates the game' do
+              t = Time.zone.now + 3.days
+              Timecop.freeze(t) do
+                update_item
+                expect(game.reload.updated_at).to be_within(0.005.seconds).of(t)
+              end
+            end
+
             it 'returns status 200' do
               update_item
               expect(response.status).to eq 200
             end
 
-            it 'returns the list item and the aggregate list item' do
+            it "returns all the game's shopping lists" do
               update_item
-              expect(JSON.parse(response.body)).to eq(JSON.parse([aggregate_list_item, list_item.reload].to_json))
+              expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
             end
           end
 
@@ -735,14 +783,46 @@ RSpec.describe 'ShoppingListItems', type: :request do
               expect(other_item.unit_weight).to eq 2
             end
 
+            it 'updates the regular list' do
+              t = Time.zone.now + 3.days
+              Timecop.freeze(t) do
+                update_item
+                expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+              end
+            end
+
+            it 'updates the aggregate list' do
+              t = Time.zone.now + 3.days
+              Timecop.freeze(t) do
+                update_item
+                expect(aggregate_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+              end
+            end
+
+            it 'updates the other list' do
+              t = Time.zone.now + 3.days
+              Timecop.freeze(t) do
+                update_item
+                expect(other_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+              end
+            end
+
+            it 'updates the game' do
+              t = Time.zone.now + 3.days
+              Timecop.freeze(t) do
+                update_item
+                expect(game.reload.updated_at).to be_within(0.005.seconds).of(t)
+              end
+            end
+
             it 'returns status 200' do
               update_item
               expect(response.status).to eq 200
             end
 
-            it 'returns all items that were changed' do
+            it "returns all the game's shopping lists" do
               update_item
-              expect(JSON.parse(response.body)).to eq(JSON.parse([aggregate_list_item, other_item.reload, list_item.reload].to_json))
+              expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
             end
           end
         end

--- a/spec/requests/shopping_list_items_spec.rb
+++ b/spec/requests/shopping_list_items_spec.rb
@@ -45,17 +45,21 @@ RSpec.describe 'ShoppingListItems', type: :request do
               expect(response.status).to eq 201
             end
 
-            it 'returns all shopping lists for the same game' do
+            it 'returns all changed shopping lists for the same game' do
               create_item
-              expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
+              expect(response.body).to eq(game.shopping_lists.to_json)
             end
           end
 
           context 'when there is an existing matching item on another list' do
-            let(:other_list) { create(:shopping_list, game: aggregate_list.game) }
+            let(:other_list) { create(:shopping_list, game:) }
             let!(:other_item) { create(:shopping_list_item, list: other_list, description: 'Corundum ingot', quantity: 2) }
 
             before do
+              # This list has nothing to do with things and should not be included in the
+              # response bodies.
+              create(:shopping_list, game:)
+
               aggregate_list.add_item_from_child_list(other_item)
             end
 
@@ -77,9 +81,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
                 expect(response.status).to eq 201
               end
 
-              it 'returns all shopping lists from the same game' do
+              it 'returns all changed shopping lists from the same game' do
                 create_item
-                expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
+                expect(response.body).to eq(game.shopping_lists.where(id: [aggregate_list.id, shopping_list.id]).to_json)
               end
             end
 
@@ -108,9 +112,14 @@ RSpec.describe 'ShoppingListItems', type: :request do
                 expect(response.status).to eq 201
               end
 
-              it 'returns all shopping lists for the same game' do
+              it 'returns all changed shopping lists for the same game' do
                 create_item
-                expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
+                expect(response.body).to eq(
+                  game
+                    .shopping_lists
+                    .where(id: [aggregate_list.id, shopping_list.id, other_list.id])
+                    .to_json,
+                )
               end
             end
           end
@@ -122,6 +131,10 @@ RSpec.describe 'ShoppingListItems', type: :request do
           let!(:list_item) { create(:shopping_list_item, list: shopping_list, description: 'Corundum ingot', quantity: 3) }
 
           before do
+            # This list has nothing to do with things and should not be included in the
+            # response bodies.
+            create(:shopping_list, game:)
+
             aggregate_list.add_item_from_child_list(other_item)
             aggregate_list.add_item_from_child_list(list_item)
           end
@@ -147,9 +160,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
               expect(response.status).to eq 200
             end
 
-            it 'returns all shopping lists for the same game' do
+            it 'returns all changed shopping lists for the same game' do
               create_item
-              expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
+              expect(response.body).to eq(game.shopping_lists.where(id: [aggregate_list.id, shopping_list.id]).to_json)
             end
           end
 
@@ -184,9 +197,14 @@ RSpec.describe 'ShoppingListItems', type: :request do
               expect(response.status).to eq 200
             end
 
-            it 'returns all shopping lists for the same game' do
+            it 'returns all changed shopping lists for the same game' do
               create_item
-              expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
+              expect(response.body).to eq(
+                game
+                  .shopping_lists
+                  .where(id: [aggregate_list.id, shopping_list.id, other_list.id])
+                  .to_json,
+              )
             end
           end
         end
@@ -374,7 +392,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
           it "returns all the game's shopping lists" do
             update_item
-            expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
+            expect(response.body).to eq(game.shopping_lists.to_json)
           end
         end
 
@@ -433,7 +451,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
             it "returns all the game's shopping lists" do
               update_item
-              expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
+              expect(response.body).to eq(game.shopping_lists.to_json)
             end
           end
 
@@ -497,7 +515,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
             it "returns all the game's shopping lists" do
               update_item
-              expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
+              expect(response.body).to eq(game.shopping_lists.to_json)
             end
           end
         end
@@ -699,7 +717,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
           it "returns all the game's shopping lists" do
             update_item
-            expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
+            expect(response.body).to eq(game.shopping_lists.to_json)
           end
         end
 
@@ -758,7 +776,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
             it "returns all the game's shopping lists" do
               update_item
-              expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
+              expect(response.body).to eq(game.shopping_lists.to_json)
             end
           end
 
@@ -822,7 +840,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
             it "returns all the game's shopping lists" do
               update_item
-              expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
+              expect(response.body).to eq(game.shopping_lists.to_json)
             end
           end
         end
@@ -1023,7 +1041,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
           it 'returns an empty response' do
             destroy_item
-            expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
+            expect(response.body).to eq(game.shopping_lists.to_json)
           end
         end
 
@@ -1083,7 +1101,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
           it "returns all the game's shopping lists" do
             destroy_item
-            expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
+            expect(response.body).to eq(game.shopping_lists.to_json)
           end
         end
       end

--- a/spec/requests/shopping_list_items_spec.rb
+++ b/spec/requests/shopping_list_items_spec.rb
@@ -416,9 +416,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
             expect(response.status).to eq 200
           end
 
-          it "returns all the game's shopping lists" do
+          it 'returns the modified shopping list items' do
             update_item
-            expect(response.body).to eq(game.shopping_lists.to_json)
+            expect(response.body).to eq([aggregate_list_item, list_item.reload].to_json)
           end
         end
 
@@ -475,9 +475,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
               expect(response.status).to eq 200
             end
 
-            it "returns all the game's shopping lists" do
+            it 'returns the two modified list items' do
               update_item
-              expect(response.body).to eq(game.shopping_lists.to_json)
+              expect(response.body).to eq([aggregate_list_item, list_item.reload].to_json)
             end
           end
 
@@ -539,9 +539,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
               expect(response.status).to eq 200
             end
 
-            it "returns all the game's shopping lists" do
+            it 'returns all the modified list items' do
               update_item
-              expect(response.body).to eq(game.shopping_lists.to_json)
+              expect(response.body).to eq([aggregate_list_item, other_item.reload, list_item.reload].to_json)
             end
           end
         end
@@ -741,9 +741,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
             expect(response.status).to eq 200
           end
 
-          it "returns all the game's shopping lists" do
+          it 'returns the modified shopping list items' do
             update_item
-            expect(response.body).to eq(game.shopping_lists.to_json)
+            expect(response.body).to eq([aggregate_list_item, list_item.reload].to_json)
           end
         end
 
@@ -800,9 +800,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
               expect(response.status).to eq 200
             end
 
-            it "returns all the game's shopping lists" do
+            it 'returns the two modified list items' do
               update_item
-              expect(response.body).to eq(game.shopping_lists.to_json)
+              expect(response.body).to eq([aggregate_list_item, list_item.reload].to_json)
             end
           end
 
@@ -864,9 +864,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
               expect(response.status).to eq 200
             end
 
-            it "returns all the game's shopping lists" do
+            it 'returns all the modified list items' do
               update_item
-              expect(response.body).to eq(game.shopping_lists.to_json)
+              expect(response.body).to eq([aggregate_list_item, other_item.reload, list_item.reload].to_json)
             end
           end
         end

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -777,14 +777,14 @@ RSpec.describe 'ShoppingLists', type: :request do
               .to change(game.shopping_lists, :count).from(2).to(0)
           end
 
-          it 'returns status 204' do
+          it 'returns status 200' do
             delete_shopping_list
-            expect(response.status).to eq 204
+            expect(response.status).to eq 200
           end
 
-          it "doesn't return any data" do
+          it 'returns an empty response body' do
             delete_shopping_list
-            expect(response.body).to be_blank
+            expect(response.body).to eq [].to_json
           end
         end
 
@@ -803,9 +803,9 @@ RSpec.describe 'ShoppingLists', type: :request do
             expect(response.status).to eq 200
           end
 
-          it 'returns the aggregate list in the body' do
+          it "returns the game's remaining shopping lists" do
             delete_shopping_list
-            expect(response.body).to eq(game.aggregate_shopping_list.to_json)
+            expect(response.body).to eq(game.shopping_lists.index_order.to_json)
           end
         end
       end

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -29,9 +29,9 @@ RSpec.describe 'ShoppingLists', type: :request do
               .to change(game.shopping_lists, :count).from(0).to(2) # because of the aggregate list
           end
 
-          it 'returns the aggregate list as well as the new list' do
+          it 'returns all shopping lists for that game' do
             create_shopping_list
-            expect(response.body).to eq([game.aggregate_shopping_list, game.shopping_lists.last].to_json)
+            expect(response.body).to eq(game.shopping_lists.index_order.to_json)
           end
 
           it 'returns status 201' do
@@ -48,9 +48,14 @@ RSpec.describe 'ShoppingLists', type: :request do
               .to change(game.shopping_lists, :count).from(1).to(2)
           end
 
-          it 'returns only the newly created list' do
+          it 'returns all shopping lists for that game' do
             create_shopping_list
-            expect(response.body).to eq(game.shopping_lists.last.to_json)
+            expect(response.body).to eq(game.shopping_lists.index_order.to_json)
+          end
+
+          it 'returns status 201' do
+            create_shopping_list
+            expect(response.status).to eq 201
           end
         end
 
@@ -69,8 +74,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
           it 'creates the shopping list with a default title' do
             create_shopping_list
-            list_attributes = JSON.parse(response.body)
-            expect(list_attributes['title']).to eq 'My List 1'
+            expect(game.shopping_lists.last.title).to eq 'My List 1'
           end
         end
       end

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'ShoppingLists', type: :request do
               .to change(game.shopping_lists, :count).from(0).to(2) # because of the aggregate list
           end
 
-          it 'returns all shopping lists for that game' do
+          it 'returns both shopping lists' do
             create_shopping_list
             expect(response.body).to eq(game.shopping_lists.index_order.to_json)
           end
@@ -41,16 +41,18 @@ RSpec.describe 'ShoppingLists', type: :request do
         end
 
         context 'when only the new shopping list has been created' do
-          let!(:aggregate_list) { create(:aggregate_shopping_list, game:, created_at: 2.seconds.ago, updated_at: 2.seconds.ago) }
+          before do
+            create(:shopping_list, game:)
+          end
 
           it 'creates one list' do
             expect { create_shopping_list }
-              .to change(game.shopping_lists, :count).from(1).to(2)
+              .to change(game.shopping_lists, :count).from(2).to(3)
           end
 
-          it 'returns all shopping lists for that game' do
+          it 'returns only the created list' do
             create_shopping_list
-            expect(response.body).to eq(game.shopping_lists.index_order.to_json)
+            expect(response.body).to eq([game.shopping_lists.unscoped.last].to_json)
           end
 
           it 'returns status 201' do

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -176,7 +176,9 @@ RSpec.describe 'ShoppingLists', type: :request do
   end
 
   describe 'PUT /shopping_lists/:id' do
-    subject(:update_shopping_list) { put "/shopping_lists/#{list_id}", params: { shopping_list: { title: 'Severin Manor' } }.to_json, headers: }
+    subject(:update_shopping_list) { put "/shopping_lists/#{list_id}", params:, headers: }
+
+    let(:params) { { shopping_list: { title: 'Severin Manor' } }.to_json }
 
     context 'when authenticated' do
       let!(:user) { create(:authenticated_user) }
@@ -190,22 +192,90 @@ RSpec.describe 'ShoppingLists', type: :request do
         let(:game) { create(:game, user:) }
         let(:list_id) { shopping_list.id }
 
-        it 'updates the title' do
-          update_shopping_list
-          expect(shopping_list.reload.title).to eq 'Severin Manor'
+        context 'when the request body sets a valid title' do
+          it 'updates the title' do
+            update_shopping_list
+            expect(shopping_list.reload.title).to eq 'Severin Manor'
+          end
+
+          it 'returns the updated list' do
+            update_shopping_list
+            # This ugly hack is needed because if we don't parse the JSON, it'll make an error
+            # if everything isn't in the exact same order, but if we just use shopping_list.attributes
+            # it won't include the list_items. Ugly.
+            expect(JSON.parse(response.body)).to eq(JSON.parse(shopping_list.reload.to_json))
+          end
+
+          it 'returns status 200' do
+            update_shopping_list
+            expect(response.status).to eq 200
+          end
         end
 
-        it 'returns the updated list' do
-          update_shopping_list
-          # This ugly hack is needed because if we don't parse the JSON, it'll make an error
-          # if everything isn't in the exact same order, but if we just use shopping_list.attributes
-          # it won't include the list_items. Ugly.
-          expect(JSON.parse(response.body)).to eq(JSON.parse(shopping_list.reload.to_json))
+        context 'when the params include a null title' do
+          let(:params) { { shopping_list: { title: nil } }.to_json }
+
+          it 'sets a default title' do
+            update_shopping_list
+            expect(shopping_list.reload.title).to eq 'My List 1'
+          end
+
+          it 'returns the updated list' do
+            update_shopping_list
+            # This ugly hack is needed because if we don't parse the JSON, it'll make an error
+            # if everything isn't in the exact same order, but if we just use shopping_list.attributes
+            # it won't include the list_items. Ugly.
+            expect(JSON.parse(response.body)).to eq(JSON.parse(shopping_list.reload.to_json))
+          end
+
+          it 'returns status 200' do
+            update_shopping_list
+            expect(response.status).to eq 200
+          end
         end
 
-        it 'returns status 200' do
-          update_shopping_list
-          expect(response.status).to eq 200
+        context 'when the "shopping_list" param is empty"' do
+          let(:params) { { shopping_list: {} }.to_json }
+
+          it "doesn't change the attributes" do
+            expect { update_shopping_list }
+              .not_to change(shopping_list.reload, :attributes)
+          end
+
+          it 'returns the updated list' do
+            update_shopping_list
+            # This ugly hack is needed because if we don't parse the JSON, it'll make an error
+            # if everything isn't in the exact same order, but if we just use shopping_list.attributes
+            # it won't include the list_items. Ugly.
+            expect(JSON.parse(response.body)).to eq(JSON.parse(shopping_list.reload.to_json))
+          end
+
+          it 'returns status 200' do
+            update_shopping_list
+            expect(response.status).to eq 200
+          end
+        end
+
+        context 'when there is no request body"' do
+          let(:params) { nil }
+
+          it "doesn't change the attributes" do
+            expect { update_shopping_list }
+              .not_to change(shopping_list.reload, :attributes)
+          end
+
+          it 'returns the updated list' do
+            update_shopping_list
+            # This ugly hack is needed because if we don't parse the JSON, it'll make an error
+            # if everything isn't in the exact same order, but if we just use shopping_list.attributes
+            # it won't include the list_items. Ugly.
+            expect(JSON.parse(response.body)).to eq(JSON.parse(shopping_list.reload.to_json))
+          end
+
+          it 'returns status 200' do
+            update_shopping_list
+            expect(response.status).to eq 200
+          end
         end
       end
 
@@ -354,7 +424,9 @@ RSpec.describe 'ShoppingLists', type: :request do
   end
 
   describe 'PATCH /shopping_lists/:id' do
-    subject(:update_shopping_list) { patch "/shopping_lists/#{list_id}", params: { shopping_list: { title: 'Severin Manor' } }.to_json, headers: }
+    subject(:update_shopping_list) { patch "/shopping_lists/#{list_id}", params:, headers: }
+
+    let(:params) { { shopping_list: { title: 'Severin Manor' } }.to_json }
 
     context 'when authenticated' do
       let!(:user) { create(:authenticated_user) }
@@ -368,22 +440,90 @@ RSpec.describe 'ShoppingLists', type: :request do
         let(:game) { create(:game, user:) }
         let(:list_id) { shopping_list.id }
 
-        it 'updates the title' do
-          update_shopping_list
-          expect(shopping_list.reload.title).to eq 'Severin Manor'
+        context 'when the request body sets a valid title' do
+          it 'updates the title' do
+            update_shopping_list
+            expect(shopping_list.reload.title).to eq 'Severin Manor'
+          end
+
+          it 'returns the updated list' do
+            update_shopping_list
+            # This ugly hack is needed because if we don't parse the JSON, it'll make an error
+            # if everything isn't in the exact same order, but if we just use shopping_list.attributes
+            # it won't include the list_items. Ugly.
+            expect(JSON.parse(response.body)).to eq(JSON.parse(shopping_list.reload.to_json))
+          end
+
+          it 'returns status 200' do
+            update_shopping_list
+            expect(response.status).to eq 200
+          end
         end
 
-        it 'returns the updated list' do
-          update_shopping_list
-          # This ugly hack is needed because if we don't parse the JSON, it'll make an error
-          # if everything isn't in the exact same order, but if we just use shopping_list.attributes
-          # it won't include the list_items. Ugly.
-          expect(JSON.parse(response.body)).to eq(JSON.parse(shopping_list.reload.to_json))
+        context 'when the params include a null title' do
+          let(:params) { { shopping_list: { title: nil } }.to_json }
+
+          it 'sets a default title' do
+            update_shopping_list
+            expect(shopping_list.reload.title).to eq 'My List 1'
+          end
+
+          it 'returns the updated list' do
+            update_shopping_list
+            # This ugly hack is needed because if we don't parse the JSON, it'll make an error
+            # if everything isn't in the exact same order, but if we just use shopping_list.attributes
+            # it won't include the list_items. Ugly.
+            expect(JSON.parse(response.body)).to eq(JSON.parse(shopping_list.reload.to_json))
+          end
+
+          it 'returns status 200' do
+            update_shopping_list
+            expect(response.status).to eq 200
+          end
         end
 
-        it 'returns status 200' do
-          update_shopping_list
-          expect(response.status).to eq 200
+        context 'when the "shopping_list" param is empty"' do
+          let(:params) { { shopping_list: {} }.to_json }
+
+          it "doesn't change the attributes" do
+            expect { update_shopping_list }
+              .not_to change(shopping_list.reload, :attributes)
+          end
+
+          it 'returns the updated list' do
+            update_shopping_list
+            # This ugly hack is needed because if we don't parse the JSON, it'll make an error
+            # if everything isn't in the exact same order, but if we just use shopping_list.attributes
+            # it won't include the list_items. Ugly.
+            expect(JSON.parse(response.body)).to eq(JSON.parse(shopping_list.reload.to_json))
+          end
+
+          it 'returns status 200' do
+            update_shopping_list
+            expect(response.status).to eq 200
+          end
+        end
+
+        context 'when there is no request body"' do
+          let(:params) { nil }
+
+          it "doesn't change the attributes" do
+            expect { update_shopping_list }
+              .not_to change(shopping_list.reload, :attributes)
+          end
+
+          it 'returns the updated list' do
+            update_shopping_list
+            # This ugly hack is needed because if we don't parse the JSON, it'll make an error
+            # if everything isn't in the exact same order, but if we just use shopping_list.attributes
+            # it won't include the list_items. Ugly.
+            expect(JSON.parse(response.body)).to eq(JSON.parse(shopping_list.reload.to_json))
+          end
+
+          it 'returns status 200' do
+            update_shopping_list
+            expect(response.status).to eq 200
+          end
         end
       end
 


### PR DESCRIPTION
## TODO

- [x] Remove feature branch from CI
- [x] Full QA with front end prior to deploy

## Context

[**Rewrite Shopping Lists page**](https://trello.com/c/oBVGCwU1/232-rewrite-shopping-lists-page)

We have reached the stage of our frontend rewrite where we are able to begin reimplementing the shopping lists page. In order to do this, we'd like to simplify response bodies from the back end to reduce the need for complex conditionals in front end response handlers.

## Constituent Cards and PRs

### [Return all shopping lists from POST /games/:game_id/shopping_lists endpoint](https://trello.com/c/KsAdkOZI/257-return-all-shopping-lists-from-post-games-gameid-shoppinglists-endpoint)

Superseded by #154

- [x] ~~**[Return all shopping lists from shopping list creation endpoint](https://github.com/danascheider/skyrim_inventory_management/pull/147) [merged]:** Ensure that the `POST /games/:game_id/shopping_lists` endpoint returns all shopping lists for the specified game~~

### [Return all shopping lists from PUT|PATCH /shopping_lists/:id endpoint](https://trello.com/c/yayXE42G/256-return-all-shopping-lists-from-putpatch-shoppinglists-id-endpoint)

- [x] **[Add request specs for PUT|PATCH /shopping_lists/:id endpoint](https://github.com/danascheider/skyrim_inventory_management/pull/149) [merged]:** Contrary to the name of the card, only adds some specs and beefs up API docs a bit

### [Return all shopping lists from DELETE /shopping_lists/:id endpoint](https://trello.com/c/nb0KVUOv/258-return-all-shopping-lists-from-delete-shoppinglists-id-endpoint)

Superseded by #155

- [x] ~~**[Return all remaining shopping lists from DELETE /shopping_lists/:id endpoint](https://github.com/danascheider/skyrim_inventory_management/pull/150) [merged]:** Does what the title says~~

### [Return all shopping lists from POST /shopping_lists/:list_id/list_items endpoint](https://trello.com/c/WwXZRisC/259-return-all-shopping-lists-from-post-shoppinglists-listid-listitems-endpoint)

Superseded by #156

- [x] ~~**[Return all shopping lists from POST /shopping_lists/:list_id/list_items endpoint](https://github.com/danascheider/skyrim_inventory_management/pull/151) [merged]:** Ensure all of a game's shopping lists are returned when a list item is created (or updated via a POST request) on one of the lists~~

### [Return all shopping lists from PUT|PATCH /shopping_list_items/:id endpoint](https://trello.com/c/mGo0xf6i/260-return-all-shopping-lists-from-putpatch-shoppinglistitems-id-endpoint)

Superseded by #159

- [x] ~~**[Return all of a game's shopping lists when updating list items](https://github.com/danascheider/skyrim_inventory_management/pull/152):** Return all of a game's shopping lists in success responses from the `PUT|PATCH /shopping_list_items/:id` endpoint~~

### [Return all shopping lists from DELETE /shopping_list_items/:id endpoint](https://trello.com/c/1Vo9TcMe/261-return-all-shopping-lists-from-delete-shoppinglistitems-id-endpoint)

Superseded by #158

- [x] ~~**[Return all of a game's shopping lists from the list item deletion endpoint](https://github.com/danascheider/skyrim_inventory_management/pull/153) [merged]:** Return all of a game's shopping lists from the list item deletion endpoint on a successful response~~

### [Return only created shopping lists from creation endpoint](https://trello.com/c/fFvysZ4Q/263-return-only-created-shopping-lists-from-creation-endpoint)

- [x] **[Return only created shopping lists from creation endpoint](https://github.com/danascheider/skyrim_inventory_management/pull/154) [merged]:** Supersedes #147, ensuring only newly created shopping lists are returned from the creation endpoint instead of all shopping lists

### [Return IDs of deleted lists from DELETE /shopping_lists/:id endpoint](https://trello.com/c/611KOMJq/264-return-ids-of-deleted-lists-from-delete-shoppinglists-id-endpoint)

- [x] **[Return IDs of deleted lists from DELETE /shopping_lists/:id endpoint](https://github.com/danascheider/skyrim_inventory_management/pull/155) [merged]:** Supersedes #150, changing the shape of the response body returned on a success response from the shopping list deletion endpoint

### [Fix bug unsetting unit weights](https://trello.com/c/WvDvo4uD/270-fix-bug-unsetting-unit-weights)

- [x] **[Fix bug unsetting unit weights](https://github.com/danascheider/skyrim_inventory_management/pull/160) [merged]:** Enable unit weights to be set to `nil` for aggregatable list items

### No Cards

- [x] **[Return only changed shopping lists from list item creation endpoint](https://github.com/danascheider/skyrim_inventory_management/pull/156) [merged]:** Supersedes #151, changing the shape of the response body returned on a success response from the shopping list item creation endpoint
- [x] **[Fix bug where aggregate list not returned from item creation endpoint](https://github.com/danascheider/skyrim_inventory_management/pull/157) [merged]:** Fix bug in #156 preventing aggregate list from being returned as a changed list
- [x] **[Modify response bodies for DELETE /shopping_list_items/:id endpoint](https://github.com/danascheider/skyrim_inventory_management/pull/158) [merged]:** Supersedes #153, returning only modified shopping lists from the shopping list item deletion endpoint
- [x] **[Return all modified shopping list items from the shopping list item update endpoint](https://github.com/danascheider/skyrim_inventory_management/pull/159) [merged]:** Supersedes #152, returning only modified shopping list _items_ from the shopping list item update endpoint