### PR TITLE
Rematch canonical misc item if changed attributes lead to a different match

### DIFF
--- a/app/models/misc_item.rb
+++ b/app/models/misc_item.rb
@@ -18,9 +18,12 @@ class MiscItem < ApplicationRecord
   DUPLICATE_MATCH = 'is a duplicate of a unique in-game item'
   DOES_NOT_MATCH = "doesn't match any item that exists in Skyrim"
 
+  def canonical_model
+    canonical_misc_item
+  end
+
   def canonical_models
-    return [] if name.blank?
-    return [canonical_misc_item] if canonical_misc_item.present?
+    return Canonical::MiscItem.where(id: canonical_misc_item_id) if canonical_model_matches?
 
     canonicals = Canonical::MiscItem.where('name ILIKE ?', name)
 
@@ -69,6 +72,14 @@ class MiscItem < ApplicationRecord
     return if items.count == 1 && items.first == self
 
     errors.add(:base, DUPLICATE_MATCH)
+  end
+
+  def canonical_model_matches?
+    return false if canonical_model.nil?
+    return false unless name.casecmp(canonical_model.name).zero?
+    return false unless unit_weight.nil? || unit_weight == canonical_model.unit_weight
+
+    true
   end
 
   def attributes_to_match

--- a/spec/models/misc_item_spec.rb
+++ b/spec/models/misc_item_spec.rb
@@ -128,19 +128,7 @@ RSpec.describe MiscItem, type: :model do
   describe '#canonical_models' do
     subject(:canonical_models) { item.canonical_models }
 
-    context 'when the item has an association defined' do
-      let(:item) { create(:misc_item, :with_matching_canonical) }
-
-      before do
-        create(:canonical_misc_item, name: item.name)
-      end
-
-      it 'includes only the associated model' do
-        expect(canonical_models).to contain_exactly(item.canonical_misc_item)
-      end
-    end
-
-    context 'when the item does not have an association defined' do
+    context 'when there are matching canonical models' do
       let(:item) { create(:misc_item, name: 'Wedding Ring') }
 
       context 'when only the name has to match' do
@@ -176,6 +164,34 @@ RSpec.describe MiscItem, type: :model do
         it 'returns the matching models' do
           expect(canonical_models).to contain_exactly(*matching_canonicals)
         end
+      end
+    end
+
+    context 'when there are no matching canonical models' do
+      let(:item) { build(:misc_item) }
+
+      it 'returns an empty ActiveRecord::Relation', :aggregate_failures do
+        expect(canonical_models).to be_an ActiveRecord::Relation
+        expect(canonical_models).to be_empty
+      end
+    end
+
+    context 'when the canonical model changes' do
+      let(:item) { create(:misc_item, :with_matching_canonical) }
+
+      let!(:new_canonical) do
+        create(
+          :canonical_misc_item,
+          name: 'Jeweled Flagon',
+          unit_weight: 0,
+        )
+      end
+
+      it 'returns the canonical that matches' do
+        item.name = 'jeweled flagon'
+        item.unit_weight = 0
+
+        expect(canonical_models).to contain_exactly(new_canonical)
       end
     end
   end

--- a/spec/models/misc_item_spec.rb
+++ b/spec/models/misc_item_spec.rb
@@ -125,6 +125,26 @@ RSpec.describe MiscItem, type: :model do
     end
   end
 
+  describe '#canonical_model' do
+    subject(:canonical_model) { item.canonical_model }
+
+    context 'when there is a canonical misc item assigned' do
+      let(:item) { build(:misc_item, :with_matching_canonical) }
+
+      it 'returns the canonical misc item' do
+        expect(canonical_model).to eq item.canonical_misc_item
+      end
+    end
+
+    context 'when there is no canonical misc item assigned' do
+      let(:item) { build(:misc_item) }
+
+      it 'returns nil' do
+        expect(canonical_model).to be_nil
+      end
+    end
+  end
+
   describe '#canonical_models' do
     subject(:canonical_models) { item.canonical_models }
 


### PR DESCRIPTION
## Context

[**Revisit conditional assignment of canonical models**](https://trello.com/c/EIdSrLs6/317-revisit-conditional-assignment-of-canonical-models)

Currently, if a `Canonical::MiscItem` is associated to a `MiscItem`, it stays associated even if the attributes of the in-game item change. This was intended to prevent expensive database queries if a canonical model is already assigned. However, it results in a lot of validation errors when attributes are changed to those that match a different canonical. Instead, we should enable the canonical to be changed and only raise validation errors if there are no canonicals that match.

## Changes

* Enable `MiscItem`s to get a new `Canonical::MiscItem` if changed attributes lead to a different match
* Update tests

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [ ] ~~Added and updated API docs and developer docs as appropriate~~

## Related PRs

* #227 
* #228 
* #229 
* #230 
* #231 
