### PR TITLE
Match JewelryItem models to canonicals on both attributes and enchantments

### DIFF
--- a/docs/in_game_items/jewelry-item.md
+++ b/docs/in_game_items/jewelry-item.md
@@ -10,6 +10,8 @@ The `JewelryItem` model represents in-game items of the `Canonical::JewelryItem`
 * `unit_weight`
 * `magical_effects`
 
+Since `JewelryItem` models can also be enchanted, they are also matched to canonical models based on any enchantments they have. Enchantments must match both the `enchantment_id` and the `strength` (if present) of the enchantment on the canonical model.
+
 ## Associations
 
 Because `JewelryItem` models may (at least theoretically) have user-added enchantments in addition to those present on the canonical model, the `JewelryItem` model has its own associations to `EnchantablesEnchantment` and `Enchantment`. Enchantments that exist on the canonical model will be automatically added to the `JewelryItem` model when it is saved and a single matching `Canonical::JewelryItem` has been identified.

--- a/spec/models/jewelry_item_spec.rb
+++ b/spec/models/jewelry_item_spec.rb
@@ -226,6 +226,73 @@ RSpec.describe JewelryItem, type: :model do
     end
   end
 
+  describe 'adding enchantments' do
+    let(:item) { create(:jewelry_item, name: 'foobar') }
+
+    before do
+      create_list(
+        :canonical_jewelry_item,
+        2,
+        :with_enchantments,
+        name: 'Foobar',
+        enchantable:,
+      )
+    end
+
+    context 'when the added enchantment eliminates all canonical matches' do
+      subject(:add_enchantment) { create(:enchantables_enchantment, enchantable: item) }
+
+      let(:enchantable) { false }
+
+      it "doesn't allow the enchantment to be added", :aggregate_failures do
+        expect { add_enchantment }
+          .to raise_error(ActiveRecord::RecordInvalid)
+
+        expect(item.enchantments.reload.length).to eq 0
+      end
+    end
+
+    context 'when the added enchantment narrows it down to one canonical match' do
+      subject(:add_enchantment) do
+        create(
+          :enchantables_enchantment,
+          enchantable: item,
+          enchantment: Canonical::JewelryItem.last.enchantments.first,
+        )
+      end
+
+      let(:enchantable) { false }
+
+      it 'sets the canonical clothing item' do
+        expect { add_enchantment }
+          .to change(item.reload, :canonical_jewelry_item)
+                .from(nil)
+                .to(Canonical::JewelryItem.last)
+      end
+
+      it 'adds missing enchantments' do
+        add_enchantment
+        expect(item.enchantments.reload.length).to eq 2
+      end
+    end
+
+    context 'when there are still multiple canonicals after adding the enchantment' do
+      subject(:add_enchantment) { create(:enchantables_enchantment, enchantable: item) }
+
+      let(:enchantable) { true }
+
+      it "doesn't assign a canonical clothing item" do
+        expect { add_enchantment }
+          .not_to change(item.reload, :canonical_jewelry_item)
+      end
+
+      it "doesn't add additional enchantments" do
+        add_enchantment
+        expect(item.enchantments.reload.length).to eq 1
+      end
+    end
+  end
+
   describe '#jewelry_type' do
     subject(:jewelry_type) { item.jewelry_type }
 


### PR DESCRIPTION
## Context

[**Match JewelryItem models to canonicals based on enchantments**](https://trello.com/c/lGhtcHKf/349-match-jewelryitem-models-to-canonicals-based-on-enchantments)

When an in-game item model is enchantable, it should be matched with canonical models based on both its attributes and any enchantments it has. However, this logic is missing from the `JewelryItem` model, which is currently matched based solely on attributes.

## Changes

* Ensure that enchantments are considered when matching `JewelryItem` models to canonicals
* Add tests for new behaviour
* Update docs 

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

There is [planned work](https://trello.com/c/9i7Z0bjc/345-ensure-associations-updated-when-canonical-models-rematched) to update and remove enchantments, as appropriate, when canonical models are changed. This PR is just to ensure they are considered when matching.