### PR TITLE
Rematch canonical book if changed attributes lead to a different match

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -34,7 +34,7 @@ class Book < ApplicationRecord
   end
 
   def canonical_models
-    return Canonical::Book.where(id: canonical_book_id) if canonical_book_id.present?
+    return Canonical::Book.where(id: canonical_book_id) if canonical_model_matches?
 
     canonicals = Canonical::Book.where('title ILIKE :title OR :title ILIKE ANY(title_variants)', title:)
     canonicals = canonicals.where(**attributes_to_match) if attributes_to_match.any?
@@ -82,6 +82,15 @@ class Book < ApplicationRecord
     return if books.count == 1 && books.first == self
 
     errors.add(:base, DUPLICATE_MATCH)
+  end
+
+  def canonical_model_matches?
+    return false if canonical_model.nil?
+    return false unless title.casecmp(canonical_model.title).zero?
+    return false unless unit_weight.nil? || unit_weight == canonical_model.unit_weight
+    return false unless skill_name.nil? || skill_name == canonical_model.skill_name
+
+    true
   end
 
   def attributes_to_match

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -105,14 +105,6 @@ RSpec.describe Book, type: :model do
   describe '#canonical_models' do
     subject(:canonical_models) { book.canonical_models }
 
-    context 'when there is a canonical book assigned' do
-      let(:book) { build(:book, :with_matching_canonical) }
-
-      it 'returns the canonical book' do
-        expect(canonical_models).to contain_exactly(book.canonical_book)
-      end
-    end
-
     context 'when there is a single matching canonical model' do
       let(:book) { build(:book, title: 'foo', unit_weight: 2) }
 
@@ -137,6 +129,28 @@ RSpec.describe Book, type: :model do
 
       it 'includes all matching canonicals' do
         expect(canonical_models).to contain_exactly(Canonical::Book.first, Canonical::Book.last)
+      end
+    end
+
+    context 'when the matching canonical changes' do
+      let(:book) { create(:book, :with_matching_canonical) }
+
+      let!(:new_canonical) do
+        create(
+          :canonical_book,
+          title: 'Black Book: Epistolary Acumen',
+          unit_weight: 1,
+          book_type: 'Black Book',
+          authors: ['The Transparent One'],
+        )
+      end
+
+      it 'identifies the new canonical model' do
+        book.title = 'Black book: epistolary acumen'
+        book.unit_weight = nil
+        book.authors = ['The Transparent One']
+
+        expect(canonical_models).to contain_exactly(new_canonical)
       end
     end
 


### PR DESCRIPTION
## Context

[**Revisit conditional assignment of canonical models**](https://trello.com/c/EIdSrLs6/317-revisit-conditional-assignment-of-canonical-models)

When a `Book` model has a `Canonical::Book` associated, that `Canonical::Book` never changes. However, this isn't the behaviour we want, since the model's attributes could be changed in such a way that it no longer matches its `Canonical::Book` but does match another one. We want to make sure that, in this scenario, the `Canonical::Book` assigned changes to the one that actually matches instead of just raising validation errors.

## Changes

* Enable reassignment of `Canonical::Book` associations to `Book` models in the event attributes change or the canonical no longer matches
* Update tests

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [ ] ~~Added and updated API docs and developer docs as appropriate~~

## Related PRs

* #227 
