### PR TITLE
Create non-canonical Ingredient model

### DIFF
--- a/app/models/canonical/ingredient.rb
+++ b/app/models/canonical/ingredient.rb
@@ -23,6 +23,12 @@ module Canonical
              inverse_of: :ingredient
     has_many :recipes, through: :canonical_recipes_ingredients, class_name: 'Canonical::Book', source: :recipe
 
+    has_many :ingredients,
+             dependent: :nullify,
+             class_name: '::Ingredient',
+             foreign_key: 'canonical_ingredient_id',
+             inverse_of: :canonical_ingredient
+
     validates :name, presence: true
     validates :item_code, presence: true, uniqueness: { message: 'must be unique' }
     validates :ingredient_type, inclusion: { in: VALID_TYPES, message: TYPE_VALIDATION_MESSAGE, allow_blank: true }

--- a/app/models/canonical/ingredients_alchemical_property.rb
+++ b/app/models/canonical/ingredients_alchemical_property.rb
@@ -25,7 +25,9 @@ module Canonical
     private
 
     def ensure_max_of_four_per_ingredient
-      errors.add(:ingredient, "already has #{MAX_PER_INGREDIENT} alchemical properties") if ingredient.alchemical_properties.length >= MAX_PER_INGREDIENT
+      return if ingredient.alchemical_properties.length < MAX_PER_INGREDIENT
+
+      errors.add(:ingredient, "already has #{MAX_PER_INGREDIENT} alchemical properties")
     end
   end
 end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -7,6 +7,7 @@ class Game < ApplicationRecord
 
   has_many :armors, dependent: :destroy
   has_many :clothing_items, dependent: :destroy
+  has_many :ingredients, dependent: :destroy
 
   # `before_save` callbacks need to be defined before
   # `before_destroy` callbacks, which need to be defined here

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class Ingredient < ApplicationRecord
+  DOES_NOT_MATCH = "doesn't match an ingredient that exists in Skyrim"
+
+  belongs_to :game
+  belongs_to :canonical_ingredient,
+             class_name: 'Canonical::Ingredient',
+             optional: true,
+             inverse_of: :ingredients
+
+  validates :name, presence: true
+  validate :ensure_match_exists
+
+  before_validation :set_canonical_ingredient
+
+  private
+
+  def set_canonical_ingredient
+    matching = Canonical::Ingredient.where('name ILIKE ?', name)
+
+    self.canonical_ingredient = matching.first if matching.count == 1
+  end
+
+  def ensure_match_exists
+    return if canonical_ingredient.present?
+    return if Canonical::Ingredient.where('name ILIKE ?', name).present?
+
+    errors.add(:base, DOES_NOT_MATCH)
+  end
+end

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -24,7 +24,7 @@ class Ingredient < ApplicationRecord
 
     matching = Canonical::Ingredient.where('name ILIKE ?', name)
 
-    return matching unless alchemical_properties.any?
+    return matching if alchemical_properties.empty?
 
     ingredients_alchemical_properties.each do |join_model|
       matching = matching.joins(:canonical_ingredients_alchemical_properties).where(

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -9,6 +9,11 @@ class Ingredient < ApplicationRecord
              optional: true,
              inverse_of: :ingredients
 
+  has_many :ingredients_alchemical_properties, dependent: :destroy, inverse_of: :ingredient
+  has_many :alchemical_properties,
+           -> { select 'alchemical_properties.*, ingredients_alchemical_properties.priority' },
+           through: :ingredients_alchemical_properties
+
   validates :name, presence: true
   validate :ensure_match_exists
 

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -47,8 +47,7 @@ class Ingredient < ApplicationRecord
   end
 
   def ensure_match_exists
-    return if canonical_ingredient.present?
-    return if Canonical::Ingredient.where('name ILIKE ?', name).present?
+    return if canonical_ingredients.any?
 
     errors.add(:base, DOES_NOT_MATCH)
   end

--- a/app/models/ingredients_alchemical_property.rb
+++ b/app/models/ingredients_alchemical_property.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class IngredientsAlchemicalProperty < ApplicationRecord
+  belongs_to :ingredient
+  belongs_to :alchemical_property
+
+  validates :alchemical_property_id, uniqueness: { scope: :ingredient_id, message: 'must form a unique combination with ingredient' }
+  validates :priority,
+            allow_blank: true,
+            uniqueness: { scope: :ingredient_id, message: 'must be unique per ingredient' },
+            numericality: {
+              greater_than_or_equal_to: 1,
+              less_than_or_equal_to: 4,
+              only_integer: true,
+            }
+  validates :strength_modifier, allow_blank: true, numericality: { greater_than: 0 }
+  validates :duration_modifier, allow_blank: true, numericality: { greater_than: 0 }
+  validate :ensure_max_of_four_per_ingredient, on: :create
+
+  MAX_PER_INGREDIENT = 4
+
+  def ensure_max_of_four_per_ingredient
+    return if ingredient.nil?
+    return if ingredient.alchemical_properties.length < MAX_PER_INGREDIENT
+
+    errors.add(:ingredient, "already has #{MAX_PER_INGREDIENT} alchemical properties")
+  end
+end

--- a/app/models/ingredients_alchemical_property.rb
+++ b/app/models/ingredients_alchemical_property.rb
@@ -4,17 +4,28 @@ class IngredientsAlchemicalProperty < ApplicationRecord
   belongs_to :ingredient
   belongs_to :alchemical_property
 
-  validates :alchemical_property_id, uniqueness: { scope: :ingredient_id, message: 'must form a unique combination with ingredient' }
+  validates :alchemical_property_id,
+            uniqueness: {
+              scope: :ingredient_id,
+              message: 'must form a unique combination with ingredient',
+            }
   validates :priority,
             allow_blank: true,
-            uniqueness: { scope: :ingredient_id, message: 'must be unique per ingredient' },
+            uniqueness: {
+              scope: :ingredient_id,
+              message: 'must be unique per ingredient',
+            },
             numericality: {
               greater_than_or_equal_to: 1,
               less_than_or_equal_to: 4,
               only_integer: true,
             }
-  validates :strength_modifier, allow_blank: true, numericality: { greater_than: 0 }
-  validates :duration_modifier, allow_blank: true, numericality: { greater_than: 0 }
+  validates :strength_modifier,
+            allow_blank: true,
+            numericality: { greater_than: 0 }
+  validates :duration_modifier,
+            allow_blank: true,
+            numericality: { greater_than: 0 }
   validate :ensure_match_exists
   validate :ensure_max_of_four_per_ingredient, on: :create
 
@@ -38,9 +49,10 @@ class IngredientsAlchemicalProperty < ApplicationRecord
   end
 
   def canonical_model
-    models = canonical_models
-
-    @canonical_model ||= models.first if models.count == 1
+    @canonical_model ||= begin
+      models = canonical_models
+      models.first if models.count == 1
+    end
   end
 
   private
@@ -60,7 +72,7 @@ class IngredientsAlchemicalProperty < ApplicationRecord
   end
 
   def ensure_match_exists
-    return if canonical_models.present?
+    return if canonical_models.any?
 
     errors.add(:base, DOES_NOT_MATCH)
   end

--- a/app/models/ingredients_alchemical_property.rb
+++ b/app/models/ingredients_alchemical_property.rb
@@ -15,14 +15,53 @@ class IngredientsAlchemicalProperty < ApplicationRecord
             }
   validates :strength_modifier, allow_blank: true, numericality: { greater_than: 0 }
   validates :duration_modifier, allow_blank: true, numericality: { greater_than: 0 }
+  validate :ensure_match_exists
   validate :ensure_max_of_four_per_ingredient, on: :create
 
+  before_validation :set_attributes_from_canonical, if: -> { canonical_model.present? }
+
+  delegate :canonical_ingredients, to: :ingredient
+
   MAX_PER_INGREDIENT = 4
+  DOES_NOT_MATCH = 'is not consistent with any ingredient that exists in Skyrim'
+
+  def canonical_models
+    matching_attrs = {
+      alchemical_property_id:,
+      ingredient_id: canonical_ingredients.ids,
+      strength_modifier:,
+      duration_modifier:,
+      priority:,
+    }.compact
+
+    Canonical::IngredientsAlchemicalProperty.where(**matching_attrs)
+  end
+
+  def canonical_model
+    models = canonical_models
+
+    @canonical_model ||= models.first if models.count == 1
+  end
+
+  private
 
   def ensure_max_of_four_per_ingredient
-    return if ingredient.nil?
     return if ingredient.alchemical_properties.length < MAX_PER_INGREDIENT
 
     errors.add(:ingredient, "already has #{MAX_PER_INGREDIENT} alchemical properties")
+  end
+
+  def set_attributes_from_canonical
+    return if canonical_model.nil?
+
+    self.priority = canonical_model.priority
+    self.strength_modifier = canonical_model.strength_modifier
+    self.duration_modifier = canonical_model.duration_modifier
+  end
+
+  def ensure_match_exists
+    return if canonical_models.present?
+
+    errors.add(:base, DOES_NOT_MATCH)
   end
 end

--- a/app/models/ingredients_alchemical_property.rb
+++ b/app/models/ingredients_alchemical_property.rb
@@ -33,7 +33,6 @@ class IngredientsAlchemicalProperty < ApplicationRecord
 
   delegate :canonical_ingredients, to: :ingredient
 
-  MAX_PER_INGREDIENT = 4
   DOES_NOT_MATCH = 'is not consistent with any ingredient that exists in Skyrim'
 
   def canonical_models
@@ -58,9 +57,12 @@ class IngredientsAlchemicalProperty < ApplicationRecord
   private
 
   def ensure_max_of_four_per_ingredient
-    return if ingredient.alchemical_properties.length < MAX_PER_INGREDIENT
+    return if ingredient.alchemical_properties.length < Canonical::IngredientsAlchemicalProperty::MAX_PER_INGREDIENT
 
-    errors.add(:ingredient, "already has #{MAX_PER_INGREDIENT} alchemical properties")
+    errors.add(
+      :ingredient,
+      "already has #{Canonical::IngredientsAlchemicalProperty::MAX_PER_INGREDIENT} alchemical properties",
+    )
   end
 
   def set_attributes_from_canonical

--- a/db/migrate/20230523215512_create_ingredients.rb
+++ b/db/migrate/20230523215512_create_ingredients.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateIngredients < ActiveRecord::Migration[7.0]
+  def change
+    create_table :ingredients do |t|
+      t.references :game, null: false, foreign_key: true
+      t.references :canonical_ingredient, foreign_key: true
+      t.string :name
+      t.decimal :unit_weight, scale: 2, precision: 5
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230523225250_create_ingredients_alchemical_properties.rb
+++ b/db/migrate/20230523225250_create_ingredients_alchemical_properties.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class CreateIngredientsAlchemicalProperties < ActiveRecord::Migration[7.0]
+  def change
+    create_table :ingredients_alchemical_properties do |t|
+      t.references :ingredient, null: false, foreign_key: true
+      t.references :alchemical_property,
+                   null: false,
+                   foreign_key: true,
+                   index: {
+                     name: 'index_ingredients_alc_properties_on_alc_property_id',
+                   }
+
+      t.integer :priority
+      t.decimal :strength_modifier
+      t.decimal :duration_modifier
+
+      t.index %i[alchemical_property_id ingredient_id], unique: true, name: 'index_ingredients_alc_properties_on_property_and_ingr_ids'
+      t.index %i[priority ingredient_id], unique: true, name: 'index_ingrs_alc_props_on_priority_and_ingr_id'
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_23_215512) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_23_225250) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -357,6 +357,20 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_23_215512) do
     t.index ["game_id"], name: "index_ingredients_on_game_id"
   end
 
+  create_table "ingredients_alchemical_properties", force: :cascade do |t|
+    t.bigint "ingredient_id", null: false
+    t.bigint "alchemical_property_id", null: false
+    t.integer "priority"
+    t.decimal "strength_modifier"
+    t.decimal "duration_modifier"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["alchemical_property_id", "ingredient_id"], name: "index_ingredients_alc_properties_on_property_and_ingr_ids", unique: true
+    t.index ["alchemical_property_id"], name: "index_ingredients_alc_properties_on_alc_property_id"
+    t.index ["ingredient_id"], name: "index_ingredients_alchemical_properties_on_ingredient_id"
+    t.index ["priority", "ingredient_id"], name: "index_ingrs_alc_props_on_priority_and_ingr_id", unique: true
+  end
+
   create_table "inventory_items", force: :cascade do |t|
     t.bigint "list_id", null: false
     t.string "description", null: false
@@ -477,6 +491,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_23_215512) do
   add_foreign_key "games", "users"
   add_foreign_key "ingredients", "canonical_ingredients"
   add_foreign_key "ingredients", "games"
+  add_foreign_key "ingredients_alchemical_properties", "alchemical_properties"
+  add_foreign_key "ingredients_alchemical_properties", "ingredients"
   add_foreign_key "inventory_items", "inventory_lists", column: "list_id"
   add_foreign_key "inventory_lists", "games"
   add_foreign_key "inventory_lists", "inventory_lists", column: "aggregate_list_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_22_214529) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_23_215512) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -346,6 +346,17 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_22_214529) do
     t.index ["user_id"], name: "index_games_on_user_id"
   end
 
+  create_table "ingredients", force: :cascade do |t|
+    t.bigint "game_id", null: false
+    t.bigint "canonical_ingredient_id"
+    t.string "name"
+    t.decimal "unit_weight", precision: 5, scale: 2
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["canonical_ingredient_id"], name: "index_ingredients_on_canonical_ingredient_id"
+    t.index ["game_id"], name: "index_ingredients_on_game_id"
+  end
+
   create_table "inventory_items", force: :cascade do |t|
     t.bigint "list_id", null: false
     t.string "description", null: false
@@ -464,6 +475,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_22_214529) do
   add_foreign_key "clothing_items", "games"
   add_foreign_key "enchantables_enchantments", "enchantments"
   add_foreign_key "games", "users"
+  add_foreign_key "ingredients", "canonical_ingredients"
+  add_foreign_key "ingredients", "games"
   add_foreign_key "inventory_items", "inventory_lists", column: "list_id"
   add_foreign_key "inventory_lists", "games"
   add_foreign_key "inventory_lists", "inventory_lists", column: "aggregate_list_id"

--- a/docs/in_game_items/README.md
+++ b/docs/in_game_items/README.md
@@ -7,6 +7,9 @@ This documentation covers the scope and purpose of non-canonical in-game items, 
 ## Table of Contents
 
 * [In-Game Items](/docs/in_game_items/in-game-items.md): An overview of in-game item models, which models exist, and associations between them
-* Specific models:
+* Models:
   * [Armor](/docs/in_game_items/armor.md)
   * [Clothing Item](/docs/in_game_items/clothing-item.md)
+  * [Ingredient](/docs/in_game_items/ingredient.md)
+* Join models:
+  * [IngredientsAlchemicalProperty](/docs/in_game_items/ingredients-alchemical-property.md)

--- a/docs/in_game_items/in-game-items.md
+++ b/docs/in_game_items/in-game-items.md
@@ -4,6 +4,8 @@ The following non-[canonical](/docs/canonical_models/README.md) in-game item mod
 
 * [`Armor`](/app/models/armor.rb): armour items corresponding to `Canonical::Armor` pieces
 * [`ClothingItem`](/app/models/clothing_item.rb): clothing items that are not armour or jewellery, corresponding to `Canonical::ClothingItem`s
+* [`Ingredient`](/app/models/ingredient.rb): ingredients corresponding to the `Canonical::Ingredient` class
+* [`IngredientsAlchemicalProperty`](/app/models/ingredients_alchemical_property.rb): join model between `Ingredient` and `AlchemicalProperty` models
 
 Non-canonical in-game items represent individual item instances. For the purpose of inventory lists, they can also represent sets of items with identical characteristics whose quantities are then implied by the `quantity` field on the inventory item. (Note that, at this writing, inventory list functionality is not yet fully implemented.)
 
@@ -13,9 +15,9 @@ Non-canonical in-game items represent individual item instances. For the purpose
 
 Every in-game item has to correspond to at least one canonical model. Because not all attributes are pertinent to users and not all should be able to be set by them, non-canonical models do not have the same fields and associations as the canonical models. Instead, non-canonical models include the subset of canonical fields that are visible to or discoverable by players.
 
-When an in-game item is created, it is validated to ensure that it has at least one potential canonical match. These matches are based on fields set on the non-canonical model; in other words, fields that are `nil` on the non-canonical model are not considered for the match. Only fields set to a non-`nil` value must match the canonical model.
+When an in-game item is created, it is validated to ensure that it has at least one potential canonical match. These matches are based on fields set on the non-canonical model, or in [some cases](/docs/in_game_items/ingredient.md), associations that are present on that model; in other words, fields that are `nil` on the non-canonical model are not considered for the match. Only fields set to a non-`nil` value, or associations that have been created on the non-canonical model, must match the canonical model.
 
-If the in-game item matches only one canonical model, that model is set as the `canonical_<model>` for that item.
+If the in-game item matches exactly one canonical model, that model is set as the `canonical_<model>` for that item. If there are no matching canonical models, validation fails.
 
 ### Auto-Populating Fields
 

--- a/docs/in_game_items/ingredient.md
+++ b/docs/in_game_items/ingredient.md
@@ -1,0 +1,13 @@
+# Ingredient
+
+The `Ingredient` model represents in-game items of the `Canonical::Ingredient` type. This model has some special characteristics that set it apart from other in-game items. Some of these correspond to characteristics of the `Canonical::Ingredient` model, in particular the aspect of [alchemical properties](/docs/canonical_models/canonical-ingredient.md#accessing-alchemical-properties).
+
+## Matching to Canonical Models
+
+Matching an `Ingredient` to a `Canonical::Ingredient` is a bit more complex than matching the previously-introduced [`Armor`](/docs/in_game_items/armor.md) and [`ClothingItem`](/docs/in_game_items/clothing-item.md) models to their corresponding canonical models. This is because ingredients may be uniquely identified by their alchemical properties, which are associations and not attributes of the model itself.
+
+When an `Ingredient` is created, it is then matched to a subset of canonical ingredients by its `name` attribute (the only attribute of `Canonical::Ingredient` also present on `Ingredient`). If the ingredient has alchemical properties, these are further narrowed down based on those associations, checking for the `alchemical_property_id` and `priority` defined on the [`IngredientsAlchemicalProperty`](/docs/in_game_items/ingredients-alchemical-property.md) model. If these match for all defined alchemical properties, it is considered a match.
+
+## The `IngredientsAlchemicalProperty` Join Model
+
+The `Ingredient` model is associated to the `AlchemicalProperty` model via the `IngredientsAlchemicalProperty` join model. This model has [its own docs](/docs/in_game_items/ingredients-alchemical-property.md) but it is worth mentioning here as well. The join table contains attributes about the `priority` (1-4) of the alchemical property on the ingredient, its `strength_modifier` and its `duration_modifier`. More information is available in the [canonical model docs](/docs/canonical_models/canonical-ingredients-alchemical-property.md).

--- a/docs/in_game_items/ingredients-alchemical-property.md
+++ b/docs/in_game_items/ingredients-alchemical-property.md
@@ -1,0 +1,19 @@
+# IngredientsAlchemicalProperty
+
+The `IngredientsAlchemicalProperty` model is a join model between `Ingredient` and `AlchemicalProperty`. Most of its idiosyncrasies are mirrored in the `Canonical::IngredientsAlchemicalProperty` model.
+
+## Count Limit
+
+Ingredients in Skyrim all have exactly 4 alchemical properties, each with a `priority` numbered 1-4. A validation exists to prevent a fifth alchemical property from being added to an ingredient.
+
+## Priority
+
+In Skyrim, each ingredient's properties have a `priority` that affects which potions are produced, how strong they are, and how long the effects last when they are combined with other ingredients. More information is available in the [canonical model docs](/docs/canonical_models/canonical-ingredients-alchemical-property.md#priority) and the [UESP wiki](https://en.uesp.net/wiki/Skyrim:Alchemy_Effects). The `priority` is a number between 1 and 4, inclusive.
+
+The value of `priority` on a model must be unique for its associated `Ingredient` model. So, if 4 models have the same `ingredient` and all have a `priority` defined, each of the integers from 1-4 will be represented. As noted in the docs for the canonical model, `priority` is not a required attribute because, if an ingredient has 4 alchemical properties, changing the priority of those properties involves first setting `priority` to `NULL` on two or more of the join models.
+
+## Matching Canonical Models
+
+Unlike primary in-game items, these join models do not have a direct association to their corresponding canonical models. They do, however, have a `#canonical_models` method that returns all `Canonical::IngredientAlchemicalProperty` models that match their `priority`, `strength_modifier`, and `duration_modifier` values (at least, any of these values that are defined on the non-canonical model). On each save, validations ensure that at least one matching canonical model exists.
+
+If a there is exactly one matching canonical model, a `before_validation` hook sets the `priority`, `strength_modifier`, and `duration_modifier` values to match it on each save.

--- a/spec/models/ingredient_spec.rb
+++ b/spec/models/ingredient_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Ingredient, type: :model do
+  describe 'validations' do
+    let(:ingredient) { build(:ingredient) }
+
+    it 'is invalid without a name' do
+      ingredient.name = nil
+      ingredient.validate
+      expect(ingredient.errors[:name]).to include "can't be blank"
+    end
+
+    context 'when there are multiple matching canonical ingredients' do
+      before do
+        create_list(:canonical_ingredient, 3, name: ingredient.name)
+      end
+
+      it 'is valid' do
+        expect(ingredient).to be_valid
+      end
+    end
+
+    context 'when there is one matching canonical ingredient' do
+      before do
+        create(:canonical_ingredient, name: ingredient.name)
+      end
+
+      it 'is valid' do
+        expect(ingredient).to be_valid
+      end
+    end
+
+    context 'when there are no matching canonical ingredients' do
+      it 'is invalid' do
+        ingredient.validate
+        expect(ingredient.errors[:base]).to include "doesn't match an ingredient that exists in Skyrim"
+      end
+    end
+  end
+
+  describe '::before_validation' do
+    let(:ingredient) { build(:ingredient) }
+
+    context 'when there is a matching canonical ingredient' do
+      let!(:matching_canonical) { create(:canonical_ingredient, name: ingredient.name) }
+
+      it 'sets the canonical_ingredient' do
+        ingredient.validate
+        expect(ingredient.canonical_ingredient).to eq matching_canonical
+      end
+    end
+
+    context 'when there are multiple matching canonical ingredients' do
+      let!(:matching_canonicals) { create_list(:canonical_ingredient, 2, name: ingredient.name) }
+
+      it "doesn't set the canonical ingredient" do
+        ingredient.validate
+        expect(ingredient.canonical_ingredient).to be_nil
+      end
+    end
+
+    context 'when there is no matching canonical ingredient' do
+      it "doesn't set the canonical ingredient" do
+        ingredient.validate
+        expect(ingredient.canonical_ingredient).to be_nil
+      end
+    end
+  end
+end

--- a/spec/models/ingredient_spec.rb
+++ b/spec/models/ingredient_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Ingredient, type: :model do
       end
 
       it 'returns the canonical ingredient' do
-        expect(canonical_ingredients).to eq [canonical_ingredient]
+        expect(canonical_ingredients).to contain_exactly(canonical_ingredient)
       end
     end
 

--- a/spec/models/ingredient_spec.rb
+++ b/spec/models/ingredient_spec.rb
@@ -51,12 +51,12 @@ RSpec.describe Ingredient, type: :model do
         create(:canonical_ingredient)
       end
 
-      it 'returns the canonical ingredient in an array' do
+      it 'returns the canonical ingredient' do
         expect(canonical_ingredients).to eq [canonical_ingredient]
       end
     end
 
-    context 'when there are multiple matching canonical ingredients' do
+    context 'when there are matching canonical ingredients' do
       context 'when only the names have to match' do
         let!(:matching_canonicals) { create_list(:canonical_ingredient, 3, name: 'Blue Mountain Flower') }
         let(:ingredient) { create(:ingredient, name: 'Blue Mountain Flower') }
@@ -100,8 +100,8 @@ RSpec.describe Ingredient, type: :model do
             )
           end
 
-          it 'returns the matching join models' do
-            expect(canonical_ingredients).to eq [matching_canonicals.second, matching_canonicals.last]
+          it 'returns the matching models' do
+            expect(canonical_ingredients).to contain_exactly(matching_canonicals.second, matching_canonicals.last)
           end
         end
 
@@ -130,8 +130,6 @@ RSpec.describe Ingredient, type: :model do
         end
       end
     end
-
-    context 'when there is one matching canonical ingredient'
 
     context 'when there are no matching canonical ingredients' do
       let(:ingredient) { build(:ingredient) }

--- a/spec/models/ingredients_alchemical_property_spec.rb
+++ b/spec/models/ingredients_alchemical_property_spec.rb
@@ -2,17 +2,21 @@
 
 require 'rails_helper'
 
-RSpec.describe Canonical::IngredientsAlchemicalProperty, type: :model do
+RSpec.describe IngredientsAlchemicalProperty, type: :model do
+  before do
+    create(:canonical_ingredient)
+  end
+
   describe 'validations' do
     describe 'number of records per ingredient' do
-      let!(:ingredient) { create(:canonical_ingredient, :with_alchemical_properties) }
+      let!(:ingredient) { create(:ingredient, :with_alchemical_properties) }
 
       it 'cannot have more than 4 records corresponding to one ingredient' do
         # Since the alchemical properties are added in FactoryBot's after(:create) hook,
         # the ingredient needs to be reloaded before Rails/RSpec will know about them.
         ingredient.reload
 
-        new_association = build(:canonical_ingredients_alchemical_property, ingredient:)
+        new_association = build(:ingredients_alchemical_property, ingredient:)
 
         new_association.validate
         expect(new_association.errors[:ingredient]).to include 'already has 4 alchemical properties'
@@ -20,12 +24,33 @@ RSpec.describe Canonical::IngredientsAlchemicalProperty, type: :model do
     end
 
     describe 'priority' do
-      describe 'uniqueness' do
-        let(:ingredient) { create(:canonical_ingredient) }
+      let(:ingredient) { create(:ingredient) }
 
+      it "can't be less than 1" do
+        model = build(:ingredients_alchemical_property, priority: 0)
+
+        model.validate
+        expect(model.errors[:priority]).to include 'must be greater than or equal to 1'
+      end
+
+      it "can't be more than 4" do
+        model = build(:ingredients_alchemical_property, priority: 5)
+
+        model.validate
+        expect(model.errors[:priority]).to include 'must be less than or equal to 4'
+      end
+
+      it 'must be an integer' do
+        model = build(:ingredients_alchemical_property, priority: 3.2)
+
+        model.validate
+        expect(model.errors[:priority]).to include 'must be an integer'
+      end
+
+      describe 'uniqueness' do
         before do
           create(
-            :canonical_ingredients_alchemical_property,
+            :ingredients_alchemical_property,
             priority: 1,
             ingredient:,
           )
@@ -33,7 +58,7 @@ RSpec.describe Canonical::IngredientsAlchemicalProperty, type: :model do
 
         it 'must be unique per ingredient' do
           model = build(
-            :canonical_ingredients_alchemical_property,
+            :ingredients_alchemical_property,
             priority: 1,
             ingredient:,
           )
@@ -42,38 +67,17 @@ RSpec.describe Canonical::IngredientsAlchemicalProperty, type: :model do
           expect(model.errors[:priority]).to include 'must be unique per ingredient'
         end
 
-        it "isn't required to be globally unique" do
-          model = build(:canonical_ingredients_alchemical_property, priority: 1)
+        it "doesn't have to be globally unique" do
+          model = build(:ingredients_alchemical_property, priority: 1)
 
           expect(model).to be_valid
         end
-      end
-
-      it "can't be less than 1" do
-        model = build(:canonical_ingredients_alchemical_property, priority: 0)
-
-        model.validate
-        expect(model.errors[:priority]).to include 'must be greater than or equal to 1'
-      end
-
-      it "can't be more than 4" do
-        model = build(:canonical_ingredients_alchemical_property, priority: 5)
-
-        model.validate
-        expect(model.errors[:priority]).to include 'must be less than or equal to 4'
-      end
-
-      it 'must be an integer' do
-        model = build(:canonical_ingredients_alchemical_property, priority: 1.5)
-
-        model.validate
-        expect(model.errors[:priority]).to include 'must be an integer'
       end
     end
 
     describe 'strength_modifier' do
       it 'must be greater than zero' do
-        model = build(:canonical_ingredients_alchemical_property, strength_modifier: 0)
+        model = build(:ingredients_alchemical_property, strength_modifier: 0)
 
         model.validate
         expect(model.errors[:strength_modifier]).to include 'must be greater than 0'
@@ -82,7 +86,7 @@ RSpec.describe Canonical::IngredientsAlchemicalProperty, type: :model do
 
     describe 'duration_modifier' do
       it 'must be greater than zero' do
-        model = build(:canonical_ingredients_alchemical_property, duration_modifier: 0)
+        model = build(:ingredients_alchemical_property, duration_modifier: 0)
 
         model.validate
         expect(model.errors[:duration_modifier]).to include 'must be greater than 0'
@@ -91,16 +95,16 @@ RSpec.describe Canonical::IngredientsAlchemicalProperty, type: :model do
 
     describe 'alchemical_property_id' do
       it 'must be unique per ingredient' do
-        existing_model = create(:canonical_ingredients_alchemical_property)
+        existing_model = create(:ingredients_alchemical_property)
         model = build(
-          :canonical_ingredients_alchemical_property,
+          :ingredients_alchemical_property,
           ingredient: existing_model.ingredient,
           alchemical_property: existing_model.alchemical_property,
           priority: 1,
         )
 
         model.validate
-        expect(model.errors[:alchemical_property_id]).to include 'must form a unique combination with canonical ingredient'
+        expect(model.errors[:alchemical_property_id]).to include 'must form a unique combination with ingredient'
       end
     end
   end

--- a/spec/models/ingredients_alchemical_property_spec.rb
+++ b/spec/models/ingredients_alchemical_property_spec.rb
@@ -3,13 +3,15 @@
 require 'rails_helper'
 
 RSpec.describe IngredientsAlchemicalProperty, type: :model do
-  before do
-    create(:canonical_ingredient)
-  end
-
   describe 'validations' do
+    let(:ingredient) { build(:ingredient) }
+
+    before do
+      create(:canonical_ingredient)
+    end
+
     describe 'number of records per ingredient' do
-      let!(:ingredient) { create(:ingredient, :with_alchemical_properties) }
+      let!(:ingredient) { create(:ingredient_with_matching_canonical, :with_associations_and_properties) }
 
       it 'cannot have more than 4 records corresponding to one ingredient' do
         # Since the alchemical properties are added in FactoryBot's after(:create) hook,
@@ -20,6 +22,63 @@ RSpec.describe IngredientsAlchemicalProperty, type: :model do
 
         new_association.validate
         expect(new_association.errors[:ingredient]).to include 'already has 4 alchemical properties'
+      end
+    end
+
+    describe 'canonical_models' do
+      context 'when there is one matching canonical model' do
+        let!(:canonical_ingredient) { create(:canonical_ingredient, :with_alchemical_properties) }
+        let(:ingredient) { create(:ingredient, canonical_ingredient:) }
+        let(:model) { build(:ingredients_alchemical_property, ingredient:) }
+
+        before do
+          canonical_ingredient.reload
+
+          model.alchemical_property_id = canonical_ingredient.alchemical_properties.second.id
+          model.priority = canonical_ingredient.alchemical_properties.second.priority
+          model.save!
+        end
+
+        it 'is valid' do
+          expect(model).to be_valid
+        end
+      end
+
+      context 'when are multiple matching canonical models' do
+        let!(:canonical_ingredient) { create(:canonical_ingredient, :with_alchemical_properties) }
+        let!(:second_canonical) { create(:canonical_ingredient, :with_alchemical_properties) }
+        let(:ingredient) { create(:ingredient) }
+        let(:join_model) { canonical_ingredient.canonical_ingredients_alchemical_properties.second }
+        let(:model) { build(:ingredients_alchemical_property, ingredient:) }
+
+        before do
+          canonical_ingredient.reload
+          second_canonical.reload
+
+          second_canonical
+            .canonical_ingredients_alchemical_properties
+            .find_by(priority: join_model.priority)
+            .update!(alchemical_property_id: join_model.alchemical_property_id)
+
+          model.alchemical_property_id = join_model.alchemical_property_id
+          model.priority = join_model.priority
+          model.save!
+        end
+
+        it 'is valid' do
+          expect(model).to be_valid
+        end
+      end
+
+      context 'when there are no matching canonical models' do
+        let!(:canonical_ingredient) { create(:canonical_ingredient) }
+        let(:ingredient) { create(:ingredient, canonical_ingredient:) }
+        let(:model) { build(:ingredients_alchemical_property, ingredient:) }
+
+        it 'is invalid' do
+          model.validate
+          expect(model.errors[:base]).to include 'is not consistent with any ingredient that exists in Skyrim'
+        end
       end
     end
 
@@ -51,6 +110,7 @@ RSpec.describe IngredientsAlchemicalProperty, type: :model do
         before do
           create(
             :ingredients_alchemical_property,
+            :valid,
             priority: 1,
             ingredient:,
           )
@@ -68,7 +128,7 @@ RSpec.describe IngredientsAlchemicalProperty, type: :model do
         end
 
         it "doesn't have to be globally unique" do
-          model = build(:ingredients_alchemical_property, priority: 1)
+          model = build(:ingredients_alchemical_property, :valid, priority: 1)
 
           expect(model).to be_valid
         end
@@ -95,7 +155,7 @@ RSpec.describe IngredientsAlchemicalProperty, type: :model do
 
     describe 'alchemical_property_id' do
       it 'must be unique per ingredient' do
-        existing_model = create(:ingredients_alchemical_property)
+        existing_model = create(:ingredients_alchemical_property, :valid)
         model = build(
           :ingredients_alchemical_property,
           ingredient: existing_model.ingredient,
@@ -106,6 +166,158 @@ RSpec.describe IngredientsAlchemicalProperty, type: :model do
         model.validate
         expect(model.errors[:alchemical_property_id]).to include 'must form a unique combination with ingredient'
       end
+    end
+  end
+
+  describe '#canonical_models' do
+    subject(:canonical_models) { model.canonical_models }
+
+    context 'when there is one matching canonical model' do
+      let!(:canonical_ingredient) { create(:canonical_ingredient, :with_alchemical_properties) }
+      let(:ingredient) { create(:ingredient, canonical_ingredient:) }
+      let(:model) { build(:ingredients_alchemical_property, ingredient:) }
+
+      before do
+        canonical_ingredient.reload
+
+        model.alchemical_property_id = canonical_ingredient.alchemical_properties.second.id
+        model.priority = canonical_ingredient.alchemical_properties.second.priority
+        model.save!
+      end
+
+      it 'returns the model' do
+        expect(canonical_models).to eq [canonical_ingredient.canonical_ingredients_alchemical_properties.second]
+      end
+    end
+
+    context 'when are multiple matching canonical models' do
+      let!(:canonical_ingredient) { create(:canonical_ingredient, :with_alchemical_properties) }
+      let!(:second_canonical) { create(:canonical_ingredient, :with_alchemical_properties) }
+      let(:ingredient) { create(:ingredient) }
+      let(:join_model) { canonical_ingredient.canonical_ingredients_alchemical_properties.second }
+      let(:model) { build(:ingredients_alchemical_property, ingredient:) }
+
+      before do
+        canonical_ingredient.reload
+        second_canonical.reload
+
+        second_canonical
+          .canonical_ingredients_alchemical_properties
+          .find_by(priority: join_model.priority)
+          .update!(alchemical_property_id: join_model.alchemical_property_id)
+
+        model.alchemical_property_id = join_model.alchemical_property_id
+        model.priority = join_model.priority
+        model.save!
+      end
+
+      it 'returns the matching models' do
+        expect(canonical_models).to contain_exactly(
+          *Canonical::IngredientsAlchemicalProperty
+            .where(alchemical_property_id: join_model.alchemical_property_id)
+            .to_a,
+        )
+      end
+    end
+
+    context 'when there are no matching canonical models' do
+      let!(:canonical_ingredient) { create(:canonical_ingredient) }
+      let(:ingredient) { create(:ingredient, canonical_ingredient:) }
+      let(:model) { build(:ingredients_alchemical_property, ingredient:) }
+
+      it 'is empty' do
+        expect(canonical_models).to be_empty
+      end
+    end
+  end
+
+  describe '#canonical_model' do
+    subject(:canonical_model) { model.reload.canonical_model }
+
+    context 'when there is one matching canonical model' do
+      let!(:canonical_ingredient) { create(:canonical_ingredient, :with_alchemical_properties) }
+      let(:ingredient) { create(:ingredient, canonical_ingredient:) }
+      let(:model) { build(:ingredients_alchemical_property, ingredient:) }
+
+      before do
+        canonical_ingredient.reload
+
+        model.alchemical_property_id = canonical_ingredient.alchemical_properties.second.id
+        model.priority = canonical_ingredient.alchemical_properties.second.priority
+        model.save!
+      end
+
+      it 'returns the model' do
+        expect(canonical_model).to eq canonical_ingredient.canonical_ingredients_alchemical_properties.second
+      end
+    end
+
+    context 'when are multiple matching canonical models' do
+      let!(:canonical_ingredient) { create(:canonical_ingredient, :with_alchemical_properties) }
+      let!(:second_canonical) { create(:canonical_ingredient, :with_alchemical_properties) }
+      let(:ingredient) { create(:ingredient) }
+      let(:join_model) { canonical_ingredient.canonical_ingredients_alchemical_properties.second }
+      let(:model) { build(:ingredients_alchemical_property, ingredient:) }
+
+      before do
+        canonical_ingredient.reload
+        second_canonical.reload
+
+        second_canonical
+          .canonical_ingredients_alchemical_properties
+          .find_by(priority: join_model.priority)
+          .update!(alchemical_property_id: join_model.alchemical_property_id)
+
+        model.alchemical_property_id = join_model.alchemical_property_id
+        model.priority = join_model.priority
+        model.save!
+      end
+
+      it 'is nil' do
+        expect(canonical_model).to be_nil
+      end
+    end
+
+    context 'when there are no matching canonical models' do
+      subject(:canonical_model) { model.canonical_model }
+
+      let!(:canonical_ingredient) { create(:canonical_ingredient) }
+      let(:ingredient) { create(:ingredient, canonical_ingredient:) }
+      let(:model) { build(:ingredients_alchemical_property, ingredient:) }
+
+      it 'is empty' do
+        expect(canonical_model).to be_nil
+      end
+    end
+  end
+
+  describe '::before_validation' do
+    let!(:canonical_model) do
+      create(
+        :canonical_ingredients_alchemical_property,
+        priority: 3,
+        strength_modifier: 1.5,
+        duration_modifier: 2.3,
+      )
+    end
+
+    let(:canonical_ingredient) { canonical_model.ingredient }
+    let(:ingredient) { create(:ingredient, canonical_ingredient:) }
+
+    let(:model) do
+      build(
+        :ingredients_alchemical_property,
+        alchemical_property: canonical_model.alchemical_property,
+        ingredient:,
+        priority: nil,
+      )
+    end
+
+    it 'sets values from the canonical model', :aggregate_failures do
+      model.validate
+      expect(model.priority).to eq 3
+      expect(model.strength_modifier).to eq 1.5
+      expect(model.duration_modifier).to eq 2.3
     end
   end
 end

--- a/spec/support/factories/ingredients.rb
+++ b/spec/support/factories/ingredients.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :ingredient do
+    game
+
+    name { 'Blue Mountain Flower' }
+  end
+end

--- a/spec/support/factories/ingredients.rb
+++ b/spec/support/factories/ingredients.rb
@@ -13,5 +13,27 @@ FactoryBot.define do
         end
       end
     end
+
+    factory :ingredient_with_matching_canonical do
+      canonical_ingredient
+
+      trait :with_associations do
+        association :canonical_ingredient, factory: %i[canonical_ingredient with_alchemical_properties]
+      end
+
+      trait :with_associations_and_properties do
+        association :canonical_ingredient, factory: %i[canonical_ingredient with_alchemical_properties]
+
+        after(:create) do |model|
+          model.canonical_ingredient.canonical_ingredients_alchemical_properties.each do |join_model|
+            create(
+              :ingredients_alchemical_property,
+              ingredient: model,
+              **join_model.attributes.except('ingredient_id', 'created_at', 'updated_at'),
+            )
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/support/factories/ingredients.rb
+++ b/spec/support/factories/ingredients.rb
@@ -5,5 +5,13 @@ FactoryBot.define do
     game
 
     name { 'Blue Mountain Flower' }
+
+    trait :with_alchemical_properties do
+      after(:create) do |ingredient|
+        4.times do |n|
+          create(:ingredients_alchemical_property, ingredient:, priority: n + 1)
+        end
+      end
+    end
   end
 end

--- a/spec/support/factories/ingredients_alchemical_properties.rb
+++ b/spec/support/factories/ingredients_alchemical_properties.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     sequence(:priority) {|n| (n % 4) + 1 }
 
     trait :valid do
-      association :ingredient, factory: :ingredient_with_matching_canonical
+      association :ingredient, factory: :ingredient_with_matching_canonical, strategy: :create
 
       after(:build) do |model|
         matching_model = create(

--- a/spec/support/factories/ingredients_alchemical_properties.rb
+++ b/spec/support/factories/ingredients_alchemical_properties.rb
@@ -6,5 +6,20 @@ FactoryBot.define do
     alchemical_property
 
     sequence(:priority) {|n| (n % 4) + 1 }
+
+    trait :valid do
+      association :ingredient, factory: :ingredient_with_matching_canonical
+
+      after(:build) do |model|
+        matching_model = create(
+          :canonical_ingredients_alchemical_property,
+          ingredient: model.ingredient.canonical_ingredient,
+          alchemical_property: model.alchemical_property,
+          priority: 1,
+        )
+
+        model.priority = matching_model.priority
+      end
+    end
   end
 end

--- a/spec/support/factories/ingredients_alchemical_properties.rb
+++ b/spec/support/factories/ingredients_alchemical_properties.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :ingredients_alchemical_property do
+    ingredient
+    alchemical_property
+
+    sequence(:priority) {|n| (n % 4) + 1 }
+  end
+end


### PR DESCRIPTION
## Context

[**Create non-canonical Ingredient model**](https://trello.com/c/LhzhuYpF/306-create-non-canonical-ingredient-model)

We are creating non-canonical models to represent items players can discover in-game. The next model we need to create is `Ingredient`. This model will play a critical role in the upcoming ingredients epic.

## Changes

* Create non-canonical `Ingredient` model
* Create non-canonical `IngredientsAlchemicalProperty` join model
* Add factories for new models
* Add tests for new models
* Update docs

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [ ] Added and updated API docs and developer docs as appropriate

## Considerations

I decided not to create a direct association between the `Canonical::IngredientAlchemicalProperty` and `IngredientAlchemicalProperty` models. This will slow down validations slightly but I don't currently see a compelling reason to add such an association and it feels like it would complicate things.