### PR TITLE
Add NOT NULL constraint to effect_type on alchemical properties

### DIFF
--- a/db/migrate/20231101224647_add_not_null_constraint_to_effect_type_on_alchemical_properties.rb
+++ b/db/migrate/20231101224647_add_not_null_constraint_to_effect_type_on_alchemical_properties.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddNotNullConstraintToEffectTypeOnAlchemicalProperties < ActiveRecord::Migration[7.1]
+  def change
+    change_column_null :alchemical_properties, :effect_type, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_01_220130) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_01_224647) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,7 +21,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_01_220130) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "description", null: false
-    t.string "effect_type"
+    t.string "effect_type", null: false
     t.index ["name"], name: "index_alchemical_properties_on_name", unique: true
   end
 


### PR DESCRIPTION
## Context

[**Remove potion_type field from Canonical::Potion**](https://trello.com/c/JPj2WxPA/322-remove-potiontype-field-from-canonicalpotion)

In #222 we added a column, `effect_type`, to the `alchemical_properties` table and updated canonical JSON data for the backfill. We want this column to be `NOT NULL`, but it wasn't possible to add a constraint in that PR due to the fact the backfill hadn't run yet.

## Changes

* Migration to add a `NOT NULL` constraint to the `effect_type` column on the `alchemical_properties` table

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~