### PR TITLE
Return only changed shopping lists from list item creation endpoint

### DIFF
--- a/docs/api/resources/shopping-list-items.md
+++ b/docs/api/resources/shopping-list-items.md
@@ -70,7 +70,7 @@ Allowed fields are:
 * `notes` (string, optional): Any notes about the item or what it is for
 * `unit_weight` (decimal, optional): The unit weight of the item as given in the game, precise to one decimal place
 
-A successful response will return a JSON array of all shopping lists for the game to which the created or updated list item ultimately belongs, including all the list items on each list.
+A successful response will return a JSON array of all changed shopping lists for the game to which the created or updated list item ultimately belongs, including all the list items on each list.
 
 ### Example Request
 
@@ -96,7 +96,7 @@ Content-Type: application/json
 
 If there is no item with a matching description on the requested shopping list, a new item will be created and the server will return a 201 response. If there is an item with a matching description, its notes and quantity will be combined with the notes and quantity in the client request and a 200 response will be returned.
 
-The body for both responses is a JSON array containing all shopping lists for the game to which the created or updated list item ultimately belongs. Each shopping list includes its list items.
+The body for both responses is a JSON array containing all _changed_ shopping lists for the game to which the created or updated list item ultimately belongs, i.e., those that have had items added, updated, or removed. Each shopping list includes its list items.
 
 ```json
 [
@@ -152,26 +152,6 @@ The body for both responses is a JSON array containing all shopping lists for th
         "description": "Iron ingot",
         "quantity": 3,
         "notes": "3 locks",
-        "unit_weight": 1.0,
-        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
-      }
-    ]
-  },
-  {
-    "id": 52,
-    "game_id": 8234,
-    "aggregate": false,
-    "aggregate_list_id": 43,
-    "title": "Severin Manor",
-    "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "list_items": [
-      {
-        "list_id": 52,
-        "description": "Iron ingot",
-        "quantity": 1,
-        "notes": "2 hinges",
         "unit_weight": 1.0,
         "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
         "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"

--- a/spec/controller_services/shopping_list_items_controller/create_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/create_service_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe ShoppingListItemsController::CreateService do
           end
 
           it 'sets all the changed shopping lists as the resource' do
-            expect(perform.resource).to eq(game.shopping_lists.where(id: [aggregate_list.id, shopping_list.id, other_list.id]))
+            expect(perform.resource).to eq([aggregate_list, other_list, shopping_list])
           end
         end
       end

--- a/spec/controller_services/shopping_list_items_controller/create_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/create_service_spec.rb
@@ -35,27 +35,36 @@ RSpec.describe ShoppingListItemsController::CreateService do
             expect(perform).to be_a(Service::CreatedResult)
           end
 
-          it "sets the resource to all the game's shopping lists" do
-            expect(perform.resource).to eq game.shopping_lists.reload.index_order
+          it 'sets the resource to all the changed shopping lists' do
+            expect(perform.resource).to eq [aggregate_list, shopping_list]
           end
         end
 
         context 'when there is an existing matching item on another list' do
           let(:other_list) { create(:shopping_list, game: aggregate_list.game, aggregate_list:) }
-          let!(:other_item) { create(:shopping_list_item, list: other_list, description: 'Necklace', quantity: 1) }
+          let!(:other_item) { create(:shopping_list_item, list: other_list, description: 'Necklace', unit_weight: 1, quantity: 1) }
 
           before do
+            # This should not be included in the resource body
+            create(:shopping_list, game:)
+
             aggregate_list.add_item_from_child_list(other_item)
           end
 
           context 'when the unit_weight is not set' do
             it 'creates a new item on the list' do
               expect { perform }
-                .to change(shopping_list.list_items, :count).from(0).to(1)
+                .to change(shopping_list.list_items, :count).from(0).to eq 1
+            end
+
+            it 'sets the unit weight on the new item' do
+              perform
+              expect(shopping_list.list_items.unscoped.last.unit_weight).to eq 1
             end
 
             it 'updates the item on the aggregate list', :aggregate_failures do
               perform
+              expect(aggregate_list.list_items.first.unit_weight).to eq 1
               expect(aggregate_list.list_items.first.quantity).to eq 3
               expect(aggregate_list.list_items.first.notes).to eq 'Hello world'
             end
@@ -64,8 +73,8 @@ RSpec.describe ShoppingListItemsController::CreateService do
               expect(perform).to be_a(Service::CreatedResult)
             end
 
-            it "sets all the game's shopping lists as the resource" do
-              expect(perform.resource).to eq(game.shopping_lists.reload.index_order)
+            it 'sets all the changed shopping lists as the resource' do
+              expect(perform.resource).to eq([aggregate_list, shopping_list])
             end
           end
 
@@ -94,8 +103,8 @@ RSpec.describe ShoppingListItemsController::CreateService do
               expect(perform).to be_a(Service::CreatedResult)
             end
 
-            it "sets all the game's shopping lists as the resource" do
-              expect(perform.resource).to eq(game.shopping_lists.reload.index_order)
+            it 'sets all the changed shopping lists as the resource' do
+              expect(perform.resource).to eq([aggregate_list, other_list, shopping_list])
             end
           end
         end
@@ -107,6 +116,9 @@ RSpec.describe ShoppingListItemsController::CreateService do
         let!(:list_item) { create(:shopping_list_item, list: shopping_list, description: 'Necklace', quantity: 1) }
 
         before do
+          # This should not be included in the resource body
+          create(:shopping_list, game:)
+
           aggregate_list.add_item_from_child_list(other_item)
           aggregate_list.add_item_from_child_list(list_item)
         end
@@ -133,8 +145,8 @@ RSpec.describe ShoppingListItemsController::CreateService do
             expect(perform).to be_a(Service::OKResult)
           end
 
-          it "sets all the game's shopping lists as the resource" do
-            expect(perform.resource).to eq(game.shopping_lists.reload.index_order)
+          it 'sets all the changed shopping lists as the resource' do
+            expect(perform.resource).to eq([aggregate_list, shopping_list])
           end
         end
 
@@ -168,8 +180,8 @@ RSpec.describe ShoppingListItemsController::CreateService do
             expect(perform).to be_a(Service::OKResult)
           end
 
-          it "sets all the game's shopping lists as the resource" do
-            expect(perform.resource).to eq(game.shopping_lists.reload.index_order)
+          it 'sets all the changed shopping lists as the resource' do
+            expect(perform.resource).to eq(game.shopping_lists.where(id: [aggregate_list.id, shopping_list.id, other_list.id]))
           end
         end
       end

--- a/spec/requests/shopping_list_items_spec.rb
+++ b/spec/requests/shopping_list_items_spec.rb
@@ -392,7 +392,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
           it "returns all the game's shopping lists" do
             update_item
-            expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
+            expect(response.body).to eq(game.shopping_lists.to_json)
           end
         end
 
@@ -451,7 +451,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
             it "returns all the game's shopping lists" do
               update_item
-              expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
+              expect(response.body).to eq(game.shopping_lists.to_json)
             end
           end
 
@@ -515,7 +515,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
             it "returns all the game's shopping lists" do
               update_item
-              expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
+              expect(response.body).to eq(game.shopping_lists.to_json)
             end
           end
         end
@@ -717,7 +717,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
           it "returns all the game's shopping lists" do
             update_item
-            expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
+            expect(response.body).to eq(game.shopping_lists.to_json)
           end
         end
 
@@ -776,7 +776,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
             it "returns all the game's shopping lists" do
               update_item
-              expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
+              expect(response.body).to eq(game.shopping_lists.to_json)
             end
           end
 
@@ -840,7 +840,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
             it "returns all the game's shopping lists" do
               update_item
-              expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
+              expect(response.body).to eq(game.shopping_lists.to_json)
             end
           end
         end
@@ -1041,7 +1041,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
           it 'returns an empty response' do
             destroy_item
-            expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
+            expect(response.body).to eq(game.shopping_lists.to_json)
           end
         end
 
@@ -1101,7 +1101,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
           it "returns all the game's shopping lists" do
             destroy_item
-            expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
+            expect(response.body).to eq(game.shopping_lists.to_json)
           end
         end
       end

--- a/spec/requests/shopping_list_items_spec.rb
+++ b/spec/requests/shopping_list_items_spec.rb
@@ -45,17 +45,21 @@ RSpec.describe 'ShoppingListItems', type: :request do
               expect(response.status).to eq 201
             end
 
-            it 'returns all shopping lists for the same game' do
+            it 'returns all changed shopping lists for the same game' do
               create_item
-              expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
+              expect(response.body).to eq(game.shopping_lists.to_json)
             end
           end
 
           context 'when there is an existing matching item on another list' do
-            let(:other_list) { create(:shopping_list, game: aggregate_list.game) }
+            let(:other_list) { create(:shopping_list, game:) }
             let!(:other_item) { create(:shopping_list_item, list: other_list, description: 'Corundum ingot', quantity: 2) }
 
             before do
+              # This list has nothing to do with things and should not be included in the
+              # response bodies.
+              create(:shopping_list, game:)
+
               aggregate_list.add_item_from_child_list(other_item)
             end
 
@@ -77,9 +81,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
                 expect(response.status).to eq 201
               end
 
-              it 'returns all shopping lists from the same game' do
+              it 'returns all changed shopping lists from the same game' do
                 create_item
-                expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
+                expect(response.body).to eq(game.shopping_lists.where(id: [aggregate_list.id, shopping_list.id]).to_json)
               end
             end
 
@@ -108,9 +112,14 @@ RSpec.describe 'ShoppingListItems', type: :request do
                 expect(response.status).to eq 201
               end
 
-              it 'returns all shopping lists for the same game' do
+              it 'returns all changed shopping lists for the same game' do
                 create_item
-                expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
+                expect(response.body).to eq(
+                  game
+                    .shopping_lists
+                    .where(id: [aggregate_list.id, shopping_list.id, other_list.id])
+                    .to_json,
+                )
               end
             end
           end
@@ -122,6 +131,10 @@ RSpec.describe 'ShoppingListItems', type: :request do
           let!(:list_item) { create(:shopping_list_item, list: shopping_list, description: 'Corundum ingot', quantity: 3) }
 
           before do
+            # This list has nothing to do with things and should not be included in the
+            # response bodies.
+            create(:shopping_list, game:)
+
             aggregate_list.add_item_from_child_list(other_item)
             aggregate_list.add_item_from_child_list(list_item)
           end
@@ -147,9 +160,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
               expect(response.status).to eq 200
             end
 
-            it 'returns all shopping lists for the same game' do
+            it 'returns all changed shopping lists for the same game' do
               create_item
-              expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
+              expect(response.body).to eq(game.shopping_lists.where(id: [aggregate_list.id, shopping_list.id]).to_json)
             end
           end
 
@@ -184,9 +197,14 @@ RSpec.describe 'ShoppingListItems', type: :request do
               expect(response.status).to eq 200
             end
 
-            it 'returns all shopping lists for the same game' do
+            it 'returns all changed shopping lists for the same game' do
               create_item
-              expect(response.body).to eq(game.shopping_lists.reload.index_order.to_json)
+              expect(response.body).to eq(
+                game
+                  .shopping_lists
+                  .where(id: [aggregate_list.id, shopping_list.id, other_list.id])
+                  .to_json,
+              )
             end
           end
         end


### PR DESCRIPTION
## Context

* [**Rewrite Shopping Lists page**](https://trello.com/c/oBVGCwU1/232-rewrite-shopping-lists-page)
* [**Determine best approach to updating aggregatable models**](https://trello.com/c/GO0zCmKC/262-determine-best-approach-to-updating-aggregatable-models)

In #151, we updated the shopping list item creation endpoint to return all of a game's shopping lists and their list items. The goal of this was to simplify front-end response handling, however, there was a flaw in this approach: simply returning all the shopping lists and setting them as the `shoppingLists` array on the front end would cause the page to be reorganised frequently, with the most-recently modified lists always being first.

For the shopping list item creation endpoint, we opted to take the middle way: return shopping lists from the endpoint and not just list items like before, but only return the changed shopping lists and not every one for that game. The front end will then be responsible for determining the appropriate order for the returned lists in the display.

## Changes

* Return all changed shopping lists for the relevant game when a shopping list item is created
* Update RSpec tests
* Update docs

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

### Drawbacks to This Approach

Although this approach will mitigate the problem of shopping lists being moved around on the page, it will still result in the list items for each list being reorganised. This could be jarring for users if they have multiple lists expanded and can see their list items move around when they submit the form. However, we are going to experiment with this and see how big a deal it really turns out to be before reverting to the original response body that included the list items only. The reason for this is that it is much less computationally expensive on the front end to replace a shopping list in the array than to find the shopping list the list item belongs to and change just one list item.

### Response Status

Currently, the endpoint returns a 201 status if the list item was created, and 200 if it is combined with another item of the same description on the same list. I debated whether to change this because the front end only really cares if the response was successful, since it is just replacing lists with those from the response regardless. However, I couldn't decide which status to use for the single status and thought the distinction might eventually be important, so I left it as-is. If it becomes too annoying or isn't useful in the future we can change it.
