### PR TITLE
Nullify canonical models that no longer match

### DIFF
--- a/app/models/armor.rb
+++ b/app/models/armor.rb
@@ -42,7 +42,7 @@ class Armor < ApplicationRecord
   end
 
   def canonical_models
-    return Canonical::Armor.where(id: canonical_armor.id) if canonical_model_matches?
+    return Canonical::Armor.where(id: canonical_armor_id) if canonical_model_matches?
 
     query = 'name ILIKE :name'
     query += ' AND magical_effects ILIKE :magical_effects' if magical_effects.present?

--- a/app/models/armor.rb
+++ b/app/models/armor.rb
@@ -62,12 +62,14 @@ class Armor < ApplicationRecord
   private
 
   def set_canonical_armor
-    unless canonical_models.count == 1
+    canonicals = canonical_models
+
+    unless canonicals.count == 1
       clear_canonical_armor
       return
     end
 
-    self.canonical_armor = canonical_models.first
+    self.canonical_armor = canonicals.first
     self.name = canonical_armor.name # in case casing differs
     self.magical_effects = canonical_armor.magical_effects
     self.unit_weight = canonical_armor.unit_weight

--- a/app/models/armor.rb
+++ b/app/models/armor.rb
@@ -97,7 +97,7 @@ class Armor < ApplicationRecord
     return false if canonical_model.nil?
     return false unless name.casecmp(canonical_model.name).zero?
     return false unless unit_weight.nil? || unit_weight == canonical_model.unit_weight
-    return false unless magical_effects.nil? || magical_effects == canonical_model.magical_effects
+    return false unless magical_effects.nil? || magical_effects.casecmp(canonical_model.magical_effects)&.zero?
 
     true
   end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -61,12 +61,14 @@ class Book < ApplicationRecord
   private
 
   def set_canonical_book
-    unless canonical_models.count == 1
+    canonicals = canonical_models
+
+    unless canonicals.count == 1
       clear_canonical_book
       return
     end
 
-    self.canonical_book = canonical_models.first
+    self.canonical_book = canonicals.first
   end
 
   def set_values_from_canonical

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -61,7 +61,12 @@ class Book < ApplicationRecord
   private
 
   def set_canonical_book
-    self.canonical_book = canonical_models.first if canonical_models.count == 1
+    unless canonical_models.count == 1
+      clear_canonical_book
+      return
+    end
+
+    self.canonical_book = canonical_models.first
   end
 
   def set_values_from_canonical
@@ -82,6 +87,10 @@ class Book < ApplicationRecord
     return if books.count == 1 && books.first == self
 
     errors.add(:base, DUPLICATE_MATCH)
+  end
+
+  def clear_canonical_book
+    self.canonical_book_id = nil
   end
 
   def canonical_model_matches?

--- a/app/models/clothing_item.rb
+++ b/app/models/clothing_item.rb
@@ -46,12 +46,14 @@ class ClothingItem < ApplicationRecord
   private
 
   def set_canonical_clothing_item
-    unless canonical_models.count == 1
+    canonicals = canonical_models
+
+    unless canonicals.count == 1
       clear_canonical_clothing_item
       return
     end
 
-    self.canonical_clothing_item = canonical_models.first
+    self.canonical_clothing_item = canonicals.first
     self.name = canonical_clothing_item.name # in case casing differs
     self.unit_weight = canonical_clothing_item.unit_weight
     self.magical_effects = canonical_clothing_item.magical_effects

--- a/app/models/clothing_item.rb
+++ b/app/models/clothing_item.rb
@@ -79,7 +79,7 @@ class ClothingItem < ApplicationRecord
   def canonical_model_matches?
     return false if canonical_model.nil?
     return false unless name.casecmp(canonical_model.name).zero?
-    return false unless magical_effects&.casecmp(canonical_model.magical_effects)&.zero?
+    return false unless magical_effects.nil? || magical_effects.casecmp(canonical_model.magical_effects)&.zero?
     return false unless unit_weight.nil? || unit_weight == canonical_model.unit_weight
 
     true

--- a/app/models/misc_item.rb
+++ b/app/models/misc_item.rb
@@ -33,26 +33,16 @@ class MiscItem < ApplicationRecord
   private
 
   def set_canonical_misc_item
-    return if canonical_models.blank?
-    return if canonical_models.count > 1 && unit_weight.blank?
+    canonicals = canonical_models
 
-    associate_first_available_match
+    unless canonicals.count == 1
+      clear_canonical_misc_item
+      return
+    end
 
-    return if canonical_misc_item.blank?
-
+    self.canonical_misc_item = canonicals.first
     self.name = canonical_misc_item.name
     self.unit_weight = canonical_misc_item.unit_weight
-  end
-
-  def associate_first_available_match
-    return if canonical_misc_item.present?
-
-    canonical_models.each do |model|
-      next if model.unique_item && model.misc_items.where(game_id:).any?
-
-      self.canonical_misc_item = model
-      break
-    end
   end
 
   def validate_association
@@ -72,6 +62,10 @@ class MiscItem < ApplicationRecord
     return if items.count == 1 && items.first == self
 
     errors.add(:base, DUPLICATE_MATCH)
+  end
+
+  def clear_canonical_misc_item
+    self.canonical_misc_item_id = nil
   end
 
   def canonical_model_matches?

--- a/app/models/potion.rb
+++ b/app/models/potion.rb
@@ -38,12 +38,14 @@ class Potion < ApplicationRecord
   private
 
   def set_canonical_potion
-    unless canonical_models.count == 1
+    canonicals = canonical_models
+
+    unless canonicals.count == 1
       clear_canonical_potion
       return
     end
 
-    self.canonical_potion = canonical_models.first
+    self.canonical_potion = canonicals.first
     self.name = canonical_potion.name
     self.unit_weight = canonical_potion.unit_weight
     self.magical_effects = canonical_potion.magical_effects

--- a/app/models/potion.rb
+++ b/app/models/potion.rb
@@ -67,7 +67,7 @@ class Potion < ApplicationRecord
   def canonical_model_matches?
     return false if canonical_model.nil?
     return false unless name.casecmp(canonical_model.name).zero?
-    return false unless magical_effects.nil? || magical_effects.casecmp(canonical_model.magical_effects).zero?
+    return false unless magical_effects.nil? || magical_effects.casecmp(canonical_model.magical_effects)&.zero?
 
     if alchemical_properties.any?
       potions_alchemical_properties.each do |prop|

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -9,8 +9,6 @@ class Property < ApplicationRecord
   has_many :shopping_lists, dependent: nil
   has_many :inventory_lists, dependent: nil
 
-  validate :ensure_max, on: :create, if: :count_is_max
-
   validates :canonical_property, uniqueness: { scope: :game_id, message: 'must be unique per game' }
 
   validates :name,
@@ -27,6 +25,7 @@ class Property < ApplicationRecord
             inclusion: { in: Canonical::Property::VALID_CITIES, message: 'must be a Skyrim city in which an ownable property is located', allow_blank: true },
             uniqueness: { scope: :game_id, message: 'must be unique per game if present', allow_nil: true }
 
+  validate :ensure_max, on: :create, if: :count_is_max
   validate :ensure_alchemy_lab_available, if: -> { has_alchemy_lab == true && canonical_property&.alchemy_lab_available == false }
   validate :ensure_arcane_enchanter_available, if: -> { has_arcane_enchanter == true && canonical_property&.arcane_enchanter_available == false }
   validate :ensure_forge_available, if: -> { has_forge == true && canonical_property&.forge_available == false }
@@ -112,6 +111,8 @@ class Property < ApplicationRecord
   def canonical_model_matches?
     return false if canonical_model.nil?
     return false unless name&.casecmp(canonical_model.name)&.zero?
+    return false unless hold.nil? || hold == canonical_model.hold
+    return false unless city.nil? || city == canonical_model.city
 
     true
   end

--- a/app/models/staff.rb
+++ b/app/models/staff.rb
@@ -82,7 +82,7 @@ class Staff < ApplicationRecord
   def canonical_model_matches?
     return false if canonical_model.nil?
     return false unless name.casecmp(canonical_model.name).zero?
-    return false unless magical_effects.nil? || magical_effects.casecmp(canonical_model.magical_effects).zero?
+    return false unless magical_effects.nil? || magical_effects.casecmp(canonical_model.magical_effects)&.zero?
     return false unless unit_weight.nil? || unit_weight == canonical_model.unit_weight
 
     true

--- a/app/models/staff.rb
+++ b/app/models/staff.rb
@@ -44,12 +44,14 @@ class Staff < ApplicationRecord
   private
 
   def set_canonical_staff
-    unless canonical_models.count == 1
+    canonicals = canonical_models
+
+    unless canonicals.count == 1
       clear_canonical_staff
       return
     end
 
-    self.canonical_staff = canonical_models.first
+    self.canonical_staff = canonicals.first
     self.name = canonical_staff.name
     self.unit_weight = canonical_staff.unit_weight
     self.magical_effects = canonical_staff.magical_effects

--- a/app/models/weapon.rb
+++ b/app/models/weapon.rb
@@ -90,12 +90,14 @@ class Weapon < ApplicationRecord
   private
 
   def set_canonical_weapon
-    unless canonical_models.count == 1
+    canonicals = canonical_models
+
+    unless canonicals.count == 1
       clear_canonical_weapon
       return
     end
 
-    self.canonical_weapon = canonical_models.first
+    self.canonical_weapon = canonicals.first
   end
 
   def set_values_from_canonical

--- a/app/models/weapon.rb
+++ b/app/models/weapon.rb
@@ -134,7 +134,7 @@ class Weapon < ApplicationRecord
   def canonical_model_matches?
     return false if canonical_model.nil?
     return false unless name.casecmp(canonical_model.name).zero?
-    return false unless magical_effects&.casecmp(canonical_model.magical_effects)&.zero?
+    return false unless magical_effects.nil? || magical_effects.casecmp(canonical_model.magical_effects)&.zero?
     return false unless unit_weight.nil? || unit_weight == canonical_model.unit_weight
     return false unless category.nil? || category == canonical_model.category
     return false unless weapon_type.nil? || weapon_type == canonical_model.weapon_type

--- a/app/validators/clothing_item_validator.rb
+++ b/app/validators/clothing_item_validator.rb
@@ -2,13 +2,12 @@
 
 class ClothingItemValidator < ActiveModel::Validator
   NO_CANONICAL_MATCHES = "doesn't match a clothing item that exists in Skyrim"
-  DOES_NOT_MATCH = 'does not match value on canonical model'
   DUPLICATE_MATCH = 'is a duplicate of a unique in-game item'
 
   def validate(record)
     @record = record
 
-    if @record.canonical_models.blank?
+    if @record.canonical_models.none?
       @record.errors.add(:base, NO_CANONICAL_MATCHES)
       return
     end

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -203,7 +203,7 @@ RSpec.describe Book, type: :model do
     end
   end
 
-  describe 'before_validation' do
+  describe '::before_validation' do
     subject(:validate) { book.validate }
 
     context 'when there is one matching canonical book' do
@@ -263,6 +263,79 @@ RSpec.describe Book, type: :model do
         expect(book.authors).to be_blank
         expect(book.unit_weight).to be_nil
         expect(book.skill_name).to be_nil
+      end
+    end
+
+    context 'when updating the attributes of an in-game item' do
+      let(:book) { create(:book, :with_matching_canonical) }
+
+      context 'when the update results in a new canonical match' do
+        let!(:new_canonical) do
+          create(
+            :canonical_book,
+            title: "Sinderion's Field Journal",
+          )
+        end
+
+        it 'changes the canonical association' do
+          book.title = "sinderion's field journal"
+
+          expect { validate }
+            .to change(book, :canonical_book)
+                  .to(new_canonical)
+        end
+
+        it 'updates attributes' do
+          book.title = "sinderion's field journal"
+
+          validate
+
+          expect(book.title).to eq "Sinderion's Field Journal"
+        end
+      end
+
+      context 'when the update results in an ambiguous match' do
+        before do
+          create_list(
+            :canonical_book,
+            2,
+            title: "Sinderion's Field Journal",
+          )
+        end
+
+        it 'sets the canonical_book to nil' do
+          book.title = "sinderion's field journal"
+
+          expect { validate }
+            .to change(book, :canonical_book)
+                  .to(nil)
+        end
+
+        it "doesn't update attributes" do
+          book.title = "sinderion's field journal"
+
+          validate
+
+          expect(book.title).not_to eq "Sinderion's Field Journal"
+        end
+      end
+
+      context 'when the update results in no canonical matches' do
+        it 'sets the canonical_book to nil' do
+          book.title = "sinderion's field journal"
+
+          expect { validate }
+            .to change(book, :canonical_book)
+                  .to(nil)
+        end
+
+        it "doesn't update attributes" do
+          book.title = "sinderion's field journal"
+
+          validate
+
+          expect(book.title).not_to eq "Sinderion's Field Journal"
+        end
       end
     end
   end

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -328,14 +328,6 @@ RSpec.describe Book, type: :model do
             .to change(book, :canonical_book)
                   .to(nil)
         end
-
-        it "doesn't update attributes" do
-          book.title = "sinderion's field journal"
-
-          validate
-
-          expect(book.title).not_to eq "Sinderion's Field Journal"
-        end
       end
     end
   end

--- a/spec/models/ingredient_spec.rb
+++ b/spec/models/ingredient_spec.rb
@@ -359,7 +359,6 @@ RSpec.describe Ingredient, type: :model do
       context 'when the update results in no canonical matches' do
         it 'sets the canonical ingredient association to nil' do
           ingredient.name = 'horseradish'
-          ingredient.unit_weight = nil
 
           expect { validate }
             .to change(ingredient, :canonical_ingredient)

--- a/spec/models/jewelry_item_spec.rb
+++ b/spec/models/jewelry_item_spec.rb
@@ -248,6 +248,8 @@ RSpec.describe JewelryItem, type: :model do
   end
 
   describe '::before_validation' do
+    subject(:validate) { item.validate }
+
     context 'when there is a single matching canonical model' do
       let!(:matching_canonical) do
         create(
@@ -273,12 +275,12 @@ RSpec.describe JewelryItem, type: :model do
       end
 
       it 'assigns the canonical jewelry item' do
-        item.validate
+        validate
         expect(item.canonical_jewelry_item).to eq matching_canonical
       end
 
       it 'sets the attributes', :aggregate_failures do
-        item.validate
+        validate
         expect(item.name).to eq 'Gold Diamond Ring'
         expect(item.unit_weight).to eq 0.2
         expect(item.magical_effects).to eq 'Some magical effects to differentiate'
@@ -299,7 +301,82 @@ RSpec.describe JewelryItem, type: :model do
       let(:item) { create(:jewelry_item, name: 'Gold Diamond Ring', unit_weight: 0.2) }
 
       it "doesn't add enchantments" do
+        validate
         expect(item.enchantables_enchantments).to be_blank
+      end
+    end
+
+    context 'when updating in-game item attributes' do
+      let(:item) { create(:jewelry_item, :with_matching_canonical) }
+
+      context 'when the update changes the associated canonical' do
+        let!(:new_canonical) do
+          create(
+            :canonical_jewelry_item,
+            name: 'Silver Jeweled Necklace',
+            unit_weight: 3.0,
+          )
+        end
+
+        it 'sets the new canonical model as the association' do
+          item.name = 'silver jeweled necklace'
+          item.unit_weight = nil
+
+          expect { validate }
+            .to change(item, :canonical_jewelry_item)
+                  .to(new_canonical)
+        end
+
+        it 'updates attributes', :aggregate_failures do
+          item.name = 'silver jeweled necklace'
+          item.unit_weight = nil
+
+          validate
+
+          expect(item.name).to eq 'Silver Jeweled Necklace'
+          expect(item.unit_weight).to eq 3
+        end
+      end
+
+      context 'when the update results in an ambiguous match' do
+        before do
+          create_list(
+            :canonical_jewelry_item,
+            2,
+            name: 'Silver Jeweled Necklace',
+            unit_weight: 3.0,
+          )
+        end
+
+        it 'sets the canonical jewelry item to nil' do
+          item.name = 'silver jeweled necklace'
+          item.unit_weight = nil
+
+          expect { validate }
+            .to change(item, :canonical_jewelry_item)
+                  .to(nil)
+        end
+
+        it "doesn't update attributes", :aggregate_failures do
+          item.name = 'silver jeweled necklace'
+          item.unit_weight = nil
+
+          validate
+
+          expect(item.name).to eq 'silver jeweled necklace'
+          expect(item.unit_weight).to be_nil
+        end
+      end
+
+      context 'when the update results in no canonical matches' do
+        it 'sets the canonical jewelry item to nil' do
+          item.name = 'silver jeweled necklace'
+          item.unit_weight = nil
+
+          expect { validate }
+            .to change(item, :canonical_jewelry_item)
+                  .to(nil)
+        end
       end
     end
   end

--- a/spec/models/jewelry_item_spec.rb
+++ b/spec/models/jewelry_item_spec.rb
@@ -371,7 +371,6 @@ RSpec.describe JewelryItem, type: :model do
       context 'when the update results in no canonical matches' do
         it 'sets the canonical jewelry item to nil' do
           item.name = 'silver jeweled necklace'
-          item.unit_weight = nil
 
           expect { validate }
             .to change(item, :canonical_jewelry_item)


### PR DESCRIPTION
## Context

[**Revisit conditional assignment of canonical models**](https://trello.com/c/EIdSrLs6/317-revisit-conditional-assignment-of-canonical-models)

During the course of our work enabling canonical matches to be changed if an in-game item is updated, we realised that, for many of the prior PRs related to this, we failed to ensure that canonical models that no longer match get removed as associations (unless being immediately replaced by one that matches better). This could cause problems if an update to an in-game item model resulted in an ambiguous match with multiple canonical models (or none for that matter) but the `canonical_<model>` association remained.

While working on this PR, I unearthed some serious bugs. While in previous PRs we ensured that the `#canonical_models` method for each model returned the correct canonical match(es), but in the case of several models we failed to test, or implement, the changes that would actually cause the correct match to be _set_ as the `canonical_<model>`. These bugs are fixed in this PR, as are minor logic errors around `magical_effects` fields, which are now matched case-insensitively with canonical models.

## Changes

* Ensure canonical associations are being set correctly on in-game items
* Nullify the `canonical_<model>` field if an attribute update leads to ambiguous, or no, canonical matches
* Fix bug where `nil` `magical_effects` value leads to canonical models never matching
* Ensure `magical_effects` fields are always matched case-insensitively to canonicals
* Some cleanup and performance optimisations
* Add missing tests
* Test new behaviour

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [ ] ~~Added and updated API docs and developer docs as appropriate~~

## Related PRs

* #227 
* #228 
* #229 
* #230 
* #231 
* #232 
* #233 
* #234 
* #235 
* #236 