### PR TITLE
Add homestead fields to Canonical::Property model

### DIFF
--- a/db/migrate/20230925053242_add_new_fields_to_canonical_property.rb
+++ b/db/migrate/20230925053242_add_new_fields_to_canonical_property.rb
@@ -15,6 +15,7 @@ class AddNewFieldsToCanonicalProperty < ActiveRecord::Migration[7.0]
       t.column :apiary_available, :boolean, default: false
       t.column :grain_mill_available, :boolean, default: false
       t.column :fish_hatchery_available, :boolean, default: false
+      t.column :cellar_available, :boolean, default: false
     end
   end
 end

--- a/db/migrate/20230925053242_add_new_fields_to_canonical_property.rb
+++ b/db/migrate/20230925053242_add_new_fields_to_canonical_property.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class AddNewFieldsToCanonicalProperty < ActiveRecord::Migration[7.0]
+  def change
+    change_table :canonical_properties do |t|
+      t.column :enchanters_tower_available, :boolean, default: false
+      t.column :alchemy_tower_available, :boolean, default: false
+      t.column :library_available, :boolean, default: false
+      t.column :bedrooms_available, :boolean, default: false
+      t.column :storage_room_available, :boolean, default: false
+      t.column :armory_available, :boolean, default: false
+      t.column :greenhouse_available, :boolean, default: false
+      t.column :trophy_room_available, :boolean, default: false
+      t.column :kitchen_available, :boolean, default: false
+      t.column :apiary_available, :boolean, default: false
+      t.column :grain_mill_available, :boolean, default: false
+      t.column :fish_hatchery_available, :boolean, default: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_11_234456) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_25_053242) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -225,6 +225,18 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_11_234456) do
     t.boolean "forge_available", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "enchanters_tower_available", default: false
+    t.boolean "alchemy_tower_available", default: false
+    t.boolean "library_available", default: false
+    t.boolean "bedrooms_available", default: false
+    t.boolean "storage_room_available", default: false
+    t.boolean "armory_available", default: false
+    t.boolean "greenhouse_available", default: false
+    t.boolean "trophy_room_available", default: false
+    t.boolean "kitchen_available", default: false
+    t.boolean "apiary_available", default: false
+    t.boolean "grain_mill_available", default: false
+    t.boolean "fish_hatchery_available", default: false
     t.index ["city"], name: "index_canonical_properties_on_city", unique: true
     t.index ["hold"], name: "index_canonical_properties_on_hold", unique: true
     t.index ["name"], name: "index_canonical_properties_on_name", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -237,6 +237,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_25_053242) do
     t.boolean "apiary_available", default: false
     t.boolean "grain_mill_available", default: false
     t.boolean "fish_hatchery_available", default: false
+    t.boolean "cellar_available", default: false
     t.index ["city"], name: "index_canonical_properties_on_city", unique: true
     t.index ["hold"], name: "index_canonical_properties_on_hold", unique: true
     t.index ["name"], name: "index_canonical_properties_on_name", unique: true

--- a/docs/canonical_models/README.md
+++ b/docs/canonical_models/README.md
@@ -20,3 +20,4 @@ The documentation here covers the purpose of canonical models, the canonical mod
   * [`Canonical::Ingredient`](/docs/canonical_models/canonical-ingredient.md): Additional details about special characteristics of the `Canonical::Ingredient` model
   * [`Canonical::IngredientsAlchemicalProperty`](/docs/canonical_models/canonical-ingredients-alchemical-property.md): Additional details about special characteristics of the `Canonical::IngredientsAlchemicalProperty` model
   * [`Canonical::MiscItem`](/docs/canonical_models/canonical-misc-item.md): Additional details about special characteristics of the `Canonical::MiscItem` model and associated data
+  * [`Canonical::Property`](/docs/canonical_models/canonical-property.md): Additional details about special characteristics of the `Canonical::Property` model

--- a/docs/canonical_models/canonical-property.md
+++ b/docs/canonical_models/canonical-property.md
@@ -31,6 +31,12 @@ The three homesteads (Lakeview Manor, Heljarchen Hall and Windstad Manor) are se
 
 Each homestead also has a cellar that can be built; this is where the forge will be located, should the player choose to build one, as well as shrines to the Nine Divines.
 
+Each homestead also has one outdoor element unique to it:
+
+* Apiary (Lakeview Manor)
+* Grain Mill (Heljarchen Hall)
+* Fish Hatchery (Windstad Manor)
+
 ## Properties as Locations
 
 Properties are different from other types of "items" in SIM in two ways:

--- a/docs/canonical_models/canonical-property.md
+++ b/docs/canonical_models/canonical-property.md
@@ -1,0 +1,41 @@
+# Canonical::Property
+
+The `Canonical::Property` model represents a property that can be owned or belong to the player in Skyrim. There are 10 properties in Skyrim, assuming the Hearthfire add-on is present:
+
+* The Arch-Mage's Quarters (College of Winterhold)
+* Breezehome (Whiterun)
+* Vlindrel Hall (Markarth)
+* Proudspire Manor (Solitude)
+* Honeyside (Riften)
+* Hjerim (Windhelm)
+* Severin Manor (Raven Rock)
+* Lakeview Manor (Falkreath)
+* Heljarchen Hall (The Pale)
+* Windstad Manor (Hjaalmarch)
+
+Of these, the last three are [homesteads](https://elderscrolls.fandom.com/wiki/Homestead_(Hearthfire)) that the user can build in the course of the game.
+
+## Attributes
+
+One of the common characteristics of most properties in Skyrim (other than Severin Manor and the Arch-Mage's Quarters) is that the user gets to choose which items to purchase or build for them. As such, most of the fields on the `Canonical::Property` model are booleans indicating whether particular features are possible for a given property.
+
+## Homesteads
+
+The three homesteads (Lakeview Manor, Heljarchen Hall and Windstad Manor) are set apart by the fact that the player starts with them as land and must build the houses on them. Each homestead has a small house, main hall and cellar that can be built. Additionally, the homesteads each have three wings. Each wing has three possible rooms that can be built there, as shown in the table below (the three rooms for each wing are mutually exclusive, but this logic is handled in the non-canonical model).
+
+| **Location**   | **Tower**           | **Room with Outdoor Patio** | **Downstairs Room** |
+| -------------- | ------------------- | --------------------------- | ------------------- |
+| **West Wing**  | Enchanter's Tower   | Bedrooms                    | Greenhouse          |
+| **North Wing** | Alchemy Laboratory* | Storage Room                | Trophy Room         |
+| **East Wing**  | Library             | Armory                      | Kitchen             |
+
+Each homestead also has a cellar that can be built; this is where the forge will be located, should the player choose to build one, as well as shrines to the Nine Divines.
+
+## Properties as Locations
+
+Properties are different from other types of "items" in SIM in two ways:
+
+1. Each property is also a location (often with sublocations)
+2. Properties are an organising element in SIM - users will be able to associate inventory and shopping lists with specific properties
+
+The implications of both of these factors are being uncovered as we continue building out the back end.

--- a/lib/tasks/canonical_models/canonical_properties.json
+++ b/lib/tasks/canonical_models/canonical_properties.json
@@ -6,7 +6,18 @@
       "city": "Winterhold",
       "alchemy_lab_available": true,
       "arcane_enchanter_available": true,
-      "forge_available": false
+      "forge_available": false,
+      "enchanters_tower_available": false,
+      "alchemy_tower_available": false,
+      "library_available": false,
+      "bedrooms_available": false,
+      "storage_room_available": false,
+      "armory_available": false,
+      "greenhouse_available": false,
+      "kitchen_available": false,
+      "apiary_available": false,
+      "grain_mill_available": false,
+      "fish_hatchery_available": false
     }
   },
   {
@@ -16,7 +27,18 @@
       "city": "Whiterun",
       "alchemy_lab_available": true,
       "arcane_enchanter_available": false,
-      "forge_available": false
+      "forge_available": false,
+      "enchanters_tower_available": false,
+      "alchemy_tower_available": false,
+      "library_available": false,
+      "bedrooms_available": false,
+      "storage_room_available": false,
+      "armory_available": false,
+      "greenhouse_available": false,
+      "kitchen_available": false,
+      "apiary_available": false,
+      "grain_mill_available": false,
+      "fish_hatchery_available": false
     }
   },
   {
@@ -26,7 +48,18 @@
       "city": null,
       "alchemy_lab_available": true,
       "arcane_enchanter_available": true,
-      "forge_available": true
+      "forge_available": true,
+      "enchanters_tower_available": true,
+      "alchemy_tower_available": true,
+      "library_available": true,
+      "bedrooms_available": true,
+      "storage_room_available": true,
+      "armory_available": true,
+      "greenhouse_available": true,
+      "kitchen_available": true,
+      "apiary_available": false,
+      "grain_mill_available": true,
+      "fish_hatchery_available": false
     }
   },
   {
@@ -36,7 +69,18 @@
       "city": "Windhelm",
       "alchemy_lab_available": true,
       "arcane_enchanter_available": true,
-      "forge_available": false
+      "forge_available": false,
+      "enchanters_tower_available": false,
+      "alchemy_tower_available": false,
+      "library_available": false,
+      "bedrooms_available": false,
+      "storage_room_available": false,
+      "armory_available": false,
+      "greenhouse_available": false,
+      "kitchen_available": false,
+      "apiary_available": false,
+      "grain_mill_available": false,
+      "fish_hatchery_available": false
     }
   },
   {
@@ -46,7 +90,18 @@
       "city": "Riften",
       "alchemy_lab_available": true,
       "arcane_enchanter_available": true,
-      "forge_available": false
+      "forge_available": false,
+      "enchanters_tower_available": false,
+      "alchemy_tower_available": false,
+      "library_available": false,
+      "bedrooms_available": false,
+      "storage_room_available": false,
+      "armory_available": false,
+      "greenhouse_available": false,
+      "kitchen_available": false,
+      "apiary_available": false,
+      "grain_mill_available": false,
+      "fish_hatchery_available": false
     }
   },
   {
@@ -56,7 +111,18 @@
       "city": null,
       "alchemy_lab_available": true,
       "arcane_enchanter_available": true,
-      "forge_available": true
+      "forge_available": true,
+      "enchanters_tower_available": true,
+      "alchemy_tower_available": true,
+      "library_available": true,
+      "bedrooms_available": true,
+      "storage_room_available": true,
+      "armory_available": true,
+      "greenhouse_available": true,
+      "kitchen_available": true,
+      "apiary_available": true,
+      "grain_mill_available": false,
+      "fish_hatchery_available": false
     }
   },
   {
@@ -66,7 +132,18 @@
       "city": "Solitude",
       "alchemy_lab_available": true,
       "arcane_enchanter_available": true,
-      "forge_available": false
+      "forge_available": false,
+      "enchanters_tower_available": false,
+      "alchemy_tower_available": false,
+      "library_available": false,
+      "bedrooms_available": false,
+      "storage_room_available": false,
+      "armory_available": false,
+      "greenhouse_available": false,
+      "kitchen_available": false,
+      "apiary_available": false,
+      "grain_mill_available": false,
+      "fish_hatchery_available": false
     }
   },
   {
@@ -76,7 +153,18 @@
       "city": "Raven Rock",
       "alchemy_lab_available": true,
       "arcane_enchanter_available": true,
-      "forge_available": true
+      "forge_available": true,
+      "enchanters_tower_available": false,
+      "alchemy_tower_available": false,
+      "library_available": false,
+      "bedrooms_available": false,
+      "storage_room_available": false,
+      "armory_available": false,
+      "greenhouse_available": false,
+      "kitchen_available": false,
+      "apiary_available": false,
+      "grain_mill_available": false,
+      "fish_hatchery_available": false
     }
   },
   {
@@ -86,7 +174,18 @@
       "city": "Markarth",
       "alchemy_lab_available": true,
       "arcane_enchanter_available": true,
-      "forge_available": false
+      "forge_available": false,
+      "enchanters_tower_available": false,
+      "alchemy_tower_available": false,
+      "library_available": false,
+      "bedrooms_available": false,
+      "storage_room_available": false,
+      "armory_available": false,
+      "greenhouse_available": false,
+      "kitchen_available": false,
+      "apiary_available": false,
+      "grain_mill_available": false,
+      "fish_hatchery_available": false
     }
   },
   {
@@ -96,7 +195,18 @@
       "city": null,
       "alchemy_lab_available": true,
       "arcane_enchanter_available": true,
-      "forge_available": true
+      "forge_available": true,
+      "enchanters_tower_available": true,
+      "alchemy_tower_available": true,
+      "library_available": true,
+      "bedrooms_available": true,
+      "storage_room_available": true,
+      "armory_available": true,
+      "greenhouse_available": true,
+      "kitchen_available": true,
+      "apiary_available": false,
+      "grain_mill_available": false,
+      "fish_hatchery_available": true
     }
   }
 ]

--- a/lib/tasks/canonical_models/canonical_properties.json
+++ b/lib/tasks/canonical_models/canonical_properties.json
@@ -17,7 +17,8 @@
       "kitchen_available": false,
       "apiary_available": false,
       "grain_mill_available": false,
-      "fish_hatchery_available": false
+      "fish_hatchery_available": false,
+      "cellar_available": false
     }
   },
   {
@@ -38,7 +39,8 @@
       "kitchen_available": false,
       "apiary_available": false,
       "grain_mill_available": false,
-      "fish_hatchery_available": false
+      "fish_hatchery_available": false,
+      "cellar_available": false
     }
   },
   {
@@ -59,7 +61,8 @@
       "kitchen_available": true,
       "apiary_available": false,
       "grain_mill_available": true,
-      "fish_hatchery_available": false
+      "fish_hatchery_available": false,
+      "cellar_available": true
     }
   },
   {
@@ -80,7 +83,8 @@
       "kitchen_available": false,
       "apiary_available": false,
       "grain_mill_available": false,
-      "fish_hatchery_available": false
+      "fish_hatchery_available": false,
+      "cellar_available": false
     }
   },
   {
@@ -101,7 +105,8 @@
       "kitchen_available": false,
       "apiary_available": false,
       "grain_mill_available": false,
-      "fish_hatchery_available": false
+      "fish_hatchery_available": false,
+      "cellar_available": false
     }
   },
   {
@@ -122,7 +127,8 @@
       "kitchen_available": true,
       "apiary_available": true,
       "grain_mill_available": false,
-      "fish_hatchery_available": false
+      "fish_hatchery_available": false,
+      "cellar_available": true
     }
   },
   {
@@ -143,7 +149,8 @@
       "kitchen_available": false,
       "apiary_available": false,
       "grain_mill_available": false,
-      "fish_hatchery_available": false
+      "fish_hatchery_available": false,
+      "cellar_available": false
     }
   },
   {
@@ -164,7 +171,8 @@
       "kitchen_available": false,
       "apiary_available": false,
       "grain_mill_available": false,
-      "fish_hatchery_available": false
+      "fish_hatchery_available": false,
+      "cellar_available": false
     }
   },
   {
@@ -185,7 +193,8 @@
       "kitchen_available": false,
       "apiary_available": false,
       "grain_mill_available": false,
-      "fish_hatchery_available": false
+      "fish_hatchery_available": false,
+      "cellar_available": false
     }
   },
   {
@@ -206,7 +215,8 @@
       "kitchen_available": true,
       "apiary_available": false,
       "grain_mill_available": false,
-      "fish_hatchery_available": true
+      "fish_hatchery_available": true,
+      "cellar_available": true
     }
   }
 ]


### PR DESCRIPTION
## Context

[**Add fields to Canonical::Property**](https://trello.com/c/xcXiFJIp/327-add-fields-to-canonicalproperty)

The homestead properties - Lakeview Manor, Heljarchen Hall, and Windstad Manor - have numerous rooms that are able to be added to the houses (some of which are mutually exclusive). Canonical models should indicate which rooms are available to be added to each home. The `Property` model will be modified to indicate which rooms a property actually has, and validations will be added to verify that only a maximum of one of each mutually exclusive group of rooms (there are 3 mutually exclusive rooms for each wing of a homestead) is present.

Fields added (all booleans defaulting to `false`) are:

* `enchanters_tower_available`
* `alchemy_tower_available`
* `library_available`
* `bedrooms_available`
* `storage_room_available`
* `armory_available`
* `greenhouse_available`
* `trophy_room_available`
* `kitchen_available`
* `cellar_available`
* `apiary_available`
* `grain_mill_available`
* `fish_hatchery_available`

## Changes

* Add indicated fields to the `canonical_properties` table
* Update JSON data on canonical properties to add new fields
* Add docs on canonical properties

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] Added and updated API docs and developer docs as appropriate
