### PR TITLE
Return IDs of deleted lists from DELETE /shopping_lists/:id endpoint

### DIFF
--- a/docs/api/resources/shopping-lists.md
+++ b/docs/api/resources/shopping-lists.md
@@ -440,7 +440,7 @@ A 500 error response, which is always a result of an unforeseen problem, include
 
 ## DELETE /shopping_lists/:id
 
-Destroys the given shopping list, and any shopping list items on it, if it exists and belongs to the authenticated user. If the list to be destroyed is the user's only regular (non-aggregate) shopping list, the aggregate list will also be destroyed. The response body will include any remaining shopping lists belonging to the game to which the requested list belongs.
+Destroys the given shopping list, and any shopping list items on it, if it exists and belongs to the authenticated user. If the list to be destroyed is the user's only regular (non-aggregate) shopping list, the aggregate list will also be destroyed. The body of a successful response includes an array of deleted list IDs and the updated aggregate list (unless it was also deleted).
 
 ### Example Request
 
@@ -457,13 +457,14 @@ Authorization: Bearer xxxxxxxxxxxx
 
 #### Example Bodies
 
-The response body will be an array of any remaining shopping lists belonging to the same game as the destroyed list(s).
+The response body will be a JSON object with a `"deleted"` key pointing to an array of deleted lists. If only the target list was destroyed, this array will include one member. If the target list was the game's last regular shopping list and the aggregate list was therefore also destroyed, the array will include two members. If the aggregate list was not destroyed, it will be returned as well, with its updated list items, under the `"aggregate"` key.
 
-Body including an aggregate list and an additional list that was not destroyed:
+Body including an aggregate list that was not destroyed:
 
 ```json
-[
-  {
+{
+  "deleted": [835],
+  "aggregate": {
     "id": 834,
     "user_id": 16,
     "aggregate": true,
@@ -483,35 +484,16 @@ Body including an aggregate list and an additional list that was not destroyed:
         "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
       }
     ]
-  },
-  {
-    "id": 835,
-    "user_id": 16,
-    "aggregate": false,
-    "aggregate_list_id": 834,
-    "title": "Vlindrel Hall",
-    "created_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00",
-    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "list_items": [
-      {
-        "id": 31,
-        "list_id": 835,
-        "description": "Ebony sword",
-        "quantity": 1,
-        "notes": "To enchant with Soul Trap",
-        "unit_weight": 14.0,
-        "created_at": "Tue, 15 Jun 2021 12:34:32.713457000 UTC +00:00",
-        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
-      }
-    ]
   }
-]
+}
 ```
 
-Empty body indicating aggregate list was also destroyed:
+Body when the aggregate list was also destroyed:
 
 ```json
-[]
+{
+  "deleted": [834, 835]
+}
 ```
 
 ### Error Responses

--- a/spec/controller_services/shopping_lists_controller/destroy_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/destroy_service_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'service/no_content_result'
 require 'service/method_not_allowed_result'
 require 'service/not_found_result'
 require 'service/ok_result'
@@ -13,20 +12,26 @@ RSpec.describe ShoppingListsController::DestroyService do
     let(:user) { create(:user) }
 
     context 'when all goes well' do
-      let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
       let!(:shopping_list) { create(:shopping_list_with_list_items, game:) }
       let(:game) { create(:game, user:) }
 
       context 'when the game has additional regular lists' do
-        let!(:third_list) { create(:shopping_list_with_list_items, game:, aggregate_list:) }
+        let!(:third_list) { create(:shopping_list_with_list_items, game:) }
+
+        let(:expected_resource) do
+          {
+            deleted: [shopping_list.id],
+            aggregate: game.aggregate_shopping_list,
+          }
+        end
 
         before do
           shopping_list.list_items.each do |list_item|
-            aggregate_list.add_item_from_child_list(list_item)
+            game.aggregate_shopping_list.add_item_from_child_list(list_item)
           end
 
           third_list.list_items.each do |list_item|
-            aggregate_list.add_item_from_child_list(list_item)
+            game.aggregate_shopping_list.add_item_from_child_list(list_item)
           end
         end
 
@@ -47,14 +52,14 @@ RSpec.describe ShoppingListsController::DestroyService do
           expect(perform).to be_a(Service::OKResult)
         end
 
-        it "sets the resource as the game's remaining lists" do
-          expect(perform.resource).to eq game.shopping_lists.index_order
+        it 'includes the deleted list ID and the aggregate list as the resource' do
+          expect(perform.resource).to eq expected_resource
         end
 
         describe 'updating the aggregate list' do
           before do
             items = create_list(:shopping_list_item, 2, list: third_list)
-            items.each {|item| aggregate_list.add_item_from_child_list(item) }
+            items.each {|item| shopping_list.aggregate_list.add_item_from_child_list(item) }
 
             # Because in the code it finds the shopping list by ID and then gets the aggregate list
             # off that instance, the tests don't have access to the instance of the aggregate list that
@@ -62,8 +67,8 @@ RSpec.describe ShoppingListsController::DestroyService do
             user_lists = user.shopping_lists
             allow(user).to receive(:shopping_lists).and_return(user_lists)
             allow(user_lists).to receive(:find).and_return(shopping_list)
-            allow(shopping_list).to receive(:aggregate_list).and_return(aggregate_list)
-            allow(aggregate_list).to receive(:remove_item_from_child_list).twice
+            allow(shopping_list).to receive(:aggregate_list).and_return(shopping_list.aggregate_list)
+            allow(shopping_list.aggregate_list).to receive(:remove_item_from_child_list).twice
           end
 
           it 'calls #remove_item_from_child_list for each item', :aggregate_failures do
@@ -77,9 +82,15 @@ RSpec.describe ShoppingListsController::DestroyService do
       end
 
       context "when this is the game's last regular list" do
+        let(:expected_resource) do
+          {
+            deleted: [shopping_list.aggregate_list_id, shopping_list.id],
+          }
+        end
+
         before do
           shopping_list.list_items.each do |item|
-            shopping_list.aggregate_list.add_item_from_child_list(item)
+            game.aggregate_shopping_list.add_item_from_child_list(item)
           end
         end
 
@@ -100,8 +111,8 @@ RSpec.describe ShoppingListsController::DestroyService do
           expect(perform).to be_a(Service::OKResult)
         end
 
-        it 'returns an empty resource body' do
-          expect(perform.resource).to eq []
+        it 'returns an array of deleted list IDs as the resource' do
+          expect(perform.resource).to eq expected_resource
         end
       end
     end


### PR DESCRIPTION
## Context

[**Return IDs of deleted lists from DELETE /shopping_lists/:id endpoint**](https://trello.com/c/611KOMJq/264-return-ids-of-deleted-lists-from-delete-shoppinglists-id-endpoint)

We've realised some issues with the implementation of our endpoints in that the new response bodies added in #150 are causing shopping lists to be rearranged too much on the page due to the `index_order` scope on shopping lists and their items. We've decided to change the response bodies so it's easier for the front end to ensure that the lists stay in their expected position until page reload.

## Changes

* Change response body shape of `DELETE /shopping_lists/:id` endpoint
* Update RSpec tests
* Update docs

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

This made the code in the `ShoppingListsController::DestroyService` a little uglier but I didn't really know a better way to implement it.
