### PR TITLE
Create non-canonical ClothingItem model

### DIFF
--- a/app/models/canonical/clothing_item.rb
+++ b/app/models/canonical/clothing_item.rb
@@ -15,6 +15,12 @@ module Canonical
              -> { select 'enchantments.*, enchantables_enchantments.strength as strength' },
              through: :enchantables_enchantments
 
+    has_many :clothing_items,
+             inverse_of: :canonical_clothing_item,
+             dependent: :nullify,
+             foreign_key: 'canonical_clothing_item_id',
+             class_name: '::ClothingItem'
+
     validates :name, presence: true
     validates :item_code, presence: true, uniqueness: { message: 'must be unique' }
     validates :unit_weight, presence: true, numericality: { greater_than_or_equal_to: 0 }

--- a/app/models/clothing_item.rb
+++ b/app/models/clothing_item.rb
@@ -17,7 +17,13 @@ class ClothingItem < ApplicationRecord
            source: :enchantment
 
   validates :name, presence: true
-  validates :unit_weight, numericality: { greater_than_or_equal_to: 0, allow_nil: true }
+  validates :unit_weight,
+            numericality: {
+              greater_than_or_equal_to: 0,
+              allow_nil: true,
+            }
+
+  validates_with ClothingItemValidator
 
   before_validation :set_canonical_clothing_item
 

--- a/app/models/clothing_item.rb
+++ b/app/models/clothing_item.rb
@@ -21,6 +21,8 @@ class ClothingItem < ApplicationRecord
 
   before_validation :set_canonical_clothing_item
 
+  after_create :set_enchantments, if: -> { canonical_clothing_item.present? }
+
   def canonical_clothing_items
     return Array.wrap(canonical_clothing_item) if canonical_clothing_item
 
@@ -39,5 +41,18 @@ class ClothingItem < ApplicationRecord
     self.name = canonical_clothing_item.name # in case casing differs
     self.unit_weight = canonical_clothing_item.unit_weight
     self.magical_effects = canonical_clothing_item.magical_effects
+
+    set_enchantments if persisted?
+  end
+
+  def set_enchantments
+    return if canonical_clothing_item.enchantments.empty?
+
+    canonical_clothing_item.enchantables_enchantments.each do |model|
+      enchantables_enchantments.find_or_create_by!(
+        enchantment_id: model.enchantment_id,
+        strength: model.strength,
+      )
+    end
   end
 end

--- a/app/models/clothing_item.rb
+++ b/app/models/clothing_item.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class ClothingItem < ApplicationRecord
+  belongs_to :game
+
+  belongs_to :canonical_clothing_item,
+             optional: true,
+             inverse_of: :clothing_items,
+             class_name: 'Canonical::ClothingItem'
+
+  has_many :enchantables_enchantments,
+           dependent: :destroy,
+           as: :enchantable
+  has_many :enchantments,
+           -> { select 'enchantments.*, enchantables_enchantments.strength as strength' },
+           through: :enchantables_enchantments,
+           source: :enchantment
+
+  validates :name, presence: true
+  validates :unit_weight, numericality: { greater_than_or_equal_to: 0, allow_nil: true }
+end

--- a/app/models/clothing_item.rb
+++ b/app/models/clothing_item.rb
@@ -18,4 +18,26 @@ class ClothingItem < ApplicationRecord
 
   validates :name, presence: true
   validates :unit_weight, numericality: { greater_than_or_equal_to: 0, allow_nil: true }
+
+  before_validation :set_canonical_clothing_item
+
+  def canonical_clothing_items
+    return Array.wrap(canonical_clothing_item) if canonical_clothing_item
+
+    attrs_to_match = { unit_weight:, magical_effects: }.compact
+
+    canonicals = Canonical::ClothingItem.where('name ILIKE ?', name)
+    attrs_to_match.any? ? canonicals.where(**attrs_to_match) : canonicals
+  end
+
+  private
+
+  def set_canonical_clothing_item
+    return unless canonical_clothing_items.count == 1
+
+    self.canonical_clothing_item ||= canonical_clothing_items.first
+    self.name = canonical_clothing_item.name # in case casing differs
+    self.unit_weight = canonical_clothing_item.unit_weight
+    self.magical_effects = canonical_clothing_item.magical_effects
+  end
 end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -6,6 +6,7 @@ class Game < ApplicationRecord
   belongs_to :user
 
   has_many :armors, dependent: :destroy
+  has_many :clothing_items, dependent: :destroy
 
   # `before_save` callbacks need to be defined before
   # `before_destroy` callbacks, which need to be defined here

--- a/app/validators/clothing_item_validator.rb
+++ b/app/validators/clothing_item_validator.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class ClothingItemValidator < ActiveModel::Validator
+  NO_CANONICAL_MATCHES = "doesn't match a clothing item that exists in Skyrim"
+  DOES_NOT_MATCH = 'does not match value on canonical model'
+
+  def validate(record)
+    @record = record
+
+    if @record.canonical_clothing_items.blank?
+      @record.errors.add(:base, NO_CANONICAL_MATCHES)
+      return
+    end
+
+    validate_against_canonical if @record.canonical_clothing_item.present?
+  end
+
+  private
+
+  attr_reader :record
+
+  def validate_against_canonical
+    canonical = record.canonical_clothing_item
+
+    record.errors.add(:unit_weight, DOES_NOT_MATCH) unless record.unit_weight == canonical.unit_weight
+    record.errors.add(:magical_effects, DOES_NOT_MATCH) unless record.magical_effects == canonical.magical_effects
+  end
+end

--- a/db/migrate/20230522214529_create_clothing_items.rb
+++ b/db/migrate/20230522214529_create_clothing_items.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateClothingItems < ActiveRecord::Migration[7.0]
+  def change
+    create_table :clothing_items do |t|
+      t.references :game, null: false, foreign_key: true
+      t.references :canonical_clothing_item, foreign_key: true
+
+      t.string :name, null: false
+      t.decimal :unit_weight
+      t.string :magical_effects
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_21_004856) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_22_214529) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -303,6 +303,18 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_21_004856) do
     t.index ["item_code"], name: "index_canonical_weapons_on_item_code", unique: true
   end
 
+  create_table "clothing_items", force: :cascade do |t|
+    t.bigint "game_id", null: false
+    t.bigint "canonical_clothing_item_id"
+    t.string "name", null: false
+    t.decimal "unit_weight"
+    t.string "magical_effects"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["canonical_clothing_item_id"], name: "index_clothing_items_on_canonical_clothing_item_id"
+    t.index ["game_id"], name: "index_clothing_items_on_game_id"
+  end
+
   create_table "enchantables_enchantments", force: :cascade do |t|
     t.bigint "enchantment_id", null: false
     t.bigint "enchantable_id", null: false
@@ -448,6 +460,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_21_004856) do
   add_foreign_key "canonical_staves_spells", "canonical_staves", column: "staff_id"
   add_foreign_key "canonical_staves_spells", "spells"
   add_foreign_key "canonical_temperables_tempering_materials", "canonical_materials", column: "material_id"
+  add_foreign_key "clothing_items", "canonical_clothing_items"
+  add_foreign_key "clothing_items", "games"
   add_foreign_key "enchantables_enchantments", "enchantments"
   add_foreign_key "games", "users"
   add_foreign_key "inventory_items", "inventory_lists", column: "list_id"

--- a/docs/in_game_items/README.md
+++ b/docs/in_game_items/README.md
@@ -6,5 +6,7 @@ This documentation covers the scope and purpose of non-canonical in-game items, 
 
 ## Table of Contents
 
-* [In-Game Items](/docs/in_game_items/in-game-items.md)
-* [Armor](/docs/in_game_items/armor.md)
+* [In-Game Items](/docs/in_game_items/in-game-items.md): An overview of in-game item models, which models exist, and associations between them
+* Specific models:
+  * [Armor](/docs/in_game_items/armor.md)
+  * [Clothing Item](/docs/in_game_items/clothing-item.md)

--- a/docs/in_game_items/clothing-item.md
+++ b/docs/in_game_items/clothing-item.md
@@ -1,0 +1,15 @@
+# Clothing Item
+
+The `ClothingItem` model represents in-game clothing items that are not armour or jewellery, backed by the `Canonical::ClothingItem` model.
+
+## Matching Attributes
+
+`ClothingItem` models are matched to `Canonical::ClothingItem` models using the following fields:
+
+* `name`
+* `unit_weight`
+* `magical_effects`
+
+## Associations
+
+Because `ClothingItem` models may (at least theoretically) have user-added enchantments in addition to those present on the canonical model, the `ClothingItem` model has its own associations to `EnchantablesEnchantment` and `Enchantment`. The canonical model's enchantments will automatically be added to the `ClothingItem` model when it is saved and has a single matching `Canonical::ClothingItem` model.

--- a/docs/in_game_items/in-game-items.md
+++ b/docs/in_game_items/in-game-items.md
@@ -3,6 +3,7 @@
 The following non-[canonical](/docs/canonical_models/README.md) in-game item models exist in the SIM database:
 
 * [`Armor`](/app/models/armor.rb): armour items corresponding to `Canonical::Armor` pieces
+* [`ClothingItem`](/app/models/clothing_item.rb): clothing items that are not armour or jewellery, corresponding to `Canonical::ClothingItem`s
 
 Non-canonical in-game items represent individual item instances. For the purpose of inventory lists, they can also represent sets of items with identical characteristics whose quantities are then implied by the `quantity` field on the inventory item. (Note that, at this writing, inventory list functionality is not yet fully implemented.)
 

--- a/spec/models/clothing_item_spec.rb
+++ b/spec/models/clothing_item_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe ClothingItem, type: :model do
   describe 'validations' do
     let(:item) { build(:clothing_item) }
 
+    before do
+      allow_any_instance_of(ClothingItemValidator).to receive(:validate)
+    end
+
     it 'is invalid without a name' do
       item.name = nil
       item.validate
@@ -18,7 +22,10 @@ RSpec.describe ClothingItem, type: :model do
       expect(item.errors[:unit_weight]).to include 'must be greater than or equal to 0'
     end
 
-    it 'validates against canonical models'
+    it 'validates against canonical models' do
+      expect_any_instance_of(ClothingItemValidator).to receive(:validate).with(item)
+      item.validate
+    end
   end
 
   describe '::before_validation' do
@@ -87,7 +94,6 @@ RSpec.describe ClothingItem, type: :model do
       let(:item) { build(:clothing_item) }
 
       it 'is invalid' do
-        pending
         item.validate
         expect(item.errors[:base]).to include "doesn't match a clothing item that exists in Skyrim"
       end

--- a/spec/models/clothing_item_spec.rb
+++ b/spec/models/clothing_item_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ClothingItem, type: :model do
+  describe 'validations' do
+    let(:item) { build(:clothing_item) }
+
+    it 'is invalid without a name' do
+      item.name = nil
+      item.validate
+      expect(item.errors[:name]).to include "can't be blank"
+    end
+
+    it 'is invalid with unit weight less than 0' do
+      item.unit_weight = -1
+      item.validate
+      expect(item.errors[:unit_weight]).to include 'must be greater than or equal to 0'
+    end
+
+    it 'validates against canonical models'
+  end
+end

--- a/spec/models/clothing_item_spec.rb
+++ b/spec/models/clothing_item_spec.rb
@@ -20,4 +20,136 @@ RSpec.describe ClothingItem, type: :model do
 
     it 'validates against canonical models'
   end
+
+  describe '::before_validation' do
+    context 'when there is a single matching canonical model' do
+      let!(:matching_canonical) do
+        create(
+          :canonical_clothing_item,
+          :with_enchantments,
+          name: 'Fine Clothes',
+          unit_weight: 1,
+          magical_effects: 'Something',
+        )
+      end
+
+      let(:item) do
+        build(
+          :clothing_item,
+          name: 'Fine clothes',
+          unit_weight: 1,
+        )
+      end
+
+      before do
+        create(:canonical_clothing_item, name: 'Fine Clothes', unit_weight: 2)
+      end
+
+      it 'assigns the canonical clothing item' do
+        item.validate
+        expect(item.canonical_clothing_item).to eq matching_canonical
+      end
+
+      it 'sets the attributes', :aggregate_failures do
+        item.validate
+        expect(item.name).to eq 'Fine Clothes'
+        expect(item.magical_effects).to eq 'Something'
+      end
+    end
+
+    context 'when there are multiple matching canonical models' do
+      let!(:matching_canonicals) do
+        create_list(
+          :canonical_clothing_item,
+          2,
+          :with_enchantments,
+          name: 'Fine Clothes',
+          unit_weight: 1,
+        )
+      end
+
+      let(:item) { build(:clothing_item, name: 'Fine clothes') }
+
+      it "doesn't set the corresponding canonical clothing item" do
+        item.validate
+        expect(item.canonical_clothing_item).to be_nil
+      end
+
+      it "doesn't set other attributes", :aggregate_failures do
+        item.validate
+        expect(item.name).to eq 'Fine clothes'
+        expect(item.unit_weight).to be_nil
+        expect(item.magical_effects).to be_nil
+      end
+    end
+
+    context 'when there are no matching canonical models' do
+      let(:item) { build(:clothing_item) }
+
+      it 'is invalid' do
+        pending
+        item.validate
+        expect(item.errors[:base]).to include "doesn't match a clothing item that exists in Skyrim"
+      end
+    end
+  end
+
+  describe '#canonical_clothing_items' do
+    subject(:canonical_clothing_items) { item.canonical_clothing_items }
+
+    context 'when the item has an association defined' do
+      let(:item) do
+        create(
+          :clothing_item,
+          canonical_clothing_item:,
+          name: 'Fine Clothes',
+          unit_weight: 1,
+          magical_effects: nil,
+        )
+      end
+
+      let(:canonical_clothing_item) do
+        create(
+          :canonical_clothing_item,
+          name: 'Fine Clothes',
+          unit_weight: 1,
+          magical_effects: nil,
+        )
+      end
+
+      it 'returns the associated model in an array' do
+        expect(canonical_clothing_items).to eq [canonical_clothing_item]
+      end
+    end
+
+    context 'when the item does not have an association defined' do
+      before do
+        create(:canonical_clothing_item, name: 'Something Else')
+      end
+
+      context 'when only the name has to match' do
+        let!(:matching_canonicals) { create_list(:canonical_clothing_item, 3, name: item.name, unit_weight: 2.5) }
+
+        let(:item) { build(:clothing_item, unit_weight: nil) }
+
+        it 'returns all matching items' do
+          expect(canonical_clothing_items).to eq matching_canonicals
+        end
+      end
+
+      context 'when multiple attributes have to match' do
+        let!(:matching_canonicals) { create_list(:canonical_clothing_item, 3, name: item.name, unit_weight: 2.5) }
+
+        let(:item) { build(:clothing_item, unit_weight: 2.5) }
+
+        before do
+          create(:canonical_clothing_item, name: item.name, unit_weight: 1)
+        end
+
+        it 'returns only the items for which all values match' do
+          expect(canonical_clothing_items).to eq matching_canonicals
+        end
+      end
+    end
+  end
 end

--- a/spec/models/enchantables_enchantment_spec.rb
+++ b/spec/models/enchantables_enchantment_spec.rb
@@ -63,6 +63,18 @@ RSpec.describe EnchantablesEnchantment, type: :model do
           expect(enchantable_type).to eq 'Armor'
         end
       end
+
+      context 'when the association is a clothing item' do
+        let(:item) { create(:clothing_item) }
+
+        before do
+          create(:canonical_clothing_item)
+        end
+
+        it 'sets the enchantable type' do
+          expect(enchantable_type).to eq 'ClothingItem'
+        end
+      end
     end
   end
 end

--- a/spec/support/factories/canonical/clothing_items.rb
+++ b/spec/support/factories/canonical/clothing_items.rb
@@ -10,5 +10,11 @@ FactoryBot.define do
     unique_item { false }
     rare_item { false }
     quest_item { false }
+
+    trait :with_enchantments do
+      after(:create) do |item|
+        create_list(:enchantables_enchantment, 2, enchantable: item)
+      end
+    end
   end
 end

--- a/spec/support/factories/clothing_items.rb
+++ b/spec/support/factories/clothing_items.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :clothing_item do
+    game
+
+    name { 'Fine Clothes' }
+
+    trait :with_enchantments do
+      after(:create) do |item|
+        create_list(:enchantables_enchantment, 2, enchantable: item)
+      end
+    end
+  end
+end

--- a/spec/validators/clothing_item_validator_spec.rb
+++ b/spec/validators/clothing_item_validator_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ClothingItemValidator do
+  subject(:validate) { described_class.new.validate(item) }
+
+  let(:item) { build(:clothing_item) }
+
+  context 'when there is no matching canonical clothing item' do
+    it 'sets an error' do
+      validate
+      expect(item.errors[:base]).to include "doesn't match a clothing item that exists in Skyrim"
+    end
+  end
+
+  context 'when the record has a canonical model' do
+    let(:canonical_clothing_item) do
+      create(
+        :canonical_clothing_item,
+        unit_weight: 1,
+        name: 'Fine Clothes',
+        magical_effects: 'Something',
+      )
+    end
+
+    context 'when the unit weight does not match' do
+      let(:item) do
+        build(
+          :clothing_item,
+          canonical_clothing_item:,
+          name: 'Fine Clothes',
+          unit_weight: 2.5,
+          magical_effects: 'Something',
+        )
+      end
+
+      it 'sets an error' do
+        validate
+        expect(item.errors[:unit_weight]).to include 'does not match value on canonical model'
+      end
+    end
+
+    context 'when the magical effects do not match' do
+      let(:item) do
+        build(
+          :clothing_item,
+          canonical_clothing_item:,
+          name: 'Fine Clothes',
+          unit_weight: 1,
+          magical_effects: 'Nothing',
+        )
+      end
+
+      it 'sets an error' do
+        validate
+        expect(item.errors[:magical_effects]).to include 'does not match value on canonical model'
+      end
+    end
+  end
+
+  context 'when there are multiple matching canonical clothing items' do
+    let!(:canonicals) { create_list(:canonical_clothing_item, 2, name: item.name) }
+
+    it 'is valid' do
+      expect(item).to be_valid
+    end
+  end
+end


### PR DESCRIPTION
## Context

[**Create non-canonical ClothingItem model**](https://trello.com/c/2Hg14z0M/305-create-non-canonical-clothingitem-model)

We are creating non-canonical versions of the canonical models in SIM to represent items that a user discovers in-game. The `Armor` model was added in #175. This PR adds the `ClothingItem` model, representing clothing items that are neither armour nor jewellery and corresponding to the `Canonical::ClothingItem` model.

## Changes

* Create `clothing_items` table
* Create `ClothingItem` model
* Create `ClothingItemValidator`
* Add factory and tests
* Update docs

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate
