### PR TITLE
Correct format of spells array to prevent errors in production

### DIFF
--- a/lib/tasks/canonical_models/canonical_staves.json
+++ b/lib/tasks/canonical_models/canonical_staves.json
@@ -260,10 +260,12 @@
       "leveled": false,
       "quest_reward": false
     },
-    "spells": {
-      "name": "Wall of Flames",
-      "strength": 50
-    },
+    "spells": [
+      {
+        "name": "Wall of Flames",
+        "strength": null
+      }
+    ],
     "powers": []
   },
   {


### PR DESCRIPTION
## Context

[**Create non-canonical Staff model**](https://trello.com/c/HRIc59Zc/311-create-non-canonical-staff-model)

In #187 I added Hevnoraak's Staff to staff data. However, I mistakenly put the `"spells"` value as an object rather than an array of objects. When I tried to sync the canonical models in production it raised an error.

## Changes

* Ensure spells are an array of objects

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~

## Considerations

I also changed the strength of the "Wall of Storms" spell to `null` from `50`. 50 is the default strength for this spell and I notice that staves with the "Wall of Flames" and "Wall of Frost" spells do not indicate a strength.