### PR TITLE
Modify response bodies for DELETE /shopping_list_items/:id endpoint

### DIFF
--- a/app/controller_services/shopping_list_items_controller/destroy_service.rb
+++ b/app/controller_services/shopping_list_items_controller/destroy_service.rb
@@ -22,7 +22,7 @@ class ShoppingListItemsController < ApplicationController
         aggregate_list.remove_item_from_child_list(shopping_list_item.attributes)
       end
 
-      Service::OKResult.new(resource: game.shopping_lists.index_order)
+      Service::OKResult.new(resource: [aggregate_list.reload, shopping_list.reload])
     rescue ActiveRecord::RecordNotFound
       Service::NotFoundResult.new
     rescue StandardError => e

--- a/docs/api/resources/shopping-list-items.md
+++ b/docs/api/resources/shopping-list-items.md
@@ -419,7 +419,7 @@ Authorization: Bearer xxxxxxxxxxx
 
 #### Example Body
 
-The response body will be an array of all shopping lists belonging to the game to which the deleted list item ultimately belongs. This object also includes the shopping list items on each list.
+The response body includes the shopping list from which the item was deleted as well as the aggregate list, with the aggregate list first.
 
 ```json
 [
@@ -444,8 +444,8 @@ The response body will be an array of all shopping lists belonging to the game t
       {
         "list_id": 43,
         "description": "Iron ingot",
-        "quantity": 4,
-        "notes": "3 locks -- 2 hinges",
+        "quantity": 3,
+        "notes": "3 locks",
         "unit_weight": 1.0,
         "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
         "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
@@ -475,26 +475,6 @@ The response body will be an array of all shopping lists belonging to the game t
         "description": "Iron ingot",
         "quantity": 3,
         "notes": "3 locks",
-        "unit_weight": 1.0,
-        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
-      }
-    ]
-  },
-  {
-    "id": 52,
-    "game_id": 8234,
-    "aggregate": false,
-    "aggregate_list_id": 43,
-    "title": "Severin Manor",
-    "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "list_items": [
-      {
-        "list_id": 52,
-        "description": "Iron ingot",
-        "quantity": 1,
-        "notes": "2 hinges",
         "unit_weight": 1.0,
         "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
         "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"

--- a/spec/controller_services/shopping_list_items_controller/destroy_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/destroy_service_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe ShoppingListItemsController::DestroyService do
           expect(perform).to be_a Service::OKResult
         end
 
-        it "returns all the game's shopping lists as the resource" do
+        it 'sets the aggregate list and the regular list as the resource' do
           expect(perform.resource).to eq([aggregate_list, shopping_list])
         end
       end

--- a/spec/controller_services/shopping_list_items_controller/destroy_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/destroy_service_spec.rb
@@ -38,8 +38,8 @@ RSpec.describe ShoppingListItemsController::DestroyService do
           expect(perform).to be_a Service::OKResult
         end
 
-        it "sets all the game's shopping lists as the resource" do
-          expect(perform.resource).to eq(game.shopping_lists.reload.index_order)
+        it 'sets the aggregate list and the regular list as the resource' do
+          expect(perform.resource).to eq([aggregate_list, shopping_list])
         end
 
         it 'sets the updated_at timestamp on the shopping list' do
@@ -104,7 +104,7 @@ RSpec.describe ShoppingListItemsController::DestroyService do
         end
 
         it "returns all the game's shopping lists as the resource" do
-          expect(perform.resource).to eq(game.shopping_lists.reload.index_order)
+          expect(perform.resource).to eq([aggregate_list, shopping_list])
         end
       end
     end

--- a/spec/requests/shopping_list_items_spec.rb
+++ b/spec/requests/shopping_list_items_spec.rb
@@ -1065,9 +1065,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
             expect(response.status).to eq 200
           end
 
-          it 'returns an empty response' do
+          it 'returns the aggregate list and the regular list' do
             destroy_item
-            expect(response.body).to eq(game.shopping_lists.to_json)
+            expect(response.body).to eq([aggregate_list.reload, shopping_list.reload].to_json)
           end
         end
 
@@ -1125,9 +1125,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
             expect(response.status).to eq 200
           end
 
-          it "returns all the game's shopping lists" do
+          it 'returns the aggregate list and the regular list' do
             destroy_item
-            expect(response.body).to eq(game.shopping_lists.to_json)
+            expect(response.body).to eq([aggregate_list.reload, shopping_list.reload].to_json)
           end
         end
       end


### PR DESCRIPTION
## Context

In #153, we modified the `DELETE /shopping_list_items/:id` endpoint to return all of a game's shopping lists, not realising that this would cause issues with the lists in the UI being excessively rearranged on every request. We would like to return only the regular list the item was deleted from and the aggregate list for that game.

## Changes

* Return only the aggregate list and the shopping list from which an item was directly removed on success responses from the `DELETE /shopping_list_items/:id` endpoint
* Update tests
* Update docs

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate
