### PR TITLE
Return all modified shopping list items from the shopping list item update endpoint

### DIFF
--- a/app/controller_services/shopping_list_items_controller/update_service.rb
+++ b/app/controller_services/shopping_list_items_controller/update_service.rb
@@ -28,7 +28,7 @@ class ShoppingListItemsController < ApplicationController
         aggregate_list.update_item_from_child_list(list_item.description, delta_qty, params[:unit_weight], old_notes, params[:notes])
       end
 
-      Service::OKResult.new(resource: game.shopping_lists.index_order)
+      Service::OKResult.new(resource: params[:unit_weight] ? all_matching_items : [aggregate_list_item, list_item.reload])
     rescue ActiveRecord::RecordInvalid
       Service::UnprocessableEntityResult.new(errors: list_item.error_array)
     rescue ActiveRecord::RecordNotFound
@@ -56,6 +56,10 @@ class ShoppingListItemsController < ApplicationController
 
     def game
       @game ||= shopping_list.game
+    end
+
+    def aggregate_list_item
+      aggregate_list.list_items.find_by('description ILIKE ?', list_item.description)
     end
 
     def all_matching_items

--- a/app/models/concerns/aggregatable.rb
+++ b/app/models/concerns/aggregatable.rb
@@ -103,7 +103,7 @@ module Aggregatable
 
     existing_item = list_items.find_by('description ILIKE ?', description)
 
-    raise AggregateListError.new('invalid data to update aggregate list item') if existing_item.nil? || delta_quantity < (-existing_item.quantity) || (unit_weight && (!unit_weight.is_a?(Numeric) || unit_weight < 0))
+    raise AggregateListError.new('Invalid data to update aggregate list item') if existing_item.nil? || delta_quantity < (-existing_item.quantity) || (unit_weight && (!unit_weight.is_a?(Numeric) || unit_weight < 0))
 
     existing_item.quantity += delta_quantity
     existing_item.notes = if old_notes.nil? && new_notes.present?

--- a/docs/api/resources/shopping-list-items.md
+++ b/docs/api/resources/shopping-list-items.md
@@ -269,87 +269,28 @@ Content-Type: application/json
 
 #### Example Body
 
-The body is a JSON array containing all shopping lists belonging to the same game, including the items on each list. This is because items on any of the lists may have been changed and it is easier for clients to receive the relevant data in its context.
+The body is a JSON array containing all shopping list items modified in the course of handling the request. Clients should take note of each item's `list_id` value to associate the item to a shopping list. Note that, if an item's unit weight is updated, this weight will be updated on any lists with a corresponding list item, so there may be more than two list items included in the response.
 
 ```json
 [
   {
-    "id": 43,
-    "game_id": 8234,
-    "aggregate": true,
-    "aggregate_list_id": null,
-    "title": "All Items",
+    "list_id": 43,
+    "description": "Unenchanted ebony sword",
+    "quantity": 1,
+    "notes": "Need an unenchanted sword to start Companions questline",
+    "unit_weight": null,
     "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "list_items": [
-      {
-        "list_id": 43,
-        "description": "Unenchanted ebony sword",
-        "quantity": 1,
-        "notes": "Need an unenchanted sword to start Companions questline",
-        "unit_weight": null,
-        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
-      },
-      {
-        "list_id": 43,
-        "description": "Iron ingot",
-        "quantity": 4,
-        "notes": "3 locks -- 2 hinges",
-        "unit_weight": 1.0,
-        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
-      }
-    ]
+    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
   },
   {
-    "id": 46,
-    "game_id": 8234,
-    "aggregate": false,
-    "aggregate_list_id": 43,
-    "title": "Lakeview Manor",
+    "list_id": 46,
+    "description": "Unenchanted ebony sword",
+    "quantity": 1,
+    "notes": "Need an unenchanted sword to start Companions questline",
+    "unit_weight": null,
     "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "list_items": [
-      {
-        "list_id": 46,
-        "description": "Unenchanted ebony sword",
-        "quantity": 1,
-        "notes": "Need an unenchanted sword to start Companions questline",
-        "unit_weight": null,
-        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
-      },
-      {
-        "list_id": 46,
-        "description": "Iron ingot",
-        "quantity": 3,
-        "notes": "3 locks",
-        "unit_weight": 1.0,
-        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
-      }
-    ]
-  },
-  {
-    "id": 52,
-    "game_id": 8234,
-    "aggregate": false,
-    "aggregate_list_id": 43,
-    "title": "Severin Manor",
-    "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-    "list_items": [
-      {
-        "list_id": 52,
-        "description": "Iron ingot",
-        "quantity": 1,
-        "notes": "2 hinges",
-        "unit_weight": 1.0,
-        "created_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00",
-        "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
-      }
-    ]
+    "updated_at": "Thu, 17 Jun 2021 11:59:16.891338000 UTC +00:00"
+  }
   }
 ]
 ```

--- a/spec/controller_services/shopping_list_items_controller/update_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/update_service_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe ShoppingListItemsController::UpdateService do
           expect(perform).to be_a(Service::OKResult)
         end
 
-        it "returns all the game's shopping lists as the resource" do
-          expect(perform.resource).to eq(game.shopping_lists.reload.index_order)
+        it 'returns the modified shopping list items as the resource' do
+          expect(perform.resource).to eq [aggregate_list_item, list_item.reload]
         end
       end
 
@@ -75,8 +75,8 @@ RSpec.describe ShoppingListItemsController::UpdateService do
             expect(perform).to be_a(Service::OKResult)
           end
 
-          it "returns all the game's shopping lists as the resource" do
-            expect(perform.resource).to eq(game.shopping_lists.reload.index_order)
+          it 'returns the two modified list items as the resource' do
+            expect(perform.resource).to eq([aggregate_list_item, list_item.reload])
           end
         end
 
@@ -105,8 +105,8 @@ RSpec.describe ShoppingListItemsController::UpdateService do
             expect(perform).to be_a(Service::OKResult)
           end
 
-          it "returns all the game's shopping lists as the resource" do
-            expect(perform.resource).to eq(game.shopping_lists.reload.index_order)
+          it 'returns all modified list items as the resource' do
+            expect(perform.resource).to eq([aggregate_list_item, other_item.reload, list_item.reload])
           end
         end
       end

--- a/spec/requests/shopping_list_items_spec.rb
+++ b/spec/requests/shopping_list_items_spec.rb
@@ -418,7 +418,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
           it 'returns the modified shopping list items' do
             update_item
-            expect(response.body).to eq([aggregate_list_item.reload, list_item.reload].to_json)
+            expect(response.body).to eq([aggregate_list_item, list_item.reload].to_json)
           end
         end
 
@@ -743,7 +743,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
           it 'returns the modified shopping list items' do
             update_item
-            expect(response.body).to eq([aggregate_list_item.reload, list_item.reload].to_json)
+            expect(response.body).to eq([aggregate_list_item, list_item.reload].to_json)
           end
         end
 

--- a/spec/requests/shopping_list_items_spec.rb
+++ b/spec/requests/shopping_list_items_spec.rb
@@ -416,9 +416,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
             expect(response.status).to eq 200
           end
 
-          it "returns all the game's shopping lists" do
+          it 'returns the modified shopping list items' do
             update_item
-            expect(response.body).to eq(game.shopping_lists.to_json)
+            expect(response.body).to eq([aggregate_list_item.reload, list_item.reload].to_json)
           end
         end
 
@@ -475,9 +475,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
               expect(response.status).to eq 200
             end
 
-            it "returns all the game's shopping lists" do
+            it 'returns the two modified list items' do
               update_item
-              expect(response.body).to eq(game.shopping_lists.to_json)
+              expect(response.body).to eq([aggregate_list_item, list_item.reload].to_json)
             end
           end
 
@@ -539,9 +539,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
               expect(response.status).to eq 200
             end
 
-            it "returns all the game's shopping lists" do
+            it 'returns all the modified list items' do
               update_item
-              expect(response.body).to eq(game.shopping_lists.to_json)
+              expect(response.body).to eq([aggregate_list_item, other_item.reload, list_item.reload].to_json)
             end
           end
         end
@@ -741,9 +741,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
             expect(response.status).to eq 200
           end
 
-          it "returns all the game's shopping lists" do
+          it 'returns the modified shopping list items' do
             update_item
-            expect(response.body).to eq(game.shopping_lists.to_json)
+            expect(response.body).to eq([aggregate_list_item.reload, list_item.reload].to_json)
           end
         end
 
@@ -800,9 +800,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
               expect(response.status).to eq 200
             end
 
-            it "returns all the game's shopping lists" do
+            it 'returns the two modified list items' do
               update_item
-              expect(response.body).to eq(game.shopping_lists.to_json)
+              expect(response.body).to eq([aggregate_list_item, list_item.reload].to_json)
             end
           end
 
@@ -864,9 +864,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
               expect(response.status).to eq 200
             end
 
-            it "returns all the game's shopping lists" do
+            it 'returns all the modified list items' do
               update_item
-              expect(response.body).to eq(game.shopping_lists.to_json)
+              expect(response.body).to eq([aggregate_list_item, other_item.reload, list_item.reload].to_json)
             end
           end
         end


### PR DESCRIPTION
## Context

In #152, we modified the response body from the shopping list item update endpoint to return all shopping lists for the game. Unfortunately, this had unintended consequences as it results in rearranging list items on the screen even when only incrementing quantity. We need to revert to an approach more like the original ones. The endpoint needs to return all modified list items and only those list items.

## Changes

* Return only modified shopping list items from shopping list items update endpoint
* Update RSpec tests
* Update API docs

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

Testing whether `params[:unit_weight]` is present to determine whether other list items were updated is kind of a hack, in that the items would only be updated if it is present _and different from the existing value_. However, there are only two possible edge cases here:

1. The `:unit_weight` param is present but there are only two items - the one on the regular list and the one on the aggregate list
2. The `:unit_weight` param is present but equal to the existing value

In the first case, there would only be two items changed anyway and those would be the ones included in the response. In the second case, more items than need be would be returned to the front end. However, I don't see significant consequences to this since the client will be configured to handle any number of changed list items in the response, so the worst thing that can happen is it has to iterate through one more item in the array.