### PR TITLE
Match armor models to canonicals based on enchantments

### DIFF
--- a/app/models/armor.rb
+++ b/app/models/armor.rb
@@ -48,7 +48,28 @@ class Armor < ApplicationRecord
     query += ' AND magical_effects ILIKE :magical_effects' if magical_effects.present?
 
     canonicals = Canonical::Armor.where(query, name:, magical_effects:)
-    attributes_to_match.any? ? canonicals.where(**attributes_to_match) : canonicals
+    canonicals = attributes_to_match.any? ? canonicals.where(**attributes_to_match) : canonicals
+
+    return canonicals if enchantments.none?
+
+    enchantables_enchantments.each do |join_model|
+      canonicals = if join_model.strength.present?
+                     canonicals.left_outer_joins(:enchantables_enchantments).where(
+                       '(enchantables_enchantments.enchantment_id = :enchantment_id AND enchantables_enchantments.enchantable_type = :type AND enchantables_enchantments.strength = :strength) OR canonical_armors.enchantable = true',
+                       enchantment_id: join_model.enchantment_id,
+                       type: 'Canonical::Armor',
+                       strength: join_model.strength,
+                     )
+                   else
+                     canonicals.left_outer_joins(:enchantables_enchantments).where(
+                       '(enchantables_enchantments.enchantment_id = :enchantment_id AND enchantables_enchantments.enchantable_type = :type) OR canonical_armors.enchantable = true',
+                       enchantment_id: join_model.enchantment_id,
+                       type: 'Canonical::Armor',
+                     )
+                   end
+    end
+
+    canonicals.uniq
   end
 
   def crafting_materials

--- a/app/models/armor.rb
+++ b/app/models/armor.rb
@@ -48,7 +48,7 @@ class Armor < ApplicationRecord
     query += ' AND magical_effects ILIKE :magical_effects' if magical_effects.present?
 
     canonicals = Canonical::Armor.where(query, name:, magical_effects:)
-    canonicals = attributes_to_match.any? ? canonicals.where(**attributes_to_match) : canonicals
+    canonicals = canonicals.where(**attributes_to_match) if attributes_to_match.any?
 
     return canonicals if enchantments.none?
 

--- a/docs/in_game_items/armor.md
+++ b/docs/in_game_items/armor.md
@@ -11,6 +11,11 @@ The `Armor` model represents in-game items of the `Canonical::Armor` type.
 * `weight`
 * `magical_effects`
 
+If an `Armor` model has enchantments, its enchantments are also matched against any canonical matches. To match a canonical model, one of two things has to be the case:
+
+1. All enchantments on the in-game item match in both `enchantment_id` and `strength` (if present)
+2. The canonical model has its `enchantable` attribute set to `true`, indicating that user-added enchantments are allowed
+
 ## Associations
 
 Because `Armor` models may (at least theoretically) have user-added enchantments in addition to those present on the canonical model, the `Armor` model has its own associations to `EnchantablesEnchantment` and `Enchantment`. The canonical model's enchantments will automatically be added to the `Armor` model when it is saved and has a single matching `Canonical::Armor` model.

--- a/docs/in_game_items/in-game-items.md
+++ b/docs/in_game_items/in-game-items.md
@@ -22,9 +22,9 @@ Non-canonical in-game items represent individual item instances. For the purpose
 
 Every in-game item has to correspond to at least one canonical model. Because not all attributes are directly pertinent to users and not all should be able to be set by them, non-canonical models do not have the same fields and associations as the canonical models. Instead, non-canonical models include the subset of canonical fields that are visible to or discoverable by players.
 
-When an in-game item is created, it is validated to ensure that it has at least one potential canonical match. These matches are based on fields set on the non-canonical model, or in [some cases](/docs/in_game_items/ingredient.md), associations that are present on that model; in other words, fields that are `nil` on the non-canonical model are not considered for the match. Only fields set to a non-`nil` value, or associations that have been created on the non-canonical model, must match the canonical model.
+When an in-game item is saved, it is validated to ensure that it has at least one potential canonical match. These matches are based on fields set on the non-canonical model, or in [some cases](/docs/in_game_items/ingredient.md), associations that are present on that model; in other words, fields that are `nil` on the non-canonical model are not considered for the match. Only fields set to a non-`nil` value, or associations that have been created on the non-canonical model, must match the canonical model.
 
-If the in-game item matches exactly one canonical model, that model is set as the `canonical_<model>` for that item. If there are no matching canonical models, validation fails.
+If the in-game item matches exactly one canonical model, that model is set as the `canonical_<model>` for that item. If there are no matching canonical models, validation fails. If the in-game item model is updated such that it no longer matches the currently-associated canonical model, the matching algorithm will be run again. If the update results in ambiguous, or no, canonical matches, the `canonical_<model>_id` will be set to `nil`. As before, ambiguous matches are allowed, but validation will fail if there are no matches (other than for [potions](/docs/in_game_items/potion.md), which can be player-created and don't always have canonical matches).
 
 ### Auto-Populating Fields
 
@@ -32,4 +32,4 @@ Some fields and associations on canonical models are either not visible to users
 
 When a non-canonical item is matched to a single canonical model, fields and associations that are visible to the user (i.e., those like weight that the user can automatically see just because they've seen the item) are automatically populated or created on the non-canonical item. Certain associations, such as `crafting_materials` and `tempering_materials` on weapons and armour items, will not differ for separate instances and are therefore delegated to the canonical model to prevent the need to create redundant models.
 
-Canonical models are initially found using a case-insensitive matching by name. For this reason, the name of the non-canonical model is also updated to match the casing of the canonical model's name.
+Canonical models are initially found using a case-insensitive matching by name (or `title` and `title_variants` for books). For this reason, the name of the non-canonical model is also updated to match the casing of the canonical model's name.

--- a/spec/models/weapon_spec.rb
+++ b/spec/models/weapon_spec.rb
@@ -569,72 +569,68 @@ RSpec.describe Weapon, type: :model do
   end
 
   describe 'adding enchantments' do
-    context 'when no canonical model is assigned' do
-      let(:weapon) { create(:weapon, name: 'foobar') }
+    let(:weapon) { create(:weapon, name: 'foobar') }
 
-      context 'when there are multiple matching canonicals' do
-        before do
-          create_list(
-            :canonical_weapon,
-            2,
-            :with_enchantments,
-            name: 'Foobar',
-            enchantable:,
-          )
-        end
+    before do
+      create_list(
+        :canonical_weapon,
+        2,
+        :with_enchantments,
+        name: 'Foobar',
+        enchantable:,
+      )
+    end
 
-        context 'when the added enchantment eliminates all canoncial matches' do
-          subject(:add_enchantment) { create(:enchantables_enchantment, enchantable: weapon) }
+    context 'when the added enchantment eliminates all canoncial matches' do
+      subject(:add_enchantment) { create(:enchantables_enchantment, enchantable: weapon) }
 
-          let(:enchantable) { false }
+      let(:enchantable) { false }
 
-          it "doesn't allow the enchantment to be added", :aggregate_failures do
-            expect { add_enchantment }
-              .to raise_error(ActiveRecord::RecordInvalid)
+      it "doesn't allow the enchantment to be added", :aggregate_failures do
+        expect { add_enchantment }
+          .to raise_error(ActiveRecord::RecordInvalid)
 
-            expect(weapon.enchantments.reload.length).to eq 0
-          end
-        end
+        expect(weapon.enchantments.reload.length).to eq 0
+      end
+    end
 
-        context 'when the added enchantment narrows it down to one canonical match' do
-          subject(:add_enchantment) do
-            create(
-              :enchantables_enchantment,
-              enchantable: weapon,
-              enchantment: Canonical::Weapon.last.enchantments.first,
-            )
-          end
+    context 'when the added enchantment narrows it down to one canonical match' do
+      subject(:add_enchantment) do
+        create(
+          :enchantables_enchantment,
+          enchantable: weapon,
+          enchantment: Canonical::Weapon.last.enchantments.first,
+        )
+      end
 
-          let(:enchantable) { false }
+      let(:enchantable) { false }
 
-          it 'sets the canonical weapon' do
-            expect { add_enchantment }
-              .to change(weapon.reload, :canonical_weapon)
-                    .from(nil)
-                    .to(Canonical::Weapon.last)
-          end
+      it 'sets the canonical weapon' do
+        expect { add_enchantment }
+          .to change(weapon.reload, :canonical_weapon)
+                .from(nil)
+                .to(Canonical::Weapon.last)
+      end
 
-          it 'adds missing enchantments' do
-            add_enchantment
-            expect(weapon.enchantments.reload.length).to eq 2
-          end
-        end
+      it 'adds missing enchantments' do
+        add_enchantment
+        expect(weapon.enchantments.reload.length).to eq 2
+      end
+    end
 
-        context 'when there are still multiple canonicals after adding the enchantment' do
-          subject(:add_enchantment) { create(:enchantables_enchantment, enchantable: weapon) }
+    context 'when there are still multiple canonicals after adding the enchantment' do
+      subject(:add_enchantment) { create(:enchantables_enchantment, enchantable: weapon) }
 
-          let(:enchantable) { true }
+      let(:enchantable) { true }
 
-          it "doesn't assign a canonical weapon" do
-            expect { add_enchantment }
-              .not_to change(weapon.reload, :canonical_weapon)
-          end
+      it "doesn't assign a canonical weapon" do
+        expect { add_enchantment }
+          .not_to change(weapon.reload, :canonical_weapon)
+      end
 
-          it "doesn't add additional enchantments" do
-            add_enchantment
-            expect(weapon.enchantments.reload.length).to eq 1
-          end
-        end
+      it "doesn't add additional enchantments" do
+        add_enchantment
+        expect(weapon.enchantments.reload.length).to eq 1
       end
     end
   end


### PR DESCRIPTION
## Context

[**Match Armor models to canonicals based on enchantments**](https://trello.com/c/sv9Nc1Mw/347-match-armor-models-to-canonicals-based-on-enchantments)

When an in-game item model is able to have enchantments, alchemical properties, or other associations, those associations should be used along with attributes to match the model to possible canonical matches. However, we seem to have overlooked this on the Armor model.

## Changes

* Ensure that enchantments on `Armor` models are considered, along with attributes, in identifying canonical matches
* Add tests for new behaviour
* Update docs
* Remove some contexts from the weapon spec that were the only contexts at their level of nesting

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

There is [another card](https://trello.com/c/9i7Z0bjc/345-ensure-associations-updated-when-canonical-models-rematched) to ensure that, if the canonical model changes, associations are added or removed as appropriate.

I'll also check our other models and make sure that others with associations are also matched based on those associations.