### PR TITLE
Create non-canonical JewelryItem model

### DIFF
--- a/app/models/canonical/jewelry_item.rb
+++ b/app/models/canonical/jewelry_item.rb
@@ -6,6 +6,8 @@ module Canonical
 
     BOOLEAN_VALUES = [true, false].freeze
     BOOLEAN_VALIDATION_MESSAGE = 'must be true or false'
+    JEWELRY_TYPES = %w[ring circlet amulet].freeze
+    JEWELRY_TYPE_VALIDATION_MESSAGE = 'must be "ring", "circlet", or "amulet"'
 
     has_many :enchantables_enchantments,
              dependent: :destroy,
@@ -23,11 +25,17 @@ module Canonical
              through: :canonical_craftables_crafting_materials,
              source: :material
 
+    has_many :jewelry_items,
+             inverse_of: :canonical_jewelry_item,
+             dependent: :nullify,
+             foreign_key: 'canonical_jewelry_item_id',
+             class_name: '::JewelryItem'
+
     validates :name, presence: true
     validates :item_code, presence: true, uniqueness: { message: 'must be unique' }
     validates :jewelry_type,
               presence: true,
-              inclusion: { in: %w[ring circlet amulet], message: 'must be "ring", "circlet", or "amulet"' }
+              inclusion: { in: JEWELRY_TYPES, message: JEWELRY_TYPE_VALIDATION_MESSAGE }
     validates :unit_weight, presence: true, numericality: { greater_than_or_equal_to: 0 }
     validates :purchasable, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }
     validates :unique_item, inclusion: { in: BOOLEAN_VALUES, message: BOOLEAN_VALIDATION_MESSAGE }

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -8,6 +8,7 @@ class Game < ApplicationRecord
   has_many :armors, dependent: :destroy
   has_many :clothing_items, dependent: :destroy
   has_many :ingredients, dependent: :destroy
+  has_many :jewelry_items, dependent: :destroy
 
   # `before_save` callbacks need to be defined before
   # `before_destroy` callbacks, which need to be defined here

--- a/app/models/jewelry_item.rb
+++ b/app/models/jewelry_item.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class JewelryItem < ApplicationRecord
+  belongs_to :game
+  belongs_to :canonical_jewelry_item,
+             optional: true,
+             inverse_of: :jewelry_items,
+             class_name: 'Canonical::JewelryItem'
+
+  validates :name, presence: true
+  validates :jewelry_type,
+            allow_blank: true,
+            inclusion: {
+              in: Canonical::JewelryItem::JEWELRY_TYPES,
+              message: Canonical::JewelryItem::JEWELRY_TYPE_VALIDATION_MESSAGE,
+            }
+  validates :unit_weight,
+            allow_blank: true,
+            numericality: {
+              greater_than_or_equal_to: 0,
+            }
+end

--- a/app/models/jewelry_item.rb
+++ b/app/models/jewelry_item.rb
@@ -20,5 +20,7 @@ class JewelryItem < ApplicationRecord
               greater_than_or_equal_to: 0,
             }
 
-  delegate :crafting_materials, to: :canonical_jewelry_item
+  def crafting_materials
+    canonical_jewelry_item&.crafting_materials
+  end
 end

--- a/app/models/jewelry_item.rb
+++ b/app/models/jewelry_item.rb
@@ -19,4 +19,6 @@ class JewelryItem < ApplicationRecord
             numericality: {
               greater_than_or_equal_to: 0,
             }
+
+  delegate :crafting_materials, to: :canonical_jewelry_item
 end

--- a/app/models/jewelry_item.rb
+++ b/app/models/jewelry_item.rb
@@ -1,11 +1,21 @@
 # frozen_string_literal: true
 
 class JewelryItem < ApplicationRecord
+  DOES_NOT_MATCH = "doesn't match any jewelry item that exists in Skyrim"
+
   belongs_to :game
   belongs_to :canonical_jewelry_item,
              optional: true,
              inverse_of: :jewelry_items,
              class_name: 'Canonical::JewelryItem'
+
+  has_many :enchantables_enchantments,
+           dependent: :destroy,
+           as: :enchantable
+  has_many :enchantments,
+           -> { select 'enchantments.*, enchantables_enchantments.strength as strength' },
+           through: :enchantables_enchantments,
+           source: :enchantment
 
   validates :name, presence: true
   validates :jewelry_type,
@@ -20,7 +30,57 @@ class JewelryItem < ApplicationRecord
               greater_than_or_equal_to: 0,
             }
 
+  validate :ensure_match_exists
+
+  before_validation :set_canonical_jewelry_item
+  after_create :set_enchantments, if: -> { canonical_jewelry_item.present? }
+
   def crafting_materials
     canonical_jewelry_item&.crafting_materials
+  end
+
+  def canonical_jewelry_items
+    return [canonical_jewelry_item] if canonical_jewelry_item.present?
+
+    attrs_to_match = {
+      jewelry_type:,
+      unit_weight:,
+      magical_effects:,
+    }.compact
+
+    canonicals = Canonical::JewelryItem.where('name ILIKE ?', name)
+    attrs_to_match.any? ? canonicals.where(**attrs_to_match) : canonicals
+  end
+
+  private
+
+  def ensure_match_exists
+    return if canonical_jewelry_items.any?
+
+    errors.add(:base, DOES_NOT_MATCH)
+  end
+
+  def set_canonical_jewelry_item
+    return unless canonical_jewelry_items.count == 1
+
+    self.canonical_jewelry_item ||= canonical_jewelry_items.first
+
+    self.name = canonical_jewelry_item.name
+    self.unit_weight = canonical_jewelry_item.unit_weight
+    self.jewelry_type = canonical_jewelry_item.jewelry_type
+    self.magical_effects = canonical_jewelry_item.magical_effects
+
+    set_enchantments if persisted?
+  end
+
+  def set_enchantments
+    return if canonical_jewelry_item.enchantments.empty?
+
+    canonical_jewelry_item.enchantables_enchantments.each do |model|
+      enchantables_enchantments.find_or_create_by!(
+        enchantment_id: model.enchantment_id,
+        strength: model.strength,
+      )
+    end
   end
 end

--- a/db/migrate/20230527230835_create_jewelry_items.rb
+++ b/db/migrate/20230527230835_create_jewelry_items.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateJewelryItems < ActiveRecord::Migration[7.0]
+  def change
+    create_table :jewelry_items do |t|
+      t.references :game, null: false, foreign_key: true
+      t.references :canonical_jewelry_item, foreign_key: true
+      t.string :name
+      t.decimal :unit_weight
+      t.string :jewelry_type
+      t.string :magical_effects
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_23_225250) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_27_230835) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -395,6 +395,19 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_23_225250) do
     t.index ["title", "game_id"], name: "index_inventory_lists_on_title_and_game_id", unique: true
   end
 
+  create_table "jewelry_items", force: :cascade do |t|
+    t.bigint "game_id", null: false
+    t.bigint "canonical_jewelry_item_id"
+    t.string "name"
+    t.decimal "unit_weight"
+    t.string "jewelry_type"
+    t.string "magical_effects"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["canonical_jewelry_item_id"], name: "index_jewelry_items_on_canonical_jewelry_item_id"
+    t.index ["game_id"], name: "index_jewelry_items_on_game_id"
+  end
+
   create_table "powers", force: :cascade do |t|
     t.string "name", null: false
     t.string "power_type", null: false
@@ -496,6 +509,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_23_225250) do
   add_foreign_key "inventory_items", "inventory_lists", column: "list_id"
   add_foreign_key "inventory_lists", "games"
   add_foreign_key "inventory_lists", "inventory_lists", column: "aggregate_list_id"
+  add_foreign_key "jewelry_items", "canonical_jewelry_items"
+  add_foreign_key "jewelry_items", "games"
   add_foreign_key "properties", "canonical_properties"
   add_foreign_key "properties", "games"
   add_foreign_key "shopping_list_items", "shopping_lists", column: "list_id"

--- a/docs/in_game_items/README.md
+++ b/docs/in_game_items/README.md
@@ -8,8 +8,10 @@ This documentation covers the scope and purpose of non-canonical in-game items, 
 
 * [In-Game Items](/docs/in_game_items/in-game-items.md): An overview of in-game item models, which models exist, and associations between them
 * Models:
-  * [Armor](/docs/in_game_items/armor.md)
-  * [Clothing Item](/docs/in_game_items/clothing-item.md)
-  * [Ingredient](/docs/in_game_items/ingredient.md)
+  * [`Armor`](/docs/in_game_items/armor.md)
+  * [`ClothingItem`](/docs/in_game_items/clothing-item.md)
+  * [`Ingredient`](/docs/in_game_items/ingredient.md)
+  * [`JewelryItem`](/docs/in_game_items/jewelry-item.md)
 * Join models:
-  * [IngredientsAlchemicalProperty](/docs/in_game_items/ingredients-alchemical-property.md)
+  * [`IngredientsAlchemicalProperty`](/docs/in_game_items/ingredients-alchemical-property.md)
+  * `EnchantablesEnchantment` (both canonical and non-canonical use same table)

--- a/docs/in_game_items/in-game-items.md
+++ b/docs/in_game_items/in-game-items.md
@@ -5,6 +5,7 @@ The following non-[canonical](/docs/canonical_models/README.md) in-game item mod
 * [`Armor`](/app/models/armor.rb): armour items corresponding to `Canonical::Armor` pieces
 * [`ClothingItem`](/app/models/clothing_item.rb): clothing items that are not armour or jewellery, corresponding to `Canonical::ClothingItem`s
 * [`Ingredient`](/app/models/ingredient.rb): ingredients corresponding to the `Canonical::Ingredient` class
+* [`JewelryItem`](/app/models/jewelry_item.rb): jewelry items corresponding to the `Canonical::JewelryItem` class
 * [`IngredientsAlchemicalProperty`](/app/models/ingredients_alchemical_property.rb): join model between `Ingredient` and `AlchemicalProperty` models
 
 Non-canonical in-game items represent individual item instances. For the purpose of inventory lists, they can also represent sets of items with identical characteristics whose quantities are then implied by the `quantity` field on the inventory item. (Note that, at this writing, inventory list functionality is not yet fully implemented.)

--- a/docs/in_game_items/jewelry-item.md
+++ b/docs/in_game_items/jewelry-item.md
@@ -1,0 +1,22 @@
+# Jewelry Item
+
+The `JewelryItem` model represents in-game items of the `Canonical::JewelryItem` class. These are items classified as clothing that are not better classified as [`Armor`](/docs/in_game_items/armor.md) or [`ClothingItem`s](/docs/in_game_items/clothing-item.md).
+
+## Matching Attributes
+
+`JewelryItem` models are matched to `Canonical::JewelryItem` models using the following fields:
+
+* `name`
+* `unit_weight`
+* `jewelry_type`
+* `magical_effects`
+
+## Associations
+
+Because `JewelryItem` models may (at least theoretically) have user-added enchantments in addition to those present on the canonical model, the `JewelryItem` model has its own associations to `EnchantablesEnchantment` and `Enchantment`. Enchantments that exist on the canonical model will be automatically added to the `JewelryItem` model when it is saved and a single matching `Canonical::JewelryItem` has been identified.
+
+The `Canonical::JewelryItem` model has associations to `crafting_materials` that will be the same for all non-canonical models that inherit from a given canonical model. For this reason, calling `#crafting_materials` on a non-canonical `JewelryItem` model will return the crafting materials for its corresponding `Canonical::JewelryItem` if one exists.
+
+## Auto-Populated Fields
+
+Jewelry items don't have any attributes that are initially hidden from users and discoverable as they play the game. For that reason, all matching attributes are set and enchantments added as soon as a single canonical model is able to be identified.

--- a/spec/models/jewelry_item_spec.rb
+++ b/spec/models/jewelry_item_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe JewelryItem, type: :model do
 
       it 'can be blank' do
         item.jewelry_type = nil
-        expect(item).to be_valid
+        item.validate
+        expect(item.errors[:jewelry_type]).to be_blank
       end
     end
 
@@ -36,7 +37,41 @@ RSpec.describe JewelryItem, type: :model do
 
       it 'can be blank' do
         item.unit_weight = nil
-        expect(item).to be_valid
+        item.validate
+        expect(item.errors[:unit_weight]).to be_blank
+      end
+    end
+
+    describe '#canonical_jewelry_items' do
+      context 'when there is a single matching canonical jewelry item' do
+        let(:item) { build(:jewelry_item, :with_matching_canonical) }
+
+        it 'is valid' do
+          expect(item).to be_valid
+        end
+      end
+
+      context 'when there are multiple matching canonical jewelry items' do
+        before do
+          create_list(
+            :canonical_jewelry_item,
+            2,
+            name: item.name,
+          )
+        end
+
+        it 'is valid' do
+          expect(item).to be_valid
+        end
+      end
+
+      context 'when there are no matching canonical jewelry items' do
+        let(:item) { build(:jewelry_item) }
+
+        it 'adds errors' do
+          item.validate
+          expect(item.errors[:base]).to include "doesn't match any jewelry item that exists in Skyrim"
+        end
       end
     end
   end
@@ -67,6 +102,162 @@ RSpec.describe JewelryItem, type: :model do
 
       it 'returns nil' do
         expect(crafting_materials).to be_nil
+      end
+    end
+  end
+
+  describe '#canonical_jewelry_items' do
+    subject(:canonical_jewelry_items) { item.canonical_jewelry_items }
+
+    context 'when the item has an association defined' do
+      let(:item) { create(:jewelry_item, :with_matching_canonical) }
+
+      before do
+        create(:canonical_jewelry_item, name: item.name)
+      end
+
+      it 'includes only the associated model' do
+        expect(canonical_jewelry_items).to contain_exactly(item.canonical_jewelry_item)
+      end
+    end
+
+    context 'when the item does not have an association defined' do
+      let(:item) { create(:jewelry_item, name: 'Gold diamond ring') }
+
+      context 'when only the name has to match' do
+        let!(:matching_canonicals) do
+          create_list(
+            :canonical_jewelry_item,
+            3,
+            name: 'Gold Diamond Ring',
+          )
+        end
+
+        it 'matches case-insensitively' do
+          expect(canonical_jewelry_items).to contain_exactly(*matching_canonicals)
+        end
+      end
+
+      context 'when multiple attributes have to match' do
+        let!(:matching_canonicals) do
+          create_list(
+            :canonical_jewelry_item,
+            2,
+            name: 'Gold Diamond Ring',
+            unit_weight: 0.2,
+          )
+        end
+
+        let(:item) { create(:jewelry_item, name: 'Gold diamond ring', unit_weight: 0.2) }
+
+        before do
+          create(:canonical_jewelry_item, name: 'Gold Diamond Ring', unit_weight: 3)
+        end
+
+        it 'returns the matching models' do
+          expect(canonical_jewelry_items).to contain_exactly(*matching_canonicals)
+        end
+      end
+    end
+  end
+
+  describe '::before_validation' do
+    context 'when there is a single matching canonical model' do
+      let!(:matching_canonical) do
+        create(
+          :canonical_jewelry_item,
+          :with_enchantments,
+          name: 'Gold Diamond Ring',
+          unit_weight: 0.2,
+          jewelry_type: 'ring',
+          magical_effects: 'Some magical effects to differentiate',
+        )
+      end
+
+      let(:item) do
+        build(
+          :jewelry_item,
+          name: 'Gold diamond ring',
+          unit_weight: 0.2,
+        )
+      end
+
+      before do
+        create(:canonical_jewelry_item, name: 'Gold Diamond Ring', unit_weight: 1)
+      end
+
+      it 'assigns the canonical jewelry item' do
+        item.validate
+        expect(item.canonical_jewelry_item).to eq matching_canonical
+      end
+
+      it 'sets the attributes', :aggregate_failures do
+        item.validate
+        expect(item.name).to eq 'Gold Diamond Ring'
+        expect(item.unit_weight).to eq 0.2
+        expect(item.jewelry_type).to eq 'ring'
+        expect(item.magical_effects).to eq 'Some magical effects to differentiate'
+      end
+
+      it 'adds enchantments if persisted' do
+        item.save!
+
+        # This realistically won't happen but in the interest of thoroughness...
+        item.enchantables_enchantments.each(&:destroy)
+
+        expect { item.validate }
+          .to change(item.enchantables_enchantments.reload, :length).from(0).to(2)
+      end
+    end
+
+    context 'when there are multiple matching canonical models' do
+      let!(:matching_canonicals) do
+        create_list(
+          :canonical_jewelry_item,
+          2,
+          :with_enchantments,
+          name: 'Gold Diamond Ring',
+          unit_weight: 0.2,
+        )
+      end
+
+      let(:item) { create(:jewelry_item, name: 'Gold Diamond Ring', unit_weight: 0.2) }
+
+      it "doesn't add enchantments" do
+        expect(item.enchantables_enchantments).to be_blank
+      end
+    end
+  end
+
+  describe '::after_create' do
+    let(:item) { create(:jewelry_item, name: 'Gold Diamond Ring') }
+
+    context 'when there is a single matching canonical model' do
+      before do
+        create(
+          :canonical_jewelry_item,
+          :with_enchantments,
+          name: 'Gold Diamond Ring',
+        )
+      end
+
+      it 'adds enchantments' do
+        expect(item.enchantments.length).to eq 2
+      end
+    end
+
+    context 'when there are multiple matching canonical models' do
+      before do
+        create_list(
+          :canonical_jewelry_item,
+          2,
+          :with_enchantments,
+          name: 'Gold Diamond Ring',
+        )
+      end
+
+      it "doesn't set enchantments" do
+        expect(item.enchantables_enchantments.length).to eq 0
       end
     end
   end

--- a/spec/models/jewelry_item_spec.rb
+++ b/spec/models/jewelry_item_spec.rb
@@ -40,4 +40,13 @@ RSpec.describe JewelryItem, type: :model do
       end
     end
   end
+
+  describe '#crafting_materials' do
+    let!(:canonical_jewelry_item) { create(:canonical_jewelry_item, :with_crafting_materials, name: 'Gold Diamond Ring') }
+    let(:item) { create(:jewelry_item, name: 'Gold Diamond Ring', canonical_jewelry_item:) }
+
+    it 'uses the values from the canonical model' do
+      expect(item.crafting_materials).to eq canonical_jewelry_item.crafting_materials
+    end
+  end
 end

--- a/spec/models/jewelry_item_spec.rb
+++ b/spec/models/jewelry_item_spec.rb
@@ -42,11 +42,32 @@ RSpec.describe JewelryItem, type: :model do
   end
 
   describe '#crafting_materials' do
-    let!(:canonical_jewelry_item) { create(:canonical_jewelry_item, :with_crafting_materials, name: 'Gold Diamond Ring') }
-    let(:item) { create(:jewelry_item, name: 'Gold Diamond Ring', canonical_jewelry_item:) }
+    subject(:crafting_materials) { item.crafting_materials }
 
-    it 'uses the values from the canonical model' do
-      expect(item.crafting_materials).to eq canonical_jewelry_item.crafting_materials
+    context 'when canonical_jewelry_item is set' do
+      let!(:canonical_jewelry_item) { create(:canonical_jewelry_item, :with_crafting_materials, name: 'Gold Diamond Ring') }
+      let(:item) { create(:jewelry_item, name: 'Gold Diamond Ring', canonical_jewelry_item:) }
+
+      it 'uses the values from the canonical model' do
+        expect(crafting_materials).to eq canonical_jewelry_item.crafting_materials
+      end
+    end
+
+    context 'when canonical_jewelry_item is not set' do
+      let!(:canonical_models) do
+        create_list(
+          :canonical_jewelry_item,
+          2,
+          :with_crafting_materials,
+          name: 'Gold Diamond Ring',
+        )
+      end
+
+      let(:item) { create(:jewelry_item, name: 'Gold Diamond Ring') }
+
+      it 'returns nil' do
+        expect(crafting_materials).to be_nil
+      end
     end
   end
 end

--- a/spec/models/jewelry_item_spec.rb
+++ b/spec/models/jewelry_item_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe JewelryItem, type: :model do
+  describe 'validations' do
+    let(:item) { build(:jewelry_item) }
+
+    describe '#name' do
+      it 'is invalid without a name' do
+        item.name = nil
+        item.validate
+        expect(item.errors[:name]).to include "can't be blank"
+      end
+    end
+
+    describe '#jewelry_type' do
+      it 'is invalid with an invalid value' do
+        item.jewelry_type = 'necklace'
+        item.validate
+        expect(item.errors[:jewelry_type]).to include 'must be "ring", "circlet", or "amulet"'
+      end
+
+      it 'can be blank' do
+        item.jewelry_type = nil
+        expect(item).to be_valid
+      end
+    end
+
+    describe '#unit_weight' do
+      it 'is invalid if less than 0' do
+        item.unit_weight = -5
+        item.validate
+        expect(item.errors[:unit_weight]).to include 'must be greater than or equal to 0'
+      end
+
+      it 'can be blank' do
+        item.unit_weight = nil
+        expect(item).to be_valid
+      end
+    end
+  end
+end

--- a/spec/support/factories/canonical/craftables_crafting_materials.rb
+++ b/spec/support/factories/canonical/craftables_crafting_materials.rb
@@ -2,19 +2,19 @@
 
 FactoryBot.define do
   factory :canonical_craftables_crafting_material, class: Canonical::CraftablesCraftingMaterial do
-    association :material, factory_name: :canonical_material
+    association :material, factory: :canonical_material
     quantity { 2 }
 
     trait :for_armor do
-      association :craftable, factory_name: :canonical_armor
+      association :craftable, factory: :canonical_armor
     end
 
     trait :for_jewelry do
-      association :craftable, factory_name: :canonical_jewelry_item
+      association :craftable, factory: :canonical_jewelry_item
     end
 
     trait :for_weapon do
-      association :craftable, factory_name: :canonical_weapon
+      association :craftable, factory: :canonical_weapon
     end
   end
 end

--- a/spec/support/factories/canonical/jewelry_items.rb
+++ b/spec/support/factories/canonical/jewelry_items.rb
@@ -10,5 +10,15 @@ FactoryBot.define do
     unique_item { false }
     rare_item { false }
     quest_item { false }
+
+    trait :with_crafting_materials do
+      after(:create) do |model|
+        create_list(
+          :canonical_craftables_crafting_material,
+          2,
+          craftable: model,
+        )
+      end
+    end
   end
 end

--- a/spec/support/factories/canonical/jewelry_items.rb
+++ b/spec/support/factories/canonical/jewelry_items.rb
@@ -20,5 +20,11 @@ FactoryBot.define do
         )
       end
     end
+
+    trait :with_enchantments do
+      after(:create) do |model|
+        create_list(:enchantables_enchantment, 2, enchantable: model)
+      end
+    end
   end
 end

--- a/spec/support/factories/jewelry_items.rb
+++ b/spec/support/factories/jewelry_items.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :jewelry_item do
+    game
+    name { 'Gold Diamond Ring' }
+  end
+end

--- a/spec/support/factories/jewelry_items.rb
+++ b/spec/support/factories/jewelry_items.rb
@@ -4,5 +4,9 @@ FactoryBot.define do
   factory :jewelry_item do
     game
     name { 'Gold Diamond Ring' }
+
+    trait :with_matching_canonical do
+      association :canonical_jewelry_item, factory: :canonical_jewelry_item
+    end
   end
 end


### PR DESCRIPTION
## Context

[**Create non-canonical JewelryItem model**](https://trello.com/c/Gvd0mNES/307-create-non-canonical-jewelryitem-model)

We are creating in-game item models that correspond to underlying canonical models. The next model we need to add is the `JewelryItem` model. These models represent in-game jewellery items (rings, circlets, and amulets/necklaces), which may or may not be craftable and may or may not have enchantments. Because jewellery items may (at least theoretically) be enchantable beyond enchantments existing on the canonical item, they have their own association to `enchantments` through `enchantables_enchantments`. Since crafting materials will be the same for all items matching a particular canonical model, the `JewelryItem` model does not include an association to crafting materials, using the crafting materials of the canonical model when one is identified.

## Changes

* Create `JewelryItem` model
* Update factories
* Add tests for the new model
* Add docs for the new model

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate
