### PR TITLE
Remove strength_modifier and duration_modifier from IngredientsAlchemicalProperty model

### DIFF
--- a/app/models/ingredients_alchemical_property.rb
+++ b/app/models/ingredients_alchemical_property.rb
@@ -20,12 +20,6 @@ class IngredientsAlchemicalProperty < ApplicationRecord
               less_than_or_equal_to: 4,
               only_integer: true,
             }
-  validates :strength_modifier,
-            allow_blank: true,
-            numericality: { greater_than: 0 }
-  validates :duration_modifier,
-            allow_blank: true,
-            numericality: { greater_than: 0 }
   validate :ensure_match_exists
   validate :ensure_max_of_four_per_ingredient
 
@@ -48,6 +42,18 @@ class IngredientsAlchemicalProperty < ApplicationRecord
     end
   end
 
+  def strength_modifier
+    return if canonical_model.blank?
+
+    canonical_model.strength_modifier || 1
+  end
+
+  def duration_modifier
+    return if canonical_model.blank?
+
+    canonical_model.duration_modifier || 1
+  end
+
   private
 
   def ensure_max_of_four_per_ingredient
@@ -66,8 +72,6 @@ class IngredientsAlchemicalProperty < ApplicationRecord
     return if canonical_model.nil?
 
     self.priority = canonical_model.priority
-    self.strength_modifier = canonical_model.strength_modifier
-    self.duration_modifier = canonical_model.duration_modifier
   end
 
   def ensure_match_exists
@@ -80,8 +84,6 @@ class IngredientsAlchemicalProperty < ApplicationRecord
     {
       alchemical_property_id:,
       ingredient_id: canonical_ingredients.ids,
-      strength_modifier:,
-      duration_modifier:,
       priority:,
     }.compact
   end

--- a/db/migrate/20231102193432_remove_strength_modifier_and_duration_modifier_from_ingredients_alchemical_properties.rb
+++ b/db/migrate/20231102193432_remove_strength_modifier_and_duration_modifier_from_ingredients_alchemical_properties.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RemoveStrengthModifierAndDurationModifierFromIngredientsAlchemicalProperties < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :ingredients_alchemical_properties, :strength_modifier, :decimal
+    remove_column :ingredients_alchemical_properties, :duration_modifier, :decimal
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_01_224647) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_02_193432) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -378,8 +378,6 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_01_224647) do
     t.bigint "ingredient_id", null: false
     t.bigint "alchemical_property_id", null: false
     t.integer "priority"
-    t.decimal "strength_modifier"
-    t.decimal "duration_modifier"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["alchemical_property_id", "ingredient_id"], name: "index_ingredients_alc_properties_on_property_and_ingr_ids", unique: true

--- a/docs/in_game_items/ingredients-alchemical-property.md
+++ b/docs/in_game_items/ingredients-alchemical-property.md
@@ -14,6 +14,10 @@ The value of `priority` on a model must be unique for its associated `Ingredient
 
 ## Matching Canonical Models
 
-Unlike primary in-game items, these join models do not have a direct association to their corresponding canonical models. They do, however, have a `#canonical_models` method that returns all `Canonical::IngredientAlchemicalProperty` models that match their `priority`, `strength_modifier`, and `duration_modifier` values (at least, any of these values that are defined on the non-canonical model). On each save, validations ensure that at least one matching canonical model exists.
+Unlike primary in-game items, these join models do not have a direct association to their corresponding canonical models. They do, however, have a `#canonical_models` method that returns all `Canonical::IngredientAlchemicalProperty` models that match their `priority` value. On each save, validations ensure that at least one matching canonical model exists.
 
-If a there is exactly one matching canonical model, a `before_validation` hook sets the `priority`, `strength_modifier`, and `duration_modifier` values to match it on each save.
+If a there is exactly one matching canonical model, a `before_validation` hook sets the `priority` value to match it on each save.
+
+## Strength and Duration Modifiers
+
+While the `Canonical::IngredientsAlchemicalProperty` model has `strength_modifier` and `duration_modifier` fields, these fields represent values invisible to players and therefore are not present on the `IngredientsAlchemicalProperty` model. However, these models do have `#strength_modifier` and `#duration_modifier` methods. These methods return `nil` if there are multiple matching canonical models. If there is a single canonical model, the methods return its `strength_modifier` or `duration_modifier`, or `1` if these are blank.

--- a/spec/support/factories/ingredients.rb
+++ b/spec/support/factories/ingredients.rb
@@ -15,10 +15,12 @@ FactoryBot.define do
     end
 
     factory :ingredient_with_matching_canonical do
-      canonical_ingredient
+      association :canonical_ingredient, strategy: :create
 
       trait :with_associations do
-        association :canonical_ingredient, factory: %i[canonical_ingredient with_alchemical_properties]
+        association :canonical_ingredient,
+                    factory: %i[canonical_ingredient with_alchemical_properties],
+                    strategy: :create
       end
 
       trait :with_associations_and_properties do
@@ -29,7 +31,8 @@ FactoryBot.define do
             create(
               :ingredients_alchemical_property,
               ingredient: model,
-              **join_model.attributes.except('ingredient_id', 'created_at', 'updated_at'),
+              alchemical_property: join_model.alchemical_property,
+              priority: join_model.priority,
             )
           end
         end


### PR DESCRIPTION
## Context

[**Remove strength_modifier and duration_modifier from non-canonical IngredientsAlchemicalProperty model**](https://trello.com/c/Qxnqde8s/326-remove-strengthmodifier-and-durationmodifier-from-non-canonical-ingredientsalchemicalproperty-model)

The `Canonical::IngredientsAlchemicalProperty` model has two fields, `strength_modifier` and `duration_modifier`. These indicate the impact of that ingredient on the strength or duration of the effects of potions with that alchemical property. These values are not visible to players, nor are they necessary to uniquely identify any model in the canonical data. For that reason, they shouldn't exist on the non-canonical `IngredientsAlchemicalProperty` model. However, they do.

This PR removes `strength_modifer` and `duration_modifier` from the `ingredients_alchemical_properties` table and replaces them with methods that pull the value from the canonical model, if one can be clearly identified. If there are multiple canonical matches, the methods return `nil`. If there is a canonical model but the `strength_modifier`/`duration_modifier` is `nil`, the value returned will be `1`, since the default multiplier on potion effects is 1.

## Changes

* Remove `strength_modifier` and `duration_modifier` from the `ingredients_alchemical_properties` table
* Add `#strength_modifier` and `#duration_modifier` methods to the model
* Tests for new behaviour
* Docs

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate
