### PR TITLE
Ingredient model tweaks

### DIFF
--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -24,6 +24,7 @@ class Ingredient < ApplicationRecord
     return Canonical::Ingredient.where(id: canonical_ingredient.id) if canonical_ingredient.present?
 
     matching = Canonical::Ingredient.where('name ILIKE ?', name)
+    matching = matching.where(**attributes_to_match) if attributes_to_match.any?
 
     return matching if alchemical_properties.empty?
 
@@ -45,11 +46,20 @@ class Ingredient < ApplicationRecord
 
     canonicals = canonical_ingredients
     self.canonical_ingredient = canonicals.first if canonicals.count == 1
+
+    return if canonical_ingredient.nil?
+
+    self.name = canonical_ingredient.name
+    self.unit_weight = canonical_ingredient.unit_weight
   end
 
   def ensure_match_exists
     return if canonical_ingredients.any?
 
     errors.add(:base, DOES_NOT_MATCH)
+  end
+
+  def attributes_to_match
+    { unit_weight: }.compact
   end
 end

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -15,6 +15,7 @@ class Ingredient < ApplicationRecord
            through: :ingredients_alchemical_properties
 
   validates :name, presence: true
+  validates :unit_weight, numericality: { greater_than_or_equal_to: 0, allow_blank: true }
   validate :ensure_match_exists
 
   before_validation :set_canonical_ingredient

--- a/docs/in_game_items/ingredient.md
+++ b/docs/in_game_items/ingredient.md
@@ -6,7 +6,7 @@ The `Ingredient` model represents in-game items of the `Canonical::Ingredient` t
 
 Matching an `Ingredient` to a `Canonical::Ingredient` is a bit more complex than matching the previously-introduced [`Armor`](/docs/in_game_items/armor.md) and [`ClothingItem`](/docs/in_game_items/clothing-item.md) models to their corresponding canonical models. This is because ingredients may be uniquely identified by their alchemical properties, which are associations and not attributes of the model itself.
 
-When an `Ingredient` is created, it is then matched to a subset of canonical ingredients by its `name` attribute (the only attribute of `Canonical::Ingredient` also present on `Ingredient`). If the ingredient has alchemical properties, these are further narrowed down based on those associations, checking for the `alchemical_property_id` and `priority` defined on the [`IngredientsAlchemicalProperty`](/docs/in_game_items/ingredients-alchemical-property.md) model. If these match for all defined alchemical properties, it is considered a match.
+When an `Ingredient` is created, it is then matched to a subset of canonical ingredients by its `name` and `unit_weight` attributes (the only attributes of `Canonical::Ingredient` also present on `Ingredient`). If the ingredient has alchemical properties, these are further narrowed down based on those associations, checking for the `alchemical_property_id` and `priority` defined on the [`IngredientsAlchemicalProperty`](/docs/in_game_items/ingredients-alchemical-property.md) model. If these match for all defined alchemical properties, it is considered a match.
 
 ## The `IngredientsAlchemicalProperty` Join Model
 

--- a/spec/models/ingredient_spec.rb
+++ b/spec/models/ingredient_spec.rb
@@ -82,6 +82,19 @@ RSpec.describe Ingredient, type: :model do
         end
       end
 
+      context 'when names and unit weights are defined' do
+        let!(:matching_canonicals) { create_list(:canonical_ingredient, 2, name: 'Blue Mountain Flower', unit_weight: 0.1) }
+        let(:ingredient) { create(:ingredient, name: 'Blue Mountain Flower', unit_weight: 0.1) }
+
+        before do
+          create(:canonical_ingredient, name: 'Blue Mountain Flower', unit_weight: 0.2)
+        end
+
+        it 'returns all the matching canonical ingredients' do
+          expect(ingredient.canonical_ingredients).to eq matching_canonicals
+        end
+      end
+
       # NB: No context is required for when no join model fully matches because
       #     join model validations will fail if they don't match.
       context 'when there are also alchemical properties involved' do

--- a/spec/models/ingredient_spec.rb
+++ b/spec/models/ingredient_spec.rb
@@ -6,10 +6,26 @@ RSpec.describe Ingredient, type: :model do
   describe 'validations' do
     let(:ingredient) { build(:ingredient) }
 
-    it 'is invalid without a name' do
-      ingredient.name = nil
-      ingredient.validate
-      expect(ingredient.errors[:name]).to include "can't be blank"
+    describe '#name' do
+      it "can't be blank" do
+        ingredient.name = nil
+        ingredient.validate
+        expect(ingredient.errors[:name]).to include "can't be blank"
+      end
+    end
+
+    describe '#unit_weight' do
+      it 'can be blank' do
+        ingredient.unit_weight = nil
+        ingredient.validate
+        expect(ingredient.errors[:unit_weight]).to be_empty
+      end
+
+      it 'must be at least 0' do
+        ingredient.unit_weight = -2.7
+        ingredient.validate
+        expect(ingredient.errors[:unit_weight]).to include 'must be greater than or equal to 0'
+      end
     end
 
     context 'when there are multiple matching canonical ingredients' do


### PR DESCRIPTION
## Context

In the course of other work on in-game item models, I noticed some issues with the `Ingredient` class. I was going to make the tweaks in the PR I was working on but because they turned out to be somewhat bigger changes I decided to make a separate PR.

I found two specific problems with the `Ingredient` model:

1. Matching with `Canonical::Ingredient` filters on `name` (case-insensitively as expected) but not `unit_weight`
2. There is a missing validation for `unit_weight` being at least 0

## Changes

* Filter canonical matches using both `name` and `unit_weight`
* Validate that `unit_weight`, if present, must be at least 0
* Tests for above
* Update docs

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

I'm not sure why these changes needed to be made now - the model should've been like this to begin with.
