### PR TITLE
Configure rubocop-factory_bot in .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,6 +38,7 @@ require:
   - rubocop-rails
   - rubocop-rspec
   - rubocop-performance
+  - rubocop-factory_bot
 AllCops:
   Exclude:
     - 'bin/**/*'
@@ -1223,6 +1224,35 @@ Style/YodaCondition:
   Enabled: true
   EnforcedStyle: forbid_for_all_comparison_operators
 Style/ZeroLengthPredicate:
+  Enabled: true
+
+###############################
+### FactoryBot Requirements ###
+###############################
+
+FactoryBot/AssociationStyle:
+  Enabled: true
+  EnforcedStyle: implicit
+FactoryBot/AttributeDefinedStatically:
+  Enabled: true
+FactoryBot/ConsistentParenthesesStyle:
+  Enabled: true
+  EnforcedStyle: require_parentheses
+FactoryBot/CreateList:
+  Enabled: true
+  EnforcedStyle: create_list
+FactoryBot/FactoryAssociationWithStrategy:
+  Enabled: true
+FactoryBot/FactoryClassName:
+  Enabled: true
+FactoryBot/FactoryNameStyle:
+  Enabled: true
+  EnforcedStyle: symbol
+FactoryBot/IdSequence:
+  Enabled: true
+FactoryBot/RedundantFactoryOption:
+  Enabled: true
+FactoryBot/SyntaxMethods:
   Enabled: true
 
 ##########################

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -690,7 +690,6 @@ Style/AndOr:
   EnforcedStyle: always
 Style/ArgumentsForwarding:
   Enabled: true
-  AllowOnlyRestArgument: true
 Style/ArrayJoin:
   Enabled: true
 Style/Attr:

--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,9 @@ group :development, :test do
   # Use Rubocop to enforce performance standards
   gem 'rubocop-performance', '~> 1.19', require: false
 
+  # Use Rubocop to lint factories
+  gem 'rubocop-factory_bot', '~> 2.24.0', require: false
+
   # Use WebMock to mock HTTP requests, mainly for auth purposes
   gem 'webmock', '~> 3.19'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ group :development, :test do
   gem 'rubocop-performance', '~> 1.19', require: false
 
   # Use Rubocop to lint factories
-  gem 'rubocop-factory_bot', '~> 2.24.0', require: false
+  gem 'rubocop-factory_bot', '~> 2.24', require: false
 
   # Use WebMock to mock HTTP requests, mainly for auth purposes
   gem 'webmock', '~> 3.19'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -268,6 +268,7 @@ DEPENDENCIES
   rack-cors (~> 2.0.1)
   rails (~> 7.0.8)
   rspec-rails (~> 6.0)
+  rubocop-factory_bot (~> 2.24.0)
   rubocop-performance (~> 1.19)
   rubocop-rails (~> 2.21)
   rubocop-rspec (~> 2.24)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -268,7 +268,7 @@ DEPENDENCIES
   rack-cors (~> 2.0.1)
   rails (~> 7.0.8)
   rspec-rails (~> 6.0)
-  rubocop-factory_bot (~> 2.24.0)
+  rubocop-factory_bot (~> 2.24)
   rubocop-performance (~> 1.19)
   rubocop-rails (~> 2.21)
   rubocop-rspec (~> 2.24)

--- a/spec/support/factories/canonical/misc_items.rb
+++ b/spec/support/factories/canonical/misc_items.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :canonical_misc_item, class: Canonical::MiscItem do
-    name { 'My Misc Item' }
+    name { "Wylandria's Soul Gem" }
     sequence(:item_code) {|n| "xx123x#{n}" }
     unit_weight { 1.0 }
     item_types { %w[miscellaneous] }

--- a/spec/support/factories/canonical/properties.rb
+++ b/spec/support/factories/canonical/properties.rb
@@ -2,6 +2,7 @@
 
 FactoryBot.define do
   factory :canonical_property, class: Canonical::Property do
+    name { 'Lakeview Manor' }
     alchemy_lab_available { true }
     arcane_enchanter_available { true }
     forge_available { false }

--- a/spec/support/factories/jewelry_items.rb
+++ b/spec/support/factories/jewelry_items.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     name { 'Gold Diamond Ring' }
 
     trait :with_matching_canonical do
-      association :canonical_jewelry_item, factory: :canonical_jewelry_item
+      association :canonical_jewelry_item
     end
   end
 end

--- a/spec/support/factories/misc_items.rb
+++ b/spec/support/factories/misc_items.rb
@@ -7,9 +7,7 @@ FactoryBot.define do
     name { "Wylandria's Soul Gem" }
 
     trait :with_matching_canonical do
-      association :canonical_misc_item, factory: :canonical_misc_item
-
-      name { canonical_misc_item.name }
+      association :canonical_misc_item
     end
   end
 end

--- a/spec/support/factories/properties.rb
+++ b/spec/support/factories/properties.rb
@@ -2,12 +2,10 @@
 
 FactoryBot.define do
   factory :property do
-    name { 'My House' }
+    name { 'Lakeview Manor' }
 
     trait :with_matching_canonical do
-      association :canonical_property, factory: :canonical_property
-
-      name { canonical_property.name }
+      association :canonical_property
     end
   end
 end

--- a/spec/support/factories/staves.rb
+++ b/spec/support/factories/staves.rb
@@ -4,13 +4,11 @@ FactoryBot.define do
   factory :staff do
     game
 
-    name { 'My Cool Staff' }
+    name { 'Staff of Chain Lightning' }
     unit_weight { 8 }
 
     trait :with_matching_canonical do
-      association :canonical_staff, factory: :canonical_staff
-
-      name { canonical_staff.name }
+      association :canonical_staff
     end
   end
 end

--- a/spec/support/factories/weapons.rb
+++ b/spec/support/factories/weapons.rb
@@ -7,9 +7,7 @@ FactoryBot.define do
     name { 'Dwarven War Axe' }
 
     trait :with_matching_canonical do
-      association :canonical_weapon,
-                  factory: :canonical_weapon,
-                  strategy: :create
+      association :canonical_weapon, strategy: :create
     end
 
     trait :with_enchanted_canonical do


### PR DESCRIPTION
## Context

[**Look into rubocop-factory_bot**](https://trello.com/c/ZGl66O4F/336-look-into-rubocop-facorybot)

Rubocop output indicates that `rubocop-factory_bot` is available but isn't configured for SIM. We want to enable it.

## Changes

* Add `rubocop-factory_bot` to Gemfile
* Configure Rubocop to use `rubocop-factory_bot`
* Configure `rubocop-factory_bot` cops
* Remove option causing noisy Rubocop warnings (since the option isn't relevant to our Ruby version)
* Fix violations
* Change `name` attribute on non-canonical factories so they match the canonical factory default

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~

## Considerations

I considered making another PR to change the `name` attribute on non-canonical factories, but it seemed easier to just make it part of this one.
