### PR TITLE
Rematch canonical potion if changed attributes lead to a different match

### DIFF
--- a/app/models/potion.rb
+++ b/app/models/potion.rb
@@ -38,12 +38,19 @@ class Potion < ApplicationRecord
   private
 
   def set_canonical_potion
-    return unless canonical_models.count == 1
+    unless canonical_models.count == 1
+      clear_canonical_potion
+      return
+    end
 
     self.canonical_potion = canonical_models.first
     self.name = canonical_potion.name
     self.unit_weight = canonical_potion.unit_weight
     self.magical_effects = canonical_potion.magical_effects
+  end
+
+  def clear_canonical_potion
+    self.canonical_potion_id = nil
   end
 
   def validate_unique_canonical

--- a/spec/models/potion_spec.rb
+++ b/spec/models/potion_spec.rb
@@ -90,6 +90,30 @@ RSpec.describe Potion, type: :model do
     end
   end
 
+  describe '#canonical_model' do
+    subject(:canonical_model) { potion.canonical_model }
+
+    context 'when there is a canonical model assigned' do
+      let(:potion) { create(:potion, :with_matching_canonical) }
+
+      it 'returns the canonical potion' do
+        expect(canonical_model).to eq potion.canonical_potion
+      end
+    end
+
+    context 'when there is no canonical model assigned' do
+      let(:potion) { create(:potion) }
+
+      before do
+        create_list(:canonical_potion, 2)
+      end
+
+      it 'returns nil' do
+        expect(canonical_model).to be_nil
+      end
+    end
+  end
+
   describe '#canonical_models' do
     subject(:canonical_models) { potion.canonical_models }
 

--- a/spec/support/factories/potions.rb
+++ b/spec/support/factories/potions.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :potion do
     game
 
-    name { 'Deadly Poison' }
+    name { 'My Potion' }
 
     trait :with_matching_canonical do
       association :canonical_potion, factory: %i[canonical_potion with_association]


### PR DESCRIPTION
## Context

[**Revisit conditional assignment of canonical models**](https://trello.com/c/EIdSrLs6/317-revisit-conditional-assignment-of-canonical-models)

Currently, if a potion is associated to a `Canonical::Potion`, it remains so for all time and its attributes get overwritten by the attributes from that canonical. However, the behaviour we want is slightly different. If the attributes of a potion have changed, we want it to check if the associated `Canonical::Potion` still matches, if another `Canonical::Potion` matches now, or if no canonical potion matches. If there is another matching canonical, it should be set as the `canonical_potion`.

## Changes

* Generate new `Canonical::Potion` matches if changed attributes lead to another match being better
* Clear `Canonical::Potion` association if changed attributes lead to missing or non-unique matches
* Update tests

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [ ] ~~Added and updated API docs and developer docs as appropriate~~

## Related PRs

* #227 
* #228 
* #229 
* #230 
* #231 
* #232 
