### PR TITLE
Create non-canonical MiscItem model

### DIFF
--- a/app/models/canonical/misc_item.rb
+++ b/app/models/canonical/misc_item.rb
@@ -22,6 +22,12 @@ module Canonical
       'pelt',
     ].freeze
 
+    has_many :misc_items,
+             inverse_of: :canonical_misc_item,
+             dependent: :nullify,
+             foreign_key: 'canonical_misc_item_id',
+             class_name: '::MiscItem'
+
     validates :name, presence: true
     validates :item_code, presence: true, uniqueness: { message: 'must be unique' }
     validates :unit_weight, presence: true, numericality: { greater_than_or_equal_to: 0 }

--- a/app/models/misc_item.rb
+++ b/app/models/misc_item.rb
@@ -13,7 +13,7 @@ class MiscItem < ApplicationRecord
 
   before_validation :set_canonical_misc_item
 
-  DUPLICATE_MESSAGE = 'iks a duplicate of a unique in-game item'
+  DUPLICATE_MESSAGE = 'is a duplicate of a unique in-game item'
   DOES_NOT_MATCH = "doesn't match any item that exists in Skyrim"
 
   def canonical_models
@@ -41,7 +41,7 @@ class MiscItem < ApplicationRecord
 
   def associate_first_available_match
     canonical_models.each do |model|
-      next if model.unique_item && model.misc_items.any?
+      next if model.unique_item && model.misc_items.where(game_id:).any?
 
       self.canonical_misc_item = model
       break

--- a/app/models/misc_item.rb
+++ b/app/models/misc_item.rb
@@ -40,6 +40,8 @@ class MiscItem < ApplicationRecord
   end
 
   def associate_first_available_match
+    return if canonical_misc_item.present?
+
     canonical_models.each do |model|
       next if model.unique_item && model.misc_items.where(game_id:).any?
 

--- a/app/models/misc_item.rb
+++ b/app/models/misc_item.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class MiscItem < ApplicationRecord
+  belongs_to :game
+  belongs_to :canonical_misc_item,
+             optional: true,
+             inverse_of: :misc_items,
+             class_name: 'Canonical::MiscItem'
+
+  validates :name, presence: true
+  validates :unit_weight, numericality: { greater_than_or_equal_to: 0, allow_nil: true }
+
+  def canonical_models
+    return [canonical_misc_item] if canonical_misc_item.present?
+
+    canonicals = Canonical::MiscItem.where('name ILIKE ?', name)
+
+    attributes_to_match.any? ? canonicals.where(**attributes_to_match) : canonicals
+  end
+
+  private
+
+  def attributes_to_match
+    { unit_weight: }.compact
+  end
+end

--- a/db/migrate/20230805193231_create_misc_items.rb
+++ b/db/migrate/20230805193231_create_misc_items.rb
@@ -7,7 +7,7 @@ class CreateMiscItems < ActiveRecord::Migration[7.0]
       t.references :canonical_misc_item, foreign_key: true
 
       t.string :name, null: false
-      t.decimal :unit_weight
+      t.decimal :unit_weight, scale: 2, precision: 5
 
       t.timestamps
     end

--- a/db/migrate/20230805193231_create_misc_items.rb
+++ b/db/migrate/20230805193231_create_misc_items.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateMiscItems < ActiveRecord::Migration[7.0]
+  def change
+    create_table :misc_items do |t|
+      t.references :game, null: false, foreign_key: true
+      t.references :canonical_misc_item, foreign_key: true
+
+      t.string :name, null: false
+      t.decimal :unit_weight
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_27_230835) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_05_193231) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -408,6 +408,17 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_27_230835) do
     t.index ["game_id"], name: "index_jewelry_items_on_game_id"
   end
 
+  create_table "misc_items", force: :cascade do |t|
+    t.bigint "game_id", null: false
+    t.bigint "canonical_misc_item_id"
+    t.string "name", null: false
+    t.decimal "unit_weight"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["canonical_misc_item_id"], name: "index_misc_items_on_canonical_misc_item_id"
+    t.index ["game_id"], name: "index_misc_items_on_game_id"
+  end
+
   create_table "powers", force: :cascade do |t|
     t.string "name", null: false
     t.string "power_type", null: false
@@ -511,6 +522,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_27_230835) do
   add_foreign_key "inventory_lists", "inventory_lists", column: "aggregate_list_id"
   add_foreign_key "jewelry_items", "canonical_jewelry_items"
   add_foreign_key "jewelry_items", "games"
+  add_foreign_key "misc_items", "canonical_misc_items"
+  add_foreign_key "misc_items", "games"
   add_foreign_key "properties", "canonical_properties"
   add_foreign_key "properties", "games"
   add_foreign_key "shopping_list_items", "shopping_lists", column: "list_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -412,7 +412,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_05_193231) do
     t.bigint "game_id", null: false
     t.bigint "canonical_misc_item_id"
     t.string "name", null: false
-    t.decimal "unit_weight"
+    t.decimal "unit_weight", precision: 5, scale: 2
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["canonical_misc_item_id"], name: "index_misc_items_on_canonical_misc_item_id"

--- a/docs/canonical_models/README.md
+++ b/docs/canonical_models/README.md
@@ -19,3 +19,4 @@ The documentation here covers the purpose of canonical models, the canonical mod
   * [`Canonical::Book`](/docs/canonical_models/canonical-book.md): Additional details about special characteristics of the `Canonical::Book` model
   * [`Canonical::Ingredient`](/docs/canonical_models/canonical-ingredient.md): Additional details about special characteristics of the `Canonical::Ingredient` model
   * [`Canonical::IngredientsAlchemicalProperty`](/docs/canonical_models/canonical-ingredients-alchemical-property.md): Additional details about special characteristics of the `Canonical::IngredientsAlchemicalProperty` model
+  * [`Canonical::MiscItem`](/docs/canonical_models/canonical-misc-item.md): Additional details about special characteristics of the `Canonical::MiscItem` model and associated data

--- a/docs/canonical_models/canonical-ingredient.md
+++ b/docs/canonical_models/canonical-ingredient.md
@@ -4,7 +4,7 @@ The `Canonical::Ingredient` model has a couple of special characteristics that s
 
 ## Treatment of Rare Ingredients
 
-Ingredients differ from other objects in Skyrim in that they are consumable. For this reason, an ingredient can be considered a `rare_item` in situations where a non-consumable item would not be. The challenge presented by this is augmented by the fact that it's impossible to find detailed information online about acquisition of different ingredients, especially Solstheim ingredients (designated by `ingredient_type: 'Solstheim'`). For this reason, we've shot from the hip in determining which ingredients qualify as `rare_item`s, taking into account the subjective experience of how hard it is to find something in the game.
+Ingredients differ from other objects in Skyrim (other than soul gems and crafting/tempering/building materials) in that they are consumable. For this reason, an ingredient can be considered a `rare_item` in situations where a non-consumable item would not be. The challenge presented by this is augmented by the fact that it's impossible to find detailed information online about acquisition of different ingredients, especially Solstheim ingredients (designated by `ingredient_type: 'Solstheim'`). For this reason, we've shot from the hip in determining which ingredients qualify as `rare_item`s, taking into account the subjective experience of how hard it is to find something in the game.
 
 The factors considered in determining whether an ingredient is rare include:
 

--- a/docs/canonical_models/canonical-misc-item.md
+++ b/docs/canonical_models/canonical-misc-item.md
@@ -1,0 +1,19 @@
+# Canonical::MiscItem
+
+The `Canonical::MiscItem` model has a couple of special characteristics that set it apart from other canonical models.
+
+## Indistinguishable Associations
+
+A `Canonical::MiscItem` model stores significant metadata about an item, such as whether it is rare or unique, whether it can be purchased, what type of item it is, whether it is a quest item or reward, and a description of the item (if available). However, only two of these values - the `name` and the `unit_weight` - are visible to the player. In certain cases, these two attributes are insufficient to distinguish multiple matching canonical models. Indeed, some `Canonical::MiscItem` records are distinguishable from one or more other records only by `item_code`, a low-level implementation detail of the game not generally visible to players.
+
+At this writing, there are 5 duplicate `name`s among the canonical misc items in the production database:
+
+* "Skull" (occurs twice)
+* "Reaper Gem Fragment" (occurs 3 times)
+* "Werewolf Totem" (occurs 3 times)
+* "Opaque Vessel" (occurs 3 times)
+* "Crown of Barenziah" (occurs twice)
+
+Of these, only the Skull and the Crown of Barenziah are differentiable by any attribute but item code - however, the field that differentiates them is the `description` field, which is not visible to players and not present on the `::MiscItem` model.
+
+Because of the difficulty of uniquely identifying misc items, the `::MiscItem` model uses a slightly different algorithm for assigning associations than other in-game item classes. Details are available in the docs for the in-game item class.

--- a/docs/in_game_items/README.md
+++ b/docs/in_game_items/README.md
@@ -12,6 +12,7 @@ This documentation covers the scope and purpose of non-canonical in-game items, 
   * [`ClothingItem`](/docs/in_game_items/clothing-item.md)
   * [`Ingredient`](/docs/in_game_items/ingredient.md)
   * [`JewelryItem`](/docs/in_game_items/jewelry-item.md)
+  * [`MiscItem`](/docs/in_game_items/misc-item.md)
 * Join models:
   * [`IngredientsAlchemicalProperty`](/docs/in_game_items/ingredients-alchemical-property.md)
   * `EnchantablesEnchantment` (both canonical and non-canonical use same table)

--- a/docs/in_game_items/misc-item.md
+++ b/docs/in_game_items/misc-item.md
@@ -1,0 +1,16 @@
+# Misc Item
+
+The `MiscItem` model differs from some of the other in-game items. As noted in the docs on the [canonical misc item](/docs/canonical_models/canonical-misc-item.md), misc items have some peculiarities relating to the uniqueness and differentiability of the associated canonical records. Specifically, there are a few canonical records, as noted in the docs for the canonical model, that are differentiable only by item code. Since item codes are opaque to players, none of the information a user would input about an item would be sufficient to identify what the true canonical association should be. Because of this, the `MiscItem` model uses an additional algorithm to identify its canonical association.
+
+## Matching Attributes
+
+`MiscItem` models are matched to `Canonical::MiscItem` models using only two fields:
+
+* `name`
+* `unit_weight`
+
+## Ambiguous Canonical Associations
+
+There are a small number of `Canonical::MiscItem` records that have duplicate names. None of these are differentiable by `name` and `unit_weight` alone. Indeed, as noted above, some are differentiable only by `item_code`, a low-level implementation detail of the game that was added to SIM only to differentiate otherwise identical records. This has implications for the in-game `MiscItem` model's approach to finding its association.
+
+Like other in-game item models, a `MiscItem` first identifies a pool of possible canonical matches using the `name`, matched case-insensitively, and, if set, the `unit_weight` of the item. SIM knows there is an ambiguous match when both `name` and `unit_weight` are set but there are still multiple `canonical_models`. When this happens, SIM follows an algorithm as follows to decide which canonical model to associate. SIM iterates through the possible canonical matches. For each canonical model, it checks whether the model is designated as a `unique_item` and, if so, whether it already has a corresponding in-game item for the relevant game. If a canonical model of a unique item already has an association in a given game, that model is skipped and the next is tested. If all matching canonical models are unique and already have an association for the given game, a validation error is added to the `MiscItem` model indicating it is a duplicate of a unique in-game item.

--- a/spec/models/misc_item_spec.rb
+++ b/spec/models/misc_item_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe MiscItem, type: :model do
     describe '#unit_weight' do
       it 'can be blank' do
         item.unit_weight = nil
-        expect(item.errors[:unit_weight]).to be_blank
+        expect(item.errors[:unit_weight]).to be_empty
       end
 
       it 'is invalid if less than 0' do

--- a/spec/models/misc_item_spec.rb
+++ b/spec/models/misc_item_spec.rb
@@ -239,5 +239,15 @@ RSpec.describe MiscItem, type: :model do
         end
       end
     end
+
+    context 'when there is already a canonical_misc_item assigned' do
+      let(:canonical_misc_item) { create(:canonical_misc_item, unique_item: true, rare_item: true) }
+      let(:item) { create(:misc_item, canonical_misc_item:) }
+
+      it "doesn't raise an error" do
+        item.validate
+        expect(item.errors[:base]).to be_empty
+      end
+    end
   end
 end

--- a/spec/models/misc_item_spec.rb
+++ b/spec/models/misc_item_spec.rb
@@ -73,9 +73,6 @@ RSpec.describe MiscItem, type: :model do
         create(:canonical_misc_item, name: item.name)
       end
 
-      # TODO: This might not be desirable behaviour since it prevents the associated
-      #       model from changing when the non-canonical model's matchable attributes
-      #       are updated.
       it 'includes only the associated model' do
         expect(canonical_models).to contain_exactly(item.canonical_misc_item)
       end

--- a/spec/models/misc_item_spec.rb
+++ b/spec/models/misc_item_spec.rb
@@ -162,7 +162,8 @@ RSpec.describe MiscItem, type: :model do
     end
 
     context "when multiple complete matches can't be further differentiated" do
-      let(:item) { build(:misc_item, name: 'Skull', unit_weight: 2) }
+      let(:game) { create(:game) }
+      let(:item) { build(:misc_item, name: 'Skull', unit_weight: 2, game:) }
 
       context 'when a canonical model indicates a unique item' do
         let!(:matching_canonicals) do
@@ -184,6 +185,7 @@ RSpec.describe MiscItem, type: :model do
                 canonical_misc_item: matching_canonicals.first,
                 name: 'Skull',
                 unit_weight: 2,
+                game:,
               )
             end
 
@@ -201,6 +203,7 @@ RSpec.describe MiscItem, type: :model do
                   canonical_misc_item: model,
                   name: model.name,
                   unit_weight: model.unit_weight,
+                  game:,
                 )
               end
             end

--- a/spec/models/misc_item_spec.rb
+++ b/spec/models/misc_item_spec.rb
@@ -27,9 +27,9 @@ RSpec.describe MiscItem, type: :model do
       end
     end
 
-    describe '#canonical_misc_items' do
+    describe '#canonical_misc_item' do
       context 'when there is a single matching canonical misc item' do
-        let(:item) { create(:misc_item, :with_matching_canonical) }
+        let(:item) { build(:misc_item, :with_matching_canonical) }
 
         it 'is valid' do
           expect(item).to be_valid
@@ -224,7 +224,16 @@ RSpec.describe MiscItem, type: :model do
         let!(:matching_canonicals) do
           create_list(
             :canonical_misc_item,
-            3,
+            2,
+            name: 'Skull',
+            unit_weight: 2,
+          )
+        end
+
+        before do
+          create(
+            :misc_item,
+            canonical_misc_item: matching_canonicals.first,
             name: 'Skull',
             unit_weight: 2,
           )

--- a/spec/models/misc_item_spec.rb
+++ b/spec/models/misc_item_spec.rb
@@ -242,9 +242,9 @@ RSpec.describe MiscItem, type: :model do
 
     context 'when there is already a canonical_misc_item assigned' do
       let(:canonical_misc_item) { create(:canonical_misc_item, unique_item: true, rare_item: true) }
-      let(:item) { create(:misc_item, canonical_misc_item:) }
+      let(:item) { build(:misc_item, canonical_misc_item:) }
 
-      it "doesn't raise an error" do
+      it "doesn't raise a validation error" do
         item.validate
         expect(item.errors[:base]).to be_empty
       end

--- a/spec/models/misc_item_spec.rb
+++ b/spec/models/misc_item_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MiscItem, type: :model do
+  describe 'validations' do
+    let(:item) { build(:misc_item, :with_matching_canonical) }
+
+    describe '#name' do
+      it 'is invalid without a name' do
+        item.name = nil
+        item.validate
+        expect(item.errors[:name]).to include "can't be blank"
+      end
+    end
+
+    describe '#unit_weight' do
+      it 'can be blank' do
+        item.unit_weight = nil
+        expect(item).to be_valid
+      end
+
+      it 'is invalid if less than 0' do
+        item.unit_weight = -1.2
+        item.validate
+        expect(item.errors[:unit_weight]).to include 'must be greater than or equal to 0'
+      end
+    end
+
+    describe '#canonical_misc_items' do
+      context 'when there is a single matching canonical misc item' do
+        it 'is valid' do
+          expect(item).to be_valid
+        end
+      end
+
+      context 'when there are multiple matching canonical misc items' do
+        let(:item) { build(:misc_item) }
+
+        before do
+          create_list(
+            :canonical_misc_item,
+            2,
+            name: item.name,
+          )
+        end
+
+        it 'is valid' do
+          expect(item).to be_valid
+        end
+      end
+
+      context 'when there are no matching canonical misc items' do
+        let(:item) { build(:misc_item) }
+
+        it 'adds errors' do
+          pending
+          item.validate
+          expect(item.errors[:base]).to include "doesn't match any item that exists in Skyrim"
+        end
+      end
+    end
+  end
+
+  describe '#canonical_models' do
+    subject(:canonical_models) { item.canonical_models }
+
+    context 'when the item has an association defined' do
+      let(:item) { create(:misc_item, :with_matching_canonical) }
+
+      before do
+        create(:canonical_misc_item, name: item.name)
+      end
+
+      # TODO: This might not be desirable behaviour since it prevents the associated
+      #       model from changing when the non-canonical model's matchable attributes
+      #       are updated.
+      it 'includes only the associated model' do
+        expect(canonical_models).to contain_exactly(item.canonical_misc_item)
+      end
+    end
+
+    context 'when the item does not have an association defined' do
+      let(:item) { create(:misc_item, name: 'Wedding Ring') }
+
+      context 'when only the name has to match' do
+        let!(:matching_canonicals) do
+          create_list(
+            :canonical_misc_item,
+            3,
+            name: 'wedding ring',
+          )
+        end
+
+        it 'matches case-insensitively' do
+          expect(canonical_models).to contain_exactly(*matching_canonicals)
+        end
+      end
+
+      context 'when both name and unit weight have to match' do
+        let!(:matching_canonicals) do
+          create_list(
+            :canonical_misc_item,
+            2,
+            name: "Wylandria's Soul Gem",
+            unit_weight: 0,
+          )
+        end
+
+        let(:item) { create(:misc_item, name: "Wylandria's Soul Gem", unit_weight: 0) }
+
+        before do
+          create(:canonical_misc_item, name: 'wedding ring', unit_weight: 1.0)
+        end
+
+        it 'returns the matching models' do
+          expect(canonical_models).to contain_exactly(*matching_canonicals)
+        end
+      end
+    end
+  end
+end

--- a/spec/support/factories/misc_items.rb
+++ b/spec/support/factories/misc_items.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :misc_item do
+    game
+
+    name { "Wylandria's Soul Gem" }
+
+    trait :with_matching_canonical do
+      association :canonical_misc_item, factory: :canonical_misc_item
+
+      name { canonical_misc_item.name }
+    end
+  end
+end


### PR DESCRIPTION
## Context

[**Create non-canonical MiscItem model**](https://trello.com/c/OaJu3oSB/308-create-non-canonical-miscitem-model)

We are creating in-game item models to correspond to each canonical model that already exists in SIM. The next model to be added is the `MiscItem`.

## Changes

* Migration to add `misc_items` table
* `MiscItem` model class
* Specs for `MiscItem` class
* Developer docs

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

Many of the considerations pertaining to this model can be found in the included docs. The biggest challenge with this model was that not all `Canonical::MiscItem` records can be uniquely identified by attributes visible to players, so SIM has no way of knowing which canonical model _actually_ matches the item a player has in their inventory. I resolved this problem by assigning ambiguous matches essentially randomly. Matches are narrowed down as much as possible by `name` and `unit_weight`. Then, if there are still multiple matches, the possible matches are tested to see if they are unique items and, if so, if there is already a corresponding in-game item for the given game. Unique canonical models should only have one non-canonical association per game. If all matching models are unique and already have associated models in the same game, a validation error is added to the `MiscItem` indicating it is a duplicate of a unique item.
