### PR TITLE
Create non-canonical weapon model

### DIFF
--- a/app/models/armor.rb
+++ b/app/models/armor.rb
@@ -37,7 +37,11 @@ class Armor < ApplicationRecord
 
   after_create :set_enchantments, if: -> { canonical_armor.present? }
 
-  def canonical_armors
+  def canonical_model
+    canonical_armor
+  end
+
+  def canonical_models
     return Array.wrap(canonical_armor) if canonical_armor
 
     attrs_to_match = { unit_weight:, weight:, magical_effects: }.compact
@@ -57,9 +61,9 @@ class Armor < ApplicationRecord
   private
 
   def set_canonical_armor
-    return unless canonical_armors.count == 1
+    return unless canonical_models.count == 1
 
-    self.canonical_armor ||= canonical_armors.first
+    self.canonical_armor ||= canonical_models.first
     self.name = canonical_armor.name # in case casing differs
     self.unit_weight = canonical_armor.unit_weight
     self.weight = canonical_armor.weight

--- a/app/models/canonical/weapon.rb
+++ b/app/models/canonical/weapon.rb
@@ -15,18 +15,18 @@ module Canonical
         'other',
         'sword',
         'war axe',
-      ],
+      ].freeze,
       'two-handed' => %w[
         battleaxe
         greatsword
         warhammer
-      ],
+      ].freeze,
       'archery' => %w[
         arrow
         bolt
         bow
         crossbow
-      ],
+      ].freeze,
     }.freeze
 
     has_many :enchantables_enchantments,
@@ -64,7 +64,7 @@ module Canonical
              inverse_of: :canonical_weapon,
              dependent: :nullify,
              foreign_key: 'canonical_weapon_id',
-             class_name: '::Armor'
+             class_name: '::Weapon'
 
     validates :name, presence: true
     validates :item_code, presence: true, uniqueness: { message: 'must be unique' }

--- a/app/models/canonical/weapon.rb
+++ b/app/models/canonical/weapon.rb
@@ -60,6 +60,12 @@ module Canonical
              through: :canonical_temperables_tempering_materials,
              source: :material
 
+    has_many :weapons,
+             inverse_of: :canonical_weapon,
+             dependent: :nullify,
+             foreign_key: 'canonical_weapon_id',
+             class_name: '::Armor'
+
     validates :name, presence: true
     validates :item_code, presence: true, uniqueness: { message: 'must be unique' }
     validates :category,

--- a/app/models/clothing_item.rb
+++ b/app/models/clothing_item.rb
@@ -29,7 +29,11 @@ class ClothingItem < ApplicationRecord
 
   after_create :set_enchantments, if: -> { canonical_clothing_item.present? }
 
-  def canonical_clothing_items
+  def canonical_model
+    canonical_clothing_item
+  end
+
+  def canonical_models
     return Array.wrap(canonical_clothing_item) if canonical_clothing_item
 
     attrs_to_match = { unit_weight:, magical_effects: }.compact
@@ -41,9 +45,9 @@ class ClothingItem < ApplicationRecord
   private
 
   def set_canonical_clothing_item
-    return unless canonical_clothing_items.count == 1
+    return unless canonical_models.count == 1
 
-    self.canonical_clothing_item ||= canonical_clothing_items.first
+    self.canonical_clothing_item ||= canonical_models.first
     self.name = canonical_clothing_item.name # in case casing differs
     self.unit_weight = canonical_clothing_item.unit_weight
     self.magical_effects = canonical_clothing_item.magical_effects

--- a/app/models/enchantables_enchantment.rb
+++ b/app/models/enchantables_enchantment.rb
@@ -31,20 +31,6 @@ class EnchantablesEnchantment < ApplicationRecord
     errors.none? && !canonical_enchantable?
   end
 
-  def canonical_enchantable_is_enchantable?
-    canonical_enchantable&.enchantable == true
-  end
-
-  def canonical_enchantable_has_enchantment?
-    canonical_enchantable&.enchantments&.include?(enchantment)
-  end
-
-  def canonical_enchantable
-    return if canonical_enchantable?
-
-    enchantable.canonical_model
-  end
-
   def canonical_enchantable?
     enchantable_type.start_with?('Canonical::')
   end

--- a/app/models/enchantables_enchantment.rb
+++ b/app/models/enchantables_enchantment.rb
@@ -23,7 +23,7 @@ class EnchantablesEnchantment < ApplicationRecord
 
   def valid_enchantable?
     enchantable.canonical_models.any? do |canonical|
-      canonical.enchantable || canonical.enchantments.include?(enchantment)
+      canonical.enchantable || canonical.enchantables_enchantments.where(enchantment:, strength:).any?
     end
   end
 

--- a/app/models/enchantables_enchantment.rb
+++ b/app/models/enchantables_enchantment.rb
@@ -5,4 +5,47 @@ class EnchantablesEnchantment < ApplicationRecord
   belongs_to :enchantment
 
   validates :enchantment_id, uniqueness: { scope: %i[enchantable_id enchantable_type], message: 'must form a unique combination with enchantable item' }
+
+  after_validation :validate_against_canonical,
+                   if: :should_validate_against_canonical?
+
+  after_save :save_associated!, unless: :canonical_enchantable?
+
+  private
+
+  def save_associated!
+    enchantable.save!
+  end
+
+  def validate_against_canonical
+    errors.add(:base, "doesn't match any canonical model") unless valid_enchantable?
+  end
+
+  def valid_enchantable?
+    enchantable.canonical_models.any? do |canonical|
+      canonical.enchantable || canonical.enchantments.include?(enchantment)
+    end
+  end
+
+  def should_validate_against_canonical?
+    errors.none? && !canonical_enchantable?
+  end
+
+  def canonical_enchantable_is_enchantable?
+    canonical_enchantable&.enchantable == true
+  end
+
+  def canonical_enchantable_has_enchantment?
+    canonical_enchantable&.enchantments&.include?(enchantment)
+  end
+
+  def canonical_enchantable
+    return if canonical_enchantable?
+
+    enchantable.canonical_model
+  end
+
+  def canonical_enchantable?
+    enchantable_type.start_with?('Canonical::')
+  end
 end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -13,6 +13,7 @@ class Game < ApplicationRecord
   has_many :potions, dependent: :destroy
   has_many :properties, dependent: :destroy
   has_many :staves, dependent: :destroy
+  has_many :weapons, dependent: :destroy
 
   # `before_save` callbacks need to be defined before
   # `before_destroy` callbacks, which need to be defined here

--- a/app/models/weapon.rb
+++ b/app/models/weapon.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Weapon < ApplicationRecord
+  belongs_to :game
+  belongs_to :canonical_weapon,
+             optional: true,
+             class_name: 'Canonical::Weapon',
+             inverse_of: :armors
+end

--- a/app/models/weapon.rb
+++ b/app/models/weapon.rb
@@ -75,6 +75,14 @@ class Weapon < ApplicationRecord
     canonicals.uniq
   end
 
+  def crafting_materials
+    canonical_weapon&.crafting_materials
+  end
+
+  def tempering_materials
+    canonical_weapon&.tempering_materials
+  end
+
   private
 
   def set_canonical_weapon

--- a/app/models/weapon.rb
+++ b/app/models/weapon.rb
@@ -5,5 +5,94 @@ class Weapon < ApplicationRecord
   belongs_to :canonical_weapon,
              optional: true,
              class_name: 'Canonical::Weapon',
-             inverse_of: :armors
+             inverse_of: :weapons
+
+  has_many :enchantables_enchantments,
+           dependent: :destroy,
+           as: :enchantable
+  has_many :enchantments,
+           -> { select 'enchantments.*, enchantables_enchantments.strength as strength' },
+           through: :enchantables_enchantments
+
+  validates :name, presence: true
+  validates :unit_weight,
+            numericality: {
+              greater_than_or_equal_to: 0,
+              allow_nil: true,
+            }
+  validates :category,
+            inclusion: {
+              in: Canonical::Weapon::VALID_WEAPON_TYPES.keys,
+              message: 'must be "one-handed", "two-handed", or "archery"',
+              allow_blank: true,
+            }
+  validates :weapon_type,
+            inclusion: {
+              in: Canonical::Weapon::VALID_WEAPON_TYPES.values.flatten,
+              message: 'must be a valid type of weapon that occurs in Skyrim',
+              allow_blank: true,
+            }
+  validate :ensure_canonicals_exist
+
+  before_validation :set_canonical_weapon
+  before_validation :set_values_from_canonical
+
+  after_save :set_enchantments, if: -> { canonical_weapon_changed? }
+
+  def canonical_models
+    return Canonical::Weapon.where(id: canonical_weapon.id) if canonical_weapon.present?
+
+    canonicals = Canonical::Weapon.where('name ILIKE ?', name)
+    canonicals = attributes_to_match.any? ? canonicals.where(**attributes_to_match) : canonicals
+
+    return canonicals if enchantments.none?
+
+    enchantables_enchantments.each do |join_model|
+      canonicals = if join_model.strength.present?
+                     canonicals.left_outer_joins(:enchantables_enchantments).where(
+                       '(enchantables_enchantments.enchantment_id = :enchantment_id AND enchantables_enchantments.strength = :strength) OR canonical_weapons.enchantable = true',
+                       enchantment_id: join_model.enchantment_id,
+                       strength: join_model.strength,
+                     )
+                   else
+                     canonicals.left_outer_joins(:enchantables_enchantments).where(
+                       '(enchantables_enchantments.enchantment_id = :enchantment_id AND enchantables_enchantments.strength IS NULL) OR canonical_weapons.enchantable = true',
+                       enchantment_id: join_model.enchantment_id,
+                     )
+                   end
+    end
+
+    canonicals.uniq
+  end
+
+  private
+
+  def set_canonical_weapon
+    return unless canonical_models.count == 1
+
+    self.canonical_weapon = canonical_models.first
+  end
+
+  def set_values_from_canonical
+    return if canonical_weapon.nil?
+
+    self.name = canonical_weapon.name
+    self.unit_weight = canonical_weapon.unit_weight
+    self.category = canonical_weapon.category
+    self.weapon_type = canonical_weapon.weapon_type
+    self.magical_effects = canonical_weapon.magical_effects
+  end
+
+  def attributes_to_match
+    {
+      unit_weight:,
+      category:,
+      weapon_type:,
+      magical_effects:,
+    }.compact
+  end
+
+  def ensure_canonicals_exist
+    errors.add(:base, "doesn't match a weapon that exists in Skyrim") if canonical_models.none?
+  end
 end

--- a/app/models/weapon.rb
+++ b/app/models/weapon.rb
@@ -39,6 +39,8 @@ class Weapon < ApplicationRecord
 
   after_save :set_enchantments, if: -> { canonical_weapon_changed? }
 
+  DOES_NOT_MATCH = "doesn't match a weapon that exists in Skyrim"
+
   def canonical_models
     return Canonical::Weapon.where(id: canonical_weapon.id) if canonical_weapon.present?
 
@@ -93,6 +95,6 @@ class Weapon < ApplicationRecord
   end
 
   def ensure_canonicals_exist
-    errors.add(:base, "doesn't match a weapon that exists in Skyrim") if canonical_models.none?
+    errors.add(:base, DOES_NOT_MATCH) if canonical_models.none?
   end
 end

--- a/app/models/weapon.rb
+++ b/app/models/weapon.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Weapon < ApplicationRecord
-  include ActiveModel::Dirty
-
   belongs_to :game
   belongs_to :canonical_weapon,
              optional: true,

--- a/app/validators/armor_validator.rb
+++ b/app/validators/armor_validator.rb
@@ -7,7 +7,7 @@ class ArmorValidator < ActiveModel::Validator
   def validate(record)
     @record = record
 
-    if @record.canonical_armors.blank?
+    if @record.canonical_models.blank?
       @record.errors.add(:base, NO_CANONICAL_MATCHES)
       return
     end

--- a/app/validators/clothing_item_validator.rb
+++ b/app/validators/clothing_item_validator.rb
@@ -7,7 +7,7 @@ class ClothingItemValidator < ActiveModel::Validator
   def validate(record)
     @record = record
 
-    if @record.canonical_clothing_items.blank?
+    if @record.canonical_models.blank?
       @record.errors.add(:base, NO_CANONICAL_MATCHES)
       return
     end

--- a/db/migrate/20230929213200_create_weapons.rb
+++ b/db/migrate/20230929213200_create_weapons.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CreateWeapons < ActiveRecord::Migration[7.0]
+  def change
+    create_table :weapons do |t|
+      t.references :game, null: false, foreign_key: true
+      t.references :canonical_weapon, foreign_key: true
+      t.string :name, null: false
+      t.string :category
+      t.string :weapon_type
+      t.string :magical_effects
+      t.decimal :unit_weight, scale: 2, precision: 5
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_26_231756) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_29_213200) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -560,6 +560,20 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_26_231756) do
     t.index ["uid"], name: "index_users_on_uid", unique: true
   end
 
+  create_table "weapons", force: :cascade do |t|
+    t.bigint "game_id", null: false
+    t.bigint "canonical_weapon_id"
+    t.string "name", null: false
+    t.string "category"
+    t.string "weapon_type"
+    t.string "magical_effects"
+    t.decimal "unit_weight", precision: 5, scale: 2
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["canonical_weapon_id"], name: "index_weapons_on_canonical_weapon_id"
+    t.index ["game_id"], name: "index_weapons_on_game_id"
+  end
+
   add_foreign_key "armors", "canonical_armors"
   add_foreign_key "armors", "games"
   add_foreign_key "canonical_craftables_crafting_materials", "canonical_materials", column: "material_id"
@@ -599,4 +613,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_26_231756) do
   add_foreign_key "shopping_lists", "shopping_lists", column: "aggregate_list_id"
   add_foreign_key "staves", "canonical_staves"
   add_foreign_key "staves", "games"
+  add_foreign_key "weapons", "canonical_weapons"
+  add_foreign_key "weapons", "games"
 end

--- a/docs/canonical_models/README.md
+++ b/docs/canonical_models/README.md
@@ -22,3 +22,4 @@ The documentation here covers the purpose of canonical models, the canonical mod
   * [`Canonical::MiscItem`](/docs/canonical_models/canonical-misc-item.md): Additional details about special characteristics of the `Canonical::MiscItem` model and associated data
   * [`Canonical::Property`](/docs/canonical_models/canonical-property.md): Additional details about special characteristics of the `Canonical::Property` model
   * [`Canonical::Staff`](/docs/canonical_models/canonical-staff.md): Additional details about the `Canonical::Staff` model
+  * [`Canonical::Weapon`](/docs/canonical_models/canonical-weapon.md): Additional details about the `Canonical::Weapon` model

--- a/docs/canonical_models/canonical-weapon.md
+++ b/docs/canonical_models/canonical-weapon.md
@@ -1,0 +1,7 @@
+# Canonical::Weapon
+
+The `Canonical::Weapon` model represents a weapon.
+
+## Enchantments
+
+Weapons can be enchanted with enchantments via the `EnchantablesEnchantment` join model. Each weapon can have multiple enchantments associated. In-game items corresponding to canonical weapons with `enchantable` set to `true` may have new enchantments added by the user as well. (In addition to enchantments, the `magical_effects` field enables users to specify miscellaneous magical powers the weapon has.)

--- a/docs/in_game_items/README.md
+++ b/docs/in_game_items/README.md
@@ -15,6 +15,7 @@ This documentation covers the scope and purpose of non-canonical in-game items, 
   * [`MiscItem`](/docs/in_game_items/misc-item.md)
   * [`Potion`](/docs/in_game_items/potion.md)
   * [`Staff`](/docs/in_game_items/staff.md)
+  * [`Weapon`](/docs/in_game_items/weapon.md)
 * Join models:
   * [`IngredientsAlchemicalProperty`](/docs/in_game_items/ingredients-alchemical-property.md)
   * `EnchantablesEnchantment` (both canonical and non-canonical use same table)

--- a/docs/in_game_items/in-game-items.md
+++ b/docs/in_game_items/in-game-items.md
@@ -5,8 +5,14 @@ The following non-[canonical](/docs/canonical_models/README.md) in-game item mod
 * [`Armor`](/app/models/armor.rb): armour items corresponding to `Canonical::Armor` pieces
 * [`ClothingItem`](/app/models/clothing_item.rb): clothing items that are not armour or jewellery, corresponding to `Canonical::ClothingItem`s
 * [`Ingredient`](/app/models/ingredient.rb): ingredients corresponding to the `Canonical::Ingredient` class
-* [`JewelryItem`](/app/models/jewelry_item.rb): jewelry items corresponding to the `Canonical::JewelryItem` class
 * [`IngredientsAlchemicalProperty`](/app/models/ingredients_alchemical_property.rb): join model between `Ingredient` and `AlchemicalProperty` models
+* [`JewelryItem`](/app/models/jewelry_item.rb): jewelry items corresponding to the `Canonical::JewelryItem` class
+* [`MiscItem`](/app/models/misc_item.rb): miscellaneous items corresponding to the `Canonical::MiscItem` class
+* [`Potion`](/app/models/potion.rb): potions corresponding to the `Canonical::Potion` class, as well as user-created potions
+* [`PotionsAlchemicalProperty`](/app/models/potions_alchemical_property.rb): join model between `Potion` and `AlchemicalProperty` models
+* [`Property`](/app/models/property.rb): houses and properties corresponding to the `Canonical::Property` model
+* [`Staff`](/app/models/staff.rb): staves corresponding to the `Canonical::Staff` model
+* [`Weapon`](/app/models/weapon.rb): weapons corresponding to the `Canonical::Weapon` model
 
 Non-canonical in-game items represent individual item instances. For the purpose of inventory lists, they can also represent sets of items with identical characteristics whose quantities are then implied by the `quantity` field on the inventory item. (Note that, at this writing, inventory list functionality is not yet fully implemented.)
 
@@ -14,7 +20,7 @@ Non-canonical in-game items represent individual item instances. For the purpose
 
 ### Matching with Canonical Models
 
-Every in-game item has to correspond to at least one canonical model. Because not all attributes are pertinent to users and not all should be able to be set by them, non-canonical models do not have the same fields and associations as the canonical models. Instead, non-canonical models include the subset of canonical fields that are visible to or discoverable by players.
+Every in-game item has to correspond to at least one canonical model. Because not all attributes are directly pertinent to users and not all should be able to be set by them, non-canonical models do not have the same fields and associations as the canonical models. Instead, non-canonical models include the subset of canonical fields that are visible to or discoverable by players.
 
 When an in-game item is created, it is validated to ensure that it has at least one potential canonical match. These matches are based on fields set on the non-canonical model, or in [some cases](/docs/in_game_items/ingredient.md), associations that are present on that model; in other words, fields that are `nil` on the non-canonical model are not considered for the match. Only fields set to a non-`nil` value, or associations that have been created on the non-canonical model, must match the canonical model.
 

--- a/docs/in_game_items/weapon.md
+++ b/docs/in_game_items/weapon.md
@@ -1,0 +1,23 @@
+## Weapon
+
+The `Weapon` model represents in-game items of the `Canonical::Weapon` type.
+
+## Matching Attributes
+
+`Weapon` models are matched to `Canonical::Weapon` models using the following fields:
+
+* `name` (case-insensitive)
+* `unit_weight`
+* `category`
+* `weapon_type`
+* `magical_effects`
+
+## Associations
+
+Because `Weapon` models may (at least theoretically) have user-added enchantments in addition to those present on the canonical model, the `Weapon` model has its own associations to `EnchantablesEnchantment` and `Enchantment`. The canonical model's enchantments will automatically be added to the `Weapon` model after save if it has a single matching `Canonical::Weapon` model. If additional enchantments are added, the `EnchantablesEnchantment` model validates that the canonical weapon either has the same enchantment or is `enchantable` before the join model is allowed to be created.
+
+Like the [`Armor` model](/docs/in_game_items/armor.md), a weapon's `crafting_materials` and `tempering_materials` don't differ from the canonical model, so `Weapon`s don't have their own associations and instead pull crafting and tempering materials from the `Canonical::Weapon` model if they have one.
+
+## Auto-Populated Fields
+
+Weapons don't have any attributes that are initially hidden from users and discoverable as they play the game. For that reason, all matching attributes are set and enchantments added as soon as a single canonical model is able to be identified.

--- a/spec/models/armor_spec.rb
+++ b/spec/models/armor_spec.rb
@@ -236,8 +236,8 @@ RSpec.describe Armor, type: :model do
     end
   end
 
-  describe '#canonical_armors' do
-    subject(:canonical_armors) { armor.canonical_armors }
+  describe '#canonical_models' do
+    subject(:canonical_models) { armor.canonical_models }
 
     context 'when the item has an association defined' do
       let(:armor) do
@@ -262,7 +262,7 @@ RSpec.describe Armor, type: :model do
       end
 
       it 'returns the associated model in an array' do
-        expect(canonical_armors).to eq [canonical_armor]
+        expect(canonical_models).to contain_exactly(canonical_armor)
       end
     end
 
@@ -277,7 +277,7 @@ RSpec.describe Armor, type: :model do
         let(:armor) { build(:armor, unit_weight: nil) }
 
         it 'returns all matching items' do
-          expect(canonical_armors).to eq matching_canonicals
+          expect(canonical_models).to eq matching_canonicals
         end
       end
 
@@ -291,7 +291,7 @@ RSpec.describe Armor, type: :model do
         end
 
         it 'returns only the items for which all values match' do
-          expect(canonical_armors).to eq matching_canonicals
+          expect(canonical_models).to eq matching_canonicals
         end
       end
     end

--- a/spec/models/armor_spec.rb
+++ b/spec/models/armor_spec.rb
@@ -291,7 +291,7 @@ RSpec.describe Armor, type: :model do
         end
 
         it 'returns only the items for which all values match' do
-          expect(canonical_models).to eq matching_canonicals
+          expect(canonical_models).to contain_exactly(*matching_canonicals)
         end
       end
     end

--- a/spec/models/armor_spec.rb
+++ b/spec/models/armor_spec.rb
@@ -277,7 +277,7 @@ RSpec.describe Armor, type: :model do
         let(:armor) { build(:armor, unit_weight: nil) }
 
         it 'returns all matching items' do
-          expect(canonical_models).to eq matching_canonicals
+          expect(canonical_models).to contain_exactly(*matching_canonicals)
         end
       end
 

--- a/spec/models/clothing_item_spec.rb
+++ b/spec/models/clothing_item_spec.rb
@@ -176,8 +176,8 @@ RSpec.describe ClothingItem, type: :model do
     end
   end
 
-  describe '#canonical_clothing_items' do
-    subject(:canonical_clothing_items) { item.canonical_clothing_items }
+  describe '#canonical_models' do
+    subject(:canonical_models) { item.canonical_models }
 
     context 'when the item has an association defined' do
       let(:item) do
@@ -200,7 +200,7 @@ RSpec.describe ClothingItem, type: :model do
       end
 
       it 'returns the associated model in an array' do
-        expect(canonical_clothing_items).to eq [canonical_clothing_item]
+        expect(canonical_models).to contain_exactly(canonical_clothing_item)
       end
     end
 
@@ -215,7 +215,7 @@ RSpec.describe ClothingItem, type: :model do
         let(:item) { build(:clothing_item, unit_weight: nil) }
 
         it 'returns all matching items' do
-          expect(canonical_clothing_items).to eq matching_canonicals
+          expect(canonical_models).to eq matching_canonicals
         end
       end
 
@@ -229,7 +229,7 @@ RSpec.describe ClothingItem, type: :model do
         end
 
         it 'returns only the items for which all values match' do
-          expect(canonical_clothing_items).to eq matching_canonicals
+          expect(canonical_models).to eq matching_canonicals
         end
       end
     end

--- a/spec/models/enchantables_enchantment_spec.rb
+++ b/spec/models/enchantables_enchantment_spec.rb
@@ -3,9 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe EnchantablesEnchantment, type: :model do
+  let(:enchantment) { create(:enchantment) }
+
   describe 'validations' do
     describe 'enchantable item and enchantment' do
-      let(:enchantment) { create(:enchantment) }
       let(:armor) { create(:canonical_armor) }
 
       it 'must form a unique combination' do
@@ -74,6 +75,116 @@ RSpec.describe EnchantablesEnchantment, type: :model do
         it 'sets the enchantable type' do
           expect(enchantable_type).to eq 'ClothingItem'
         end
+      end
+
+      context 'when the association is a jewelry item' do
+        let(:item) { create(:jewelry_item) }
+
+        before do
+          create(:canonical_jewelry_item)
+        end
+
+        it 'sets the enchantable type' do
+          expect(enchantable_type).to eq 'JewelryItem'
+        end
+      end
+
+      context 'when the association is a weapon' do
+        let(:item) { create(:weapon) }
+
+        before do
+          create(:canonical_weapon)
+        end
+
+        it 'sets the enchantable type' do
+          expect(enchantable_type).to eq 'Weapon'
+        end
+      end
+    end
+  end
+
+  describe '::after_validation' do
+    subject(:validate) { model.validate }
+
+    let(:model) { build(:enchantables_enchantment, enchantable:, enchantment:, strength: 1) }
+
+    context 'when the enchantable is a canonical model' do
+      let(:enchantable) { create(:canonical_armor) }
+
+      it "doesn't add errors" do
+        expect { validate }
+          .not_to change(model, :errors)
+      end
+    end
+
+    context 'when the enchantable is not a canonical model' do
+      let(:enchantable) { create(:armor) }
+
+      context 'when there is a canonical model that matches' do
+        before do
+          canonical = create(:canonical_armor)
+
+          create(
+            :enchantables_enchantment,
+            enchantable: canonical,
+            enchantment:,
+          )
+        end
+
+        it "doesn't add errors" do
+          expect { validate }
+            .not_to change(model, :errors)
+        end
+      end
+
+      context 'when there is no canonical model that matches' do
+        before do
+          canonicals = create_list(
+            :canonical_armor,
+            2,
+            enchantable: false,
+          )
+
+          create(
+            :enchantables_enchantment,
+            enchantable: canonicals.first,
+            enchantment:,
+            strength: 2,
+          )
+        end
+
+        it 'adds errors' do
+          validate
+          expect(model.errors[:base]).to include "doesn't match any canonical model"
+        end
+      end
+    end
+  end
+
+  describe '::after_save' do
+    subject(:save_model) { model.save! }
+
+    let(:model) { build(:enchantables_enchantment, enchantable:, enchantment:) }
+
+    before do
+      allow(enchantable).to receive(:save!)
+    end
+
+    context 'when the enchantable association is a canonical model' do
+      let(:enchantable) { create(:canonical_jewelry_item) }
+
+      it "doesn't save the enchantable association" do
+        save_model
+        expect(enchantable).not_to have_received(:save!)
+      end
+    end
+
+    context 'when the enchantable association is not a canonical model' do
+      let(:enchantable) { create(:jewelry_item, :with_matching_canonical) }
+
+      it 'saves the enchantable association' do
+        save_model
+        expect(enchantable).to have_received(:save!)
       end
     end
   end

--- a/spec/models/jewelry_item_spec.rb
+++ b/spec/models/jewelry_item_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe JewelryItem, type: :model do
       end
     end
 
-    describe '#canonical_jewelry_items' do
+    describe '#canonical_models' do
       context 'when there is a single matching canonical jewelry item' do
         let(:item) { build(:jewelry_item, :with_matching_canonical) }
 
@@ -106,8 +106,8 @@ RSpec.describe JewelryItem, type: :model do
     end
   end
 
-  describe '#canonical_jewelry_items' do
-    subject(:canonical_jewelry_items) { item.canonical_jewelry_items }
+  describe '#canonical_models' do
+    subject(:canonical_models) { item.canonical_models }
 
     context 'when the item has an association defined' do
       let(:item) { create(:jewelry_item, :with_matching_canonical) }
@@ -117,7 +117,7 @@ RSpec.describe JewelryItem, type: :model do
       end
 
       it 'includes only the associated model' do
-        expect(canonical_jewelry_items).to contain_exactly(item.canonical_jewelry_item)
+        expect(canonical_models).to contain_exactly(item.canonical_jewelry_item)
       end
     end
 
@@ -134,7 +134,7 @@ RSpec.describe JewelryItem, type: :model do
         end
 
         it 'matches case-insensitively' do
-          expect(canonical_jewelry_items).to contain_exactly(*matching_canonicals)
+          expect(canonical_models).to contain_exactly(*matching_canonicals)
         end
       end
 
@@ -155,7 +155,7 @@ RSpec.describe JewelryItem, type: :model do
         end
 
         it 'returns the matching models' do
-          expect(canonical_jewelry_items).to contain_exactly(*matching_canonicals)
+          expect(canonical_models).to contain_exactly(*matching_canonicals)
         end
       end
     end
@@ -197,16 +197,6 @@ RSpec.describe JewelryItem, type: :model do
         expect(item.unit_weight).to eq 0.2
         expect(item.jewelry_type).to eq 'ring'
         expect(item.magical_effects).to eq 'Some magical effects to differentiate'
-      end
-
-      it 'adds enchantments if persisted' do
-        item.save!
-
-        # This realistically won't happen but in the interest of thoroughness...
-        item.enchantables_enchantments.each(&:destroy)
-
-        expect { item.validate }
-          .to change(item.enchantables_enchantments.reload, :length).from(0).to(2)
       end
     end
 

--- a/spec/models/weapon_spec.rb
+++ b/spec/models/weapon_spec.rb
@@ -88,6 +88,7 @@ RSpec.describe Weapon, type: :model do
         it 'assigns the canonical_weapon' do
           expect { validate }
             .to change(weapon, :canonical_weapon)
+                  .from(nil)
                   .to(matching_canonical)
         end
 
@@ -175,7 +176,7 @@ RSpec.describe Weapon, type: :model do
       end
 
       context 'when there are enchantments' do
-        context 'when the weapon itself has no enchantments' do
+        context 'when the in-game item model has no enchantments' do
           let(:weapon) { build(:weapon, name: 'foobar') }
 
           before do
@@ -208,7 +209,7 @@ RSpec.describe Weapon, type: :model do
           end
         end
 
-        context 'when the weapon itself is already enchanted' do
+        context 'when the in-game item model is already enchanted' do
           let(:weapon) { create(:weapon, name: 'foobar') }
 
           let!(:canonicals) do
@@ -481,7 +482,7 @@ RSpec.describe Weapon, type: :model do
 
           let(:enchantable) { false }
 
-          it "doesn't allow enchantments if they eliminate all canonical matches", :aggregate_failures do
+          it "doesn't allow the enchantment to be added", :aggregate_failures do
             expect { add_enchantment }
               .to raise_error(ActiveRecord::RecordInvalid)
 

--- a/spec/models/weapon_spec.rb
+++ b/spec/models/weapon_spec.rb
@@ -473,7 +473,65 @@ RSpec.describe Weapon, type: :model do
     end
   end
 
-  describe 'delegated methods'
+  describe 'delegated methods' do
+    describe '#crafting_materials' do
+      subject(:crafting_materials) { weapon.crafting_materials }
+
+      context 'when there is a canonical weapon assigned' do
+        let(:weapon) { create(:weapon, name: 'Foobar', canonical_weapon:) }
+        let(:canonical_weapon) { create(:canonical_weapon, :with_crafting_materials, name: 'Foobar') }
+
+        it 'returns the crafting materials for the canonical' do
+          expect(crafting_materials).to eq canonical_weapon.crafting_materials
+        end
+      end
+
+      context 'when there is no canonical weapon assigned' do
+        let(:weapon) { create(:weapon, name: 'Foobar') }
+
+        before do
+          create_list(
+            :canonical_weapon,
+            2,
+            name: 'Foobar',
+          )
+        end
+
+        it 'returns nil' do
+          expect(crafting_materials).to be_nil
+        end
+      end
+    end
+
+    describe '#tempering_materials' do
+      subject(:tempering_materials) { weapon.tempering_materials }
+
+      context 'when there is a canonical weapon assigned' do
+        let(:weapon) { create(:weapon, name: 'Foobar', canonical_weapon:) }
+        let(:canonical_weapon) { create(:canonical_weapon, :with_tempering_materials, name: 'Foobar') }
+
+        it 'returns the tempering materials for the canonical' do
+          expect(tempering_materials).to eq canonical_weapon.tempering_materials
+        end
+      end
+
+      context 'when there is no canonical weapon assigned' do
+        let(:weapon) { create(:weapon, name: 'Foobar') }
+
+        before do
+          create_list(
+            :canonical_weapon,
+            2,
+            name: 'Foobar',
+          )
+        end
+
+        it 'returns an empty array' do
+          expect(tempering_materials).to be_nil
+        end
+      end
+    end
+  end
 
   describe 'adding enchantments' do
     context 'when no canonical model is assigned' do

--- a/spec/models/weapon_spec.rb
+++ b/spec/models/weapon_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Weapon, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/weapon_spec.rb
+++ b/spec/models/weapon_spec.rb
@@ -38,72 +38,36 @@ RSpec.describe Weapon, type: :model do
 
     context 'when there is a canonical model assigned' do
       let(:canonical_weapon) { weapon.canonical_weapon }
+      let(:weapon) { build(:weapon, :with_enchanted_canonical) }
 
-      context 'when the canonical model has no enchantments' do
-        let(:weapon) { build(:weapon, :with_matching_canonical) }
-
-        before do
-          # A second possible match
-          create(
-            :canonical_weapon,
-            name: canonical_weapon.name,
-            category: canonical_weapon.category,
-            weapon_type: canonical_weapon.weapon_type,
-            unit_weight: canonical_weapon.unit_weight,
-          )
-        end
-
-        it "doesn't change the canonical model" do
-          expect { validate }
-            .not_to change(weapon, :canonical_weapon)
-        end
-
-        it 'sets values on the weapon model', :aggregate_failures do
-          validate
-          expect(weapon.name).to eq canonical_weapon.name
-          expect(weapon.category).to eq canonical_weapon.category
-          expect(weapon.weapon_type).to eq canonical_weapon.weapon_type
-          expect(weapon.unit_weight).to eq canonical_weapon.unit_weight
-        end
-
-        it "doesn't add enchantments" do
-          validate
-          expect(weapon.enchantments).to be_empty
-        end
+      before do
+        # A second possible match
+        create(
+          :canonical_weapon,
+          name: canonical_weapon.name,
+          category: canonical_weapon.category,
+          weapon_type: canonical_weapon.weapon_type,
+          unit_weight: canonical_weapon.unit_weight,
+        )
       end
 
-      context 'when the canonical model has enchantments' do
-        let(:weapon) { build(:weapon, :with_enchanted_canonical) }
+      it "doesn't change the canonical model" do
+        expect { validate }
+          .not_to change(weapon, :canonical_weapon)
+      end
 
-        before do
-          # A second possible match
-          create(
-            :canonical_weapon,
-            name: canonical_weapon.name,
-            category: canonical_weapon.category,
-            weapon_type: canonical_weapon.weapon_type,
-            unit_weight: canonical_weapon.unit_weight,
-          )
-        end
+      it "doesn't add enchantments" do
+        validate
+        expect(weapon.enchantments).to be_empty
+      end
 
-        it "doesn't change the canonical model" do
-          expect { validate }
-            .not_to change(weapon, :canonical_weapon)
-        end
-
-        it "doesn't add enchantments" do
-          validate
-          expect(weapon.enchantments).to be_empty
-        end
-
-        it 'sets values on the weapon model', :aggregate_failures do
-          validate
-          expect(weapon.name).to eq canonical_weapon.name
-          expect(weapon.category).to eq canonical_weapon.category
-          expect(weapon.weapon_type).to eq canonical_weapon.weapon_type
-          expect(weapon.unit_weight).to eq canonical_weapon.unit_weight
-          expect(weapon.magical_effects).to eq canonical_weapon.magical_effects
-        end
+      it 'sets values on the weapon model', :aggregate_failures do
+        validate
+        expect(weapon.name).to eq canonical_weapon.name
+        expect(weapon.category).to eq canonical_weapon.category
+        expect(weapon.weapon_type).to eq canonical_weapon.weapon_type
+        expect(weapon.unit_weight).to eq canonical_weapon.unit_weight
+        expect(weapon.magical_effects).to eq canonical_weapon.magical_effects
       end
     end
 

--- a/spec/models/weapon_spec.rb
+++ b/spec/models/weapon_spec.rb
@@ -183,12 +183,19 @@ RSpec.describe Weapon, type: :model do
           let!(:canonicals) do
             [
               create(:canonical_weapon, :with_enchantments, name: 'Foobar'),
-              create(:canonical_weapon, :with_enchantments, name: 'Foobar', enchantable: false),
+              create(:canonical_weapon, name: 'Foobar', enchantable: false),
               create(:canonical_weapon, name: 'Foobar', enchantable: false),
             ]
           end
 
           before do
+            create(
+              :enchantables_enchantment,
+              enchantable: canonicals.second,
+              enchantment: canonicals.first.enchantments.first,
+              strength: 2, # test that matching is done by strength too
+            )
+
             create(
               :enchantables_enchantment,
               enchantable: weapon,

--- a/spec/models/weapon_spec.rb
+++ b/spec/models/weapon_spec.rb
@@ -3,5 +3,413 @@
 require 'rails_helper'
 
 RSpec.describe Weapon, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'validations' do
+    subject(:validate) { weapon.validate }
+
+    let(:weapon) { build(:weapon) }
+
+    it 'is invalid without a name' do
+      weapon.name = nil
+      validate
+      expect(weapon.errors[:name]).to include "can't be blank"
+    end
+
+    it 'is invalid with an invalid category name' do
+      weapon.category = 'foo'
+      validate
+      expect(weapon.errors[:category]).to include 'must be "one-handed", "two-handed", or "archery"'
+    end
+
+    it 'is invalid with an invalid weapon type' do
+      weapon.weapon_type = 'foo'
+      validate
+      expect(weapon.errors[:weapon_type]).to include 'must be a valid type of weapon that occurs in Skyrim'
+    end
+
+    it 'is invalid with a negative unit weight' do
+      weapon.unit_weight = -0.5
+      validate
+      expect(weapon.errors[:unit_weight]).to include 'must be greater than or equal to 0'
+    end
+  end
+
+  describe '::before_validation' do
+    subject(:validate) { weapon.validate }
+
+    context 'when there is a canonical model assigned' do
+      let(:canonical_weapon) { weapon.canonical_weapon }
+
+      context 'when the canonical model has no enchantments' do
+        let(:weapon) { build(:weapon, :with_matching_canonical) }
+
+        before do
+          # A second possible match
+          create(
+            :canonical_weapon,
+            name: canonical_weapon.name,
+            category: canonical_weapon.category,
+            weapon_type: canonical_weapon.weapon_type,
+            unit_weight: canonical_weapon.unit_weight,
+          )
+        end
+
+        it "doesn't change the canonical model" do
+          expect { validate }
+            .not_to change(weapon, :canonical_weapon)
+        end
+
+        it 'sets values on the weapon model', :aggregate_failures do
+          validate
+          expect(weapon.name).to eq canonical_weapon.name
+          expect(weapon.category).to eq canonical_weapon.category
+          expect(weapon.weapon_type).to eq canonical_weapon.weapon_type
+          expect(weapon.unit_weight).to eq canonical_weapon.unit_weight
+        end
+
+        it "doesn't add enchantments" do
+          validate
+          expect(weapon.enchantments).to be_empty
+        end
+      end
+
+      context 'when the canonical model has enchantments' do
+        let(:weapon) { build(:weapon, :with_enchanted_canonical) }
+
+        before do
+          # A second possible match
+          create(
+            :canonical_weapon,
+            name: canonical_weapon.name,
+            category: canonical_weapon.category,
+            weapon_type: canonical_weapon.weapon_type,
+            unit_weight: canonical_weapon.unit_weight,
+          )
+        end
+
+        it "doesn't change the canonical model" do
+          expect { validate }
+            .not_to change(weapon, :canonical_weapon)
+        end
+
+        it "doesn't add enchantments" do
+          validate
+          expect(weapon.enchantments).to be_empty
+        end
+
+        it 'sets values on the weapon model', :aggregate_failures do
+          validate
+          expect(weapon.name).to eq canonical_weapon.name
+          expect(weapon.category).to eq canonical_weapon.category
+          expect(weapon.weapon_type).to eq canonical_weapon.weapon_type
+          expect(weapon.unit_weight).to eq canonical_weapon.unit_weight
+        end
+      end
+    end
+
+    context 'when there is a single matching canonical model' do
+      context 'when the canonical model has no enchantments' do
+        let(:weapon) { build(:weapon, name: 'foobar', unit_weight: 12) }
+
+        let!(:matching_canonical) { create(:canonical_weapon, name: 'Foobar', unit_weight: 12) }
+
+        before do
+          create(
+            :canonical_weapon,
+            name: 'Foobar',
+            unit_weight: 14
+          )
+        end
+
+        it 'adds the canonical_weapon' do
+          expect { validate }
+            .to change(weapon, :canonical_weapon)
+                  .to(matching_canonical)
+        end
+
+        it 'sets values on the weapon model', :aggregate_failures do
+          validate
+          expect(weapon.name).to eq matching_canonical.name
+          expect(weapon.category).to eq matching_canonical.category
+          expect(weapon.weapon_type).to eq matching_canonical.weapon_type
+          expect(weapon.unit_weight).to eq matching_canonical.unit_weight
+        end
+
+        it "doesn't set enchantments" do
+          validate
+          expect(weapon.enchantments).to be_empty
+        end
+      end
+
+      context 'when the canonical model has enchantments' do
+        context 'when the in-game item model has no enchantments' do
+          let(:weapon) { build(:weapon, name: 'foobar', unit_weight: 12) }
+
+          let!(:matching_canonical) { create(:canonical_weapon, :with_enchantments, name: 'Foobar', unit_weight: 12) }
+
+          before do
+            create(
+              :canonical_weapon,
+              name: 'Foobar',
+              unit_weight: 14,
+            )
+          end
+
+          it 'assigns the canonical_weapon' do
+            expect { validate }
+              .to change(weapon, :canonical_weapon)
+                    .to(matching_canonical)
+          end
+
+          it 'sets values on the weapon model', :aggregate_failures do
+            validate
+            expect(weapon.name).to eq matching_canonical.name
+            expect(weapon.category).to eq matching_canonical.category
+            expect(weapon.weapon_type).to eq matching_canonical.weapon_type
+            expect(weapon.unit_weight).to eq matching_canonical.unit_weight
+            expect(weapon.magical_effects).to eq matching_canonical.magical_effects
+          end
+
+          it "doesn't set enchantments" do
+            validate
+            expect(weapon.enchantments).to be_empty
+          end
+        end
+
+        context 'when the in-game item has enchantments' do
+          let(:weapon) { create(:weapon, name: 'foobar') }
+
+          context 'when enchantments match on the canonical' do
+            let!(:canonicals) do
+              [
+                create(:canonical_weapon, :with_enchantments, name: 'Foobar'),
+                create(:canonical_weapon, :with_enchantments, name: 'Foobar', enchantable: false),
+                create(:canonical_weapon, name: 'Foobar', enchantable: false)
+              ]
+            end
+
+            before do
+              create(
+                :enchantables_enchantment,
+                enchantable: weapon,
+                enchantment: canonicals.first.enchantments.first,
+                strength: canonicals.first.enchantments.first.strength
+              )
+
+              weapon.enchantables_enchantments.reload
+            end
+
+            it 'assigns the canonical_weapon' do
+              validate
+              expect(weapon.canonical_weapon).to eq canonicals.first
+            end
+
+            it 'sets values on the weapon model', :aggregate_failures do
+              validate
+              expect(weapon.name).to eq canonicals.first.name
+              expect(weapon.category).to eq canonicals.first.category
+              expect(weapon.weapon_type).to eq canonicals.first.weapon_type
+              expect(weapon.unit_weight).to eq canonicals.first.unit_weight
+              expect(weapon.magical_effects).to eq canonicals.first.magical_effects
+            end
+
+            it "sets enchantments" do
+              expect(weapon.reload.enchantments.length).to eq 1
+            end
+          end
+
+          context 'when there are non-matching enchantments' do
+            context 'when there is an enchantable canonical' do
+              let!(:canonicals) do
+                [
+                  create(:canonical_weapon, :with_enchantments, name: 'Foobar', unit_weight: 12, enchantable: true),
+                  create(:canonical_weapon, :with_enchantments, name: 'Foobar', enchantable: false),
+                ]
+              end
+
+              before do
+                create(:enchantables_enchantment, enchantable: weapon)
+              end
+
+              it 'assigns the enchantable canonical' do
+                validate
+                expect(weapon.canonical_weapon).to eq canonicals.first
+              end
+
+              it 'sets values on the weapon model', :aggregate_failures do
+                validate
+                expect(weapon.name).to eq 'Foobar'
+                expect(weapon.category).to eq 'one-handed' # These values are the defaults for
+                expect(weapon.weapon_type).to eq 'war axe' # the Canonical::Weapon factory.
+                expect(weapon.unit_weight).to eq 12
+                expect(weapon.magical_effects).to be_nil
+              end
+
+              it "doesn't set enchantments" do
+                expect { validate }
+                  .not_to change(weapon.enchantments.reload, :length)
+              end
+            end
+
+            context 'when the canonicals are not enchantable' do
+              let!(:canonicals) do
+                [
+                  create(:canonical_weapon, :with_enchantments, name: 'Foobar', unit_weight: 12, enchantable: false),
+                  create(:canonical_weapon, :with_enchantments, name: 'Foobar', enchantable: false),
+                ]
+              end
+
+              before do
+                create(:enchantables_enchantment, enchantable: weapon)
+              end
+
+              it "doesn't set a canonical weapon" do
+                validate
+                expect(weapon.canonical_weapon).to be_nil
+              end
+
+              it "doesn't set values", :aggregate_failures do
+                validate
+                expect(weapon.name).to eq 'foobar'
+              end
+
+              it 'sets an error' do
+                validate
+                expect(weapon.errors[:base]).to include "doesn't match a weapon that exists in Skyrim"
+              end
+            end
+          end
+        end
+      end
+    end
+
+    context 'when there are multiple matching canonical models' do
+      context 'when there are no enchantments involved' do
+        let(:weapon) { build(:weapon, name: 'foobar') }
+
+        before do
+          create_list(:canonical_weapon, 2, name: 'Foobar')
+        end
+
+        it "doesn't assign a canonical_weapon" do
+          validate
+          expect(weapon.canonical_weapon).to be_nil
+        end
+
+        it "doesn't set values", :aggregate_failures do
+          validate
+          expect(weapon.name).to eq 'foobar'
+          expect(weapon.category).to be_nil
+          expect(weapon.weapon_type).to be_nil
+          expect(weapon.unit_weight).to be_nil
+          expect(weapon.magical_effects).to be_nil
+        end
+      end
+
+      context 'when there are enchantments' do
+        context 'when the weapon itself has no enchantments' do
+          let(:weapon) { build(:weapon, name: 'foobar') }
+
+          before do
+            create(:canonical_weapon, :with_enchantments, name: 'Foobar')
+            create(:canonical_weapon, name: 'Foobar')
+          end
+
+          it "doesn't assign a canonical_weapon" do
+            validate
+            expect(weapon.canonical_weapon).to be_nil
+          end
+
+          it "doesn't set values", :aggregate_failures do
+            validate
+            expect(weapon.name).to eq 'foobar'
+            expect(weapon.category).to be_nil
+            expect(weapon.weapon_type).to be_nil
+            expect(weapon.unit_weight).to be_nil
+            expect(weapon.magical_effects).to be_nil
+          end
+
+          it "doesn't set enchantments" do
+            validate
+            expect(weapon.enchantments).to be_empty
+          end
+
+          it "doesn't set errors" do
+            validate
+            expect(weapon.errors[:base]).to be_empty
+          end
+        end
+
+        context 'when the weapon itself is already enchanted' do
+          let(:weapon) { create(:weapon, name: 'foobar') }
+
+          let!(:canonicals) do
+            [
+              create(:canonical_weapon, :with_enchantments, name: 'Foobar', enchantable: false),
+              create(:canonical_weapon, :with_enchantments, name: 'FoObAr', enchantable: false),
+              create(:canonical_weapon, :with_enchantments, name: 'fOoBaR', enchantable: false),
+              create(:canonical_weapon, name: 'fOObAR', enchantable: true)
+            ]
+          end
+
+          before do
+            create(
+              :enchantables_enchantment,
+              enchantable: weapon,
+              enchantment: canonicals.first.enchantments.first,
+              strength: canonicals.first.enchantments.first.strength
+            )
+          end
+
+          it "doesn't assign a canonical_weapon" do
+            validate
+            expect(weapon.canonical_weapon).to be_nil
+          end
+
+          it "doesn't set values", :aggregate_failures do
+            validate
+            expect(weapon.name).to eq 'foobar'
+            expect(weapon.category).to be_nil
+            expect(weapon.weapon_type).to be_nil
+            expect(weapon.unit_weight).to be_nil
+            expect(weapon.magical_effects).to be_nil
+          end
+
+          it "doesn't set enchantments" do
+            expect { validate }
+              .not_to change(weapon.enchantments, :length)
+          end
+
+          it "doesn't set errors" do
+            validate
+            expect(weapon.errors[:base]).to be_empty
+          end
+        end
+      end
+    end
+
+    context 'when there are no matching canonical models' do
+      let(:weapon) { build(:weapon, name: 'Foobar') }
+
+      before do
+        create_list(:canonical_weapon, 2)
+      end
+
+      it 'adds an error' do
+        validate
+        expect(weapon.errors[:base]).to include "doesn't match a weapon that exists in Skyrim"
+      end
+    end
+  end
+
+  describe 'delegated methods'
+
+  describe 'adding enchantments' do
+    context 'when no canonical model is assigned'
+
+    context 'when there is a canonical model assigned' do
+      context 'when the canonical model is enchantable'
+
+      context 'when the canonical model is not enchantable'
+    end
+  end
 end

--- a/spec/models/weapon_spec.rb
+++ b/spec/models/weapon_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe Weapon, type: :model do
           create(
             :canonical_weapon,
             name: 'Foobar',
-            unit_weight: 14
+            unit_weight: 14,
           )
         end
 
@@ -183,7 +183,7 @@ RSpec.describe Weapon, type: :model do
               [
                 create(:canonical_weapon, :with_enchantments, name: 'Foobar'),
                 create(:canonical_weapon, :with_enchantments, name: 'Foobar', enchantable: false),
-                create(:canonical_weapon, name: 'Foobar', enchantable: false)
+                create(:canonical_weapon, name: 'Foobar', enchantable: false),
               ]
             end
 
@@ -192,7 +192,7 @@ RSpec.describe Weapon, type: :model do
                 :enchantables_enchantment,
                 enchantable: weapon,
                 enchantment: canonicals.first.enchantments.first,
-                strength: canonicals.first.enchantments.first.strength
+                strength: canonicals.first.enchantments.first.strength,
               )
 
               weapon.enchantables_enchantments.reload
@@ -212,7 +212,7 @@ RSpec.describe Weapon, type: :model do
               expect(weapon.magical_effects).to eq canonicals.first.magical_effects
             end
 
-            it "sets enchantments" do
+            it 'sets enchantments' do
               expect(weapon.reload.enchantments.length).to eq 1
             end
           end
@@ -347,7 +347,7 @@ RSpec.describe Weapon, type: :model do
               create(:canonical_weapon, :with_enchantments, name: 'Foobar', enchantable: false),
               create(:canonical_weapon, :with_enchantments, name: 'FoObAr', enchantable: false),
               create(:canonical_weapon, :with_enchantments, name: 'fOoBaR', enchantable: false),
-              create(:canonical_weapon, name: 'fOObAR', enchantable: true)
+              create(:canonical_weapon, name: 'fOObAR', enchantable: true),
             ]
           end
 
@@ -356,7 +356,7 @@ RSpec.describe Weapon, type: :model do
               :enchantables_enchantment,
               enchantable: weapon,
               enchantment: canonicals.first.enchantments.first,
-              strength: canonicals.first.enchantments.first.strength
+              strength: canonicals.first.enchantments.first.strength,
             )
           end
 

--- a/spec/support/factories/canonical/weapons.rb
+++ b/spec/support/factories/canonical/weapons.rb
@@ -21,5 +21,25 @@ FactoryBot.define do
         create_list(:enchantables_enchantment, 2, enchantable: item)
       end
     end
+
+    trait :with_tempering_materials do
+      after(:create) do |item|
+        create_list(
+          :canonical_temperables_tempering_material,
+          2,
+          temperable: item,
+        )
+      end
+    end
+
+    trait :with_crafting_materials do
+      after(:create) do |item|
+        create_list(
+          :canonical_craftables_crafting_material,
+          2,
+          craftable: item,
+        )
+      end
+    end
   end
 end

--- a/spec/support/factories/canonical/weapons.rb
+++ b/spec/support/factories/canonical/weapons.rb
@@ -15,5 +15,11 @@ FactoryBot.define do
     quest_item { false }
     leveled { false }
     enchantable { true }
+
+    trait :with_enchantments do
+      after(:create) do |item|
+        create_list(:enchantables_enchantment, 2, enchantable: item)
+      end
+    end
   end
 end

--- a/spec/support/factories/weapons.rb
+++ b/spec/support/factories/weapons.rb
@@ -7,13 +7,17 @@ FactoryBot.define do
     name { 'Ancient Nord War Axe of Cold' }
 
     trait :with_matching_canonical do
-      association :canonical_weapon, factory: :canonical_weapon
+      association :canonical_weapon,
+                  factory: :canonical_weapon,
+                  strategy: :create
 
       name { canonical_weapon.name }
     end
 
     trait :with_enchanted_canonical do
-      association :canonical_weapon, factory: %i[canonical_weapon with_enchantments]
+      association :canonical_weapon,
+                  factory: %i[canonical_weapon with_enchantments],
+                  strategy: :create
 
       name { canonical_weapon.name }
     end

--- a/spec/support/factories/weapons.rb
+++ b/spec/support/factories/weapons.rb
@@ -11,5 +11,11 @@ FactoryBot.define do
 
       name { canonical_weapon.name }
     end
+
+    trait :with_enchanted_canonical do
+      association :canonical_weapon, factory: %i[canonical_weapon with_enchantments]
+
+      name { canonical_weapon.name }
+    end
   end
 end

--- a/spec/support/factories/weapons.rb
+++ b/spec/support/factories/weapons.rb
@@ -10,16 +10,12 @@ FactoryBot.define do
       association :canonical_weapon,
                   factory: :canonical_weapon,
                   strategy: :create
-
-      name { canonical_weapon.name }
     end
 
     trait :with_enchanted_canonical do
       association :canonical_weapon,
                   factory: %i[canonical_weapon with_enchantments],
                   strategy: :create
-
-      name { canonical_weapon.name }
     end
   end
 end

--- a/spec/support/factories/weapons.rb
+++ b/spec/support/factories/weapons.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :weapon do
     game
 
-    name { 'Ancient Nord War Axe of Cold' }
+    name { 'Dwarven War Axe' }
 
     trait :with_matching_canonical do
       association :canonical_weapon,

--- a/spec/support/factories/weapons.rb
+++ b/spec/support/factories/weapons.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :weapon do
+    game
+
+    name { 'Ancient Nord War Axe of Cold' }
+
+    trait :with_matching_canonical do
+      association :canonical_weapon, factory: :canonical_weapon
+
+      name { canonical_weapon.name }
+    end
+  end
+end


### PR DESCRIPTION
## Context

[**Create non-canonical Weapon model**](https://trello.com/c/fVI5kDfy/312-create-non-canonical-weapon-model)

We are creating non-canonical versions of most of our canonical models. The next one is the `Weapon` model. This is one of the most critical in-game item types in Skyrim.

## Changes

* Migration creating `weapons` table
* Non-canonical `Weapon` model
* Validations and hooks to `EnchantablesEnchantment` against canonical models
* Small changes to other canonical models with associations to `EnchantablesEnchantment`
* Tests for the new model
* Docs for the new model

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

Testing this work was challenging because the desired start state for a lot of test cases was precluded by SIM's validations and hooks. I ended up having to exploit edge cases to make sure that test data got instantiated correctly. For example, to make sure that weapons have enchantments added from a canonical match after saving, I had to first create multiple canonical models without enchantments, save the weapon (so that there would be multiple canonical matches and no `canonical_weapon` would be assigned), and then add enchantments to the canonicals to ensure they would be added at the appropriate time during the tests.

I decided not to add validations to the `Weapon` model to test for a correct combination of `weapon_type` and `category`, because the `Canonical::Weapon` model already has this validation, meaning that any `Weapon` with an incorrect combination would fail matching against canonicals.

## TODO

- [x] Test that enchantments are matched based on `strength` and not just enchantment ID