### PR TITLE
Update Webmock to 3.19.1 and loosen versioning requirement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ group :development, :test do
   gem 'rubocop-performance', '~> 1.19', require: false
 
   # Use WebMock to mock HTTP requests, mainly for auth purposes
-  gem 'webmock', '~> 3.18.1'
+  gem 'webmock', '~> 3.19'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,7 +66,7 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-    addressable (2.8.1)
+    addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     base64 (0.1.1)
@@ -141,7 +141,7 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.4.6)
-    public_suffix (5.0.1)
+    public_suffix (5.0.3)
     puma (6.4.0)
       nio4r (~> 2.0)
     racc (1.7.1)
@@ -240,7 +240,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
-    webmock (3.18.1)
+    webmock (3.19.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
@@ -273,7 +273,7 @@ DEPENDENCIES
   rubocop-rspec (~> 2.24)
   spring (~> 4.0)
   timecop (~> 0.9.8)
-  webmock (~> 3.18.1)
+  webmock (~> 3.19)
 
 RUBY VERSION
    ruby 3.2.2p53


### PR DESCRIPTION
## Context

Since Dependabot PRs are [still failing CI](https://trello.com/c/4zqZx1V6/334-fix-ci-for-dependabot-prs), we are doing updates manually. This PR updates Webmock from 3.18.1 to 3.19.1. It also updates the version requirement from the stricter `~> 3.18.1` to the more lax `~> 3.19`.

## Changes

* Update Webmock from 3.18.1 to 3.19.1
* Loosen versioning requirement for Webmock to not restrict minor version upgrades

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~