### PR TITLE
Update Timecop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ group :development, :test do
   gem 'rspec-rails', '~> 6.0'
 
   # Use Timecop to freeze time in tests (for testing timestamps, etc.)
-  gem 'timecop', '~> 0.9.5'
+  gem 'timecop', '~> 0.9.6'
 
   # Use DatabaseCleaner to clear the database between specs
   gem 'database_cleaner-active_record', '~> 2.1'

--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ group :development, :test do
   gem 'rspec-rails', '~> 6.0'
 
   # Use Timecop to freeze time in tests (for testing timestamps, etc.)
-  gem 'timecop', '~> 0.9.6'
+  gem 'timecop', '~> 0.9.7'
 
   # Use DatabaseCleaner to clear the database between specs
   gem 'database_cleaner-active_record', '~> 2.1'

--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ group :development, :test do
   gem 'rspec-rails', '~> 6.0'
 
   # Use Timecop to freeze time in tests (for testing timestamps, etc.)
-  gem 'timecop', '~> 0.9.7'
+  gem 'timecop', '~> 0.9.8'
 
   # Use DatabaseCleaner to clear the database between specs
   gem 'database_cleaner-active_record', '~> 2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -227,7 +227,7 @@ GEM
     ruby2_keywords (0.0.5)
     spring (4.1.1)
     thor (1.2.1)
-    timecop (0.9.6)
+    timecop (0.9.8)
     timeout (0.4.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -264,7 +264,7 @@ DEPENDENCIES
   rubocop-rails (~> 2.14)
   rubocop-rspec (~> 2.24)
   spring (~> 4.0)
-  timecop (~> 0.9.6)
+  timecop (~> 0.9.7)
   webmock (~> 3.18.1)
 
 RUBY VERSION

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,7 +264,7 @@ DEPENDENCIES
   rubocop-rails (~> 2.14)
   rubocop-rspec (~> 2.24)
   spring (~> 4.0)
-  timecop (~> 0.9.5)
+  timecop (~> 0.9.6)
   webmock (~> 3.18.1)
 
 RUBY VERSION

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,7 +264,7 @@ DEPENDENCIES
   rubocop-rails (~> 2.14)
   rubocop-rspec (~> 2.24)
   spring (~> 4.0)
-  timecop (~> 0.9.7)
+  timecop (~> 0.9.8)
   webmock (~> 3.18.1)
 
 RUBY VERSION


### PR DESCRIPTION
## Context

In #192 Dependabot updated the `timecop` gem to version 0.9.8. That caused a number of test failures in CI. When this happened with a previous Dependabot PR the tests worked when I made a new PR updating the same gem, so this is my attempt on this one.

## Changes

* Update Timecop gem to 0.9.8
* Bump minimum Timecop version to 0.9.8

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~
