### PR TITLE
Rematch canonical clothing item if changed attributes lead to a different match

### DIFF
--- a/app/models/clothing_item.rb
+++ b/app/models/clothing_item.rb
@@ -34,12 +34,10 @@ class ClothingItem < ApplicationRecord
   end
 
   def canonical_models
-    return Array.wrap(canonical_clothing_item) if canonical_clothing_item
-
-    attrs_to_match = { unit_weight:, magical_effects: }.compact
+    return Canonical::ClothingItem.where(id: canonical_clothing_item_id) if canonical_model_matches?
 
     canonicals = Canonical::ClothingItem.where('name ILIKE ?', name)
-    attrs_to_match.any? ? canonicals.where(**attrs_to_match) : canonicals
+    attributes_to_match.any? ? canonicals.where(**attributes_to_match) : canonicals
   end
 
   private
@@ -64,5 +62,21 @@ class ClothingItem < ApplicationRecord
         strength: model.strength,
       )
     end
+  end
+
+  def canonical_model_matches?
+    return false if canonical_model.nil?
+    return false unless name.casecmp(canonical_model.name).zero?
+    return false unless unit_weight.nil? || unit_weight == canonical_model.unit_weight
+    return false unless magical_effects.nil? || magical_effects == canonical_model.magical_effects
+
+    true
+  end
+
+  def attributes_to_match
+    {
+      unit_weight:,
+      magical_effects:,
+    }.compact
   end
 end

--- a/app/validators/clothing_item_validator.rb
+++ b/app/validators/clothing_item_validator.rb
@@ -13,21 +13,12 @@ class ClothingItemValidator < ActiveModel::Validator
       return
     end
 
-    validate_against_canonical if @record.canonical_clothing_item.present?
+    validate_unique_canonical
   end
 
   private
 
   attr_reader :record
-
-  def validate_against_canonical
-    canonical = record.canonical_clothing_item
-
-    validate_unique_canonical
-
-    record.errors.add(:unit_weight, DOES_NOT_MATCH) unless record.unit_weight == canonical.unit_weight
-    record.errors.add(:magical_effects, DOES_NOT_MATCH) unless record.magical_effects == canonical.magical_effects
-  end
 
   def validate_unique_canonical
     return unless record.canonical_clothing_item&.unique_item

--- a/spec/models/clothing_item_spec.rb
+++ b/spec/models/clothing_item_spec.rb
@@ -179,32 +179,7 @@ RSpec.describe ClothingItem, type: :model do
   describe '#canonical_models' do
     subject(:canonical_models) { item.canonical_models }
 
-    context 'when the item has an association defined' do
-      let(:item) do
-        create(
-          :clothing_item,
-          canonical_clothing_item:,
-          name: 'Fine Clothes',
-          unit_weight: 1,
-          magical_effects: nil,
-        )
-      end
-
-      let(:canonical_clothing_item) do
-        create(
-          :canonical_clothing_item,
-          name: 'Fine Clothes',
-          unit_weight: 1,
-          magical_effects: nil,
-        )
-      end
-
-      it 'returns the associated model in an array' do
-        expect(canonical_models).to contain_exactly(canonical_clothing_item)
-      end
-    end
-
-    context 'when the item does not have an association defined' do
+    context 'when there are matching canonical models' do
       before do
         create(:canonical_clothing_item, name: 'Something Else')
       end
@@ -231,6 +206,25 @@ RSpec.describe ClothingItem, type: :model do
         it 'returns only the items for which all values match' do
           expect(canonical_models).to eq matching_canonicals
         end
+      end
+    end
+
+    context "when the matching canonical model isn't the one that's assigned" do
+      let(:item) { create(:clothing_item, :with_matching_canonical) }
+
+      let!(:new_canonical) do
+        create(
+          :canonical_clothing_item,
+          name: 'Roughspun Tunic',
+          unit_weight: 1,
+        )
+      end
+
+      it 'returns the matching canonical model' do
+        item.name = 'roughspun tunic'
+        item.unit_weight = 1
+
+        expect(canonical_models).to contain_exactly(new_canonical)
       end
     end
   end

--- a/spec/support/factories/clothing_items.rb
+++ b/spec/support/factories/clothing_items.rb
@@ -6,6 +6,10 @@ FactoryBot.define do
 
     name { 'Fine Clothes' }
 
+    trait :with_matching_canonical do
+      association :canonical_clothing_item, strategy: :create
+    end
+
     trait :with_enchantments do
       after(:create) do |item|
         create_list(:enchantables_enchantment, 2, enchantable: item)

--- a/spec/validators/clothing_item_validator_spec.rb
+++ b/spec/validators/clothing_item_validator_spec.rb
@@ -14,51 +14,6 @@ RSpec.describe ClothingItemValidator do
     end
   end
 
-  context 'when the record has a canonical model' do
-    let(:canonical_clothing_item) do
-      create(
-        :canonical_clothing_item,
-        unit_weight: 1,
-        name: 'Fine Clothes',
-        magical_effects: 'Something',
-      )
-    end
-
-    context 'when the unit weight does not match' do
-      let(:item) do
-        build(
-          :clothing_item,
-          canonical_clothing_item:,
-          name: 'Fine Clothes',
-          unit_weight: 2.5,
-          magical_effects: 'Something',
-        )
-      end
-
-      it 'sets an error' do
-        validate
-        expect(item.errors[:unit_weight]).to include 'does not match value on canonical model'
-      end
-    end
-
-    context 'when the magical effects do not match' do
-      let(:item) do
-        build(
-          :clothing_item,
-          canonical_clothing_item:,
-          name: 'Fine Clothes',
-          unit_weight: 1,
-          magical_effects: 'Nothing',
-        )
-      end
-
-      it 'sets an error' do
-        validate
-        expect(item.errors[:magical_effects]).to include 'does not match value on canonical model'
-      end
-    end
-  end
-
   context 'when there are multiple matching canonical clothing items' do
     let!(:canonicals) { create_list(:canonical_clothing_item, 2, name: item.name) }
 


### PR DESCRIPTION
## Context

[**Revisit conditional assignment of canonical models**](https://trello.com/c/EIdSrLs6/317-revisit-conditional-assignment-of-canonical-models)

If a non-canonical model's attributes change, we want to make sure that that model can be associated to a new canonical model that matches the changed attributes. Currently, if a `ClothingItem` model's attributes change when it has a canonical model assigned, the result is a validation error as it no longer matches the assigned canonical. However, if it does match another, we should simply associate it to that one instead of raising an error.

## Changes

* Enable `ClothingItem` models to change their `Canonical::ClothingItem` association when attributes change
* Update `ClothingItemValidator` to remove validations against a canonical model - it now either matches a canonical or it doesn't
* Update clothing item factory to include `:with_matching_canonical` trait
* Update tests for `ClothingItem` and `ClothingItemValidator`

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [ ] ~~Added and updated API docs and developer docs as appropriate~~

## Related PRs

* #227 
* #228 