### PR TITLE
Return all of a game's shopping lists from the list item deletion endpoint

### DIFF
--- a/docs/api/resources/shopping-list-items.md
+++ b/docs/api/resources/shopping-list-items.md
@@ -538,7 +538,7 @@ Three error responses are possible.
 
 No body will be returned with a 404 error, which is returned if the specified shopping list item doesn't exist or doesn't belong to the authenticated user.
 
-A 405 error, which is returned if the specified shopping list item is on an aggregate shopping list, comes with the following body:\
+A 405 error, which is returned if the specified shopping list item is on an aggregate shopping list, comes with the following body:
 
 ```json
 {

--- a/docs/api/resources/shopping-list-items.md
+++ b/docs/api/resources/shopping-list-items.md
@@ -436,24 +436,92 @@ Authorization: Bearer xxxxxxxxxxx
 #### Statuses
 
 * 200 OK
-* 204 No Content
 
 #### Example Body
 
-The API will return a 204 response if the list item has been destroyed along with the corresponding item on the aggregate list. This response does not include a body. On the other hand, if the aggregate list item has been updated rather than destroyed, it will be returned and the status code will be 200.
+The response body will be an array of all shopping lists belonging to the game to which the deleted list item ultimately belongs. This object also includes the shopping list items on each list.
 
-Example 200 response body containing the updated aggregate list item:
 ```json
-{
-  "id": 87,
-  "list_id": 238,
-  "description": "Ebony sword",
-  "quantity": 9,
-  "unit_weight": 14.0,
-  "notes": "To sell -- To enchant with 'Absorb Health'",
-  "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-  "updated_at": "Fri, 02 Jul 2021 12:04:27.161932000 UTC +00:00"
-}
+[
+  {
+    "id": 43,
+    "game_id": 8234,
+    "aggregate": true,
+    "aggregate_list_id": null,
+    "title": "All Items",
+    "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "list_items": [
+      {
+        "list_id": 43,
+        "description": "Unenchanted ebony sword",
+        "quantity": 1,
+        "notes": "Need an unenchanted sword to start Companions questline",
+        "unit_weight": null,
+        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      },
+      {
+        "list_id": 43,
+        "description": "Iron ingot",
+        "quantity": 4,
+        "notes": "3 locks -- 2 hinges",
+        "unit_weight": 1.0,
+        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      }
+    ]
+  },
+  {
+    "id": 46,
+    "game_id": 8234,
+    "aggregate": false,
+    "aggregate_list_id": 43,
+    "title": "Lakeview Manor",
+    "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "list_items": [
+      {
+        "list_id": 46,
+        "description": "Unenchanted ebony sword",
+        "quantity": 1,
+        "notes": "Need an unenchanted sword to start Companions questline",
+        "unit_weight": null,
+        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      },
+      {
+        "list_id": 46,
+        "description": "Iron ingot",
+        "quantity": 3,
+        "notes": "3 locks",
+        "unit_weight": 1.0,
+        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      }
+    ]
+  },
+  {
+    "id": 52,
+    "game_id": 8234,
+    "aggregate": false,
+    "aggregate_list_id": 43,
+    "title": "Severin Manor",
+    "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "list_items": [
+      {
+        "list_id": 52,
+        "description": "Iron ingot",
+        "quantity": 1,
+        "notes": "2 hinges",
+        "unit_weight": 1.0,
+        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
+        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+      }
+    ]
+  }
+]
 ```
 
 ### Error Responses
@@ -470,16 +538,16 @@ Three error responses are possible.
 
 No body will be returned with a 404 error, which is returned if the specified shopping list item doesn't exist or doesn't belong to the authenticated user.
 
-A 405 error, which is returned if the specified shopping list item is on an aggregate shopping list, comes with the following body:
+A 405 error, which is returned if the specified shopping list item is on an aggregate shopping list, comes with the following body:\
+
 ```json
 {
-  "errors": [
-    "Cannot manually delete an item from an aggregate shopping list"
-  ]
+  "errors": ["Cannot manually delete an item from an aggregate shopping list"]
 }
 ```
 
 A 500 error response, which is always a result of an unforeseen problem, includes the error message:
+
 ```json
 {
   "errors": ["Something went horribly wrong"]

--- a/spec/controller_services/shopping_list_items_controller/destroy_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/destroy_service_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'service/no_content_result'
 require 'service/ok_result'
 require 'service/not_found_result'
 require 'service/method_not_allowed_result'
@@ -35,12 +34,12 @@ RSpec.describe ShoppingListItemsController::DestroyService do
             .to change(aggregate_list.list_items, :count).from(1).to(0)
         end
 
-        it 'returns a Service::NoContentResult' do
-          expect(perform).to be_a Service::NoContentResult
+        it 'returns a Service::OKResult' do
+          expect(perform).to be_a Service::OKResult
         end
 
-        it 'does not return data' do
-          expect(perform.resource).to be nil
+        it "sets all the game's shopping lists as the resource" do
+          expect(perform.resource).to eq(game.shopping_lists.reload.index_order)
         end
 
         it 'sets the updated_at timestamp on the shopping list' do
@@ -104,8 +103,8 @@ RSpec.describe ShoppingListItemsController::DestroyService do
           expect(perform).to be_a Service::OKResult
         end
 
-        it 'returns the updated aggregate list item' do
-          expect(perform.resource).to eq aggregate_list.list_items.first
+        it "returns all the game's shopping lists as the resource" do
+          expect(perform.resource).to eq(game.shopping_lists.reload.index_order)
         end
       end
     end

--- a/spec/requests/shopping_list_items_spec.rb
+++ b/spec/requests/shopping_list_items_spec.rb
@@ -1016,14 +1016,14 @@ RSpec.describe 'ShoppingListItems', type: :request do
             end
           end
 
-          it 'returns status 204' do
+          it 'returns status 200' do
             destroy_item
-            expect(response.status).to eq 204
+            expect(response.status).to eq 200
           end
 
           it 'returns an empty response' do
             destroy_item
-            expect(response.body).to be_empty
+            expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
           end
         end
 
@@ -1081,9 +1081,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
             expect(response.status).to eq 200
           end
 
-          it 'returns the aggregate list item' do
+          it "returns all the game's shopping lists" do
             destroy_item
-            expect(JSON.parse(response.body)).to eq(JSON.parse(aggregate_list.list_items.first.to_json))
+            expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
           end
         end
       end


### PR DESCRIPTION
## Context

[**Return all shopping lists from DELETE /shopping_list_items/:id endpoint**](https://trello.com/c/1Vo9TcMe/261-return-all-shopping-lists-from-delete-shoppinglistitems-id-endpoint)

We have decided that shopping list item endpoints, requests to which can create, modify, or delete multiple records in the database, should return all the shopping lists belonging to the game that owns the requested list item. This is part of an effort to simplify data to, in turn, simplify front end logic.

## Changes

* Ensure the `DELETE /shopping_list_items/:id` endpoint returns all of the corresponding game's shopping lists in a successful response
* Update RSpec tests
* Update API docs

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate
