### PR TITLE
Rematch canonical ingredient if changed attributes lead to a different match

### DIFF
--- a/app/models/ingredients_alchemical_property.rb
+++ b/app/models/ingredients_alchemical_property.rb
@@ -34,10 +34,8 @@ class IngredientsAlchemicalProperty < ApplicationRecord
   end
 
   def canonical_model
-    @canonical_model ||= begin
-      models = canonical_models
-      models.first if models.count == 1
-    end
+    models = canonical_models
+    models.first if models.count == 1
   end
 
   def strength_modifier

--- a/app/models/ingredients_alchemical_property.rb
+++ b/app/models/ingredients_alchemical_property.rb
@@ -25,8 +25,6 @@ class IngredientsAlchemicalProperty < ApplicationRecord
 
   before_validation :set_attributes_from_canonical, if: -> { canonical_model.present? }
 
-  delegate :canonical_ingredients, to: :ingredient
-
   DOES_NOT_MATCH = 'is not consistent with any ingredient that exists in Skyrim'
 
   def canonical_models
@@ -83,7 +81,7 @@ class IngredientsAlchemicalProperty < ApplicationRecord
   def attributes_to_match
     {
       alchemical_property_id:,
-      ingredient_id: canonical_ingredients.ids,
+      ingredient_id: ingredient.canonical_models.ids,
       priority:,
     }.compact
   end

--- a/spec/models/ingredient_spec.rb
+++ b/spec/models/ingredient_spec.rb
@@ -121,21 +121,28 @@ RSpec.describe Ingredient, type: :model do
     end
   end
 
-  describe '#canonical_ingredients' do
-    subject(:canonical_ingredients) { ingredient.reload.canonical_ingredients }
+  describe '#canonical_model' do
+    subject(:canonical_model) { ingredient.canonical_model }
 
-    context 'when the model has a canonical ingredient assigned' do
-      let(:ingredient) { create(:ingredient, canonical_ingredient:) }
-      let(:canonical_ingredient) { create(:canonical_ingredient) }
+    context 'when a canonical ingredient is assigned' do
+      let(:ingredient) { create(:ingredient_with_matching_canonical) }
 
-      before do
-        create(:canonical_ingredient)
-      end
-
-      it 'returns the canonical ingredient' do
-        expect(canonical_ingredients).to contain_exactly(canonical_ingredient)
+      it 'returns the canonical model' do
+        expect(canonical_model).to eq ingredient.canonical_ingredient
       end
     end
+
+    context 'when no canonical ingredient is assigned' do
+      let(:ingredient) { build(:ingredient) }
+
+      it 'returns nil' do
+        expect(canonical_model).to be_nil
+      end
+    end
+  end
+
+  describe '#canonical_models' do
+    subject(:canonical_models) { ingredient.canonical_models }
 
     context 'when there are matching canonical ingredients' do
       context 'when only the names have to match' do
@@ -143,7 +150,7 @@ RSpec.describe Ingredient, type: :model do
         let(:ingredient) { create(:ingredient, name: 'Blue Mountain Flower') }
 
         it 'returns all the matching canonical ingredients' do
-          expect(ingredient.canonical_ingredients).to eq matching_canonicals
+          expect(ingredient.canonical_models).to eq matching_canonicals
         end
       end
 
@@ -156,7 +163,7 @@ RSpec.describe Ingredient, type: :model do
         end
 
         it 'returns all the matching canonical ingredients' do
-          expect(ingredient.canonical_ingredients).to eq matching_canonicals
+          expect(ingredient.canonical_models).to eq matching_canonicals
         end
       end
 
@@ -192,10 +199,12 @@ RSpec.describe Ingredient, type: :model do
               alchemical_property:,
               priority: alchemical_property.priority,
             )
+
+            ingredient.reload
           end
 
           it 'returns the matching models' do
-            expect(canonical_ingredients).to contain_exactly(matching_canonicals.second, matching_canonicals.last)
+            expect(canonical_models).to contain_exactly(matching_canonicals.second, matching_canonicals.last)
           end
         end
 
@@ -216,10 +225,12 @@ RSpec.describe Ingredient, type: :model do
               alchemical_property:,
               priority: 4,
             )
+
+            ingredient.reload
           end
 
           it 'includes only the model that fully matches' do
-            expect(canonical_ingredients).to contain_exactly(matching_canonicals.last)
+            expect(canonical_models).to contain_exactly(matching_canonicals.last)
           end
         end
       end
@@ -229,7 +240,7 @@ RSpec.describe Ingredient, type: :model do
       let(:ingredient) { build(:ingredient) }
 
       it 'is empty' do
-        expect(ingredient.canonical_ingredients).to be_empty
+        expect(canonical_models).to be_empty
       end
     end
   end

--- a/spec/models/ingredient_spec.rb
+++ b/spec/models/ingredient_spec.rb
@@ -243,6 +243,25 @@ RSpec.describe Ingredient, type: :model do
         expect(canonical_models).to be_empty
       end
     end
+
+    context 'when the canonical model changes' do
+      let(:ingredient) { create(:ingredient_with_matching_canonical) }
+
+      let!(:new_canonical) do
+        create(
+          :canonical_ingredient,
+          name: 'Powdered Mammoth Tusk',
+          unit_weight: 0.1,
+        )
+      end
+
+      it 'returns the canonical that matches' do
+        ingredient.name = 'powdered mammoth tusk'
+        ingredient.unit_weight = 0.1
+
+        expect(canonical_models).to contain_exactly(new_canonical)
+      end
+    end
   end
 
   describe '::before_validation' do


### PR DESCRIPTION
## Context

[**Revisit conditional assignment of canonical models**](https://trello.com/c/EIdSrLs6/317-revisit-conditional-assignment-of-canonical-models)

When an `Ingredient` model is associated to a `Canonical::Ingredient`, calling `#canonical_ingredients` on the model returns the `Canonical::Ingredient` model that is already assigned, in an `ActiveRecord::Relation` object. The goal of this was to avoid expensive database lookups when there was already an assigned canonical model. However, the result is that, if an ingredient's attributes change, it results in validation errors since it is validated against the existing canonical - even if there is another canonical that matches. We want the database to be queried again if the `Ingredient` no longer matches its assigned canonical.

## Changes

* Change `#canonical_ingredients` method to be `#canonical_models` in line with other in-game item classes
* Enable associated canonical ingredient to be changed if attributes are updated
* Update `IngredientsAlchemicalProperty` model to use `ingredient.canonical_models` instead of delegating `#canonical_ingredients` to `ingredient`
* Update tests

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [ ] ~~Added and updated API docs and developer docs as appropriate~~

## Related PRs

* #227 
* #228 
* #229
