### PR TITLE
Rematch canonical staff if changed attributes lead to a different match

### DIFF
--- a/app/models/spell.rb
+++ b/app/models/spell.rb
@@ -7,11 +7,21 @@ class Spell < ApplicationRecord
            dependent: :destroy,
            class_name: 'Canonical::StavesSpell',
            inverse_of: :spell
-  has_many :staves, through: :canonical_staves_spells
+  has_many :staves, through: :canonical_staves_spells, class_name: 'Canonical::Staff'
 
   validates :name, presence: true, uniqueness: { message: 'must be unique' }
-  validates :school, presence: true, inclusion: { in: Skyrim::MAGIC_SCHOOLS, message: 'must be a valid school of magic' }
-  validates :level, presence: true, inclusion: { in: Skyrim::DIFFICULTY_LEVELS, message: 'must be "Novice", "Apprentice", "Adept", "Expert", or "Master"' }
+  validates :school,
+            presence: true,
+            inclusion: {
+              in: Skyrim::MAGIC_SCHOOLS,
+              message: 'must be a valid school of magic',
+            }
+  validates :level,
+            presence: true,
+            inclusion: {
+              in: Skyrim::DIFFICULTY_LEVELS,
+              message: 'must be "Novice", "Apprentice", "Adept", "Expert", or "Master"',
+            }
   validates :strength_unit,
             inclusion: {
               in: %w[point percentage level],

--- a/spec/models/staff_spec.rb
+++ b/spec/models/staff_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe Staff, type: :model do
       let(:staff) { create(:staff, :with_matching_canonical) }
 
       it "doesn't change anything" do
-        expect { staff.validate }
+        expect { validate }
           .not_to change(staff.reload, :canonical_staff)
       end
     end
@@ -240,12 +240,12 @@ RSpec.describe Staff, type: :model do
       end
 
       it 'associates the canonical staff' do
-        staff.validate
+        validate
         expect(staff.canonical_staff).to eq canonical_staff
       end
 
       it 'sets values from the canonical model', :aggregate_failures do
-        staff.validate
+        validate
         expect(staff.name).to eq 'My Staff'
         expect(staff.unit_weight).to eq 8
         expect(staff.magical_effects).to eq 'Does stuff'


### PR DESCRIPTION
## Context

[**Revisit conditional assignment of canonical models**](https://trello.com/c/EIdSrLs6/317-revisit-conditional-assignment-of-canonical-models)

Currently, once a `Staff` model is associated to a `Canonical::Staff` (i.e., its `canonical_staff_id` has been set), the canonical staff associated no longer changes. Instead, any attribute changes the user makes get overwritten on the next `before_validation` hook. This is bad UX if it would be possible to instead change the `canonical_staff` to one that matches the new attributes. In this PR, the canonical staff is changed in this scenario, or the association removed if the changes result in an ambiguous (or no) match. As before, if there are no matching canonicals at all, validation will fail.

## Changes

* Allow reassignment of `canonical_staff` on `Staff` model when attributes change
* Set `canonical_staff` to `nil` if changed attributes result in an ambiguous (or no) canonical match
* Update tests
* Reformat code in `Spell` class to eliminate long lines

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [ ] ~~Added and updated API docs and developer docs as appropriate~~

## Related PRs

* #227 
* #228 
* #229 
* #230 
* #231 
* #232 
* #233 
* #234 
