### PR TITLE
Rematch canonical property if changed attributes lead to a different match

### DIFF
--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -106,7 +106,7 @@ class Property < ApplicationRecord
   end
 
   def ensure_matches_canonical_property
-    errors.add(:base, DOES_NOT_MATCH) if canonical_property.blank?
+    errors.add(:base, DOES_NOT_MATCH) if canonical_model.nil?
   end
 
   def canonical_model_matches?

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -48,6 +48,10 @@ class Property < ApplicationRecord
     'windstad manor',
   ].freeze
 
+  def canonical_model
+    canonical_property
+  end
+
   def homestead?
     HOMESTEADS.include?(name&.downcase)
   end
@@ -55,7 +59,9 @@ class Property < ApplicationRecord
   private
 
   def set_canonical_model
-    self.canonical_property ||= Canonical::Property.find_by('name ILIKE ?', name)
+    return if canonical_model_matches?
+
+    self.canonical_property = Canonical::Property.find_by('name ILIKE ?', name)
   end
 
   def set_values_from_canonical
@@ -101,5 +107,12 @@ class Property < ApplicationRecord
 
   def ensure_matches_canonical_property
     errors.add(:base, DOES_NOT_MATCH) if canonical_property.blank?
+  end
+
+  def canonical_model_matches?
+    return false if canonical_model.nil?
+    return false unless name&.casecmp(canonical_model.name)&.zero?
+
+    true
   end
 end

--- a/docs/in_game_items/property.md
+++ b/docs/in_game_items/property.md
@@ -1,10 +1,10 @@
 # Property
 
-The `Property` class represents in-game instances of the [`Canonical::Property`](/docs/canonical_models/canonical-property.md) type. Properties differ slightly from other in-game items in two ways:
+The `Property` class represents in-game instances of the [`Canonical::Property`](/docs/canonical_models/canonical-property.md) type. Properties differ slightly from other in-game items in three ways:
 
 * A property is also a location (in some cases with sublocations)
 * A property can be associated with inventory and shopping lists (functionality that will be built out further for the MVP)
-
+* All properties must always be associated to a `Canonical::Property`
 
 Additionally, a number of characteristics of a property cannot be determined by the `Canonical::Property` associated. Users can add different amenities or, in the case of [homesteads](https://elderscrolls.fandom.com/wiki/Homestead_(Hearthfire)), build entirely different rooms on the property. For that reason, the `Canonical::Property` model has a number of attributes like `alchemy_lab_available` and `enchanters_tower_available` indicating whether the amenity or room _can be added_ to the property instead of whether it is actually present.
 

--- a/docs/in_game_items/property.md
+++ b/docs/in_game_items/property.md
@@ -5,11 +5,14 @@ The `Property` class represents in-game instances of the [`Canonical::Property`]
 * A property is also a location (in some cases with sublocations)
 * A property can be associated with inventory and shopping lists (functionality that will be built out further for the MVP)
 
+
 Additionally, a number of characteristics of a property cannot be determined by the `Canonical::Property` associated. Users can add different amenities or, in the case of [homesteads](https://elderscrolls.fandom.com/wiki/Homestead_(Hearthfire)), build entirely different rooms on the property. For that reason, the `Canonical::Property` model has a number of attributes like `alchemy_lab_available` and `enchanters_tower_available` indicating whether the amenity or room _can be added_ to the property instead of whether it is actually present.
 
 ## Matching to a Canonical Model
 
-Unlike other canonical models, of which there can be many, the `Canonical::Property` model only has 10 possible instances and all have a unique `name`. For this reason, unlike other canonical models, the `Canonical::Property` is identified using the `name` attribute alone (case insensitive). This is done in a `before_validation` action. In a second `before_validation` action, the `name`, `city`, and `hold` are set based on the values on the canonical property (if present). Finally, on validation, the property is marked invalid if there is no `canonical_property` assigned.
+Unlike other canonical models, of which there can be many, the `Canonical::Property` model only has 10 possible instances and all have a unique `name`. For this reason, unlike other canonical models, the `Canonical::Property` is identified using the `name` attribute alone (case insensitive). This is done in a `before_validation` action. In a second `before_validation` action, the `name`, `city`, and `hold` are set based on the values on the canonical property (if present). Finally, on validation, the property is marked invalid if there is no `canonical_property_id`.
+
+Because canonical properties are uniquely named and limited in number, `Property` models don't have the same potential for ambiguous matches that other in-game items have. There will always be either one or zero matches. In the case where there are no matches, validations will fail due to the missing required association.
 
 ## Validations
 

--- a/spec/models/canonical/sync/ingredients_spec.rb
+++ b/spec/models/canonical/sync/ingredients_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Canonical::Sync::Ingredients do
         it 'adds alchemical properties' do
           perform
           expect(item_in_json.alchemical_properties.pluck(:name))
-            .to eq ['Weakness to Frost', 'Fortify Sneak', 'Weakness to Poison', 'Fortify Restoration']
+            .to contain_exactly('Weakness to Frost', 'Fortify Sneak', 'Weakness to Poison', 'Fortify Restoration')
         end
       end
 

--- a/spec/models/property_spec.rb
+++ b/spec/models/property_spec.rb
@@ -278,6 +278,17 @@ RSpec.describe Property, type: :model do
     end
   end
 
+  describe '#canonical_model' do
+    subject(:canonical_model) { property.canonical_model }
+
+    let(:property) { create(:property, name: 'pRoUdSpIrE mAnOr') }
+    let(:canonical_property) { Canonical::Property.find_by(name: 'Proudspire Manor') }
+
+    it 'returns the canonical property' do
+      expect(canonical_model).to eq canonical_property
+    end
+  end
+
   describe 'setting a canonical model' do
     subject(:validate) { property.validate }
 

--- a/spec/models/property_spec.rb
+++ b/spec/models/property_spec.rb
@@ -94,7 +94,8 @@ RSpec.describe Property, type: :model do
     end
 
     describe 'uniqueness' do
-      let(:canonical_property) { Canonical::Property.first }
+      let(:property) { build(:property, name: "arch-mage's quarters", game:) }
+      let(:canonical_property) { Canonical::Property.find_by(name: "Arch-Mage's Quarters") }
 
       before do
         game.properties.create!(
@@ -106,22 +107,16 @@ RSpec.describe Property, type: :model do
       end
 
       it 'has a unique combination of game and canonical property' do
-        property.game = game
-        property.canonical_property = canonical_property
         validate
         expect(property.errors[:canonical_property]).to include 'must be unique per game'
       end
 
       it 'has a unique name per game' do
-        property.game = game
-        property.name = canonical_property.name
         validate
         expect(property.errors[:name]).to include 'must be unique per game'
       end
 
       it 'has a unique hold per game' do
-        property.game = game
-        property.hold = canonical_property.hold
         validate
         expect(property.errors[:hold]).to include 'must be unique per game'
       end
@@ -129,10 +124,10 @@ RSpec.describe Property, type: :model do
 
     describe 'arcane enchanter availability' do
       context 'when an arcane enchanter is not available at the given property' do
+        let(:property) { build(:property, name: 'breezehome') }
         let(:canonical_property) { Canonical::Property.find_by(name: 'Breezehome') }
 
         it 'cannot have an arcane enchanter' do
-          property.canonical_property_id = canonical_property.id
           property.has_arcane_enchanter = true
           validate
           expect(property.errors[:has_arcane_enchanter]).to include 'cannot be true because this property cannot have an arcane enchanter in Skyrim'
@@ -160,10 +155,10 @@ RSpec.describe Property, type: :model do
 
     describe 'forge availability' do
       context 'when a forge is not available at the given property' do
+        let(:property) { build(:property, name: 'breezehome') }
         let(:canonical_property) { Canonical::Property.find_by(name: 'Breezehome') }
 
         it 'cannot have a forge' do
-          property.canonical_property_id = canonical_property.id
           property.has_forge = true
           validate
           expect(property.errors[:has_forge]).to include 'cannot be true because this property cannot have a forge in Skyrim'
@@ -191,10 +186,10 @@ RSpec.describe Property, type: :model do
 
     describe 'apiary availability' do
       context 'when an apiary is not available at the given property' do
+        let(:property) { build(:property, name: 'breezehome') }
         let(:canonical_property) { Canonical::Property.find_by(name: 'Breezehome') }
 
         it 'cannot have an apiary' do
-          property.canonical_property_id = canonical_property.id
           property.has_apiary = true
           validate
           expect(property.errors[:has_apiary]).to include 'cannot be true because this property cannot have an apiary in Skyrim'
@@ -222,10 +217,10 @@ RSpec.describe Property, type: :model do
 
     describe 'grain mill availability' do
       context 'when a grain mill is not available at the given property' do
+        let(:property) { build(:property) }
         let(:canonical_property) { Canonical::Property.find_by(name: 'Lakeview Manor') }
 
         it 'cannot have a grain mill' do
-          property.canonical_property_id = canonical_property.id
           property.has_grain_mill = true
           validate
           expect(property.errors[:has_grain_mill]).to include 'cannot be true because this property cannot have a grain mill in Skyrim'
@@ -253,10 +248,10 @@ RSpec.describe Property, type: :model do
 
     describe 'fish hatchery availability' do
       context 'when a fish hatchery is not available at the given property' do
+        let(:property) { build(:property) }
         let(:canonical_property) { Canonical::Property.find_by(name: 'Lakeview Manor') }
 
         it 'cannot have a fish hatchery' do
-          property.canonical_property_id = canonical_property.id
           property.has_fish_hatchery = true
           validate
           expect(property.errors[:has_fish_hatchery]).to include 'cannot be true because this property cannot have a fish hatchery in Skyrim'
@@ -303,6 +298,19 @@ RSpec.describe Property, type: :model do
       it 'sets the canonical property', :aggregate_failures do
         validate
         expect(property.canonical_property).to eq canonical_property
+      end
+    end
+
+    context 'when updating the model changes the canonical property' do
+      let(:property) { create(:property) }
+      let(:canonical_property) { Canonical::Property.find_by(name: 'Severin Manor') }
+
+      it 'changes the canonical property' do
+        property.name = 'Severin Manor'
+
+        expect { validate }
+          .to change(property, :canonical_property)
+                .to(canonical_property)
       end
     end
   end

--- a/spec/models/property_spec.rb
+++ b/spec/models/property_spec.rb
@@ -125,7 +125,6 @@ RSpec.describe Property, type: :model do
     describe 'arcane enchanter availability' do
       context 'when an arcane enchanter is not available at the given property' do
         let(:property) { build(:property, name: 'breezehome') }
-        let(:canonical_property) { Canonical::Property.find_by(name: 'Breezehome') }
 
         it 'cannot have an arcane enchanter' do
           property.has_arcane_enchanter = true
@@ -135,17 +134,13 @@ RSpec.describe Property, type: :model do
       end
 
       context 'when an arcane enchanter is available at the given property' do
-        let(:canonical_property) { Canonical::Property.find_by(name: 'Lakeview Manor') }
-
         it 'can have an arcane enchanter' do
-          property.canonical_property_id = canonical_property.id
           property.has_arcane_enchanter = true
           validate
           expect(property.errors[:has_arcane_enchanter]).to be_empty
         end
 
         it "doesn't have to have an arcane enchanter" do
-          property.canonical_property_id = canonical_property.id
           property.has_arcane_enchanter = false
           validate
           expect(property.errors[:has_arcane_enchanter]).to be_empty
@@ -156,7 +151,6 @@ RSpec.describe Property, type: :model do
     describe 'forge availability' do
       context 'when a forge is not available at the given property' do
         let(:property) { build(:property, name: 'breezehome') }
-        let(:canonical_property) { Canonical::Property.find_by(name: 'Breezehome') }
 
         it 'cannot have a forge' do
           property.has_forge = true
@@ -166,17 +160,15 @@ RSpec.describe Property, type: :model do
       end
 
       context 'when a forge is available at the given property' do
-        let(:canonical_property) { Canonical::Property.find_by(name: 'Lakeview Manor') }
+        let(:property) { build(:property) }
 
         it 'can have a forge' do
-          property.canonical_property_id = canonical_property.id
           property.has_forge = true
           validate
           expect(property.errors[:has_forge]).to be_empty
         end
 
         it "doesn't have to have a forge" do
-          property.canonical_property_id = canonical_property.id
           property.has_forge = false
           validate
           expect(property.errors[:has_forge]).to be_empty
@@ -187,7 +179,6 @@ RSpec.describe Property, type: :model do
     describe 'apiary availability' do
       context 'when an apiary is not available at the given property' do
         let(:property) { build(:property, name: 'breezehome') }
-        let(:canonical_property) { Canonical::Property.find_by(name: 'Breezehome') }
 
         it 'cannot have an apiary' do
           property.has_apiary = true
@@ -197,17 +188,15 @@ RSpec.describe Property, type: :model do
       end
 
       context 'when an apiary is available at the given property' do
-        let(:canonical_property) { Canonical::Property.find_by(name: 'Lakeview Manor') }
+        let(:property) { build(:property, name: 'Lakeview Manor') }
 
         it 'can have an apiary' do
-          property.canonical_property_id = canonical_property.id
           property.has_apiary = true
           validate
           expect(property.errors[:has_apiary]).to be_empty
         end
 
         it "doesn't have to have an apiary" do
-          property.canonical_property_id = canonical_property.id
           property.has_apiary = false
           validate
           expect(property.errors[:has_apiary]).to be_empty
@@ -218,7 +207,6 @@ RSpec.describe Property, type: :model do
     describe 'grain mill availability' do
       context 'when a grain mill is not available at the given property' do
         let(:property) { build(:property) }
-        let(:canonical_property) { Canonical::Property.find_by(name: 'Lakeview Manor') }
 
         it 'cannot have a grain mill' do
           property.has_grain_mill = true
@@ -228,17 +216,15 @@ RSpec.describe Property, type: :model do
       end
 
       context 'when a grain mill is available at the given property' do
-        let(:canonical_property) { Canonical::Property.find_by(name: 'Heljarchen Hall') }
+        let(:property) { build(:property, name: 'Heljarchen Hall') }
 
         it 'can have a grain mill' do
-          property.canonical_property_id = canonical_property.id
           property.has_grain_mill = true
           validate
           expect(property.errors[:has_grain_mill]).to be_empty
         end
 
         it "doesn't have to have a grain mill" do
-          property.canonical_property_id = canonical_property.id
           property.has_grain_mill = false
           validate
           expect(property.errors[:has_grain_mill]).to be_empty
@@ -249,7 +235,6 @@ RSpec.describe Property, type: :model do
     describe 'fish hatchery availability' do
       context 'when a fish hatchery is not available at the given property' do
         let(:property) { build(:property) }
-        let(:canonical_property) { Canonical::Property.find_by(name: 'Lakeview Manor') }
 
         it 'cannot have a fish hatchery' do
           property.has_fish_hatchery = true
@@ -259,17 +244,15 @@ RSpec.describe Property, type: :model do
       end
 
       context 'when a fish hatchery is available at the given property' do
-        let(:canonical_property) { Canonical::Property.find_by(name: 'Windstad Manor') }
+        let(:property) { build(:property, name: 'windstad manor') }
 
         it 'can have a fish hatchery' do
-          property.canonical_property_id = canonical_property.id
           property.has_fish_hatchery = true
           validate
           expect(property.errors[:has_fish_hatchery]).to be_empty
         end
 
         it "doesn't have to have a fish hatchery" do
-          property.canonical_property_id = canonical_property.id
           property.has_fish_hatchery = false
           validate
           expect(property.errors[:has_fish_hatchery]).to be_empty

--- a/spec/support/factories/properties.rb
+++ b/spec/support/factories/properties.rb
@@ -5,9 +5,5 @@ FactoryBot.define do
     game
 
     name { 'Lakeview Manor' }
-
-    trait :with_matching_canonical do
-      association :canonical_property
-    end
   end
 end

--- a/spec/support/factories/properties.rb
+++ b/spec/support/factories/properties.rb
@@ -2,6 +2,8 @@
 
 FactoryBot.define do
   factory :property do
+    game
+
     name { 'Lakeview Manor' }
 
     trait :with_matching_canonical do


### PR DESCRIPTION
## Context

[**Revisit conditional assignment of canonical models**](https://trello.com/c/EIdSrLs6/317-revisit-conditional-assignment-of-canonical-models)

Currently, once a `Property` model is associated to a `Canonical::Property`, the association doesn't change. However, if attributes change, it would be better UX to simply change the associated canonical rather than raising validation errors, raising validation errors only if the change results in no canonical matches. This PR ensures that the canonical model can change.

## Changes

* Enable `Canonical::Property` association to change on the `Property` model if attributes change
* Update tests
* Add `game` association to `property` factory
* Fix (unrelated) flaky test

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [ ] ~~Added and updated API docs and developer docs as appropriate~~

## Considerations

Unlike other models, the `Property` model is required to have a `canonical_property` association. This is because canonical properties are uniquely named and limited in number, so there would be no scenario in which a match was ambiguous.

## Related PRs

* #227 
* #228 
* #229 
* #230 
* #231 
* #232 
* #233 