### PR TITLE
Rematch canonical weapon if changed attributes lead to a different match

### DIFF
--- a/app/models/weapon.rb
+++ b/app/models/weapon.rb
@@ -134,6 +134,7 @@ class Weapon < ApplicationRecord
   def canonical_model_matches?
     return false if canonical_model.nil?
     return false unless name.casecmp(canonical_model.name).zero?
+    return false unless magical_effects&.casecmp(canonical_model.magical_effects)&.zero?
     return false unless unit_weight.nil? || unit_weight == canonical_model.unit_weight
     return false unless category.nil? || category == canonical_model.category
     return false unless weapon_type.nil? || weapon_type == canonical_model.weapon_type

--- a/app/models/weapon.rb
+++ b/app/models/weapon.rb
@@ -49,7 +49,7 @@ class Weapon < ApplicationRecord
   end
 
   def canonical_models
-    return Canonical::Weapon.where(id: canonical_weapon.id) if canonical_model_matches?
+    return Canonical::Weapon.where(id: canonical_weapon_id) if canonical_model_matches?
 
     query = 'name ILIKE :name'
     query += ' AND magical_effects ILIKE :magical_effects' if magical_effects.present?

--- a/app/models/weapon.rb
+++ b/app/models/weapon.rb
@@ -49,9 +49,12 @@ class Weapon < ApplicationRecord
   end
 
   def canonical_models
-    return Canonical::Weapon.where(id: canonical_weapon.id) if canonical_weapon.present?
+    return Canonical::Weapon.where(id: canonical_weapon.id) if canonical_model_matches?
 
-    canonicals = Canonical::Weapon.where('name ILIKE ?', name)
+    query = 'name ILIKE :name'
+    query += ' AND magical_effects ILIKE :magical_effects' if magical_effects.present?
+
+    canonicals = Canonical::Weapon.where(query, name:, magical_effects:)
     canonicals = attributes_to_match.any? ? canonicals.where(**attributes_to_match) : canonicals
 
     return canonicals if enchantments.none?
@@ -87,7 +90,10 @@ class Weapon < ApplicationRecord
   private
 
   def set_canonical_weapon
-    return unless canonical_models.count == 1
+    unless canonical_models.count == 1
+      clear_canonical_weapon
+      return
+    end
 
     self.canonical_weapon = canonical_models.first
   end
@@ -125,13 +131,26 @@ class Weapon < ApplicationRecord
     errors.add(:base, DUPLICATE_MATCH)
   end
 
+  def canonical_model_matches?
+    return false if canonical_model.nil?
+    return false unless name.casecmp(canonical_model.name).zero?
+    return false unless unit_weight.nil? || unit_weight == canonical_model.unit_weight
+    return false unless category.nil? || category == canonical_model.category
+    return false unless weapon_type.nil? || weapon_type == canonical_model.weapon_type
+
+    true
+  end
+
   def attributes_to_match
     {
       unit_weight:,
       category:,
       weapon_type:,
-      magical_effects:,
     }.compact
+  end
+
+  def clear_canonical_weapon
+    self.canonical_weapon_id = nil
   end
 
   def ensure_canonicals_exist

--- a/docs/in_game_items/weapon.md
+++ b/docs/in_game_items/weapon.md
@@ -7,10 +7,10 @@ The `Weapon` model represents in-game items of the `Canonical::Weapon` type.
 `Weapon` models are matched to `Canonical::Weapon` models using the following fields:
 
 * `name` (case-insensitive)
+* `magical_effects` (case-insensitive)
 * `unit_weight`
 * `category`
 * `weapon_type`
-* `magical_effects`
 
 ## Associations
 


### PR DESCRIPTION
## Context

[**Revisit conditional assignment of canonical models**](https://trello.com/c/EIdSrLs6/317-revisit-conditional-assignment-of-canonical-models)

Currently, associations between `Weapon` and `Canonical::Weapon` models are permanent once associated. This results in any changed attributes being overwritten every time the `before_validation` hook runs. However, a better UX would be to check for a better canonical match if attributes are updated. This PR enables this. It also nulls the `canonical_weapon` association if changed attributes lead to ambiguous (or no) matches. As has always been the case, a validation error will always be raised if there are no canonical matches or if the item turns out to be a duplicate of a unique in-game item.

## Changes

* Match `magical_effects` case-insensitively when finding canonical matches
* Allow associated `canonical_weapon` to change when attributes are updated
* Nullify `canonical_weapon` association if changed attributes lead to ambiguous, or no, canonical matches
* Update tests
* Update docs

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

The changes to how `canonical_weapon` models are matched using `magical_effects` was not strictly related to this change but I felt it would be better UX to compare that field case-insensitively - `magical_effects` values are often long and users should not have to get all capitalisation right. That would be bad UX, especially for mobile users who fat-finger things.

## Related PRs

* #227 
* #228 
* #229 
* #230 
* #231 
* #232 
* #233 
* #234 
* #235 
