### PR TITLE
Create non-canonical Staff model

### DIFF
--- a/app/models/canonical/staff.rb
+++ b/app/models/canonical/staff.rb
@@ -21,6 +21,12 @@ module Canonical
              inverse_of: :staff
     has_many :spells, through: :canonical_staves_spells
 
+    has_many :staves,
+             inverse_of: :canonical_staff,
+             dependent: :nullify,
+             foreign_key: :canonical_staff_id,
+             class_name: '::Staff'
+
     validates :name, presence: true
     validates :item_code, presence: true, uniqueness: { message: 'must be unique' }
     validates :unit_weight, presence: true, numericality: { greater_than_or_equal_to: 0 }

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -9,6 +9,10 @@ class Game < ApplicationRecord
   has_many :clothing_items, dependent: :destroy
   has_many :ingredients, dependent: :destroy
   has_many :jewelry_items, dependent: :destroy
+  has_many :misc_items, dependent: :destroy
+  has_many :potions, dependent: :destroy
+  has_many :properties, dependent: :destroy
+  has_many :staves, dependent: :destroy
 
   # `before_save` callbacks need to be defined before
   # `before_destroy` callbacks, which need to be defined here
@@ -23,7 +27,6 @@ class Game < ApplicationRecord
   # before `dependent: :destroy` need to be defined before the
   # association is defined.
   before_destroy :destroy_aggregatable_child_models
-  has_many :properties, dependent: :destroy
   has_many :shopping_lists, -> { index_order }, dependent: :destroy, inverse_of: :game
   has_many :inventory_lists, -> { index_order }, dependent: :destroy, inverse_of: :game
 

--- a/app/models/staff.rb
+++ b/app/models/staff.rb
@@ -18,6 +18,14 @@ class Staff < ApplicationRecord
   DUPLICATE_MESSAGE = 'is a duplicate of a unique in-game item'
   DOES_NOT_MATCH = "doesn't match any item that exists in Skyrim"
 
+  def spells
+    canonical_staff&.spells || Spell.none
+  end
+
+  def powers
+    canonical_staff&.powers || Power.none
+  end
+
   def canonical_models
     return Canonical::Staff.where(id: canonical_staff.id) if canonical_staff.present?
 

--- a/app/models/staff.rb
+++ b/app/models/staff.rb
@@ -2,7 +2,55 @@
 
 class Staff < ApplicationRecord
   belongs_to :game
-  belongs_to :canonical_staff, optional: true, class_name: 'Canonical::Potion'
+  belongs_to :canonical_staff, optional: true, class_name: 'Canonical::Staff'
 
   validates :name, presence: true
+  validates :unit_weight,
+            numericality: {
+              greater_than_or_equal_to: 0,
+              allow_nil: true,
+            }
+
+  validate :validate_canonical_models
+
+  before_validation :set_canonical_staff
+
+  DUPLICATE_MESSAGE = 'is a duplicate of a unique in-game item'
+  DOES_NOT_MATCH = "doesn't match any item that exists in Skyrim"
+
+  def canonical_models
+    return Canonical::Staff.where(id: canonical_staff.id) if canonical_staff.present?
+
+    canonicals = Canonical::Staff.where('name ILIKE ?', name)
+
+    attributes_to_match.any? ? canonicals.where(**attributes_to_match) : canonicals
+  end
+
+  private
+
+  def set_canonical_staff
+    return if canonical_staff.present?
+    return unless canonical_models.count == 1
+
+    canonical = canonical_models.first
+
+    return if canonical.unique_item && canonical.staves.where(game_id:).any?
+
+    self.canonical_staff = canonical
+    self.name = canonical_staff.name
+    self.unit_weight = canonical_staff.unit_weight
+    self.magical_effects = canonical_staff.magical_effects
+  end
+
+  def attributes_to_match
+    {
+      unit_weight:,
+      magical_effects:,
+    }.compact
+  end
+
+  def validate_canonical_models
+    errors.add(:base, DOES_NOT_MATCH) if canonical_models.none?
+    errors.add(:base, DUPLICATE_MESSAGE) if canonical_staff.nil? && canonical_models.count == 1
+  end
 end

--- a/app/models/staff.rb
+++ b/app/models/staff.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Staff < ApplicationRecord
+  belongs_to :game
+  belongs_to :canonical_staff, optional: true, class_name: 'Canonical::Potion'
+
+  validates :name, presence: true
+end

--- a/db/migrate/20230926231756_create_staves.rb
+++ b/db/migrate/20230926231756_create_staves.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateStaves < ActiveRecord::Migration[7.0]
+  def change
+    create_table :staves do |t|
+      t.references :game, null: false, foreign_key: true
+      t.references :canonical_staff, foreign_key: true
+      t.string :name, null: false
+      t.decimal :unit_weight, scale: 2, precision: 5
+      t.string :magical_effects
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_25_223145) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_26_231756) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -538,6 +538,18 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_25_223145) do
     t.index ["name"], name: "index_spells_on_name", unique: true
   end
 
+  create_table "staves", force: :cascade do |t|
+    t.bigint "game_id", null: false
+    t.bigint "canonical_staff_id"
+    t.string "name", null: false
+    t.decimal "unit_weight", precision: 5, scale: 2
+    t.string "magical_effects"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["canonical_staff_id"], name: "index_staves_on_canonical_staff_id"
+    t.index ["game_id"], name: "index_staves_on_game_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "uid", null: false
     t.string "email", null: false
@@ -585,4 +597,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_25_223145) do
   add_foreign_key "shopping_list_items", "shopping_lists", column: "list_id"
   add_foreign_key "shopping_lists", "games"
   add_foreign_key "shopping_lists", "shopping_lists", column: "aggregate_list_id"
+  add_foreign_key "staves", "canonical_staves"
+  add_foreign_key "staves", "games"
 end

--- a/docs/canonical_models/README.md
+++ b/docs/canonical_models/README.md
@@ -21,3 +21,4 @@ The documentation here covers the purpose of canonical models, the canonical mod
   * [`Canonical::IngredientsAlchemicalProperty`](/docs/canonical_models/canonical-ingredients-alchemical-property.md): Additional details about special characteristics of the `Canonical::IngredientsAlchemicalProperty` model
   * [`Canonical::MiscItem`](/docs/canonical_models/canonical-misc-item.md): Additional details about special characteristics of the `Canonical::MiscItem` model and associated data
   * [`Canonical::Property`](/docs/canonical_models/canonical-property.md): Additional details about special characteristics of the `Canonical::Property` model
+  * [`Canonical::Staff`](/docs/canonical_models/canonical-staff.md): Additional details about the `Canonical::Staff` model

--- a/docs/canonical_models/canonical-staff.md
+++ b/docs/canonical_models/canonical-staff.md
@@ -1,0 +1,13 @@
+# Canonical::Staff
+
+The `Canonical::Staff` model represents a staff in Skyrim. Staves may be enchanted with spells or powers (notably not with enchantments) and their function depends on which spell or power they are enchanted with.
+
+## Spells and Powers
+
+Staves can be enchanted using spells or powers. Each staff can have multiple spells, powers, or (theoretically) both. (Note that staves cannot be enchanted with enchantments like other items can.) Spells are associated to `Canonical::Staff` model via the `Canonical::StavesSpell` join model. The join model contains a `strength` field to indicate the strength of the spell, if it differs from the base spell. Powers are associated to `Canonical::Staff` models via the polymorphic join model `Canonical::PowerablesPower`.
+
+Not all staves have spells or powers; some have miscellaneous effects described in the `magical_effects` field. Additionally, [unenchanted staves](#staff-enchanting) are available for players to enchant themselves in the [Dragonborn add-on](https://elderscrolls.fandom.com/wiki/The_Elder_Scrolls_V:_Dragonborn).
+
+## Staff Enchanting
+
+Unenchanted staves are available to purchase (in the Dragonborn add-on) from [Neloth](https://elderscrolls.fandom.com/wiki/Neloth_(Dragonborn)?so=search) to use with the [staff enchanter](https://elderscrolls.fandom.com/wiki/Staff_Enchanter) at [Tel Mithryn](https://elderscrolls.fandom.com/wiki/Tel_Mithryn). Staves enchanted using the staff enchanter are limited to the same set of spells as other staves but are further limited in that the player character must know the spell used to enchant the staff. These staves cannot be enchanted with powers.

--- a/docs/in_game_items/README.md
+++ b/docs/in_game_items/README.md
@@ -14,6 +14,7 @@ This documentation covers the scope and purpose of non-canonical in-game items, 
   * [`JewelryItem`](/docs/in_game_items/jewelry-item.md)
   * [`MiscItem`](/docs/in_game_items/misc-item.md)
   * [`Potion`](/docs/in_game_items/potion.md)
+  * [`Staff`](/docs/in_game_items/staff.md)
 * Join models:
   * [`IngredientsAlchemicalProperty`](/docs/in_game_items/ingredients-alchemical-property.md)
   * `EnchantablesEnchantment` (both canonical and non-canonical use same table)

--- a/docs/in_game_items/staff.md
+++ b/docs/in_game_items/staff.md
@@ -1,0 +1,17 @@
+# Staff
+
+The `Staff` is one of the simpler in-game items to associate to the appropriate canonical model. It has three matchable attributes:
+
+* `name`
+* `unit_weight`
+* `magical_effects`
+
+There is only one situation in which a match based on these attributes could be ambiguous: the "Forsworn Staff". There are two versions of this staff. The one with item code `"000FA2C1"` has magical effects reading, "A gout of fire that does 8 points per second. Targets on fire take extra damage." The one with item code `"000CC826"` has `nil` in the `magical_effects` field. This makes it impossible to tell if a non-canonical staff called "Forsworn Staff" has `nil` in the `magical_effects` field because the user hasn't populated it yet or because the canonical value for that field is `nil`. In other words, we have no way to know whether the `nil` in this context is meaningful.
+
+This has been treated as an edge case since it only involves one possible staff. Staves that should be matched to item `"000CC826"` will simply never be associated to a canonical model due to ambiguous matching.
+
+## Staff Enchanting
+
+One factor in staves is the fact that the user can buy unenchanted staves from [Neloth](https://elderscrolls.fandom.com/wiki/Neloth_(Dragonborn)) in [Tel Mithryn](https://elderscrolls.fandom.com/wiki/Tel_Mithryn) as part of the [Dragonborn](https://elderscrolls.fandom.com/wiki/The_Elder_Scrolls_V:_Dragonborn) add-on. These can be enchanted using the [staff enchanter](https://elderscrolls.fandom.com/wiki/Staff_Enchanter) at Tel Mithryn. When they are enchanted, they turn into a different staff with a different item code and the original unenchanted staff disappears. Because of this, it makes sense to not associate spells or powers directly to non-canonical staves and instead to use the associations on the canonical model. Instead of delegating methods, this has been implemented as methods on the non-canonical model that returns an empty ActiveRecord relation if the canonical model is not present.
+
+One possible edge case here would be staves that are differentiated by the spells or powers they are enchanted with. However, there currently are no such canonical staves. In fact, all but the "Forsworn Staff" are differentiable by `name` alone.

--- a/lib/tasks/canonical_models/canonical_staves.json
+++ b/lib/tasks/canonical_models/canonical_staves.json
@@ -1679,6 +1679,106 @@
   },
   {
     "attributes": {
+      "name": "Unenchanted Alteration Staff",
+      "item_code": "0007E646",
+      "unit_weight": 8,
+      "base_damage": 0,
+      "magical_effects": null,
+      "school": "Alteration",
+      "enemy": null,
+      "daedric": false,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false,
+      "leveled": false,
+      "quest_reward": false
+    },
+    "spells": [],
+    "powers": []
+  },
+  {
+    "attributes": {
+      "name": "Unenchanted Conjuration Staff",
+      "item_code": "07E647",
+      "unit_weight": 8,
+      "base_damage": 0,
+      "magical_effects": null,
+      "school": "Conjuration",
+      "enemy": null,
+      "daedric": false,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false,
+      "leveled": false,
+      "quest_reward": false
+    },
+    "spells": [],
+    "powers": []
+  },
+  {
+    "attributes": {
+      "name": "Unenchanted Destruction Staff",
+      "item_code": "000BE11F",
+      "unit_weight": 8,
+      "base_damage": 0,
+      "magical_effects": null,
+      "school": "Destruction",
+      "enemy": null,
+      "daedric": false,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false,
+      "leveled": false,
+      "quest_reward": false
+    },
+    "spells": [],
+    "powers": []
+  },
+  {
+    "attributes": {
+      "name": "Unenchanted Illusion Staff",
+      "item_code": "0007A91B",
+      "unit_weight": 8,
+      "base_damage": 0,
+      "magical_effects": null,
+      "school": "Illusion",
+      "enemy": null,
+      "daedric": false,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false,
+      "leveled": false,
+      "quest_reward": false
+    },
+    "spells": [],
+    "powers": []
+  },
+  {
+    "attributes": {
+      "name": "Unenchanted Restoration Staff",
+      "item_code": "00051B0C",
+      "unit_weight": 8,
+      "base_damage": 0,
+      "magical_effects": null,
+      "school": "Restoration",
+      "enemy": null,
+      "daedric": false,
+      "purchasable": true,
+      "unique_item": false,
+      "rare_item": true,
+      "quest_item": false,
+      "leveled": false,
+      "quest_reward": false
+    },
+    "spells": [],
+    "powers": []
+  },
+  {
+    "attributes": {
       "name": "Wabbajack",
       "item_code": "0002AC6F",
       "unit_weight": 10,

--- a/spec/models/staff_spec.rb
+++ b/spec/models/staff_spec.rb
@@ -243,4 +243,112 @@ RSpec.describe Staff, type: :model do
       end
     end
   end
+
+  describe '#spells' do
+    subject(:spells) { staff.spells }
+
+    let(:canonical_staff) { create(:canonical_staff) }
+
+    context 'when there is an associated canonical model with spells' do
+      let(:staff) { create(:staff, name: canonical_staff.name, canonical_staff:) }
+      let(:spell) { create(:spell) }
+
+      before do
+        create(:spell) # this shouldn't be included
+        create(:canonical_staves_spell, staff: canonical_staff, spell:)
+      end
+
+      it 'returns the spells of the associated canonical model' do
+        expect(spells).to contain_exactly(spell)
+      end
+
+      it 'returns an ActiveRecord::Relation' do
+        expect(spells).to be_an(ActiveRecord::Relation)
+      end
+    end
+
+    context 'when there is an associated canonical model without spells' do
+      let(:staff) { create(:staff, name: canonical_staff.name, canonical_staff:) }
+
+      before do
+        create(:spell) # this should not be included
+      end
+
+      it 'returns an empty ActiveRecord relation', :aggregate_failures do
+        expect(spells).to be_an(ActiveRecord::Relation)
+        expect(spells).to be_empty
+      end
+    end
+
+    context 'when there is no associated canonical model' do
+      let(:staff) { create(:staff, name: 'My Staff') }
+
+      before do
+        create_list(
+          :canonical_staff,
+          2,
+          name: 'My Staff',
+        )
+      end
+
+      it 'returns an empty ActiveRecord::Relation', :aggregate_failures do
+        expect(spells).to be_an(ActiveRecord::Relation)
+        expect(spells).to be_empty
+      end
+    end
+  end
+
+  describe '#powers' do
+    subject(:powers) { staff.powers }
+
+    let(:canonical_staff) { create(:canonical_staff) }
+
+    context 'when there is an associated canonical model with powers' do
+      let(:staff) { create(:staff, name: canonical_staff.name, canonical_staff:) }
+      let(:power) { create(:power) }
+
+      before do
+        create(:power) # this shouldn't be included
+        create(:canonical_powerables_power, powerable: canonical_staff, power:)
+      end
+
+      it 'returns the powers of the associated canonical model' do
+        expect(powers).to contain_exactly(power)
+      end
+
+      it 'returns an ActiveRecord::Relation' do
+        expect(powers).to be_an(ActiveRecord::Relation)
+      end
+    end
+
+    context 'when there is an associated canonical model without powers' do
+      let(:staff) { create(:staff, name: canonical_staff.name, canonical_staff:) }
+
+      before do
+        create(:power) # this should not be included
+      end
+
+      it 'returns an empty ActiveRecord relation', :aggregate_failures do
+        expect(powers).to be_an(ActiveRecord::Relation)
+        expect(powers).to be_empty
+      end
+    end
+
+    context 'when there is no associated canonical model' do
+      let(:staff) { create(:staff, name: 'My Staff') }
+
+      before do
+        create_list(
+          :canonical_staff,
+          2,
+          name: 'My Staff',
+        )
+      end
+
+      it 'returns an empty ActiveRecord::Relation', :aggregate_failures do
+        expect(powers).to be_an(ActiveRecord::Relation)
+        expect(powers).to be_empty
+      end
+    end
+  end
 end

--- a/spec/models/staff_spec.rb
+++ b/spec/models/staff_spec.rb
@@ -8,10 +8,239 @@ RSpec.describe Staff, type: :model do
 
     let(:staff) { build(:staff) }
 
-    it 'is invalid without a name' do
-      staff.name = nil
-      validate
-      expect(staff.errors[:name]).to include "can't be blank"
+    describe 'name' do
+      it 'is invalid without a name' do
+        staff.name = nil
+        validate
+        expect(staff.errors[:name]).to include "can't be blank"
+      end
+    end
+
+    describe 'unit_weight' do
+      it 'is invalid with a negative unit weight' do
+        staff.unit_weight = -2
+        validate
+        expect(staff.errors[:unit_weight]).to include 'must be greater than or equal to 0'
+      end
+
+      it 'can be nil' do
+        staff.unit_weight = nil
+        validate
+        expect(staff.errors[:unit_weight]).to be_empty
+      end
+    end
+
+    describe 'canonical_staff' do
+      context 'when there is a canonical_staff associated' do
+        let(:staff) { create(:staff, :with_matching_canonical) }
+
+        it 'is valid' do
+          expect(staff).to be_valid
+        end
+      end
+
+      context 'when there is no canonical_staff associated' do
+        let(:game) { create(:game) }
+        let(:staff) { build(:staff, game:, name: 'my staff') }
+
+        context 'when there are multiple matching canonical staves' do
+          before do
+            create_list(
+              :canonical_staff,
+              2,
+              name: staff.name,
+            )
+          end
+
+          it 'is valid' do
+            expect(staff).to be_valid
+          end
+        end
+
+        context 'when the matching canonical staff is unique and has an existing association' do
+          before do
+            canonical_staff = create(
+              :canonical_staff,
+              name: 'My Staff',
+              unique_item: true,
+              rare_item: true,
+            )
+
+            create(:staff, name: 'My Staff', game:, canonical_staff:)
+          end
+
+          it 'is invalid' do
+            staff.validate
+            expect(staff.errors[:base]).to include 'is a duplicate of a unique in-game item'
+          end
+        end
+
+        context 'when there are no matching canonical staves' do
+          it 'is invalid' do
+            validate
+            expect(staff.errors[:base]).to include "doesn't match any item that exists in Skyrim"
+          end
+        end
+      end
+    end
+  end
+
+  describe 'matching canonical models' do
+    subject(:canonical_models) { staff.canonical_models }
+
+    context 'when there are no matching canonical models' do
+      let(:staff) { build(:staff) }
+
+      it 'returns an empty ActiveRecord relation', :aggregate_failures do
+        expect(canonical_models).to be_empty
+        expect(canonical_models).to be_an(ActiveRecord::Relation)
+      end
+    end
+
+    context 'when there is a canonical model assigned' do
+      let(:staff) { create(:staff, :with_matching_canonical) }
+
+      it 'returns an ActiveRecord relation with only that model', :aggregate_failures do
+        expect(canonical_models).to be_an(ActiveRecord::Relation)
+        expect(canonical_models).to contain_exactly staff.canonical_staff
+      end
+    end
+
+    context 'when there are multiple matching canonical models' do
+      let(:staff) { build(:staff, magical_effects: 'This staff has magical effects') }
+
+      let!(:matching_canonicals) do
+        create_list(
+          :canonical_staff,
+          2,
+          name: staff.name,
+          magical_effects: 'This staff has magical effects',
+        )
+      end
+
+      before do
+        create(:canonical_staff, name: staff.name)
+      end
+
+      it 'returns all the matching canonical models in an ActiveRecord relation', :aggregate_failures do
+        expect(canonical_models).to be_an(ActiveRecord::Relation)
+        expect(canonical_models).to contain_exactly(*matching_canonicals)
+      end
+    end
+  end
+
+  describe 'setting a canonical model' do
+    context 'when there is an existing canonical staff' do
+      let(:staff) { create(:staff, :with_matching_canonical) }
+
+      it "doesn't change anything" do
+        expect { staff.validate }
+          .not_to change(staff.reload, :canonical_staff)
+      end
+    end
+
+    context 'when there is a single matching canonical staff' do
+      let(:game) { create(:game) }
+      let(:staff) { build(:staff, name: 'my staff', unit_weight: nil, game:) }
+
+      context 'when the matching canonical is a unique item' do
+        let!(:canonical_staff) do
+          create(
+            :canonical_staff,
+            name: 'My Staff',
+            unit_weight: 8,
+            magical_effects: 'Does stuff',
+            unique_item: true,
+            rare_item: true,
+          )
+        end
+
+        context 'when the matching canonical already has an association for that game' do
+          before do
+            create(:staff, name: 'My Staff', canonical_staff:, game:)
+          end
+
+          it "doesn't associate the canonical model" do
+            staff.validate
+            expect(staff.canonical_staff).to be_nil
+          end
+        end
+
+        context 'when the matching canonical already has an association for another game' do
+          before do
+            create(:staff, name: 'My Staff', canonical_staff:)
+          end
+
+          it 'associates the canonical model to the staff' do
+            staff.validate
+            expect(staff.canonical_staff).to eq canonical_staff
+          end
+
+          it 'sets values from the canonical model', :aggregate_failures do
+            staff.validate
+            expect(staff.name).to eq 'My Staff'
+            expect(staff.unit_weight).to eq 8
+            expect(staff.magical_effects).to eq 'Does stuff'
+          end
+        end
+
+        context 'when the matching canonical has no existing associations' do
+          it 'associates the canonical model to the staff' do
+            staff.validate
+            expect(staff.canonical_staff).to eq canonical_staff
+          end
+
+          it 'sets values from the canonical model', :aggregate_failures do
+            staff.validate
+            expect(staff.name).to eq 'My Staff'
+            expect(staff.unit_weight).to eq 8
+            expect(staff.magical_effects).to eq 'Does stuff'
+          end
+        end
+      end
+
+      context 'when the matching canonical is not unique' do
+        let!(:canonical_staff) do
+          create(
+            :canonical_staff,
+            name: 'My Staff',
+            unit_weight: 8,
+            magical_effects: 'Does stuff',
+          )
+        end
+
+        before do
+          create(:staff, name: 'My Staff', canonical_staff:, game:)
+        end
+
+        it 'allows a duplicate association' do
+          staff.validate
+          expect(staff.canonical_staff).to eq canonical_staff
+        end
+
+        it 'sets values from the canonical model', :aggregate_failures do
+          staff.validate
+          expect(staff.name).to eq 'My Staff'
+          expect(staff.unit_weight).to eq 8
+          expect(staff.magical_effects).to eq 'Does stuff'
+        end
+      end
+    end
+
+    context 'when there are multiple matching canonicals' do
+      context 'when some matchable attributes are blank' do
+        let(:staff) { build(:staff, unit_weight: nil, magical_effects: nil) }
+
+        before do
+          create(:canonical_staff, name: staff.name, unit_weight: 8, magical_effects: 'foo')
+          create(:canonical_staff, name: staff.name, unit_weight: 2)
+        end
+
+        it "doesn't associate a canonical model" do
+          staff.validate
+          expect(staff.canonical_staff).to be_nil
+        end
+      end
     end
   end
 end

--- a/spec/models/staff_spec.rb
+++ b/spec/models/staff_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Staff, type: :model do
+  describe 'validations' do
+    subject(:validate) { staff.validate }
+
+    let(:staff) { build(:staff) }
+
+    it 'is invalid without a name' do
+      staff.name = nil
+      validate
+      expect(staff.errors[:name]).to include "can't be blank"
+    end
+  end
+end

--- a/spec/models/staff_spec.rb
+++ b/spec/models/staff_spec.rb
@@ -228,18 +228,16 @@ RSpec.describe Staff, type: :model do
     end
 
     context 'when there are multiple matching canonicals' do
-      context 'when some matchable attributes are blank' do
-        let(:staff) { build(:staff, unit_weight: nil, magical_effects: nil) }
+      let(:staff) { build(:staff, unit_weight: nil, magical_effects: nil) }
 
-        before do
-          create(:canonical_staff, name: staff.name, unit_weight: 8, magical_effects: 'foo')
-          create(:canonical_staff, name: staff.name, unit_weight: 2)
-        end
+      before do
+        create(:canonical_staff, name: staff.name, unit_weight: 8, magical_effects: 'foo')
+        create(:canonical_staff, name: staff.name, unit_weight: 2)
+      end
 
-        it "doesn't associate a canonical model" do
-          staff.validate
-          expect(staff.canonical_staff).to be_nil
-        end
+      it "doesn't associate a canonical model" do
+        staff.validate
+        expect(staff.canonical_staff).to be_nil
       end
     end
   end

--- a/spec/support/factories/properties.rb
+++ b/spec/support/factories/properties.rb
@@ -2,8 +2,12 @@
 
 FactoryBot.define do
   factory :property do
-    trait :with_canonical do
-      canonical_property
+    name { 'My House' }
+
+    trait :with_matching_canonical do
+      association :canonical_property, factory: :canonical_property
+
+      name { canonical_property.name }
     end
   end
 end

--- a/spec/support/factories/staves.rb
+++ b/spec/support/factories/staves.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :staff do
+    game
+
+    name { 'My Cool Staff' }
+    unit_weight { 8 }
+
+    trait :with_matching_canonical do
+      association :canonical_staff, factory: :canonical_staff
+
+      name { canonical_staff.name }
+    end
+  end
+end


### PR DESCRIPTION
## Context

[**Create non-canonical Staff model**](https://trello.com/c/HRIc59Zc/311-create-non-canonical-staff-model)

We are creating non-canonical versions of each (most) of the canonical models in the database. The next one up is the `Staff` model, corresponding to `Canonical::Staff`.

## Changes

* Migration to add `staves` table
* New `Staff` model
* Add and update factories
* Tests for the new class
* Docs for `Canonical::Staff` and `Staff` models
* Add unenchanted staves to JSON data

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

I considered using `delegate` to delegate the `#spells` and `#powers` methods directly to the `Canonical::Staff`, but I wanted an `ActiveRecord::Relation` returned even if this was `nil`, so instead I implemented a method that returns either `Canonical::Staff#spells`/`Canonical::Staff#powers` or, if the canonical staff is `nil`, an empty `ActiveRecord::Relation`. This will have the disadvantage that we won't be able to access the `strength` attribute stored in the `Canonical::StavesSpell` join model, but so far we don't need to anyway.

In keeping with other canonical models, the `Staff`'s `#canonical_models` method will return an `ActiveRecord::Relation` containing only its associated `canonical_staff` if there is already one associated. We have identified that this is an issue as other changes made to attributes of an in-game item could change what the association should be. There is a [card](https://trello.com/c/EIdSrLs6/317-revisit-conditional-assignment-of-canonical-models) to deal with this issue for all in-game item models. There is [another card](https://trello.com/c/KfDVb7ZF/329-ensure-in-game-item-models-continue-to-match-canonicals-after-update) to make sure in-game items are validated against canonicals on update.