### PR TITLE
Update Bootsnap from 1.12.0 to 1.16.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'pg', '~> 1.3'
 gem 'puma', '~> 6.2.2'
 
 # Reduces boot times through caching; required in config/boot.rb
-gem 'bootsnap', '>= 1.12.0', require: false
+gem 'bootsnap', '~> 1.16', require: false
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 gem 'rack-cors', '~> 1.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,7 +69,7 @@ GEM
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
-    bootsnap (1.12.0)
+    bootsnap (1.16.0)
       msgpack (~> 1.2)
     builder (3.2.4)
     byebug (11.1.3)
@@ -115,7 +115,7 @@ GEM
     method_source (1.0.0)
     mini_mime (1.1.2)
     minitest (5.18.0)
-    msgpack (1.5.2)
+    msgpack (1.7.0)
     net-imap (0.3.4)
       date
       net-protocol
@@ -240,7 +240,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  bootsnap (>= 1.12.0)
+  bootsnap (~> 1.16)
   byebug (~> 11.1)
   database_cleaner-active_record (~> 2.0.1)
   dotenv (~> 2.8)


### PR DESCRIPTION
## Context

We've updated other production dependencies in #166, #168, #169, and #170. This PR is to update the less-pressing prod dependencies, which turn out to only be Bootsnap.

## Changes

* Update Bootsnap from 1.12.0 to 1.16.0

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~

## Considerations

While we ordinarily would be circumspect about upgrading 4 minor versions at a time, it seems Bootsnap doesn't really do patch versions so these are likely patches.
