### PR TITLE
Always validate that ingredients have no more than 4 alchemical properties

### DIFF
--- a/app/models/canonical/ingredients_alchemical_property.rb
+++ b/app/models/canonical/ingredients_alchemical_property.rb
@@ -18,7 +18,7 @@ module Canonical
               }
     validates :strength_modifier, allow_blank: true, numericality: { greater_than: 0 }
     validates :duration_modifier, allow_blank: true, numericality: { greater_than: 0 }
-    validate :ensure_max_of_four_per_ingredient, on: :create
+    validate :ensure_max_of_four_per_ingredient
 
     MAX_PER_INGREDIENT = 4
 

--- a/app/models/canonical/ingredients_alchemical_property.rb
+++ b/app/models/canonical/ingredients_alchemical_property.rb
@@ -26,6 +26,9 @@ module Canonical
 
     def ensure_max_of_four_per_ingredient
       return if ingredient.alchemical_properties.length < MAX_PER_INGREDIENT
+      return if persisted? &&
+        !ingredient_id_changed? &&
+        ingredient.alchemical_properties.length == MAX_PER_INGREDIENT
 
       errors.add(:ingredient, "already has #{MAX_PER_INGREDIENT} alchemical properties")
     end

--- a/app/models/ingredients_alchemical_property.rb
+++ b/app/models/ingredients_alchemical_property.rb
@@ -27,7 +27,7 @@ class IngredientsAlchemicalProperty < ApplicationRecord
             allow_blank: true,
             numericality: { greater_than: 0 }
   validate :ensure_match_exists
-  validate :ensure_max_of_four_per_ingredient, on: :create
+  validate :ensure_max_of_four_per_ingredient
 
   before_validation :set_attributes_from_canonical, if: -> { canonical_model.present? }
 

--- a/app/models/ingredients_alchemical_property.rb
+++ b/app/models/ingredients_alchemical_property.rb
@@ -58,6 +58,9 @@ class IngredientsAlchemicalProperty < ApplicationRecord
 
   def ensure_max_of_four_per_ingredient
     return if ingredient.alchemical_properties.length < Canonical::IngredientsAlchemicalProperty::MAX_PER_INGREDIENT
+    return if persisted? &&
+      !ingredient_id_changed? &&
+      ingredient.alchemical_properties.length == Canonical::IngredientsAlchemicalProperty::MAX_PER_INGREDIENT
 
     errors.add(
       :ingredient,


### PR DESCRIPTION
## Context

[**Ensure max of 4 alchemical properties per ingredient on update**](https://trello.com/c/lnJsipj5/315-ensure-max-of-4-alchemical-properties-per-ingredient-on-update)

Currently, there is one mechanism ensuring an ingredient has no more than 4 alchemical properties: a validation on the `IngredientAlchemicalProperty` and `Canonical::IngredientAlchemicalProperty` model. This validation is run on `create` for performance reasons. However, I recently realised this represented a loophole to the validation as the `ingredient` belonging to these models could be changed on update to an ingredient with 4 or more properties. This PR removes `on: :create` from these validations.

## Changes

* Validate that an ingredient only can have 4 alchemical properties 

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [ ] ~~Added and updated API docs and developer docs as appropriate~~
