### PR TITLE
Fix bug unsetting unit weights

### DIFF
--- a/app/models/concerns/aggregatable.rb
+++ b/app/models/concerns/aggregatable.rb
@@ -98,7 +98,7 @@ module Aggregatable
     existing_item&.persisted? ? existing_item : nil
   end
 
-  def update_item_from_child_list(description, delta_quantity, unit_weight, old_notes, new_notes)
+  def update_item_from_child_list(description, delta_quantity, unit_weight, old_notes, new_notes, unit_weight_changed = false)
     raise AggregateListError.new('update_item_from_child_list method only available on aggregate lists') unless aggregate_list?
 
     existing_item = list_items.find_by('description ILIKE ?', description)
@@ -112,7 +112,7 @@ module Aggregatable
                             existing_item.notes&.sub(/#{old_notes}/, new_notes.to_s).presence || new_notes
                           end
 
-    unless unit_weight.nil?
+    if unit_weight.present? || unit_weight_changed
       existing_item.unit_weight = unit_weight
 
       other_items = child_lists.all.map(&:list_items)

--- a/docs/aggregate-lists.md
+++ b/docs/aggregate-lists.md
@@ -203,7 +203,7 @@ Before including the `Listable` module in your class, you will need to define th
 
 ## Aggregatable
 
-The `Aggregatable` module provides aggregate list functionality to a list model. 
+The `Aggregatable` module provides aggregate list functionality to a list model.
 
 ### Associations
 
@@ -261,7 +261,7 @@ Should be called on an aggregate list any time an item is added to one of its ch
 
 Should be called on an aggregate list any time an item is removed/destroyed from one of its child lists. Handles logic for removing or updating list items on the aggregate list. Raises an `Aggregatable::AggregateListError` if called on a regular list. Returns the updated item from the aggregate list if its quantity is higher than that of the item removed and  otherwise `nil`.
 
-#### `update_item_from_child_list(description, delta_quantity, old_notes, new_notes)`
+#### `update_item_from_child_list(description, delta_quantity, unit_weight, old_notes, new_notes, unit_weight_changed)`
 
 Should be called on an aggregate list any time an item is updated on a child list. Raises an `Aggregatable::AggregateListError` if called on a regular list. Handles logic for updating items that already exist on a child list. Returns the updated list item from the aggregate list.
 
@@ -269,8 +269,10 @@ Arguments:
 
 * `description`: The `description` of the item that has been changed (descriptions are not editable).
 * `delta_quantity`: The difference between the new and old quantity on the updated item. Should be negative if the new quantity is lower and positive if it is higher.
+* `unit_weight`: The new `unit_weight` value of the item that has been changed
 * `old_notes`: The previous `notes` value of the item that has been changed
-* `new_notes`: Thee updated `notes` value of the item that has been changed
+* `new_notes`: The updated `notes` value of the item that has been changed
+* `unit_weight_changed`: If `unit_weight` param is `nil`, whether it was changed to `nil` (as opposed to just not being specified)
 
 #### `aggregate_list`
 

--- a/spec/models/inventory_list_spec.rb
+++ b/spec/models/inventory_list_spec.rb
@@ -663,16 +663,36 @@ RSpec.describe InventoryList, type: :model do
         end
       end
 
-      context 'when there is no unit_weight given' do
-        subject(:update_item) { aggregate_list.update_item_from_child_list(description, 1, nil, 'something', 'another thing') }
+      context 'when unit_weight is nil' do
+        context 'when the unit weight is being unset' do
+          subject(:update_item) { aggregate_list.update_item_from_child_list(description, 1, nil, 'something', 'something', true) }
 
-        before do
-          aggregate_list.list_items.create(description:, quantity: 3, unit_weight: 1, notes: 'something')
+          let(:other_list) { create(:inventory_list, game: aggregate_list.game, aggregate_list:) }
+          let!(:item_on_other_list) { create(:inventory_item, list: other_list, description:, unit_weight: 1) }
+          let!(:aggregate_list_item) { create(:inventory_item, list: aggregate_list, description:, quantity: 3, unit_weight: 1, notes: 'something') }
+
+          it 'updates the aggregate list item unit weight' do
+            update_item
+            expect(aggregate_list_item.reload.unit_weight).to be_nil
+          end
+
+          it 'updates the item on the other list' do
+            update_item
+            expect(item_on_other_list.reload.unit_weight).to be_nil
+          end
         end
 
-        it 'leaves the existing unit_weight as-is' do
-          update_item
-          expect(aggregate_list.list_items.first.unit_weight).to eq 1
+        context 'when the unit weight is not being updated' do
+          subject(:update_item) { aggregate_list.update_item_from_child_list(description, 1, nil, 'something', 'another thing', false) }
+
+          before do
+            aggregate_list.list_items.create(description:, quantity: 3, unit_weight: 1, notes: 'something')
+          end
+
+          it 'leaves the existing unit_weight as-is' do
+            update_item
+            expect(aggregate_list.reload.list_items.first.unit_weight).to eq 1
+          end
         end
       end
 

--- a/spec/requests/shopping_list_items_spec.rb
+++ b/spec/requests/shopping_list_items_spec.rb
@@ -423,9 +423,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
         end
 
         context 'when there is a matching item on another list' do
-          let!(:list_item) { create(:shopping_list_item, list: shopping_list) }
+          let!(:list_item) { create(:shopping_list_item, list: shopping_list, unit_weight: 1) }
           let!(:other_list) { create(:shopping_list, game:, aggregate_list:) }
-          let!(:other_item) { create(:shopping_list_item, list: other_list, description: list_item.description, quantity: 4) }
+          let!(:other_item) { create(:shopping_list_item, list: other_list, description: list_item.description, quantity: 4, unit_weight: 1) }
           let(:aggregate_list_item) { aggregate_list.list_items.first }
 
           before do
@@ -500,6 +500,70 @@ RSpec.describe 'ShoppingListItems', type: :request do
               update_item
               expect(other_item.reload.quantity).to eq 4
               expect(other_item.unit_weight).to eq 2
+            end
+
+            it 'updates the regular list' do
+              t = Time.zone.now + 3.days
+              Timecop.freeze(t) do
+                update_item
+                expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+              end
+            end
+
+            it 'updates the aggregate list' do
+              t = Time.zone.now + 3.days
+              Timecop.freeze(t) do
+                update_item
+                expect(aggregate_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+              end
+            end
+
+            it 'updates the other list' do
+              t = Time.zone.now + 3.days
+              Timecop.freeze(t) do
+                update_item
+                expect(other_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+              end
+            end
+
+            it 'updates the game' do
+              t = Time.zone.now + 3.days
+              Timecop.freeze(t) do
+                update_item
+                expect(game.reload.updated_at).to be_within(0.005.seconds).of(t)
+              end
+            end
+
+            it 'returns status 200' do
+              update_item
+              expect(response.status).to eq 200
+            end
+
+            it 'returns all the modified list items' do
+              update_item
+              expect(response.body).to eq([aggregate_list_item, other_item.reload, list_item.reload].to_json)
+            end
+          end
+
+          context 'when unit_weight is set to nil' do
+            let(:params) { { shopping_list_item: { quantity: 10, unit_weight: nil } }.to_json }
+
+            it 'updates the list item', :aggregate_failures do
+              update_item
+              expect(list_item.reload.quantity).to eq 10
+              expect(list_item.unit_weight).to be_nil
+            end
+
+            it 'updates the aggregate list item', :aggregate_failures do
+              update_item
+              expect(aggregate_list_item.quantity).to eq 14
+              expect(aggregate_list_item.unit_weight).to be_nil
+            end
+
+            it 'updates only the unit weight of the other list item', :aggregate_failures do
+              update_item
+              expect(other_item.reload.quantity).to eq 4
+              expect(other_item.unit_weight).to be_nil
             end
 
             it 'updates the regular list' do
@@ -748,9 +812,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
         end
 
         context 'when there is a matching item on another list' do
-          let!(:list_item) { create(:shopping_list_item, list: shopping_list) }
+          let!(:list_item) { create(:shopping_list_item, list: shopping_list, unit_weight: 1) }
           let!(:other_list) { create(:shopping_list, game:, aggregate_list:) }
-          let!(:other_item) { create(:shopping_list_item, list: other_list, description: list_item.description, quantity: 4) }
+          let!(:other_item) { create(:shopping_list_item, list: other_list, description: list_item.description, quantity: 4, unit_weight: 1) }
           let(:aggregate_list_item) { aggregate_list.list_items.first }
 
           before do
@@ -825,6 +889,70 @@ RSpec.describe 'ShoppingListItems', type: :request do
               update_item
               expect(other_item.reload.quantity).to eq 4
               expect(other_item.unit_weight).to eq 2
+            end
+
+            it 'updates the regular list' do
+              t = Time.zone.now + 3.days
+              Timecop.freeze(t) do
+                update_item
+                expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+              end
+            end
+
+            it 'updates the aggregate list' do
+              t = Time.zone.now + 3.days
+              Timecop.freeze(t) do
+                update_item
+                expect(aggregate_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+              end
+            end
+
+            it 'updates the other list' do
+              t = Time.zone.now + 3.days
+              Timecop.freeze(t) do
+                update_item
+                expect(other_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+              end
+            end
+
+            it 'updates the game' do
+              t = Time.zone.now + 3.days
+              Timecop.freeze(t) do
+                update_item
+                expect(game.reload.updated_at).to be_within(0.005.seconds).of(t)
+              end
+            end
+
+            it 'returns status 200' do
+              update_item
+              expect(response.status).to eq 200
+            end
+
+            it 'returns all the modified list items' do
+              update_item
+              expect(response.body).to eq([aggregate_list_item, other_item.reload, list_item.reload].to_json)
+            end
+          end
+
+          context 'when unit_weight is set to nil' do
+            let(:params) { { shopping_list_item: { quantity: 10, unit_weight: nil } }.to_json }
+
+            it 'updates the list item', :aggregate_failures do
+              update_item
+              expect(list_item.reload.quantity).to eq 10
+              expect(list_item.unit_weight).to be_nil
+            end
+
+            it 'updates the aggregate list item', :aggregate_failures do
+              update_item
+              expect(aggregate_list_item.quantity).to eq 14
+              expect(aggregate_list_item.unit_weight).to be_nil
+            end
+
+            it 'updates only the unit weight of the other list item', :aggregate_failures do
+              update_item
+              expect(other_item.reload.quantity).to eq 4
+              expect(other_item.unit_weight).to be_nil
             end
 
             it 'updates the regular list' do


### PR DESCRIPTION
## Context

[**Fix bug unsetting unit weights**](https://trello.com/c/WvDvo4uD/270-fix-bug-unsetting-unit-weights)

When a shopping or inventory list item is updated, if its unit weight is not specified, unit weights should not be updated on other corresponding list items, on the aggregate list or other lists belonging to the same game. On the other hand, if the unit weight is explicitly set to `nil` in the params, it should be updated to `nil` for all the corresponding list items. In the existing code, any `nil` value of `unit_weight` results in `unit_weight` not being updated for other list items, including the aggregate list item. `nil` values of the `:unit_weight` param are not differentiated from the absence of a `:unit_weight` param.

## Changes

* Add 6th argument to `Aggregatable#update_item_from_child_list` method indicating whether the `unit_weight` should be updated
* Add tests for this behaviour
* Update docs

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

6 positional arguments is a lot - 5 is already a lot - and I didn't like adding the last one. I considered changing the arguments to a single `:update_options` hash argument and checking if it had a `:unit_weight` key or not, but I thought that keeping track of available options could get confusing if we are having to actively manage lists. Changing the args to keyword args would leave us with lots of places we needed to change code, so I didn't do that either.

### Testing

It is unclear to me from reading the code what happens in the following scenario:

- There are two shopping lists, A and B
- There is an item called "Iron ingot" on list A with a unit weight of 1
- An item called "Iron ingot" is created on list B and its unit weight is not specified

This is covered by the `Aggregatable#add_item_from_child_list` method and, as such, the behaviour is not affected by this PR. However, it's important we know what it is and document it. The easiest way to test this would be through the front end.

#### Edit

Front-end testing revealed that what happens in this scenario is that the `unit_weight` of the new item is updated to be the same as that of existing items. I think this is as it should be.