### PR TITLE
Corrections to canonical data

### DIFF
--- a/lib/tasks/canonical_models/canonical_staves.json
+++ b/lib/tasks/canonical_models/canonical_staves.json
@@ -263,7 +263,8 @@
     "spells": {
       "name": "Wall of Flames",
       "strength": 50
-    }
+    },
+    "powers": []
   },
   {
     "attributes": {

--- a/lib/tasks/canonical_models/canonical_staves.json
+++ b/lib/tasks/canonical_models/canonical_staves.json
@@ -245,6 +245,28 @@
   },
   {
     "attributes": {
+      "name": "Hevnoraak's Staff",
+      "item_code": "0010076D",
+      "unit_weight": 8,
+      "base_damage": 0,
+      "magical_effects": null,
+      "school": "Destruction",
+      "enemy": "Hevnoraak",
+      "daedric": false,
+      "purchasable": false,
+      "unique_item": true,
+      "rare_item": true,
+      "quest_item": false,
+      "leveled": false,
+      "quest_reward": false
+    },
+    "spells": {
+      "name": "Wall of Flames",
+      "strength": 50
+    }
+  },
+  {
+    "attributes": {
       "name": "Minor Staff of Turning",
       "item_code": "00029B94",
       "unit_weight": 8,
@@ -338,7 +360,7 @@
       "item_code": "000940D8",
       "unit_weight": 8,
       "base_damage": 0,
-      "magical_effects": " ",
+      "magical_effects": null,
       "school": "Illusion",
       "enemy": null,
       "daedric": false,

--- a/lib/tasks/canonical_models/spells.json
+++ b/lib/tasks/canonical_models/spells.json
@@ -1399,7 +1399,7 @@
       "description": "Sprayed on the ground, it creates a wall of fire that does 50 points of fire damage per second.",
       "strength": 50,
       "strength_unit": "point",
-      "base_duration": null,
+      "base_duration": 30,
       "effects_cumulative": true
     }
   },
@@ -1411,7 +1411,7 @@
       "description": "Sprayed on the ground, it creates a wall of frost that does 50 points of frost damage per second.",
       "strength": 50,
       "strength_unit": "point",
-      "base_duration": null,
+      "base_duration": 30,
       "effects_cumulative": true
     }
   },
@@ -1423,7 +1423,7 @@
       "description": "Sprayed on the ground, it creates a wall of lightning that does 50 points of shock damage per second.",
       "strength": 50,
       "strength_unit": "point",
-      "base_duration": null,
+      "base_duration": 30,
       "effects_cumulative": true
     }
   },


### PR DESCRIPTION
## Context

[**Create non-canonical Staff model**](https://trello.com/c/HRIc59Zc/311-create-non-canonical-staff-model)

In the course of preparing to create a new non-canonical model, I realised that the JSON data is missing [Hevnoraak's Staff](https://elderscrolls.fandom.com/wiki/Hevnoraak%27s_Staff), a unique dragon priest staff. I also noticed that the "Wall of Flames", "Wall of Frost", and "Wall of Storms" spells don't have their default duration of 30 seconds populated. This PR fixes both of those things.

## Changes

* Add Hevnoraak's Staff to canonical staff JSON data
* Add durations to the three spells mentioned

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~

