### PR TITLE
Return only created shopping lists from creation endpoint

### DIFF
--- a/app/controller_services/shopping_lists_controller/create_service.rb
+++ b/app/controller_services/shopping_lists_controller/create_service.rb
@@ -23,7 +23,8 @@ class ShoppingListsController < ApplicationController
       shopping_list = game.shopping_lists.new(params)
 
       if shopping_list.save
-        Service::CreatedResult.new(resource: game.shopping_lists.index_order)
+        resource = game_has_other_lists? ? Array.wrap(shopping_list) : game.shopping_lists.index_order
+        Service::CreatedResult.new(resource:)
       else
         Service::UnprocessableEntityResult.new(errors: shopping_list.error_array)
       end
@@ -39,7 +40,11 @@ class ShoppingListsController < ApplicationController
     attr_reader :user, :game_id, :params
 
     def game
-      user.games.find(game_id)
+      @game ||= user.games.find(game_id)
+    end
+
+    def game_has_other_lists?
+      game.shopping_lists.reload.count > 2
     end
   end
 end

--- a/app/controller_services/shopping_lists_controller/create_service.rb
+++ b/app/controller_services/shopping_lists_controller/create_service.rb
@@ -44,7 +44,7 @@ class ShoppingListsController < ApplicationController
     end
 
     def game_has_other_lists?
-      game.shopping_lists.reload.count > 2
+      game.shopping_lists.count > 2
     end
   end
 end

--- a/docs/api/resources/shopping-lists.md
+++ b/docs/api/resources/shopping-lists.md
@@ -60,6 +60,7 @@ For a game with multiple lists:
     "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
     "list_items": [
       {
+        "id": 689
         "list_id": 43,
         "description": "Unenchanted ebony sword",
         "quantity": 1,
@@ -69,6 +70,7 @@ For a game with multiple lists:
         "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
       },
       {
+        "id": 134,
         "list_id": 43,
         "description": "Iron ingot",
         "quantity": 4,
@@ -89,6 +91,7 @@ For a game with multiple lists:
     "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
     "list_items": [
       {
+        "id": 845,
         "list_id": 46,
         "description": "Unenchanted ebony sword",
         "quantity": 1,
@@ -98,6 +101,7 @@ For a game with multiple lists:
         "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
       },
       {
+        "id": 76,
         "list_id": 46,
         "description": "Iron ingot",
         "quantity": 3,
@@ -118,6 +122,7 @@ For a game with multiple lists:
     "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
     "list_items": [
       {
+        "id": 11,
         "list_id": 52,
         "description": "Iron ingot",
         "quantity": 1,

--- a/docs/api/resources/shopping-lists.md
+++ b/docs/api/resources/shopping-lists.md
@@ -153,7 +153,7 @@ A 500 error response, which is always a result of an unforeseen problem, include
 
 ## POST /games/:game_id/shopping_lists
 
-Creates a new shopping list for the specified game if it exists and belongs to the authenticated user. If the game does not already have an aggregate list, an aggregate list will also be created automatically. The response is an array that includes all shopping lists belonging to the specified game. Each shopping list also includes an array with any shopping list items on that list. The JSON schema for the shopping list items is described in the [docs for shopping list items](/docs/api/resources/shopping-list-items.md). The shopping lists are returned with the aggregate list first and subsequent lists in order of most recently updated. (Adding, removing, or updating a list item on a list counts as updating the list.)
+Creates a new shopping list for the specified game if it exists and belongs to the authenticated user. If the game does not already have an aggregate list, an aggregate list will also be created automatically. The response is an array that includes all shopping lists that were created. The shopping lists are returned with the aggregate list first, if one was created while handling this request, and the regular list the user requested.
 
 The request does not have to include a body. If it does, the body should include a `"shopping_list"` object with an optional `"title"` key, the only attribute that can be set on a shopping list via this or any endpoint. If you don't include a title, your list will be titled "My List N", where _N_ is an integer equal to one plus the highest numbered default list title you have. For example, if you have lists titled "My List 1", "My List 3", and "My List 4" and you don't specify a title for your new list, your new list will be titled "My List 5".
 
@@ -201,6 +201,8 @@ Authorization: Bearer xxxxxxxxxx
 
 #### Example Body
 
+##### When an Aggregate List Is Created
+
 ```json
 [
   {
@@ -211,27 +213,6 @@ Authorization: Bearer xxxxxxxxxx
     "title": "All Items",
     "created_at": "Tue, 15 Jun 2021 11:59:16.891338000 UTC +00:00",
     "updated_at": "Tue, 15 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "list_items": [
-      {
-        "id": 33,
-        "list_id": 4,
-        "description": "Ebony sword",
-        "quantity": 1,
-        "notes": "To enchant with Soul Trap",
-        "unit_weight": 14.0,
-        "created_at": "Tue, 15 Jun 2021 12:34:32.713458000 UTC +00:00",
-        "updated_at": "Tue, 15 Jun 2021 12:34:32.713458000 UTC +00:00"
-      }
-    ]
-  },
-  {
-    "id": 12,
-    "user_id": 6,
-    "aggregate": false,
-    "aggregate_list_id": 4,
-    "title": "Custom Titled List",
-    "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
     "list_items": []
   },
   {
@@ -242,18 +223,24 @@ Authorization: Bearer xxxxxxxxxx
     "title": "My List 1",
     "created_at": "Tue, 15 Jun 2021 11:59:16.891338000 UTC +00:00",
     "updated_at": "Tue, 15 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "list_items": [
-      {
-        "id": 32,
-        "list_id": 5,
-        "description": "Ebony sword",
-        "quantity": 1,
-        "notes": "To enchant with Soul Trap",
-        "unit_weight": 14.0,
-        "created_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00",
-        "updated_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00"
-      }
-    ]
+    "list_items": []
+  }
+]
+```
+
+##### When Only a Regular List Is Created
+
+```json
+[
+  {
+    "id": 5,
+    "user_id": 6,
+    "aggregate": false,
+    "aggregate_list_id": 4,
+    "title": "My List 1",
+    "created_at": "Tue, 15 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "updated_at": "Tue, 15 Jun 2021 11:59:16.891338000 UTC +00:00",
+    "list_items": []
   }
 ]
 ```

--- a/spec/controller_services/shopping_lists_controller/create_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/create_service_spec.rb
@@ -67,14 +67,14 @@ RSpec.describe ShoppingListsController::CreateService do
       let!(:game) { create(:game, user:) }
       let(:params) { { title: 'Proudspire Manor' } }
 
-      context 'when the game has an aggregate shopping list' do
+      context 'when the game has other shopping lists' do
         before do
-          create(:aggregate_shopping_list, game:)
+          create(:shopping_list, game:)
         end
 
         it 'creates a shopping list for the given game' do
           expect { perform }
-            .to change(game.shopping_lists, :count).from(1).to(2)
+            .to change(game.shopping_lists, :count).from(2).to(3)
         end
 
         it 'returns a Service::CreatedResult' do
@@ -82,7 +82,7 @@ RSpec.describe ShoppingListsController::CreateService do
         end
 
         it 'sets the resource to the created list' do
-          expect(perform.resource).to eq game.shopping_lists.index_order
+          expect(perform.resource).to eq [game.shopping_lists.find_by(title: 'Proudspire Manor')]
         end
 
         it 'updates the game' do

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'ShoppingLists', type: :request do
               .to change(game.shopping_lists, :count).from(0).to(2) # because of the aggregate list
           end
 
-          it 'returns all shopping lists for that game' do
+          it 'returns both shopping lists' do
             create_shopping_list
             expect(response.body).to eq(game.shopping_lists.index_order.to_json)
           end
@@ -41,16 +41,18 @@ RSpec.describe 'ShoppingLists', type: :request do
         end
 
         context 'when only the new shopping list has been created' do
-          let!(:aggregate_list) { create(:aggregate_shopping_list, game:, created_at: 2.seconds.ago, updated_at: 2.seconds.ago) }
+          before do
+            create(:shopping_list, game:)
+          end
 
           it 'creates one list' do
             expect { create_shopping_list }
-              .to change(game.shopping_lists, :count).from(1).to(2)
+              .to change(game.shopping_lists, :count).from(2).to(3)
           end
 
-          it 'returns all shopping lists for that game' do
+          it 'returns only the created list' do
             create_shopping_list
-            expect(response.body).to eq(game.shopping_lists.index_order.to_json)
+            expect(response.body).to eq([game.shopping_lists.unscoped.last].to_json)
           end
 
           it 'returns status 201' do


### PR DESCRIPTION
## Context

[**Return only created shopping lists from creation endpoint**](https://trello.com/c/fFvysZ4Q/263-return-only-created-shopping-lists-from-creation-endpoint)

After implementing the change in #147, we realised a fatal flaw, which is that returning all of a game's shopping lists from this endpoint would potentially result in other shopping lists being rearranged on the page with every shopping list creation. For example, if a user had updated a couple items on existing lists and then created a new list, the lists they edited items on would also potentially be re-ordered. This could be annoying to users, so we decided that we should only return created lists from this endpoint and add front-end logic to ensure those are added to the shopping lists array in the right place.

## Changes

* Ensure only newly created shopping lists are returned from the shopping lists creation endpoint
* Update tests
* Update docs

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate