### PR TITLE
Return all shopping lists from POST /shopping_lists/:list_id/list_items endpoint

### DIFF
--- a/app/controller_services/shopping_list_items_controller/create_service.rb
+++ b/app/controller_services/shopping_list_items_controller/create_service.rb
@@ -27,17 +27,13 @@ class ShoppingListItemsController < ApplicationController
         item.save!
 
         if preexisting_item.blank?
-          aggregate_list_item = aggregate_list.add_item_from_child_list(item)
+          aggregate_list.add_item_from_child_list(item)
 
-          resource = params[:unit_weight] ? all_matching_list_items : [aggregate_list_item, item]
-
-          Service::CreatedResult.new(resource:)
+          Service::CreatedResult.new(resource: shopping_list.game.shopping_lists.index_order)
         else
-          aggregate_list_item = aggregate_list.update_item_from_child_list(params[:description], params[:quantity], params[:unit_weight], nil, params[:notes])
+          aggregate_list.update_item_from_child_list(params[:description], params[:quantity], params[:unit_weight], nil, params[:notes])
 
-          resource = params[:unit_weight] ? all_matching_list_items : [aggregate_list_item, item]
-
-          Service::OKResult.new(resource:)
+          Service::OKResult.new(resource: shopping_list.game.shopping_lists.index_order)
         end
       end
     rescue ActiveRecord::RecordInvalid

--- a/app/controller_services/shopping_lists_controller/destroy_service.rb
+++ b/app/controller_services/shopping_lists_controller/destroy_service.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'service/no_content_result'
 require 'service/method_not_allowed_result'
 require 'service/not_found_result'
 require 'service/ok_result'

--- a/docs/api/resources/shopping-list-items.md
+++ b/docs/api/resources/shopping-list-items.md
@@ -1,6 +1,6 @@
 # Shopping List Items
 
-Shopping list items represent the items on a [shopping list](/docs/api/resources/shopping-lists.md). Shopping list items on regular lists can be created, updated, and destroyed through the API. Shopping list items on aggregate shopping lists are managed automatically as the items on their other lists change. Each shopping list item belongs to a particular list and will be destroyed if the list is destroyed.
+Shopping list items represent the items on a [shopping list](/docs/api/resources/shopping-lists.md). Shopping list items on regular lists can be created, updated, and destroyed through the API. Shopping list items on aggregate shopping lists are managed automatically as the items on their child lists change. Each shopping list item belongs to a particular list and will be destroyed if the list is destroyed.
 
 There are no read routes (`GET /shopping_list_items`, `GET /shopping_list/:shopping_list_id/shopping_list_items`, or `GET /shopping_list_items/:id`) for shopping list items since all shopping list items are returned with the lists they are on when requests are made to the list routes. There are, however, routes to create, update, and destroy shopping list items.
 
@@ -8,7 +8,7 @@ All requests to shopping list item endpoints must be [authenticated](/docs/api/r
 
 ## Automatically Managed Aggregate Lists
 
-Skyrim Inventory Management makes use of automatically managed aggregate lists to help users track an aggregate of what items they need for different properties in each game. The aggregate list is created automatically when the client creates a the first regular shopping list for a game, and is destroyed automatically when the client deletes the game's last regular shopping list. When items are added, updated, or destroyed from any of a game's regular lists, aggregate list items are updated as described in this section.
+Skyrim Inventory Management makes use of automatically managed aggregate lists to help users track an aggregate of what items they need for different properties or purposes in each game. The aggregate list is created automatically when the client creates a the first regular shopping list for a game, and is destroyed automatically when the client deletes the game's last regular shopping list. When items are added, updated, or destroyed from any of a game's regular lists, aggregate list items are updated as described in this section.
 
 (Ensuring automatic management of aggregate lists does require some work on the part of SIM developers. If you are working on lists in SIM and would like information on how to keep them synced, head over to the [`Aggregatable` docs](/docs/aggregate-lists.md).)
 
@@ -70,7 +70,7 @@ Allowed fields are:
 * `notes` (string, optional): Any notes about the item or what it is for
 * `unit_weight` (decimal, optional): The unit weight of the item as given in the game, precise to one decimal place
 
-A successful response will return a JSON array of any items created or updated while handling the request. These may come in any order and will include the item requested, the aggregate list item, and, if `unit_weight` is given in the request, any other items with the same description belonging to the same game that have had their `unit_weight` changed.
+A successful response will return a JSON array of all shopping lists for the game to which the created or updated list item ultimately belongs, including all the list items on each list.
 
 ### Example Request
 
@@ -96,28 +96,87 @@ Content-Type: application/json
 
 If there is no item with a matching description on the requested shopping list, a new item will be created and the server will return a 201 response. If there is an item with a matching description, its notes and quantity will be combined with the notes and quantity in the client request and a 200 response will be returned.
 
-The body for both responses is a JSON array containing all list items that were created or updated while handling the request, including the requested item, the corresponding aggregate list item, and, if setting `unit_weight`, any other list items with the same description belonging to the same game.
+The body for both responses is a JSON array containing all shopping lists for the game to which the created or updated list item ultimately belongs. Each shopping list includes its list items.
+
 ```json
 [
   {
-    "id": 87,
-    "list_id": 238,
-    "description": "Ebony sword",
-    "quantity": 9,
-    "unit_weight": 14.0,
-    "notes": "To sell -- To enchant with 'Absorb Health'",
+    "id": 43,
+    "game_id": 8234,
+    "aggregate": true,
+    "aggregate_list_id": null,
+    "title": "All Items",
     "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "updated_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00"
+    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "list_items": [
+      {
+        "list_id": 43,
+        "description": "Unenchanted ebony sword",
+        "quantity": 1,
+        "notes": "Need an unenchanted sword to start Companions questline",
+        "unit_weight": null,
+        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      },
+      {
+        "list_id": 43,
+        "description": "Iron ingot",
+        "quantity": 4,
+        "notes": "3 locks -- 2 hinges",
+        "unit_weight": 1.0,
+        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      }
+    ]
   },
   {
-    "id": 126,
-    "list_id": 237,
-    "description": "Ebony sword",
-    "quantity": 7,
-    "unit_weight": 14.0,
-    "notes": "To enchant with 'Absorb Health'",
-    "created_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00",
-    "updated_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00"
+    "id": 46,
+    "game_id": 8234,
+    "aggregate": false,
+    "aggregate_list_id": 43,
+    "title": "Lakeview Manor",
+    "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "list_items": [
+      {
+        "list_id": 46,
+        "description": "Unenchanted ebony sword",
+        "quantity": 1,
+        "notes": "Need an unenchanted sword to start Companions questline",
+        "unit_weight": null,
+        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      },
+      {
+        "list_id": 46,
+        "description": "Iron ingot",
+        "quantity": 3,
+        "notes": "3 locks",
+        "unit_weight": 1.0,
+        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      }
+    ]
+  },
+  {
+    "id": 52,
+    "game_id": 8234,
+    "aggregate": false,
+    "aggregate_list_id": 43,
+    "title": "Severin Manor",
+    "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "list_items": [
+      {
+        "list_id": 52,
+        "description": "Iron ingot",
+        "quantity": 1,
+        "notes": "2 hinges",
+        "unit_weight": 1.0,
+        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      }
+    ]
   }
 ]
 ```
@@ -140,9 +199,7 @@ No body will be returned with a 404 error, which is returned if the specified sh
 A 405 error, which is returned if the specified shopping list is an aggregate shopping list, comes with the following body:
 ```json
 {
-  "errors": [
-    "Cannot manually manage items on an aggregate shopping list"
-  ]
+  "errors": ["Cannot manually manage items on an aggregate shopping list"]
 }
 ```
 

--- a/docs/api/resources/shopping-lists.md
+++ b/docs/api/resources/shopping-lists.md
@@ -47,12 +47,14 @@ For a game with no lists:
 []
 ```
 For a game with multiple lists:
+
 ```json
 [
   {
     "id": 43,
     "game_id": 8234,
     "aggregate": true,
+    "aggregate_list_id": null,
     "title": "All Items",
     "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
     "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",

--- a/spec/controller_services/shopping_list_items_controller/create_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/create_service_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe ShoppingListItemsController::CreateService do
             expect(perform).to be_a(Service::CreatedResult)
           end
 
-          it 'sets the new and aggregate list items as the resource' do
-            expect(perform.resource).to eq [aggregate_list.list_items.last, shopping_list.list_items.last]
+          it "sets the resource to all the game's shopping lists" do
+            expect(perform.resource).to eq game.shopping_lists.reload.index_order
           end
         end
 
@@ -64,8 +64,8 @@ RSpec.describe ShoppingListItemsController::CreateService do
               expect(perform).to be_a(Service::CreatedResult)
             end
 
-            it 'sets the resource as the aggregate list item and the regular list item' do
-              expect(perform.resource).to eq([aggregate_list.list_items.first, shopping_list.list_items.first])
+            it "sets all the game's shopping lists as the resource" do
+              expect(perform.resource).to eq(game.shopping_lists.reload.index_order)
             end
           end
 
@@ -94,8 +94,8 @@ RSpec.describe ShoppingListItemsController::CreateService do
               expect(perform).to be_a(Service::CreatedResult)
             end
 
-            it 'sets the resource as the all created or changed list items' do
-              expect(perform.resource).to eq([aggregate_list.list_items.first, other_item, shopping_list.list_items.first])
+            it "sets all the game's shopping lists as the resource" do
+              expect(perform.resource).to eq(game.shopping_lists.reload.index_order)
             end
           end
         end
@@ -133,8 +133,8 @@ RSpec.describe ShoppingListItemsController::CreateService do
             expect(perform).to be_a(Service::OKResult)
           end
 
-          it 'returns the requested item and the aggregate list item' do
-            expect(perform.resource).to eq([aggregate_list.list_items.first, list_item.reload])
+          it "sets all the game's shopping lists as the resource" do
+            expect(perform.resource).to eq(game.shopping_lists.reload.index_order)
           end
         end
 
@@ -168,8 +168,8 @@ RSpec.describe ShoppingListItemsController::CreateService do
             expect(perform).to be_a(Service::OKResult)
           end
 
-          it 'returns all the items that have been updated' do
-            expect(perform.resource).to eq [aggregate_list.list_items.first, other_item.reload, list_item.reload]
+          it "sets all the game's shopping lists as the resource" do
+            expect(perform.resource).to eq(game.shopping_lists.reload.index_order)
           end
         end
       end

--- a/spec/requests/shopping_list_items_spec.rb
+++ b/spec/requests/shopping_list_items_spec.rb
@@ -45,9 +45,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
               expect(response.status).to eq 201
             end
 
-            it 'returns the regular list item and the aggregate list item' do
+            it 'returns all shopping lists for the same game' do
               create_item
-              expect(JSON.parse(response.body)).to eq(JSON.parse([aggregate_list.list_items.last, shopping_list.list_items.last].to_json))
+              expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
             end
           end
 
@@ -77,9 +77,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
                 expect(response.status).to eq 201
               end
 
-              it 'returns the aggregate list item and the regular list item' do
+              it 'returns all shopping lists from the same game' do
                 create_item
-                expect(JSON.parse(response.body)).to eq(JSON.parse([aggregate_list.list_items.first, shopping_list.list_items.first].to_json))
+                expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
               end
             end
 
@@ -108,9 +108,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
                 expect(response.status).to eq 201
               end
 
-              it 'returns all items that were created or updated' do
+              it 'returns all shopping lists for the same game' do
                 create_item
-                expect(JSON.parse(response.body)).to eq(JSON.parse([aggregate_list.list_items.first, other_item.reload, shopping_list.list_items.first].to_json))
+                expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
               end
             end
           end
@@ -147,9 +147,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
               expect(response.status).to eq 200
             end
 
-            it 'returns the requested item and the aggregate list item' do
+            it 'returns all shopping lists for the same game' do
               create_item
-              expect(JSON.parse(response.body)).to eq(JSON.parse([aggregate_list.list_items.first, list_item.reload].to_json))
+              expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
             end
           end
 
@@ -184,9 +184,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
               expect(response.status).to eq 200
             end
 
-            it 'returns all items that have been updated' do
+            it 'returns all shopping lists for the same game' do
               create_item
-              expect(JSON.parse(response.body)).to eq(JSON.parse([aggregate_list.list_items.first, other_item.reload, list_item.reload].to_json))
+              expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
             end
           end
         end


### PR DESCRIPTION
## Context

[**Return all shopping lists from POST /shopping_lists/:list_id/list_items endpoint**](https://trello.com/c/WwXZRisC/259-return-all-shopping-lists-from-post-shoppinglists-listid-listitems-endpoint)

The shopping list item and inventory list item operations become very complex. Each request to an endpoint for these resources results in the creation, modification, or deletion of one or more resources other than the one explicitly requested. Currently, response bodies only include records that were created or updated (or `null` values for deleted records), leaving the front end to figure out what to do with these items. This involves digging into the front end's internal list of shopping lists, checking each one for the relevant list items and figuring out which items need to be added, replaced, or removed. This is such complex logic it makes more sense to simply replace the entire shopping lists array with JSON returned from the API.

This PR updates the `POST /shopping_lists/:list_id/list_items` endpoint to return all shopping lists for a given game (and their list items) with its responses, regardless of which specific records were or were not modified. The endpoint still returns a 201 response if a new record was created as a result of the request and a 200 if only existing records were changed.

## Changes

* Ensure the `POST /shopping_lists/:list_id/list_items` endpoint returns all shopping lists for the game to which the requested list belongs (for successful responses, including shopping list items)
* Update RSpec tests
* Update API docs

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

I debated with myself whether it made sense to continue having two different response statuses, given these will likely be ignored by the front end. In the end, autistic perfectionism won out: I couldn't decide if it made more sense to return a 201 response when no resource was created or a 200 response when one was. Consequently, I kept the statuses the same while changing only the response bodies.