### PR TITLE
Prevent unique canonicals from having multiple associations in the same game

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -25,6 +25,9 @@ class Book < ApplicationRecord
 
   before_validation :set_canonical_book
   before_validation :set_values_from_canonical
+  before_validation :validate_unique_canonical
+
+  DUPLICATE_MESSAGE = 'is a duplicate of a unique in-game item'
 
   def canonical_model
     canonical_book
@@ -68,6 +71,17 @@ class Book < ApplicationRecord
     self.authors = canonical_book.authors
     self.unit_weight = canonical_book.unit_weight
     self.skill_name = canonical_book.skill_name
+  end
+
+  def validate_unique_canonical
+    return unless canonical_book&.unique_item
+
+    books = canonical_book.books.where(game_id:)
+
+    return if books.count < 1
+    return if books.count == 1 && books.first == self
+
+    errors.add(:base, DUPLICATE_MESSAGE)
   end
 
   def attributes_to_match

--- a/app/models/jewelry_item.rb
+++ b/app/models/jewelry_item.rb
@@ -46,16 +46,10 @@ class JewelryItem < ApplicationRecord
   end
 
   def canonical_models
-    return [canonical_jewelry_item] if canonical_jewelry_item.present?
-
-    attrs_to_match = {
-      jewelry_type:,
-      unit_weight:,
-      magical_effects:,
-    }.compact
+    return Canonical::JewelryItem.where(id: canonical_jewelry_item_id) if canonical_jewelry_item.present?
 
     canonicals = Canonical::JewelryItem.where('name ILIKE ?', name)
-    attrs_to_match.any? ? canonicals.where(**attrs_to_match) : canonicals
+    attributes_to_match.any? ? canonicals.where(**attributes_to_match) : canonicals
   end
 
   private
@@ -98,5 +92,13 @@ class JewelryItem < ApplicationRecord
         strength: model.strength,
       )
     end
+  end
+
+  def attributes_to_match
+    {
+      jewelry_type:,
+      unit_weight:,
+      magical_effects:,
+    }.compact
   end
 end

--- a/app/validators/armor_validator.rb
+++ b/app/validators/armor_validator.rb
@@ -3,6 +3,7 @@
 class ArmorValidator < ActiveModel::Validator
   NO_CANONICAL_MATCHES = "doesn't match an armor item that exists in Skyrim"
   DOES_NOT_MATCH = 'does not match value on canonical model'
+  DUPLICATE_MATCH = 'is a duplicate of a unique in-game item'
 
   def validate(record)
     @record = record
@@ -22,8 +23,21 @@ class ArmorValidator < ActiveModel::Validator
   def validate_against_canonical
     canonical_armor = record.canonical_armor
 
+    validate_unique_canonical_match if canonical_armor.unique_item
+
     record.errors.add(:unit_weight, DOES_NOT_MATCH) unless record.unit_weight == canonical_armor.unit_weight
     record.errors.add(:weight, DOES_NOT_MATCH) unless record.weight == canonical_armor.weight
     record.errors.add(:magical_effects, DOES_NOT_MATCH) unless record.magical_effects == canonical_armor.magical_effects
+  end
+
+  def validate_unique_canonical_match
+    return unless record.canonical_armor.unique_item
+
+    armors = record.canonical_armor.armors.where(game_id: record.game_id)
+
+    return if armors.count < 1
+    return if armors.count == 1 && armors.first == record
+
+    record.errors.add(:base, DUPLICATE_MATCH)
   end
 end

--- a/app/validators/clothing_item_validator.rb
+++ b/app/validators/clothing_item_validator.rb
@@ -3,6 +3,7 @@
 class ClothingItemValidator < ActiveModel::Validator
   NO_CANONICAL_MATCHES = "doesn't match a clothing item that exists in Skyrim"
   DOES_NOT_MATCH = 'does not match value on canonical model'
+  DUPLICATE_MATCH = 'is a duplicate of a unique in-game item'
 
   def validate(record)
     @record = record
@@ -22,7 +23,23 @@ class ClothingItemValidator < ActiveModel::Validator
   def validate_against_canonical
     canonical = record.canonical_clothing_item
 
+    validate_unique_canonical
+
     record.errors.add(:unit_weight, DOES_NOT_MATCH) unless record.unit_weight == canonical.unit_weight
     record.errors.add(:magical_effects, DOES_NOT_MATCH) unless record.magical_effects == canonical.magical_effects
+  end
+
+  def validate_unique_canonical
+    return unless record.canonical_clothing_item&.unique_item
+
+    items = record
+              .canonical_clothing_item
+              .clothing_items
+              .where(game_id: record.game_id)
+
+    return if items.count < 1
+    return if items.count == 1 && items.first == record
+
+    record.errors.add(:base, DUPLICATE_MATCH)
   end
 end

--- a/docs/canonical_models/canonical-models.md
+++ b/docs/canonical_models/canonical-models.md
@@ -56,7 +56,7 @@ The `purchasable` field indicates whether an item can be purchased from a mercha
 
 #### `unique_item`
 
-The `unique_item` field is set to `true` on items that only occur at one location in the game. That location cannot be a merchant, random loot, or random drops. Items that respawn can still be considered unique if they adhere to these criteria.
+The `unique_item` field is set to `true` on items that only occur at one location in the game. That location cannot be a merchant, random loot, or random drops. When `unique_item` is set to `true` on a canonical model, SIM will prevent users from creating multiple in-game items matching that canonical model for the same associated `game`. Note that items that respawn can still be considered unique if they adhere to the criteria above. There is planned work to change this.
 
 #### `rare_item`
 

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -21,6 +21,72 @@ RSpec.describe Book, type: :model do
 
       expect(book.errors[:unit_weight]).to include 'must be greater than or equal to 0'
     end
+
+    describe 'canonical model validations' do
+      let(:book) { build(:book, canonical_book:, game:) }
+      let(:game) { create(:game) }
+
+      context 'when the canonical model is not unique' do
+        let(:canonical_book) { create(:canonical_book) }
+
+        before do
+          create_list(
+            :book,
+            3,
+            canonical_book:,
+            game:,
+          )
+        end
+
+        it 'is valid' do
+          validate
+          expect(book.errors[:base]).to be_empty
+        end
+      end
+
+      context 'when the canonical model is unique' do
+        let(:canonical_book) do
+          create(
+            :canonical_book,
+            unique_item: true,
+            rare_item: true,
+          )
+        end
+
+        context 'when the canonical model has no books' do
+          before do
+            create(:book, canonical_book:)
+          end
+
+          it 'is valid' do
+            validate
+            expect(book.errors[:base]).to be_blank
+          end
+        end
+
+        context 'when the canonical model has a book for another game' do
+          before do
+            create(:book, canonical_book:)
+          end
+
+          it 'is valid' do
+            validate
+            expect(book.errors[:base]).to be_empty
+          end
+        end
+
+        context 'when the canonical model has a book for the same game' do
+          before do
+            create(:book, canonical_book:, game:)
+          end
+
+          it 'is invalid' do
+            validate
+            expect(book.errors[:base]).to include 'is a duplicate of a unique in-game item'
+          end
+        end
+      end
+    end
   end
 
   describe '#canonical_model' do

--- a/spec/models/canonical/armor_spec.rb
+++ b/spec/models/canonical/armor_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Canonical::Armor, type: :model do
         expect(armor.errors[:weight]).to include "can't be blank"
       end
 
-      it 'is invalid with an invalid weight value' do
+      it 'is invalid with an invalid unit_weight value' do
         armor = build(:canonical_armor, weight: 'medium armor')
 
         armor.validate

--- a/spec/models/ingredient_spec.rb
+++ b/spec/models/ingredient_spec.rb
@@ -4,12 +4,14 @@ require 'rails_helper'
 
 RSpec.describe Ingredient, type: :model do
   describe 'validations' do
+    subject(:validate) { ingredient.validate }
+
     let(:ingredient) { build(:ingredient) }
 
     describe '#name' do
       it "can't be blank" do
         ingredient.name = nil
-        ingredient.validate
+        validate
         expect(ingredient.errors[:name]).to include "can't be blank"
       end
     end
@@ -17,13 +19,13 @@ RSpec.describe Ingredient, type: :model do
     describe '#unit_weight' do
       it 'can be blank' do
         ingredient.unit_weight = nil
-        ingredient.validate
+        validate
         expect(ingredient.errors[:unit_weight]).to be_empty
       end
 
       it 'must be at least 0' do
         ingredient.unit_weight = -2.7
-        ingredient.validate
+        validate
         expect(ingredient.errors[:unit_weight]).to include 'must be greater than or equal to 0'
       end
     end
@@ -50,8 +52,74 @@ RSpec.describe Ingredient, type: :model do
 
     context 'when there are no matching canonical ingredients' do
       it 'is invalid' do
-        ingredient.validate
+        validate
         expect(ingredient.errors[:base]).to include "doesn't match an ingredient that exists in Skyrim"
+      end
+    end
+
+    describe 'canonical ingredient validations' do
+      let(:ingredient) { build(:ingredient, canonical_ingredient:, game:) }
+      let(:game) { create(:game) }
+
+      context 'when the canonical ingredient is not unique' do
+        let(:canonical_ingredient) { create(:canonical_ingredient) }
+
+        before do
+          create_list(
+            :ingredient,
+            3,
+            canonical_ingredient:,
+            game:,
+          )
+        end
+
+        it 'is valid' do
+          validate
+          expect(ingredient.errors[:base]).to be_empty
+        end
+      end
+
+      context 'when the canonical ingredient is unique' do
+        let(:canonical_ingredient) do
+          create(
+            :canonical_ingredient,
+            unique_item: true,
+            rare_item: true,
+          )
+        end
+
+        context 'when the canonical ingredient has no other matches' do
+          it 'is valid' do
+            validate
+            expect(ingredient.errors[:base]).to be_empty
+          end
+        end
+
+        context 'when the canonical ingredient has another match for another game' do
+          before do
+            create(:ingredient, canonical_ingredient:)
+          end
+
+          it 'is valid' do
+            validate
+            expect(ingredient.errors[:base]).to be_empty
+          end
+        end
+
+        context 'when the canonical ingredient has another match for the same game' do
+          before do
+            create(
+              :ingredient,
+              canonical_ingredient:,
+              game:,
+            )
+          end
+
+          it 'is invalid' do
+            validate
+            expect(ingredient.errors[:base]).to include 'is a duplicate of a unique in-game item'
+          end
+        end
       end
     end
   end

--- a/spec/models/property_spec.rb
+++ b/spec/models/property_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 require 'rake'
 
 RSpec.describe Property, type: :model do
-  subject(:property) { described_class.new }
+  let(:property) { described_class.new }
 
   # rubocop:disable RSpec/BeforeAfterAll
   before(:all) do
@@ -21,6 +21,8 @@ RSpec.describe Property, type: :model do
   end
 
   describe 'validations' do
+    subject(:validate) { property.validate }
+
     let(:game) { create(:game) }
 
     before do
@@ -31,32 +33,34 @@ RSpec.describe Property, type: :model do
     end
 
     it 'is invalid without a game' do
-      property.validate
+      validate
       expect(property.errors[:game]).to include 'must exist'
     end
 
     it 'is invalid without a canonical property' do
-      property.validate
+      validate
       expect(property.errors[:base]).to include "doesn't match any ownable property that exists in Skyrim"
     end
 
     it 'must have a name' do
-      property.validate
+      validate
       expect(property.errors[:name]).to include "can't be blank"
     end
 
     it 'must have a valid name' do
-      property.validate
+      property.name = 'Camelot'
+      validate
       expect(property.errors[:name]).to include "must be an ownable property in Skyrim, or the Arch-Mage's Quarters"
     end
 
     it 'must have a hold' do
-      property.validate
+      validate
       expect(property.errors[:hold]).to include "can't be blank"
     end
 
     it 'must have a valid hold' do
-      property.validate
+      property.hold = 'Leyawiin'
+      validate
       expect(property.errors[:hold]).to include 'must be one of the nine Skyrim holds, or Solstheim'
     end
 
@@ -73,9 +77,11 @@ RSpec.describe Property, type: :model do
       property.game = game
       property.name = 'Vlindrel Hall'
       property.hold = 'The Reach'
-      property.validate
+      validate
       expect(property.errors[:game]).to include 'already has max number of ownable properties'
-      expect(Rails.logger).to have_received(:error).with('Cannot create property "Vlindrel Hall" in hold "The Reach": this game already has 10 properties')
+      expect(Rails.logger)
+        .to have_received(:error)
+              .with('Cannot create property "Vlindrel Hall" in hold "The Reach": this game already has 10 properties')
     end
 
     it 'calls the HomesteadValidator' do
@@ -84,7 +90,7 @@ RSpec.describe Property, type: :model do
               .with(property)
               .and_call_original
 
-      property.validate
+      validate
     end
 
     describe 'uniqueness' do
@@ -102,21 +108,21 @@ RSpec.describe Property, type: :model do
       it 'has a unique combination of game and canonical property' do
         property.game = game
         property.canonical_property = canonical_property
-        property.validate
+        validate
         expect(property.errors[:canonical_property]).to include 'must be unique per game'
       end
 
       it 'has a unique name per game' do
         property.game = game
         property.name = canonical_property.name
-        property.validate
+        validate
         expect(property.errors[:name]).to include 'must be unique per game'
       end
 
       it 'has a unique hold per game' do
         property.game = game
         property.hold = canonical_property.hold
-        property.validate
+        validate
         expect(property.errors[:hold]).to include 'must be unique per game'
       end
     end
@@ -128,7 +134,7 @@ RSpec.describe Property, type: :model do
         it 'cannot have an arcane enchanter' do
           property.canonical_property_id = canonical_property.id
           property.has_arcane_enchanter = true
-          property.validate
+          validate
           expect(property.errors[:has_arcane_enchanter]).to include 'cannot be true because this property cannot have an arcane enchanter in Skyrim'
         end
       end
@@ -139,14 +145,14 @@ RSpec.describe Property, type: :model do
         it 'can have an arcane enchanter' do
           property.canonical_property_id = canonical_property.id
           property.has_arcane_enchanter = true
-          property.validate
+          validate
           expect(property.errors[:has_arcane_enchanter]).to be_blank
         end
 
         it "doesn't have to have an arcane enchanter" do
           property.canonical_property_id = canonical_property.id
           property.has_arcane_enchanter = false
-          property.validate
+          validate
           expect(property.errors[:has_arcane_enchanter]).to be_blank
         end
       end
@@ -159,7 +165,7 @@ RSpec.describe Property, type: :model do
         it 'cannot have a forge' do
           property.canonical_property_id = canonical_property.id
           property.has_forge = true
-          property.validate
+          validate
           expect(property.errors[:has_forge]).to include 'cannot be true because this property cannot have a forge in Skyrim'
         end
       end
@@ -170,14 +176,14 @@ RSpec.describe Property, type: :model do
         it 'can have a forge' do
           property.canonical_property_id = canonical_property.id
           property.has_forge = true
-          property.validate
+          validate
           expect(property.errors[:has_forge]).to be_blank
         end
 
         it "doesn't have to have a forge" do
           property.canonical_property_id = canonical_property.id
           property.has_forge = false
-          property.validate
+          validate
           expect(property.errors[:has_forge]).to be_blank
         end
       end
@@ -190,7 +196,7 @@ RSpec.describe Property, type: :model do
         it 'cannot have an apiary' do
           property.canonical_property_id = canonical_property.id
           property.has_apiary = true
-          property.validate
+          validate
           expect(property.errors[:has_apiary]).to include 'cannot be true because this property cannot have an apiary in Skyrim'
         end
       end
@@ -201,14 +207,14 @@ RSpec.describe Property, type: :model do
         it 'can have an apiary' do
           property.canonical_property_id = canonical_property.id
           property.has_apiary = true
-          property.validate
+          validate
           expect(property.errors[:has_apiary]).to be_blank
         end
 
         it "doesn't have to have an apiary" do
           property.canonical_property_id = canonical_property.id
           property.has_apiary = false
-          property.validate
+          validate
           expect(property.errors[:has_apiary]).to be_blank
         end
       end
@@ -221,7 +227,7 @@ RSpec.describe Property, type: :model do
         it 'cannot have a grain mill' do
           property.canonical_property_id = canonical_property.id
           property.has_grain_mill = true
-          property.validate
+          validate
           expect(property.errors[:has_grain_mill]).to include 'cannot be true because this property cannot have a grain mill in Skyrim'
         end
       end
@@ -232,14 +238,14 @@ RSpec.describe Property, type: :model do
         it 'can have a grain mill' do
           property.canonical_property_id = canonical_property.id
           property.has_grain_mill = true
-          property.validate
+          validate
           expect(property.errors[:has_grain_mill]).to be_blank
         end
 
         it "doesn't have to have a grain mill" do
           property.canonical_property_id = canonical_property.id
           property.has_grain_mill = false
-          property.validate
+          validate
           expect(property.errors[:has_grain_mill]).to be_blank
         end
       end
@@ -252,7 +258,7 @@ RSpec.describe Property, type: :model do
         it 'cannot have a fish hatchery' do
           property.canonical_property_id = canonical_property.id
           property.has_fish_hatchery = true
-          property.validate
+          validate
           expect(property.errors[:has_fish_hatchery]).to include 'cannot be true because this property cannot have a fish hatchery in Skyrim'
         end
       end
@@ -263,14 +269,14 @@ RSpec.describe Property, type: :model do
         it 'can have a fish hatchery' do
           property.canonical_property_id = canonical_property.id
           property.has_fish_hatchery = true
-          property.validate
+          validate
           expect(property.errors[:has_fish_hatchery]).to be_blank
         end
 
         it "doesn't have to have a fish hatchery" do
           property.canonical_property_id = canonical_property.id
           property.has_fish_hatchery = false
-          property.validate
+          validate
           expect(property.errors[:has_fish_hatchery]).to be_blank
         end
       end
@@ -278,35 +284,37 @@ RSpec.describe Property, type: :model do
   end
 
   describe 'setting a canonical model' do
-    context 'when a canonical property is already assigned' do
-      subject(:property) { build(:property, name: 'Vlindrel Hall', canonical_property:) }
+    subject(:validate) { property.validate }
 
+    context 'when a canonical property is already assigned' do
+      let(:property) { build(:property, name: 'Vlindrel Hall', canonical_property:) }
       let(:canonical_property) { Canonical::Property.find_by(name: 'Vlindrel Hall') }
 
       it "doesn't change the canonical property" do
-        expect { property.validate }
+        expect { validate }
           .not_to change(property, :canonical_property)
       end
     end
 
     context 'when there is a matching canonical property' do
-      subject(:property) { build(:property, name: 'vlindrel hall') }
-
+      let(:property) { build(:property, name: 'vlindrel hall') }
       let!(:canonical_property) { Canonical::Property.find_by(name: 'Vlindrel Hall') }
 
       it 'sets the canonical property', :aggregate_failures do
-        property.validate
+        validate
         expect(property.canonical_property).to eq canonical_property
       end
     end
   end
 
   describe 'setting values from the canonical model' do
+    subject(:validate) { property.validate }
+
     context 'when a canonical model is present' do
-      subject(:property) { build(:property, name: 'hjerim') }
+      let(:property) { build(:property, name: 'hjerim') }
 
       it 'sets the property name, city, and hold', :aggregate_failures do
-        property.validate
+        validate
         expect(property.name).to eq 'Hjerim'
         expect(property.city).to eq 'Windhelm'
         expect(property.hold).to eq 'Eastmarch'

--- a/spec/models/staff_spec.rb
+++ b/spec/models/staff_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Staff, type: :model do
 
     let(:staff) { build(:staff) }
 
-    describe 'name' do
+    describe '#name' do
       it 'is invalid without a name' do
         staff.name = nil
         validate
@@ -16,7 +16,7 @@ RSpec.describe Staff, type: :model do
       end
     end
 
-    describe 'unit_weight' do
+    describe '#unit_weight' do
       it 'is invalid with a negative unit weight' do
         staff.unit_weight = -2
         validate
@@ -30,7 +30,66 @@ RSpec.describe Staff, type: :model do
       end
     end
 
-    describe 'canonical_staff' do
+    describe '#canonical_staff' do
+      let(:staff) { build(:staff, canonical_staff:, game:) }
+      let(:game) { create(:game) }
+
+      context 'when the canonical staff is not unique' do
+        let(:canonical_staff) { create(:canonical_staff) }
+
+        before do
+          create_list(
+            :staff,
+            3,
+            canonical_staff:,
+            game:,
+          )
+        end
+
+        it 'is valid' do
+          expect(staff).to be_valid
+        end
+      end
+
+      context 'when the canonical staff is unique' do
+        let(:canonical_staff) do
+          create(
+            :canonical_staff,
+            unique_item: true,
+            rare_item: true,
+          )
+        end
+
+        context 'when there are no other matches for the canonical staff' do
+          it 'is valid' do
+            expect(staff).to be_valid
+          end
+        end
+
+        context 'when the canonical staff has other matches in another game' do
+          before do
+            create(:staff, canonical_staff:)
+          end
+
+          it 'is valid' do
+            expect(staff).to be_valid
+          end
+        end
+
+        context 'when the canonical staff has other matches in the same game' do
+          before do
+            create(:staff, canonical_staff:, game:)
+          end
+
+          it 'is invalid' do
+            validate
+            expect(staff.errors[:base]).to include 'is a duplicate of a unique in-game item'
+          end
+        end
+      end
+    end
+
+    describe '#canonical_models' do
       context 'when there is a canonical_staff associated' do
         let(:staff) { create(:staff, :with_matching_canonical) }
 

--- a/spec/support/factories/armors.rb
+++ b/spec/support/factories/armors.rb
@@ -11,5 +11,9 @@ FactoryBot.define do
         create_list(:enchantables_enchantment, 2, enchantable: armor)
       end
     end
+
+    trait :with_matching_canonical do
+      association :canonical_armor, strategy: :create
+    end
   end
 end

--- a/spec/validators/armor_validator_spec.rb
+++ b/spec/validators/armor_validator_spec.rb
@@ -78,6 +78,68 @@ RSpec.describe ArmorValidator do
         expect(armor.errors[:magical_effects]).to include 'does not match value on canonical model'
       end
     end
+
+    context 'when the canonical model is not unique' do
+      let(:armor) { build(:armor, canonical_armor:, game:) }
+      let(:game) { create(:game) }
+      let(:canonical_armor) { create(:canonical_armor) }
+
+      before do
+        create_list(
+          :armor,
+          3,
+          canonical_armor:,
+          game:,
+        )
+      end
+
+      it 'is valid' do
+        validate
+        expect(armor.errors[:base]).to be_blank
+      end
+    end
+
+    context 'when the canonical model is unique' do
+      let(:armor) { build(:armor, canonical_armor:, game:) }
+      let(:game) { create(:game) }
+
+      let(:canonical_armor) do
+        create(
+          :canonical_armor,
+          unique_item: true,
+          rare_item: true,
+        )
+      end
+
+      context "when this is the canonical model's only association for this game" do
+        it 'is valid' do
+          validate
+          expect(armor.errors[:base]).to be_blank
+        end
+      end
+
+      context 'when the canonical model has a second association for another game' do
+        before do
+          create(:armor, canonical_armor:)
+        end
+
+        it 'is valid' do
+          validate
+          expect(armor.errors[:base]).to be_blank
+        end
+      end
+
+      context 'when the canonical model has a second association for the same game' do
+        before do
+          create(:armor, canonical_armor:, game:)
+        end
+
+        it 'is invalid' do
+          validate
+          expect(armor.errors[:base]).to include 'is a duplicate of a unique in-game item'
+        end
+      end
+    end
   end
 
   context 'when there are multiple matching canonical armors' do

--- a/spec/validators/clothing_item_validator_spec.rb
+++ b/spec/validators/clothing_item_validator_spec.rb
@@ -66,4 +66,57 @@ RSpec.describe ClothingItemValidator do
       expect(item).to be_valid
     end
   end
+
+  describe 'canonical clothing item validations' do
+    let(:item) { build(:clothing_item, canonical_clothing_item:, game:) }
+    let(:game) { create(:game) }
+
+    context 'when the canonical model is not unique' do
+      let(:canonical_clothing_item) { create(:canonical_clothing_item) }
+
+      it 'is valid' do
+        validate
+        expect(item.errors[:base]).to be_empty
+      end
+    end
+
+    context 'when the canonical model is unique' do
+      let(:canonical_clothing_item) do
+        create(
+          :canonical_clothing_item,
+          unique_item: true,
+          rare_item: true,
+        )
+      end
+
+      context 'when the canonical model has no other clothing items for this game' do
+        it 'is valid' do
+          validate
+          expect(item.errors[:base]).to be_empty
+        end
+      end
+
+      context 'when the canonical model has another clothing item for a different game' do
+        before do
+          create(:clothing_item, canonical_clothing_item:)
+        end
+
+        it 'is valid' do
+          item.validate
+          expect(item.errors[:base]).to be_empty
+        end
+      end
+
+      context 'when the canonical model has another clothing item for the same game' do
+        before do
+          create(:clothing_item, canonical_clothing_item:, game:)
+        end
+
+        it 'is invalid' do
+          validate
+          expect(item.errors[:base]).to include 'is a duplicate of a unique in-game item'
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

[**Prevent unique canonicals from having multiple associations in the same game**](https://trello.com/c/NzCjnIVC/328-prevent-unique-canonicals-from-having-multiple-associations-in-the-same-game)

Most of our canonical models have a boolean field called `unique_item`. If this field is set to `true`, there is only one instance of the item in the game. We want to prevent users from creating multiple instances of unique items in SIM.

## Changes

* Prevent users from creating multiples of `unique_item`s for the same `game` in SIM
* Add tests for new behaviour
* Update docs
* Miscellaneous minor cleanup/refactors

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

There is still the troubling issue of unique items that respawn. Respawning items should really not be considered unique. There is a [card](https://trello.com/c/x5bBR50K/342-dont-consider-respawning-items-unique) to change this.
