### PR TITLE
Fix bug where aggregate list not returned from item creation endpoint

### DIFF
--- a/app/controller_services/shopping_list_items_controller/create_service.rb
+++ b/app/controller_services/shopping_list_items_controller/create_service.rb
@@ -74,7 +74,7 @@ class ShoppingListItemsController < ApplicationController
     end
 
     def lists_to_be_changed
-      list_ids = if params[:unit_weight] && params[:unit_weight] != aggregate_list_item&.unit_weight
+      list_ids = if all_matching_list_items.count > 0 && params[:unit_weight] && params[:unit_weight] != aggregate_list_item&.unit_weight
                    all_matching_list_items.pluck(:list_id).push(shopping_list.id)
                  else
                    [aggregate_list.id, shopping_list.id]

--- a/spec/controller_services/shopping_list_items_controller/create_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/create_service_spec.rb
@@ -21,22 +21,46 @@ RSpec.describe ShoppingListItemsController::CreateService do
 
       context 'when there is no existing matching item on the same list' do
         context 'when there is no existing matching item on any list' do
-          it 'creates a new item on the list' do
-            expect { perform }
-              .to change(shopping_list.list_items, :count).from(0).to(1)
+          context 'when unit weight is not set' do
+            it 'creates a new item on the list' do
+              expect { perform }
+                .to change(shopping_list.list_items, :count).from(0).to(1)
+            end
+
+            it 'creates a new item on the aggregate list' do
+              expect { perform }
+                .to change(aggregate_list.list_items, :count).from(0).to(1)
+            end
+
+            it 'returns a Service::CreatedResult' do
+              expect(perform).to be_a(Service::CreatedResult)
+            end
+
+            it 'sets the resource to all the changed shopping lists' do
+              expect(perform.resource).to eq [aggregate_list, shopping_list]
+            end
           end
 
-          it 'creates a new item on the aggregate list' do
-            expect { perform }
-              .to change(aggregate_list.list_items, :count).from(0).to(1)
-          end
+          context 'when unit weight is set' do
+            let(:params) { { description: 'Necklace', quantity: 2, unit_weight: 0.3, notes: 'Hello world' } }
 
-          it 'returns a Service::CreatedResult' do
-            expect(perform).to be_a(Service::CreatedResult)
-          end
+            it 'creates a new item on the list' do
+              expect { perform }
+                .to change(shopping_list.list_items, :count).from(0).to(1)
+            end
 
-          it 'sets the resource to all the changed shopping lists' do
-            expect(perform.resource).to eq [aggregate_list, shopping_list]
+            it 'creates a new item on the aggregate list' do
+              expect { perform }
+                .to change(aggregate_list.list_items, :count).from(0).to(1)
+            end
+
+            it 'returns a Service::CreatedResult' do
+              expect(perform).to be_a(Service::CreatedResult)
+            end
+
+            it 'sets the resource to all the changed shopping lists' do
+              expect(perform.resource).to eq [aggregate_list, shopping_list]
+            end
           end
         end
 

--- a/spec/requests/shopping_list_items_spec.rb
+++ b/spec/requests/shopping_list_items_spec.rb
@@ -30,24 +30,50 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
         context 'when there is no existing matching item on the same list' do
           context 'when there is no existing matching item on any list' do
-            it 'creates a new item on the requested list' do
-              expect { create_item }
-                .to change(shopping_list.list_items, :count).from(0).to(1)
+            context 'when unit weight is not set' do
+              it 'creates a new item on the requested list' do
+                expect { create_item }
+                  .to change(shopping_list.list_items, :count).from(0).to(1)
+              end
+
+              it 'creates a new item on the aggregate list' do
+                expect { create_item }
+                  .to change(aggregate_list.list_items, :count).from(0).to(1)
+              end
+
+              it 'returns status 201' do
+                create_item
+                expect(response.status).to eq 201
+              end
+
+              it 'returns all changed shopping lists for the same game' do
+                create_item
+                expect(response.body).to eq(game.shopping_lists.to_json)
+              end
             end
 
-            it 'creates a new item on the aggregate list' do
-              expect { create_item }
-                .to change(aggregate_list.list_items, :count).from(0).to(1)
-            end
+            context 'when unit weight is set' do
+              let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 5, notes: 'To make locks' } }.to_json }
 
-            it 'returns status 201' do
-              create_item
-              expect(response.status).to eq 201
-            end
+              it 'creates a new item on the requested list' do
+                expect { create_item }
+                  .to change(shopping_list.list_items, :count).from(0).to(1)
+              end
 
-            it 'returns all changed shopping lists for the same game' do
-              create_item
-              expect(response.body).to eq(game.shopping_lists.to_json)
+              it 'creates a new item on the aggregate list' do
+                expect { create_item }
+                  .to change(aggregate_list.list_items, :count).from(0).to(1)
+              end
+
+              it 'returns status 201' do
+                create_item
+                expect(response.status).to eq 201
+              end
+
+              it 'returns all changed shopping lists for the same game' do
+                create_item
+                expect(response.body).to eq(game.shopping_lists.to_json)
+              end
             end
           end
 


### PR DESCRIPTION
## Context

* [**Rewrite Shopping Lists page**](https://trello.com/c/oBVGCwU1/232-rewrite-shopping-lists-page)
* [**Enable shopping list item creation from shopping lists page**](https://trello.com/c/o4ghq9eI/266-enable-shopping-list-item-creation-from-shopping-lists-page)

This PR should've been part of #156, where we missed a critical edge case. We want any changed shopping lists to be returned from the shopping list item creation endpoint. However, we also made the error of returning only the shopping list to which an item was directly added if:

1. The request set a unit weight for the item
2. No matching item existed on the aggregate list

## Changes

* Fix bug where only shopping list where item was directly created is returned if request sets unit weight and no aggregate list item exists
* Add tests covering this regression

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [ ] ~~Added and updated API docs and developer docs as appropriate~~

## Considerations

Docs didn't need to be updated because they already stated the desired behaviour - we didn't know the behaviour _wasn't_ the desired behaviour until after they were written.
