### PR TITLE
Match Canonical::ClothingItem models based on enchantments

### DIFF
--- a/app/models/armor.rb
+++ b/app/models/armor.rb
@@ -55,16 +55,14 @@ class Armor < ApplicationRecord
     enchantables_enchantments.each do |join_model|
       canonicals = if join_model.strength.present?
                      canonicals.left_outer_joins(:enchantables_enchantments).where(
-                       '(enchantables_enchantments.enchantment_id = :enchantment_id AND enchantables_enchantments.enchantable_type = :type AND enchantables_enchantments.strength = :strength) OR canonical_armors.enchantable = true',
+                       '(enchantables_enchantments.enchantment_id = :enchantment_id AND enchantables_enchantments.strength = :strength) OR canonical_armors.enchantable = true',
                        enchantment_id: join_model.enchantment_id,
-                       type: 'Canonical::Armor',
                        strength: join_model.strength,
                      )
                    else
                      canonicals.left_outer_joins(:enchantables_enchantments).where(
-                       '(enchantables_enchantments.enchantment_id = :enchantment_id AND enchantables_enchantments.enchantable_type = :type) OR canonical_armors.enchantable = true',
+                       '(enchantables_enchantments.enchantment_id = :enchantment_id) OR canonical_armors.enchantable = true',
                        enchantment_id: join_model.enchantment_id,
-                       type: 'Canonical::Armor',
                      )
                    end
     end

--- a/app/models/armor.rb
+++ b/app/models/armor.rb
@@ -61,7 +61,7 @@ class Armor < ApplicationRecord
                      )
                    else
                      canonicals.left_outer_joins(:enchantables_enchantments).where(
-                       '(enchantables_enchantments.enchantment_id = :enchantment_id) OR canonical_armors.enchantable = true',
+                       '(enchantables_enchantments.enchantment_id = :enchantment_id AND enchantables_enchantments.strength IS NULL) OR canonical_armors.enchantable = true',
                        enchantment_id: join_model.enchantment_id,
                      )
                    end

--- a/app/models/clothing_item.rb
+++ b/app/models/clothing_item.rb
@@ -40,7 +40,26 @@ class ClothingItem < ApplicationRecord
     query += ' AND magical_effects ILIKE :magical_effects' if magical_effects.present?
 
     canonicals = Canonical::ClothingItem.where(query, name:, magical_effects:)
-    attributes_to_match.any? ? canonicals.where(**attributes_to_match) : canonicals
+    canonicals = canonicals.where(**attributes_to_match) if attributes_to_match.any?
+
+    return canonicals if enchantments.none?
+
+    enchantables_enchantments.each do |join_model|
+      canonicals = if join_model.strength.present?
+                     canonicals.left_outer_joins(:enchantables_enchantments).where(
+                       '(enchantables_enchantments.enchantment_id = :enchantment_id AND enchantables_enchantments.strength = :strength) OR canonical_clothing_items.enchantable = true',
+                       enchantment_id: join_model.enchantment_id,
+                       strength: join_model.strength,
+                     )
+                   else
+                     canonicals.left_outer_joins(:enchantables_enchantments).where(
+                       '(enchantables_enchantments.enchantment_id = :enchantment_id AND enchantables_enchantments.strength IS NULL) OR canonical_clothing_items.enchantable = true',
+                       enchantment_id: join_model.enchantment_id,
+                     )
+                   end
+    end
+
+    canonicals.uniq
   end
 
   private

--- a/app/models/weapon.rb
+++ b/app/models/weapon.rb
@@ -62,16 +62,14 @@ class Weapon < ApplicationRecord
     enchantables_enchantments.each do |join_model|
       canonicals = if join_model.strength.present?
                      canonicals.left_outer_joins(:enchantables_enchantments).where(
-                       '(enchantables_enchantments.enchantment_id = :enchantment_id AND enchantables_enchantments.enchantable_type = :type AND enchantables_enchantments.strength = :strength) OR canonical_weapons.enchantable = true',
+                       '(enchantables_enchantments.enchantment_id = :enchantment_id AND enchantables_enchantments.strength = :strength) OR canonical_weapons.enchantable = true',
                        enchantment_id: join_model.enchantment_id,
-                       type: 'Canonical::Weapon',
                        strength: join_model.strength,
                      )
                    else
                      canonicals.left_outer_joins(:enchantables_enchantments).where(
-                       '(enchantables_enchantments.enchantment_id = :enchantment_id AND enchantables_enchantments.enchantable_type = :type AND enchantables_enchantments.strength IS NULL) OR canonical_weapons.enchantable = true',
+                       '(enchantables_enchantments.enchantment_id = :enchantment_id AND enchantables_enchantments.strength IS NULL) OR canonical_weapons.enchantable = true',
                        enchantment_id: join_model.enchantment_id,
-                       type: 'Canonical::Weapon',
                      )
                    end
     end

--- a/docs/in_game_items/clothing-item.md
+++ b/docs/in_game_items/clothing-item.md
@@ -10,6 +10,11 @@ The `ClothingItem` model represents in-game clothing items that are not armour o
 * `unit_weight`
 * `magical_effects`
 
+In addition to these, `ClothingItem` models are matched to canonicals based on any enchantments they may have. In order for a canonical model to match a `ClothingItem` with enchantments, one of the following must be true for all enchantments on the in-game item:
+
+1. The canonical model must have the same enchantment at the same strength, or
+2. The canonical model must have `enchantable` set to `true`, enabling user-added enchantments
+
 ## Associations
 
 Because `ClothingItem` models may (at least theoretically) have user-added enchantments in addition to those present on the canonical model, the `ClothingItem` model has its own associations to `EnchantablesEnchantment` and `Enchantment`. The canonical model's enchantments will automatically be added to the `ClothingItem` model when it is saved and has a single matching `Canonical::ClothingItem` model.


### PR DESCRIPTION
## Context

[**Match ClothingItem models to canonicals based on enchantments**](https://trello.com/c/He2sZUBs/348-match-clothingitem-models-to-canonicals-based-on-enchantments)

If an in-game item is enchantable, any enchantments it has should be taken into consideration when setting a canonical match. However, this logic is missing from a couple of our models, including `ClothingItem` and [`JewelryItem`](https://trello.com/c/lGhtcHKf/349-match-jewelryitem-models-to-canonicals-based-on-enchantments). (The logic was added to `Armor` in #238.)

In the course of doing this work, I noticed that matching logic included queries like,

```ruby
canonicals.left_outer_joins(:enchantables_enchantments).where(
  '(enchantables_enchantments.enchantment_id = :enchantment_id AND enchantables_enchantments.enchantable_type = :type AND enchantables_enchantments.strength = :strength) OR canonical_clothing_items.enchantable = true',
  enchantment_id: join_model.enchantment_id,
  type: 'Canonical::ClothingItem',
  strength: join_model.strength,
)
```

The observant reader will notice that `AND enchantables_enchantments.enchantable_type = :type` is redundant here, because we are already using a join with a `Canonical::ClothingItem` relation. No `EnchantablesEnchantment` in this relation will have any other `enchantable_type`. Since this issue was present in other models too, I've removed it from them as well.

## Changes

* Consider enchantments when matching `ClothingItem` models to canonical matches
* Remove redundant `AND enchantables_enchantments.enchantable_type = :type` from queries on `ClothingItem`, `Armor`, and `Weapon` models
* Add tests for new behaviour
* Update docs

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

There is additional [planned work](https://trello.com/c/9i7Z0bjc/345-ensure-associations-updated-when-canonical-models-rematched) to update/remove associations when a canonical model changes or is removed.
