### PR TITLE
Return all remaining shopping lists from DELETE /shopping_lists/:id endpoint

### DIFF
--- a/docs/api/resources/shopping-lists.md
+++ b/docs/api/resources/shopping-lists.md
@@ -495,7 +495,7 @@ Body including an aggregate list and an additional list that was not destroyed:
     "user_id": 16,
     "aggregate": false,
     "aggregate_list_id": 834,
-    "title": "All Items",
+    "title": "Vlindrel Hall",
     "created_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00",
     "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
     "list_items": [

--- a/docs/api/resources/shopping-lists.md
+++ b/docs/api/resources/shopping-lists.md
@@ -446,7 +446,7 @@ A 500 error response, which is always a result of an unforeseen problem, include
 
 ## DELETE /shopping_lists/:id
 
-Destroys the given shopping list, and any shopping list items on it, if it exists and belongs to the authenticated user. If the list to be destroyed is the user's only regular (non-aggregate) shopping list, the aggregate list will also be destroyed.
+Destroys the given shopping list, and any shopping list items on it, if it exists and belongs to the authenticated user. If the list to be destroyed is the user's only regular (non-aggregate) shopping list, the aggregate list will also be destroyed. The response body will include any remaining shopping lists belonging to the game to which the requested list belongs.
 
 ### Example Request
 
@@ -459,34 +459,65 @@ Authorization: Bearer xxxxxxxxxxxx
 
 #### Statuses
 
-* 204 No Content
 * 200 OK
 
-#### Example Body
+#### Example Bodies
 
-If the resource deleted was the user's last regular list, the aggregate list will also be destroyed and no content will be returned in the response. If the user had at least one other regular list (as well as an aggregate list), then the aggregate list will be returned with its values updated to reflect removal of the items on the list that was deleted.
+The response body will be an array of any remaining shopping lists belonging to the same game as the destroyed list(s).
+
+Body including an aggregate list and an additional list that was not destroyed:
 
 ```json
-{
-  "id": 834,
-  "user_id": 16,
-  "aggregate": true,
-  "title": "All Items",
-  "created_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00",
-  "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-  "list_items": [
-    {
-      "id": 32,
-      "list_id": 834,
-      "description": "Ebony sword",
-      "quantity": 1,
-      "notes": "To enchant with Soul Trap",
-      "unit_weight": 14.0,
-      "created_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00",
-      "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
-    }
-  ]
-}
+[
+  {
+    "id": 834,
+    "user_id": 16,
+    "aggregate": true,
+    "aggregate_list_id": null,
+    "title": "All Items",
+    "created_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00",
+    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "list_items": [
+      {
+        "id": 32,
+        "list_id": 834,
+        "description": "Ebony sword",
+        "quantity": 1,
+        "notes": "To enchant with Soul Trap",
+        "unit_weight": 14.0,
+        "created_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      }
+    ]
+  },
+  {
+    "id": 835,
+    "user_id": 16,
+    "aggregate": false,
+    "aggregate_list_id": 834,
+    "title": "All Items",
+    "created_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00",
+    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "list_items": [
+      {
+        "id": 31,
+        "list_id": 835,
+        "description": "Ebony sword",
+        "quantity": 1,
+        "notes": "To enchant with Soul Trap",
+        "unit_weight": 14.0,
+        "created_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      }
+    ]
+  }
+]
+```
+
+Empty body indicating aggregate list was also destroyed:
+
+```json
+[]
 ```
 
 ### Error Responses
@@ -504,6 +535,7 @@ If the specified list does not exist or does not belong to the authenticated use
 For a 404 response, no response body will be returned.
 
 For a 405 response:
+
 ```json
 {
   "errors": ["Cannot manually delete an aggregate shopping list"]
@@ -511,6 +543,7 @@ For a 405 response:
 ```
 
 A 500 error response, which is always a result of an unforeseen problem, includes the error message:
+
 ```json
 {
   "errors": ["Something went horribly wrong"]

--- a/spec/controller_services/shopping_lists_controller/destroy_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/destroy_service_spec.rb
@@ -18,10 +18,14 @@ RSpec.describe ShoppingListsController::DestroyService do
       let(:game) { create(:game, user:) }
 
       context 'when the game has additional regular lists' do
-        let!(:third_list) { create(:shopping_list, game:, aggregate_list:) }
+        let!(:third_list) { create(:shopping_list_with_list_items, game:, aggregate_list:) }
 
         before do
           shopping_list.list_items.each do |list_item|
+            aggregate_list.add_item_from_child_list(list_item)
+          end
+
+          third_list.list_items.each do |list_item|
             aggregate_list.add_item_from_child_list(list_item)
           end
         end
@@ -43,8 +47,8 @@ RSpec.describe ShoppingListsController::DestroyService do
           expect(perform).to be_a(Service::OKResult)
         end
 
-        it 'sets the resource as the aggregate list' do
-          expect(perform.resource).to eq aggregate_list
+        it "sets the resources as the game's remaining lists" do
+          expect(perform.resource).to eq game.shopping_lists.index_order
         end
 
         describe 'updating the aggregate list' do
@@ -92,8 +96,12 @@ RSpec.describe ShoppingListsController::DestroyService do
           end
         end
 
-        it 'returns a Service::NoContentResult' do
-          expect(perform).to be_a(Service::NoContentResult)
+        it 'returns a Service::OKResult' do
+          expect(perform).to be_a(Service::OKResult)
+        end
+
+        it 'returns an empty resource body' do
+          expect(perform.resource).to eq []
         end
       end
     end

--- a/spec/controller_services/shopping_lists_controller/destroy_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/destroy_service_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe ShoppingListsController::DestroyService do
           expect(perform).to be_a(Service::OKResult)
         end
 
-        it "sets the resources as the game's remaining lists" do
+        it "sets the resource as the game's remaining lists" do
           expect(perform.resource).to eq game.shopping_lists.index_order
         end
 

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -777,14 +777,14 @@ RSpec.describe 'ShoppingLists', type: :request do
               .to change(game.shopping_lists, :count).from(2).to(0)
           end
 
-          it 'returns status 204' do
+          it 'returns status 200' do
             delete_shopping_list
-            expect(response.status).to eq 204
+            expect(response.status).to eq 200
           end
 
-          it "doesn't return any data" do
+          it 'returns an empty response body' do
             delete_shopping_list
-            expect(response.body).to be_blank
+            expect(response.body).to eq [].to_json
           end
         end
 
@@ -803,9 +803,9 @@ RSpec.describe 'ShoppingLists', type: :request do
             expect(response.status).to eq 200
           end
 
-          it 'returns the aggregate list in the body' do
+          it "returns the game's remaining shopping lists" do
             delete_shopping_list
-            expect(response.body).to eq(game.aggregate_shopping_list.to_json)
+            expect(response.body).to eq(game.shopping_lists.index_order.to_json)
           end
         end
       end


### PR DESCRIPTION
## Context

[**Return all shopping lists from DELETE /shopping_lists/:id endpoint**](https://trello.com/c/nb0KVUOv/258-return-all-shopping-lists-from-delete-shoppinglists-id-endpoint)

We're trying to simplify API response bodies so the front end doesn't require as much conditional logic to handle them. One part of this is changing the shopping list deletion endpoint so that, instead of a possible 204 response, it always returns a 200 response with an array of any remaining shopping lists belonging to the same game.

## Changes

* Return a uniform response including all remaining shopping lists belonging to the same game when a shopping list is destroyed
* Update tests
* Update API docs

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate
