### PR TITLE
Update pg gem from 1.4.6 to 1.5.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ ruby '3.2.2'
 gem 'rails', '~> 7.0.8'
 
 # Use postgresql as the database for Active Record
-gem 'pg', '~> 1.3'
+gem 'pg', '~> 1.5'
 
 # Use Puma as the app server
 gem 'puma', '~> 6.4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,7 +140,7 @@ GEM
     parser (3.2.2.3)
       ast (~> 2.4.1)
       racc
-    pg (1.4.6)
+    pg (1.5.4)
     public_suffix (5.0.3)
     puma (6.4.0)
       nio4r (~> 2.0)
@@ -263,7 +263,7 @@ DEPENDENCIES
   factory_bot_rails (~> 6.2.0)
   faraday (~> 2.7.11)
   listen (~> 3.7)
-  pg (~> 1.3)
+  pg (~> 1.5)
   puma (~> 6.4.0)
   rack-cors (~> 2.0.1)
   rails (~> 7.0.8)


### PR DESCRIPTION
## Context

Since Dependabot PRs are [still failing CI](https://trello.com/c/4zqZx1V6/334-fix-ci-for-dependabot-prs), we are doing updates manually. This PR updates the `pg` gem from 1.4.6 to 1.5.4. It also increases the minimum version from 1.3 to 1.5.

## Changes

* Update `pg` from 1.4.6 to 1.5.4

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~