### PR TITLE
Add NOT NULL constraint to name/title attributes on in-game items

### DIFF
--- a/db/migrate/20231028000539_add_not_null_constraint_for_name_attribute_of_in_game_items.rb
+++ b/db/migrate/20231028000539_add_not_null_constraint_for_name_attribute_of_in_game_items.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddNotNullConstraintForNameAttributeOfInGameItems < ActiveRecord::Migration[7.1]
+  def change
+    change_column_null :armors, :name, false
+    change_column_null :books, :title, false
+    change_column_null :clothing_items, :name, false
+    change_column_null :ingredients, :name, false
+    change_column_null :jewelry_items, :name, false
+    change_column_null :misc_items, :name, false
+    change_column_null :potions, :name, false
+    change_column_null :properties, :name, false
+    change_column_null :staves, :name, false
+    change_column_null :weapons, :name, false
+  end
+end

--- a/db/migrate/20231028001851_add_scale_and_precision_to_all_decimal_fields.rb
+++ b/db/migrate/20231028001851_add_scale_and_precision_to_all_decimal_fields.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddScaleAndPrecisionToAllDecimalFields < ActiveRecord::Migration[7.1]
+  def change
+    change_column :armors, :unit_weight, :decimal, scale: 2, precision: 5
+    change_column :books, :unit_weight, :decimal, scale: 2, precision: 5
+    change_column :canonical_misc_items, :unit_weight, :decimal, scale: 2, precision: 5
+    change_column :canonical_potions, :unit_weight, :decimal, scale: 2, precision: 5
+    change_column :clothing_items, :unit_weight, :decimal, scale: 2, precision: 5
+    change_column :ingredients, :unit_weight, :decimal, scale: 2, precision: 5
+    change_column :jewelry_items, :unit_weight, :decimal, scale: 2, precision: 5
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_10_28_000539) do
+ActiveRecord::Schema[7.1].define(version: 2023_10_28_001851) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -28,7 +28,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_28_000539) do
     t.bigint "game_id", null: false
     t.bigint "canonical_armor_id"
     t.string "name", null: false
-    t.decimal "unit_weight"
+    t.decimal "unit_weight", precision: 5, scale: 2
     t.string "magical_effects"
     t.string "weight"
     t.datetime "created_at", null: false
@@ -42,7 +42,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_28_000539) do
     t.bigint "canonical_book_id"
     t.string "title", null: false
     t.string "authors", default: [], array: true
-    t.decimal "unit_weight"
+    t.decimal "unit_weight", precision: 5, scale: 2
     t.string "skill_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -178,7 +178,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_28_000539) do
   create_table "canonical_misc_items", force: :cascade do |t|
     t.string "name", null: false
     t.string "item_code", null: false
-    t.decimal "unit_weight", null: false
+    t.decimal "unit_weight", precision: 5, scale: 2, null: false
     t.string "item_types", default: [], null: false, array: true
     t.string "description"
     t.boolean "purchasable", null: false
@@ -194,7 +194,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_28_000539) do
   create_table "canonical_potions", force: :cascade do |t|
     t.string "name", null: false
     t.string "item_code", null: false
-    t.decimal "unit_weight", null: false
+    t.decimal "unit_weight", precision: 5, scale: 2, null: false
     t.string "potion_type", null: false
     t.string "magical_effects"
     t.boolean "purchasable", default: true, null: false
@@ -324,7 +324,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_28_000539) do
     t.bigint "game_id", null: false
     t.bigint "canonical_clothing_item_id"
     t.string "name", null: false
-    t.decimal "unit_weight"
+    t.decimal "unit_weight", precision: 5, scale: 2
     t.string "magical_effects"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -416,7 +416,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_28_000539) do
     t.bigint "game_id", null: false
     t.bigint "canonical_jewelry_item_id"
     t.string "name", null: false
-    t.decimal "unit_weight"
+    t.decimal "unit_weight", precision: 5, scale: 2
     t.string "jewelry_type"
     t.string "magical_effects"
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_10_22_210936) do
+ActiveRecord::Schema[7.1].define(version: 2023_10_28_000539) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -366,7 +366,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_22_210936) do
   create_table "ingredients", force: :cascade do |t|
     t.bigint "game_id", null: false
     t.bigint "canonical_ingredient_id"
-    t.string "name"
+    t.string "name", null: false
     t.decimal "unit_weight", precision: 5, scale: 2
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -415,7 +415,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_22_210936) do
   create_table "jewelry_items", force: :cascade do |t|
     t.bigint "game_id", null: false
     t.bigint "canonical_jewelry_item_id"
-    t.string "name"
+    t.string "name", null: false
     t.decimal "unit_weight"
     t.string "jewelry_type"
     t.string "magical_effects"


### PR DESCRIPTION
## Context

[**Add NOT NULL constraint to name attribute for all in-game items**](https://trello.com/c/R9ouYfHL/321-add-not-null-constraint-to-name-attribute-for-all-in-game-items)

In-game items are matched with canonical models first using their `name` attribute (`title` for books). There are validations for the presence of the `name`/`title` on each model, but there are some missing `NOT NULL` constraints on the database. We also would like to make sure that the `unit_weight` attribute of all canonical and in-game items has `precision: 5, scale: 2` set.

## Changes

* Migration to ensure a `NOT NULL` constraint has been added to the `name`/`title` attribute of each in-game item model
* Migration to ensure `scale: 2` and `precision: 5` on the `unit_weight` of all canonical and in-game items
* Schema updates

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~