### PR TITLE
Update pg gem from 1.3.5 to 1.4.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,7 +135,7 @@ GEM
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
-    pg (1.3.5)
+    pg (1.4.6)
     public_suffix (5.0.1)
     puma (5.6.4)
       nio4r (~> 2.0)


### PR DESCRIPTION
## Context

In the process of updating minor dependencies (i.e., not Ruby or Rails), we discovered that the `pg` gem is in need of updating. This is possibly our third-biggest dependency so we'll want to be careful that changes work locally before deploying to prod, even though they may not be the easiest to test.

## Changes

* Update `pg` gem from 1.3.5 to 1.4.6

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~

