### PR TITLE
Ensure no more than 4 alchemical effects per potion

### DIFF
--- a/app/models/canonical/potions_alchemical_property.rb
+++ b/app/models/canonical/potions_alchemical_property.rb
@@ -24,5 +24,23 @@ module Canonical
                 only_integer: true,
                 allow_blank: true,
               }
+
+    validate :ensure_max_per_potion
+
+    MAX_PER_POTION = 4
+
+    private
+
+    def ensure_max_per_potion
+      return if potion.alchemical_properties.length < MAX_PER_POTION
+      return if persisted? &&
+        !potion_id_changed? &&
+        potion.alchemical_properties.length == MAX_PER_POTION
+
+      errors.add(
+        :potion,
+        "can have a maximum of #{MAX_PER_POTION} effects",
+      )
+    end
   end
 end

--- a/app/models/potions_alchemical_property.rb
+++ b/app/models/potions_alchemical_property.rb
@@ -21,4 +21,22 @@ class PotionsAlchemicalProperty < ApplicationRecord
               only_integer: true,
               allow_nil: true,
             }
+
+  validate :ensure_max_per_potion
+
+  MAX_PER_POTION = Canonical::PotionsAlchemicalProperty::MAX_PER_POTION
+
+  private
+
+  def ensure_max_per_potion
+    return if potion.alchemical_properties.length < MAX_PER_POTION
+    return if persisted? &&
+      !potion_id_changed? &&
+      potion.alchemical_properties.length == MAX_PER_POTION
+
+    errors.add(
+      :potion,
+      "can have a maximum of #{MAX_PER_POTION} effects",
+    )
+  end
 end

--- a/docs/in_game_items/potion.md
+++ b/docs/in_game_items/potion.md
@@ -10,4 +10,4 @@ When a `Potion` is created, it is then matched to a subset of canonical potions 
 
 ## The `PotionsAlchemicalProperty` Join Model
 
-The `Potion` model is associated to the `AlchemicalProperty` model via the `PotionsAlchemicalProperty` join model. This model has [its own docs](/docs/in_game_items/potions-alchemical-property.md) but it is worth mentioning here as well. The join table contains attributes about the integer `strength` and `duration` of the property in that potion.
+The `Potion` model is associated to the `AlchemicalProperty` model via the `PotionsAlchemicalProperty` join model. This model has [its own docs](/docs/in_game_items/potions-alchemical-property.md) but it is worth mentioning here as well. The join table contains attributes about the integer `strength` and `duration` of the property in that potion. There is a validation on the join model ensuring that no potion can have more than 4 alchemical effects.

--- a/spec/models/canonical/potion_spec.rb
+++ b/spec/models/canonical/potion_spec.rb
@@ -110,7 +110,15 @@ RSpec.describe Canonical::Potion, type: :model do
       let(:alchemical_property) { create(:alchemical_property) }
 
       before do
-        potion.canonical_potions_alchemical_properties.create!(alchemical_property:, strength: 15, duration: 30)
+        potion
+          .canonical_potions_alchemical_properties
+          .create!(
+            alchemical_property:,
+            strength: 15,
+            duration: 30,
+          )
+
+        potion.reload
       end
 
       it 'returns the alchemical property' do

--- a/spec/models/canonical/potions_alchemical_property_spec.rb
+++ b/spec/models/canonical/potions_alchemical_property_spec.rb
@@ -71,5 +71,45 @@ RSpec.describe Canonical::PotionsAlchemicalProperty, type: :model do
         expect(model.errors[:duration]).to include 'must be greater than 0'
       end
     end
+
+    describe 'maximum number per potion' do
+      let(:potion) { create(:canonical_potion) }
+
+      context 'when there are fewer than 4' do
+        before do
+          create_list(
+            :canonical_potions_alchemical_property,
+            3,
+            potion:,
+          )
+
+          potion.reload
+        end
+
+        it 'is valid' do
+          model = build(:canonical_potions_alchemical_property, potion:)
+          expect(model).to be_valid
+        end
+      end
+
+      context 'when there are already 4' do
+        before do
+          create_list(
+            :canonical_potions_alchemical_property,
+            4,
+            potion:,
+          )
+
+          potion.reload
+        end
+
+        it 'is invalid' do
+          model = build(:canonical_potions_alchemical_property, potion:)
+          model.validate
+
+          expect(model.errors[:potion]).to include 'can have a maximum of 4 effects'
+        end
+      end
+    end
   end
 end

--- a/spec/models/potion_spec.rb
+++ b/spec/models/potion_spec.rb
@@ -195,6 +195,8 @@ RSpec.describe Potion, type: :model do
               strength: nil,
               duration: nil,
             )
+
+            potion.reload
           end
 
           it 'includes only matching models whose association strength and duration are also nil' do
@@ -230,6 +232,8 @@ RSpec.describe Potion, type: :model do
               strength: 16,
               duration: nil,
             )
+
+            potion.reload
           end
 
           it 'includes only models whose association duration is also nil' do
@@ -265,6 +269,8 @@ RSpec.describe Potion, type: :model do
               strength: 16,
               duration: 30,
             )
+
+            potion.reload
           end
 
           it 'includes only models whose association duration is also nil' do
@@ -300,6 +306,8 @@ RSpec.describe Potion, type: :model do
               strength: 16,
               duration: 30,
             )
+
+            potion.reload
           end
 
           it 'includes only models that fully match' do

--- a/spec/models/potions_alchemical_property_spec.rb
+++ b/spec/models/potions_alchemical_property_spec.rb
@@ -88,5 +88,44 @@ RSpec.describe PotionsAlchemicalProperty, type: :model do
           .to include 'must be greater than 0'
       end
     end
+
+    describe 'alchemical effects' do
+      let(:potion) { create(:potion) }
+      let(:model) { build(:potions_alchemical_property, potion:) }
+
+      context 'when the potion has fewer than 4 effects' do
+        before do
+          create_list(
+            :potions_alchemical_property,
+            3,
+            potion:,
+          )
+
+          potion.reload
+        end
+
+        it 'is valid' do
+          expect(model).to be_valid
+        end
+      end
+
+      context 'when the potion already has 4 or more effects' do
+        before do
+          create_list(
+            :potions_alchemical_property,
+            4,
+            potion:,
+          )
+
+          potion.reload
+        end
+
+        it 'is invalid' do
+          model.validate
+
+          expect(model.errors[:potion]).to include 'can have a maximum of 4 effects'
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

[**Ensure no more than 4 alchemical properties per potion**](https://trello.com/c/fjIrjlQb/325-ensure-no-more-than-4-alchemical-properties-per-potion)

Potions in Skyrim, whether user-created or backed by a canonical model, cannot have more than 4 alchemical effects. Canonical potions also never have more than 4 effects in the unmodded game.  We want to add validations to make sure that these models can't be associated to more than 4 alchemical properties.

## Changes

* Add validation to `Canonical::PotionsAlchemicalProperty` ensuring a max of 4 can be created per potion
* Add validation to `PotionsAlchemicalProperty` ensuring a max of 4 can be created per potion
* Test new validations
* Add line to docs

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate
