### PR TITLE
Format code better and rename method

### DIFF
--- a/app/models/canonical/ingredients_alchemical_property.rb
+++ b/app/models/canonical/ingredients_alchemical_property.rb
@@ -7,7 +7,11 @@ module Canonical
     belongs_to :alchemical_property
     belongs_to :ingredient, class_name: 'Canonical::Ingredient'
 
-    validates :alchemical_property_id, uniqueness: { scope: :ingredient_id, message: 'must form a unique combination with canonical ingredient' }
+    validates :alchemical_property_id,
+              uniqueness: {
+                scope: :ingredient_id,
+                message: 'must form a unique combination with canonical ingredient',
+              }
     validates :priority,
               allow_blank: true,
               uniqueness: { scope: :ingredient_id, message: 'must be unique per ingredient' },
@@ -18,13 +22,13 @@ module Canonical
               }
     validates :strength_modifier, allow_blank: true, numericality: { greater_than: 0 }
     validates :duration_modifier, allow_blank: true, numericality: { greater_than: 0 }
-    validate :ensure_max_of_four_per_ingredient
+    validate :ensure_max_per_ingredient
 
     MAX_PER_INGREDIENT = 4
 
     private
 
-    def ensure_max_of_four_per_ingredient
+    def ensure_max_per_ingredient
       return if ingredient.alchemical_properties.length < MAX_PER_INGREDIENT
       return if persisted? &&
         !ingredient_id_changed? &&

--- a/app/models/canonical/potions_alchemical_property.rb
+++ b/app/models/canonical/potions_alchemical_property.rb
@@ -24,7 +24,5 @@ module Canonical
                 only_integer: true,
                 allow_blank: true,
               }
-
-    MAX_PER_POTION = 4
   end
 end

--- a/app/models/canonical/potions_alchemical_property.rb
+++ b/app/models/canonical/potions_alchemical_property.rb
@@ -7,8 +7,24 @@ module Canonical
     belongs_to :alchemical_property
     belongs_to :potion, class_name: 'Canonical::Potion'
 
-    validates :alchemical_property_id, uniqueness: { scope: :potion_id, message: 'must form a unique combination with canonical potion' }
-    validates :strength, numericality: { greater_than: 0, only_integer: true, allow_blank: true }
-    validates :duration, numericality: { greater_than: 0, only_integer: true, allow_blank: true }
+    validates :alchemical_property_id,
+              uniqueness: {
+                scope: :potion_id,
+                message: 'must form a unique combination with canonical potion',
+              }
+    validates :strength,
+              numericality: {
+                greater_than: 0,
+                only_integer: true,
+                allow_blank: true,
+              }
+    validates :duration,
+              numericality: {
+                greater_than: 0,
+                only_integer: true,
+                allow_blank: true,
+              }
+
+    MAX_PER_POTION = 4
   end
 end

--- a/app/models/ingredients_alchemical_property.rb
+++ b/app/models/ingredients_alchemical_property.rb
@@ -21,7 +21,7 @@ class IngredientsAlchemicalProperty < ApplicationRecord
               only_integer: true,
             }
   validate :ensure_match_exists
-  validate :ensure_max_of_four_per_ingredient
+  validate :ensure_max_per_ingredient
 
   before_validation :set_attributes_from_canonical, if: -> { canonical_model.present? }
 
@@ -56,7 +56,7 @@ class IngredientsAlchemicalProperty < ApplicationRecord
 
   private
 
-  def ensure_max_of_four_per_ingredient
+  def ensure_max_per_ingredient
     return if ingredient.alchemical_properties.length < Canonical::IngredientsAlchemicalProperty::MAX_PER_INGREDIENT
     return if persisted? &&
       !ingredient_id_changed? &&


### PR DESCRIPTION
## Context

I was originally working on ensuring potions can have no more than 4 alchemical properties. However, I realised this work was likely not necessary. By that point, I had already made some small changes, cleaning up code formatting to reduce line length in a couple places and renaming a method in two classes whose name directly referenced a constant value.

## Changes

* Change code formatting to make shorter lines
* Rename `ensure_max_of_four_per_ingredient` methods to `ensure_max_per_ingredient` to avoid naming value set in a constant

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~