### PR TITLE
Add permissions for Dependabot to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  pull-requests: write
+
 jobs:
   runner-job:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Context

Dependabot's PRs have been failing CI, apparently due to a lack of GitHub Actions permissions. By default, Dependabot's token has read-only access but it seems it needs write access for CI to pass.

## Changes

* Increase permissions for Dependabot in CI

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~

## Considerations

[These docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions) have more info about what's going on with Dependabot in CI and how its tokens work.
