### PR TITLE
Rematch canonical jewelry item if changed attributes lead to a different match

### DIFF
--- a/db/migrate/20231105222944_remove_jewelry_type_from_jewelry_items.rb
+++ b/db/migrate/20231105222944_remove_jewelry_type_from_jewelry_items.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveJewelryTypeFromJewelryItems < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :jewelry_items, :jewelry_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_02_193432) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_05_222944) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -415,7 +415,6 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_02_193432) do
     t.bigint "canonical_jewelry_item_id"
     t.string "name", null: false
     t.decimal "unit_weight", precision: 5, scale: 2
-    t.string "jewelry_type"
     t.string "magical_effects"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/docs/in_game_items/jewelry-item.md
+++ b/docs/in_game_items/jewelry-item.md
@@ -8,7 +8,6 @@ The `JewelryItem` model represents in-game items of the `Canonical::JewelryItem`
 
 * `name`
 * `unit_weight`
-* `jewelry_type`
 * `magical_effects`
 
 ## Associations

--- a/spec/models/jewelry_item_spec.rb
+++ b/spec/models/jewelry_item_spec.rb
@@ -226,6 +226,27 @@ RSpec.describe JewelryItem, type: :model do
     end
   end
 
+  describe '#jewelry_type' do
+    subject(:jewelry_type) { item.jewelry_type }
+
+    context 'when there is a canonical jewelry item assigned' do
+      let(:item) { create(:jewelry_item, canonical_jewelry_item:) }
+      let(:canonical_jewelry_item) { create(:canonical_jewelry_item, jewelry_type: 'amulet') }
+
+      it 'returns the jewelry type of the canonical' do
+        expect(jewelry_type).to eq 'amulet'
+      end
+    end
+
+    context 'when there is no canonical jewelry item assigned' do
+      let(:item) { build(:jewelry_item) }
+
+      it 'returns nil' do
+        expect(jewelry_type).to be_nil
+      end
+    end
+  end
+
   describe '::before_validation' do
     context 'when there is a single matching canonical model' do
       let!(:matching_canonical) do

--- a/spec/models/jewelry_item_spec.rb
+++ b/spec/models/jewelry_item_spec.rb
@@ -16,20 +16,6 @@ RSpec.describe JewelryItem, type: :model do
       end
     end
 
-    describe '#jewelry_type' do
-      it 'is invalid with an invalid value' do
-        item.jewelry_type = 'necklace'
-        validate
-        expect(item.errors[:jewelry_type]).to include 'must be "ring", "circlet", or "amulet"'
-      end
-
-      it 'can be blank' do
-        item.jewelry_type = nil
-        validate
-        expect(item.errors[:jewelry_type]).to be_empty
-      end
-    end
-
     describe '#unit_weight' do
       it 'is invalid if less than 0' do
         item.unit_weight = -5
@@ -170,19 +156,7 @@ RSpec.describe JewelryItem, type: :model do
   describe '#canonical_models' do
     subject(:canonical_models) { item.canonical_models }
 
-    context 'when the item has an association defined' do
-      let(:item) { create(:jewelry_item, :with_matching_canonical) }
-
-      before do
-        create(:canonical_jewelry_item, name: item.name)
-      end
-
-      it 'includes only the associated model' do
-        expect(canonical_models).to contain_exactly(item.canonical_jewelry_item)
-      end
-    end
-
-    context 'when the item does not have an association defined' do
+    context 'when there are matching canonical models' do
       let(:item) { create(:jewelry_item, name: 'Gold diamond ring') }
 
       context 'when only the name has to match' do
@@ -218,6 +192,36 @@ RSpec.describe JewelryItem, type: :model do
         it 'returns the matching models' do
           expect(canonical_models).to contain_exactly(*matching_canonicals)
         end
+      end
+    end
+
+    context 'when there are no matching canonical models' do
+      let(:item) { build(:jewelry_item) }
+
+      it 'is empty' do
+        expect(canonical_models).to be_empty
+      end
+    end
+
+    context 'when the canonical model changes' do
+      let(:item) { create(:jewelry_item, :with_matching_canonical) }
+
+      let!(:new_canonical) do
+        create(
+          :canonical_jewelry_item,
+          name: "Neloth's Ring of Tracking",
+          jewelry_type: 'ring',
+          unit_weight: 0.3,
+          magical_effects: 'When close enough, identifies the source of the ash spawn attacks on Tel Mithryn',
+        )
+      end
+
+      it 'returns the new canonical' do
+        item.name = "Neloth's Ring of Tracking"
+        item.unit_weight = nil
+        item.magical_effects = nil
+
+        expect(canonical_models).to contain_exactly(new_canonical)
       end
     end
   end
@@ -256,7 +260,6 @@ RSpec.describe JewelryItem, type: :model do
         item.validate
         expect(item.name).to eq 'Gold Diamond Ring'
         expect(item.unit_weight).to eq 0.2
-        expect(item.jewelry_type).to eq 'ring'
         expect(item.magical_effects).to eq 'Some magical effects to differentiate'
       end
     end


### PR DESCRIPTION
## Context

[**Revisit conditional assignment of canonical models**](https://trello.com/c/EIdSrLs6/317-revisit-conditional-assignment-of-canonical-models)

Once associated to a `Canonical::JewelryItem`, a `JewelryItem` model stays associated to that canonical model forever. The purpose of this is to avoid the expensive database queries involved in identifying a canonical match. However, this results in validation errors when attributes are changed, even if they match a different canonical model. We want to rematch with a different canonical model if the current attributes don't match or if there isn't a canonical model assigned.

## Changes

* Migration to remove `jewelry_type` from `jewelry_items` table since this is defined on the canonical model
* Enable new `Canonical::JewelryItem` to be assigned if the existing association no longer matches
* Update tests

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

The decision to remove the `jewelry_type` attribute was twofold. Firstly, I realised that the `jewelry_type` was redundant on the non-canonical `JewelryItem` model, in that it can always be delegated to the canonical model if there is one. This attribute is never required to uniquely match a jewelry item. In fact, all `Canonical::JewelryItem` models currently in the production database with duplicate `name` attributes ("Gauldur Amulet Fragment", "Circlet of Extreme Magicka") also have duplicate `jewelry_type` attributes. Secondly, I was having a strange issue where, if I called `jewelry_item.jewelry_type = 'ring'`, Byebug would reveal that, in the code, the value was `"[\"ring\", nil]"` (note the outer quotes - this is a string that looks like an array). Investigations came up empty as far as possible reasons for this, so, since we didn't need the field anyway, I opted to remove it.

## Related PRs

* #227 
* #228 
* #229 
* #230 
