### PR TITLE
Return all of a game's shopping lists when updating list items

### DIFF
--- a/app/controller_services/shopping_list_items_controller/update_service.rb
+++ b/app/controller_services/shopping_list_items_controller/update_service.rb
@@ -22,16 +22,13 @@ class ShoppingListItemsController < ApplicationController
       delta_qty = params[:quantity] ? params[:quantity].to_i - list_item.quantity : 0
       old_notes = list_item.notes
 
-      aggregate_list_item = nil
       ActiveRecord::Base.transaction do
         list_item.update!(params)
 
-        aggregate_list_item = aggregate_list.update_item_from_child_list(list_item.description, delta_qty, params[:unit_weight], old_notes, params[:notes])
+        aggregate_list.update_item_from_child_list(list_item.description, delta_qty, params[:unit_weight], old_notes, params[:notes])
       end
 
-      resource = params[:unit_weight] ? all_matching_items : [aggregate_list_item, list_item]
-
-      Service::OKResult.new(resource:)
+      Service::OKResult.new(resource: game.shopping_lists.index_order)
     rescue ActiveRecord::RecordInvalid
       Service::UnprocessableEntityResult.new(errors: list_item.error_array)
     rescue ActiveRecord::RecordNotFound
@@ -55,6 +52,10 @@ class ShoppingListItemsController < ApplicationController
 
     def list_item
       @list_item ||= user.shopping_list_items.find(item_id)
+    end
+
+    def game
+      @game ||= shopping_list.game
     end
 
     def all_matching_items

--- a/docs/api/resources/shopping-list-items.md
+++ b/docs/api/resources/shopping-list-items.md
@@ -232,6 +232,7 @@ Updates a given shopping list item provided the list the item is on:
 When this happens, the corresponding list item on the aggregate list is also automatically updated to stay synced with the other lists. When the aggregate list is synced, the `notes` value may be shortened, changed, or concatenated with notes from matching items on other lists, depending on which changes were requested.
 
 Requests may specify up to three fields to update:
+
 * `quantity` (integer, greater than zero)
 * `notes` (any string)
 * `unit_weight` (decimal, 1 decimal place, greater than or equal to zero)
@@ -240,17 +241,18 @@ Requests attempting to update `description` will result in a validation error.
 
 When updating `unit_weight`, the `unit_weight` value will be updated for all shopping list items belonging to the same game and matching the description. This is to prevent the aggregate list from getting out of sync with the values on its child list items.
 
-This route supports both `PATCH` and `PUT` requests. The only difference between these requests is the HTTP method; requests are handled by the same code regardless of the method.
+This route supports both `PATCH` and `PUT` requests. Application behaviour does not differ depending on which method is used.
 
 ### Example Requests
 
-Request bodies must contain a `"shopping_list_item"` key containing attributes to be changed. Attributes that can be changed include:
+Request bodies must contain a `"shopping_list_item"` key containing attributes to be changed. Request bodies lacking this key may result in an error or unexpected behaviour. If the `"shopping_list_item"` object is empty, the item will not be changed. Attributes that can be changed include:
 
 * `quantity` (integer greater than zero)
 * `notes` (string)
 * `unit_weight` (decimal greater than or equal to zero with up to one decimal place)
 
-Using a `PATCH` request:
+#### PATCH Requests
+
 ```
 PATCH /shopping_list_items/72
 Authorization: Bearer xxxxxxxxxxx
@@ -263,7 +265,8 @@ Content-Type: application/json
 }
 ```
 
-Using a `PUT` request:
+#### PUT Requests
+
 ```
 PUT /shopping_list_items/72
 Authorization: Bearer xxxxxxxxxxx
@@ -284,38 +287,87 @@ Content-Type: application/json
 
 #### Example Body
 
-The body is a JSON array containing all list items that were updated while handling the request, including the requested item, the corresponding aggregate list item, and, if setting `unit_weight`, any other list items with the same description belonging to the same game. (This is because, when `unit_weight` is set on any list item, all matching list items belonging to the same game are updated with the same value.)
+The body is a JSON array containing all shopping lists belonging to the same game, including the items on each list. This is because items on any of the lists may have been changed and it is easier for clients to receive the relevant data in its context.
+
 ```json
 [
   {
-    "id": 87,
-    "list_id": 236,
-    "description": "Ebony sword",
-    "quantity": 9,
-    "unit_weight": 14.0,
-    "notes": "To sell -- To enchant with 'Absorb Health'",
+    "id": 43,
+    "game_id": 8234,
+    "aggregate": true,
+    "aggregate_list_id": null,
+    "title": "All Items",
     "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "updated_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00"
+    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "list_items": [
+      {
+        "list_id": 43,
+        "description": "Unenchanted ebony sword",
+        "quantity": 1,
+        "notes": "Need an unenchanted sword to start Companions questline",
+        "unit_weight": null,
+        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      },
+      {
+        "list_id": 43,
+        "description": "Iron ingot",
+        "quantity": 4,
+        "notes": "3 locks -- 2 hinges",
+        "unit_weight": 1.0,
+        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      }
+    ]
   },
   {
-    "id": 126,
-    "list_id": 237,
-    "description": "Ebony sword",
-    "quantity": 7,
-    "unit_weight": 14.0,
-    "notes": "To enchant with 'Absorb Health'",
-    "created_at": "Fri, 18 Jun 2021 02:32:31.762797000 UTC +00:00",
-    "updated_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00"
+    "id": 46,
+    "game_id": 8234,
+    "aggregate": false,
+    "aggregate_list_id": 43,
+    "title": "Lakeview Manor",
+    "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "list_items": [
+      {
+        "list_id": 46,
+        "description": "Unenchanted ebony sword",
+        "quantity": 1,
+        "notes": "Need an unenchanted sword to start Companions questline",
+        "unit_weight": null,
+        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      },
+      {
+        "list_id": 46,
+        "description": "Iron ingot",
+        "quantity": 3,
+        "notes": "3 locks",
+        "unit_weight": 1.0,
+        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      }
+    ]
   },
   {
-    "id": 102,
-    "list_id": 238,
-    "description": "Ebony sword",
-    "quantity": 7,
-    "unit_weight": 14.0,
-    "notes": "To sell",
+    "id": 52,
+    "game_id": 8234,
+    "aggregate": false,
+    "aggregate_list_id": 43,
+    "title": "Severin Manor",
     "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "updated_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00"
+    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "list_items": [
+      {
+        "list_id": 52,
+        "description": "Iron ingot",
+        "quantity": 1,
+        "notes": "2 hinges",
+        "unit_weight": 1.0,
+        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      }
+    ]
   }
 ]
 ```
@@ -336,15 +388,15 @@ Four error responses are possible.
 No body will be returned with a 404 error, which is returned if the specified shopping list item doesn't exist or doesn't belong to the authenticated user.
 
 A 405 error, which is returned if the specified shopping list item is on an aggregate shopping list, comes with the following body:
+
 ```json
 {
-  "errors": [
-    "Cannot manually update list items on an aggregate shopping list"
-  ]
+  "errors": ["Cannot manually update list items on an aggregate shopping list"]
 }
 ```
 
 A 422 error, returned as a result of a validation error, includes whichever errors prevented the list item from being created:
+
 ```json
 {
   "errors": [

--- a/docs/api/resources/shopping-list-items.md
+++ b/docs/api/resources/shopping-list-items.md
@@ -251,6 +251,8 @@ Request bodies must contain a `"shopping_list_item"` key containing attributes t
 * `notes` (string)
 * `unit_weight` (decimal greater than or equal to zero with up to one decimal place)
 
+Note that, while `unit_weight` is an editable value, it cannot be reset to `null` once it is set to a numeric value; it can only be changed to another value.
+
 #### PATCH Requests
 
 ```

--- a/spec/controller_services/shopping_list_items_controller/update_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/update_service_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe ShoppingListItemsController::UpdateService do
           expect(perform).to be_a(Service::OKResult)
         end
 
-        it 'returns the list item and aggregate list item as the resource' do
-          expect(perform.resource).to eq [aggregate_list_item, list_item.reload]
+        it "returns all the game's shopping lists as the resource" do
+          expect(perform.resource).to eq(game.shopping_lists.reload.index_order)
         end
       end
 
@@ -75,8 +75,8 @@ RSpec.describe ShoppingListItemsController::UpdateService do
             expect(perform).to be_a(Service::OKResult)
           end
 
-          it 'sets the resource to the aggregate list item and the regular list item' do
-            expect(perform.resource).to eq [aggregate_list_item, list_item.reload]
+          it "returns all the game's shopping lists as the resource" do
+            expect(perform.resource).to eq(game.shopping_lists.reload.index_order)
           end
         end
 
@@ -105,8 +105,8 @@ RSpec.describe ShoppingListItemsController::UpdateService do
             expect(perform).to be_a(Service::OKResult)
           end
 
-          it 'returns all the list items that were changed' do
-            expect(perform.resource).to eq [aggregate_list_item, other_item.reload, list_item.reload]
+          it "returns all the game's shopping lists as the resource" do
+            expect(perform.resource).to eq(game.shopping_lists.reload.index_order)
           end
         end
       end

--- a/spec/requests/shopping_list_items_spec.rb
+++ b/spec/requests/shopping_list_items_spec.rb
@@ -372,9 +372,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
             expect(response.status).to eq 200
           end
 
-          it 'returns the regular list item and the aggregate list item' do
+          it "returns all the game's shopping lists" do
             update_item
-            expect(JSON.parse(response.body)).to eq(JSON.parse([aggregate_list_item, list_item.reload].to_json))
+            expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
           end
         end
 
@@ -431,9 +431,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
               expect(response.status).to eq 200
             end
 
-            it 'returns the list item and the aggregate list item' do
+            it "returns all the game's shopping lists" do
               update_item
-              expect(JSON.parse(response.body)).to eq(JSON.parse([aggregate_list_item, list_item.reload].to_json))
+              expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
             end
           end
 
@@ -495,9 +495,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
               expect(response.status).to eq 200
             end
 
-            it 'returns all items that were changed' do
+            it "returns all the game's shopping lists" do
               update_item
-              expect(JSON.parse(response.body)).to eq(JSON.parse([aggregate_list_item, other_item.reload, list_item.reload].to_json))
+              expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
             end
           end
         end
@@ -668,14 +668,38 @@ RSpec.describe 'ShoppingListItems', type: :request do
             expect(aggregate_list_item.quantity).to eq 10
           end
 
+          it 'updates the regular list' do
+            t = Time.zone.now + 3.days
+            Timecop.freeze(t) do
+              update_item
+              expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+            end
+          end
+
+          it 'updates the aggregate list' do
+            t = Time.zone.now + 3.days
+            Timecop.freeze(t) do
+              update_item
+              expect(aggregate_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+            end
+          end
+
+          it 'updates the game' do
+            t = Time.zone.now + 3.days
+            Timecop.freeze(t) do
+              update_item
+              expect(game.reload.updated_at).to be_within(0.005.seconds).of(t)
+            end
+          end
+
           it 'returns status 200' do
             update_item
             expect(response.status).to eq 200
           end
 
-          it 'returns the regular list item and the aggregate list item' do
+          it "returns all the game's shopping lists" do
             update_item
-            expect(JSON.parse(response.body)).to eq(JSON.parse([aggregate_list_item, list_item.reload].to_json))
+            expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
           end
         end
 
@@ -703,14 +727,38 @@ RSpec.describe 'ShoppingListItems', type: :request do
               expect(aggregate_list_item.quantity).to eq 14
             end
 
+            it 'updates the regular list' do
+              t = Time.zone.now + 3.days
+              Timecop.freeze(t) do
+                update_item
+                expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+              end
+            end
+
+            it 'updates the aggregate list' do
+              t = Time.zone.now + 3.days
+              Timecop.freeze(t) do
+                update_item
+                expect(aggregate_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+              end
+            end
+
+            it 'updates the game' do
+              t = Time.zone.now + 3.days
+              Timecop.freeze(t) do
+                update_item
+                expect(game.reload.updated_at).to be_within(0.005.seconds).of(t)
+              end
+            end
+
             it 'returns status 200' do
               update_item
               expect(response.status).to eq 200
             end
 
-            it 'returns the list item and the aggregate list item' do
+            it "returns all the game's shopping lists" do
               update_item
-              expect(JSON.parse(response.body)).to eq(JSON.parse([aggregate_list_item, list_item.reload].to_json))
+              expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
             end
           end
 
@@ -735,14 +783,46 @@ RSpec.describe 'ShoppingListItems', type: :request do
               expect(other_item.unit_weight).to eq 2
             end
 
+            it 'updates the regular list' do
+              t = Time.zone.now + 3.days
+              Timecop.freeze(t) do
+                update_item
+                expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+              end
+            end
+
+            it 'updates the aggregate list' do
+              t = Time.zone.now + 3.days
+              Timecop.freeze(t) do
+                update_item
+                expect(aggregate_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+              end
+            end
+
+            it 'updates the other list' do
+              t = Time.zone.now + 3.days
+              Timecop.freeze(t) do
+                update_item
+                expect(other_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+              end
+            end
+
+            it 'updates the game' do
+              t = Time.zone.now + 3.days
+              Timecop.freeze(t) do
+                update_item
+                expect(game.reload.updated_at).to be_within(0.005.seconds).of(t)
+              end
+            end
+
             it 'returns status 200' do
               update_item
               expect(response.status).to eq 200
             end
 
-            it 'returns all items that were changed' do
+            it "returns all the game's shopping lists" do
               update_item
-              expect(JSON.parse(response.body)).to eq(JSON.parse([aggregate_list_item, other_item.reload, list_item.reload].to_json))
+              expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
             end
           end
         end


### PR DESCRIPTION
## Context

[**Return all shopping lists from PUT|PATCH /shopping_list_items/:id endpoint**](https://trello.com/c/mGo0xf6i/260-return-all-shopping-lists-from-putpatch-shoppinglistitems-id-endpoint)

Managing shopping and inventory list items is proving complicated because of the aggregating behaviour of shopping and inventory lists. When a shopping list item is updated, numerous other items on other lists may be updated as well. Currently, we send changed items in the API response body and leave it to the front end to find out which items need to be added, removed, or replaced where. However, this has resulted in very complex front end logic. For our current [front end rewrite](https://trello.com/c/jx60e2Fb/220-frontend-rewrite), we would like to simplify this logic, and one way of doing this is simply returning all shopping lists from the `PATCH|PUT /shopping_list_items/:id` endpoint, regardless of whether items on those lists have changed or not. This way, the front end can replace its entire `shoppingLists` array instead of having to figure out which items go where.

## Changes

* Return all of a game's shopping lists when one or more of its list items are updated successfully
* Update RSpec tests
* Update API docs

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate
