### PR TITLE
Designate enchantments and alchemical properties added automatically

### DIFF
--- a/app/models/armor.rb
+++ b/app/models/armor.rb
@@ -104,7 +104,9 @@ class Armor < ApplicationRecord
       enchantables_enchantments.find_or_create_by!(
         enchantment_id: model.enchantment_id,
         strength: model.strength,
-      )
+      ) do |created_model|
+        created_model.added_automatically = true
+      end
     end
   end
 

--- a/app/models/armor.rb
+++ b/app/models/armor.rb
@@ -104,9 +104,7 @@ class Armor < ApplicationRecord
       enchantables_enchantments.find_or_create_by!(
         enchantment_id: model.enchantment_id,
         strength: model.strength,
-      ) do |created_model|
-        created_model.added_automatically = true
-      end
+      ) {|new_model| new_model.added_automatically = true }
     end
   end
 

--- a/app/models/clothing_item.rb
+++ b/app/models/clothing_item.rb
@@ -87,7 +87,7 @@ class ClothingItem < ApplicationRecord
       enchantables_enchantments.find_or_create_by!(
         enchantment_id: model.enchantment_id,
         strength: model.strength,
-      )
+      ) {|new_model| new_model.added_automatically = true }
     end
   end
 

--- a/app/models/enchantables_enchantment.rb
+++ b/app/models/enchantables_enchantment.rb
@@ -4,12 +4,26 @@ class EnchantablesEnchantment < ApplicationRecord
   belongs_to :enchantable, polymorphic: true
   belongs_to :enchantment
 
-  validates :enchantment_id, uniqueness: { scope: %i[enchantable_id enchantable_type], message: 'must form a unique combination with enchantable item' }
+  validates :enchantment_id,
+            uniqueness: {
+              scope: %i[enchantable_id enchantable_type],
+              message: 'must form a unique combination with enchantable item',
+            }
+
+  validates :added_automatically,
+            inclusion: {
+              in: [true, false],
+              message: 'must be true or false',
+            }
+
+  before_validation :set_added_automatically
 
   after_validation :validate_against_canonical,
                    if: :should_validate_against_canonical?
 
   after_save :save_associated!, unless: :canonical_enchantable?
+
+  scope :added_manually, -> { where(added_automatically: false) }
 
   private
 
@@ -29,6 +43,11 @@ class EnchantablesEnchantment < ApplicationRecord
 
   def should_validate_against_canonical?
     errors.none? && !canonical_enchantable?
+  end
+
+  def set_added_automatically
+    self.added_automatically = true if canonical_enchantable?
+    self.added_automatically = false if added_automatically.nil?
   end
 
   def canonical_enchantable?

--- a/app/models/enchantables_enchantment.rb
+++ b/app/models/enchantables_enchantment.rb
@@ -23,7 +23,7 @@ class EnchantablesEnchantment < ApplicationRecord
 
   after_save :save_associated!, unless: :canonical_enchantable?
 
-  scope :added_manually, -> { where(added_automatically: false) }
+  scope :added_automatically, -> { where(added_automatically: true) }
 
   private
 

--- a/app/models/jewelry_item.rb
+++ b/app/models/jewelry_item.rb
@@ -113,7 +113,7 @@ class JewelryItem < ApplicationRecord
       enchantables_enchantments.find_or_create_by!(
         enchantment_id: model.enchantment_id,
         strength: model.strength,
-      )
+      ) {|new_model| new_model.added_automatically = true }
     end
   end
 

--- a/app/models/potions_alchemical_property.rb
+++ b/app/models/potions_alchemical_property.rb
@@ -32,7 +32,7 @@ class PotionsAlchemicalProperty < ApplicationRecord
   before_validation :set_added_automatically, if: -> { added_automatically.nil? }
   after_save :save_associated!
 
-  scope :added_manually, -> { where(added_automatically: false) }
+  scope :added_automatically, -> { where(added_automatically: true) }
 
   MAX_PER_POTION = Canonical::PotionsAlchemicalProperty::MAX_PER_POTION
 

--- a/app/models/potions_alchemical_property.rb
+++ b/app/models/potions_alchemical_property.rb
@@ -21,12 +21,25 @@ class PotionsAlchemicalProperty < ApplicationRecord
               only_integer: true,
               allow_nil: true,
             }
+  validates :added_automatically,
+            inclusion: {
+              in: [true, false],
+              message: 'must be true or false',
+            }
 
   validate :ensure_max_per_potion
+
+  before_validation :set_added_automatically, if: -> { added_automatically.nil? }
+
+  scope :added_manually, -> { where(added_automatically: false) }
 
   MAX_PER_POTION = Canonical::PotionsAlchemicalProperty::MAX_PER_POTION
 
   private
+
+  def set_added_automatically
+    self.added_automatically = false
+  end
 
   def ensure_max_per_potion
     return if potion.alchemical_properties.length < MAX_PER_POTION

--- a/app/models/potions_alchemical_property.rb
+++ b/app/models/potions_alchemical_property.rb
@@ -31,7 +31,7 @@ class PotionsAlchemicalProperty < ApplicationRecord
 
   before_validation :set_added_automatically, if: -> { added_automatically.nil? }
 
-  scope :added_manually, -> { where(added_automatically: false) }
+  scope :added_manually, -> { where(added_automatically: true) }
 
   MAX_PER_POTION = Canonical::PotionsAlchemicalProperty::MAX_PER_POTION
 

--- a/app/models/potions_alchemical_property.rb
+++ b/app/models/potions_alchemical_property.rb
@@ -30,12 +30,17 @@ class PotionsAlchemicalProperty < ApplicationRecord
   validate :ensure_max_per_potion
 
   before_validation :set_added_automatically, if: -> { added_automatically.nil? }
+  after_save :save_associated!
 
-  scope :added_manually, -> { where(added_automatically: true) }
+  scope :added_manually, -> { where(added_automatically: false) }
 
   MAX_PER_POTION = Canonical::PotionsAlchemicalProperty::MAX_PER_POTION
 
   private
+
+  def save_associated!
+    potion.save!
+  end
 
   def set_added_automatically
     self.added_automatically = false

--- a/app/models/weapon.rb
+++ b/app/models/weapon.rb
@@ -116,7 +116,7 @@ class Weapon < ApplicationRecord
       enchantables_enchantments.find_or_create_by!(
         enchantment:,
         strength: enchantment.strength,
-      )
+      ) {|new_model| new_model.added_automatically = true }
     end
   end
 

--- a/db/migrate/20231111205621_add_added_automatically_to_join_models.rb
+++ b/db/migrate/20231111205621_add_added_automatically_to_join_models.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class AddAddedAutomaticallyToJoinModels < ActiveRecord::Migration[7.1]
+  def up
+    add_column :enchantables_enchantments,
+               :added_automatically,
+               :boolean,
+               default: false
+
+    add_column :potions_alchemical_properties,
+               :added_automatically,
+               :boolean,
+               default: false
+
+    # rubocop:disable Rails/SkipsModelValidations
+    EnchantablesEnchantment.update_all(added_automatically: true)
+    PotionsAlchemicalProperty.update_all(added_automatically: true)
+    # rubocop:enable Rails/SkipsModelValidations
+
+    change_column_null :enchantables_enchantments, :added_automatically, false
+    change_column_null :potions_alchemical_properties, :added_automatically, false
+  end
+
+  def down
+    remove_column :enchantables_enchantments, :added_automatically
+    remove_column :potions_alchemical_properties, :added_automatically
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_05_222944) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_11_205621) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -339,6 +339,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_05_222944) do
     t.decimal "strength", precision: 5, scale: 2
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "added_automatically", default: false, null: false
     t.index ["enchantment_id", "enchantable_id", "enchantable_type"], name: "index_enchantables_enchantments_on_enchmnt_id_enchble_id_type", unique: true
     t.index ["enchantment_id"], name: "index_enchantables_enchantments_on_enchantment_id"
   end
@@ -452,6 +453,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_05_222944) do
     t.integer "duration"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "added_automatically", default: false, null: false
     t.index ["alchemical_property_id"], name: "index_potions_alchemical_properties_on_alchemical_property_id"
     t.index ["potion_id", "alchemical_property_id"], name: "index_potions_alc_properties_on_potion_id_alc_property_id", unique: true
     t.index ["potion_id"], name: "index_potions_alchemical_properties_on_potion_id"

--- a/docs/in_game_items/armor.md
+++ b/docs/in_game_items/armor.md
@@ -18,7 +18,7 @@ If an `Armor` model has enchantments, its enchantments are also matched against 
 
 ## Associations
 
-Because `Armor` models may (at least theoretically) have user-added enchantments in addition to those present on the canonical model, the `Armor` model has its own associations to `EnchantablesEnchantment` and `Enchantment`. The canonical model's enchantments will automatically be added to the `Armor` model when it is saved and has a single matching `Canonical::Armor` model.
+Because `Armor` models may (at least theoretically) have user-added enchantments in addition to those present on the canonical model, the `Armor` model has its own associations to `EnchantablesEnchantment` and `Enchantment`. The canonical model's enchantments will automatically be added to the `Armor` model when it is saved and has a single matching `Canonical::Armor` model. Enchantments added automatically in this way will have `added_automatically` set to `true` (this attribute is set on the `EnchantablesEnchantment` join model). Otherwise, it will be set to `false`.
 
 The `Canonical::Armor` model has associations to `tempering_materials` and `crafting_materials` that will be the same for all non-canonical models that inherit from a given canonical model. For this reason, calling `#crafting_materials` or `#tempering_materials` on a non-canonical `Armor` model will return the crafting materials or tempering materials for its corresponding `Canonical::Armor` if one exists.
 

--- a/docs/in_game_items/clothing-item.md
+++ b/docs/in_game_items/clothing-item.md
@@ -17,4 +17,4 @@ In addition to these, `ClothingItem` models are matched to canonicals based on a
 
 ## Associations
 
-Because `ClothingItem` models may (at least theoretically) have user-added enchantments in addition to those present on the canonical model, the `ClothingItem` model has its own associations to `EnchantablesEnchantment` and `Enchantment`. The canonical model's enchantments will automatically be added to the `ClothingItem` model when it is saved and has a single matching `Canonical::ClothingItem` model.
+Because `ClothingItem` models may (at least theoretically) have user-added enchantments in addition to those present on the canonical model, the `ClothingItem` model has its own associations to `EnchantablesEnchantment` and `Enchantment`. The canonical model's enchantments will automatically be added to the `ClothingItem` model when it is saved and has a single matching `Canonical::ClothingItem` model. Enchantments added automatically in this way will have `added_automatically` set to `true` on the `EnchantablesEnchantment` join model. Other enchantments will have this attribute set to `false`.

--- a/docs/in_game_items/jewelry-item.md
+++ b/docs/in_game_items/jewelry-item.md
@@ -14,7 +14,7 @@ Since `JewelryItem` models can also be enchanted, they are also matched to canon
 
 ## Associations
 
-Because `JewelryItem` models may (at least theoretically) have user-added enchantments in addition to those present on the canonical model, the `JewelryItem` model has its own associations to `EnchantablesEnchantment` and `Enchantment`. Enchantments that exist on the canonical model will be automatically added to the `JewelryItem` model when it is saved and a single matching `Canonical::JewelryItem` has been identified.
+Because `JewelryItem` models may (at least theoretically) have user-added enchantments in addition to those present on the canonical model, the `JewelryItem` model has its own associations to `EnchantablesEnchantment` and `Enchantment`. Enchantments that exist on the canonical model will be automatically added to the `JewelryItem` model when it is saved and a single matching `Canonical::JewelryItem` has been identified. Enchantments added automatically in this way will have the `added_automatically` attribute set to true on the `EnchantablesEnchantment` join model. For other enchantments, this value will be set to `false`.
 
 The `Canonical::JewelryItem` model has associations to `crafting_materials` that will be the same for all non-canonical models that inherit from a given canonical model. For this reason, calling `#crafting_materials` on a non-canonical `JewelryItem` model will return the crafting materials for its corresponding `Canonical::JewelryItem` if one exists.
 

--- a/docs/in_game_items/potion.md
+++ b/docs/in_game_items/potion.md
@@ -11,3 +11,5 @@ When a `Potion` is created, it is then matched to a subset of canonical potions 
 ## The `PotionsAlchemicalProperty` Join Model
 
 The `Potion` model is associated to the `AlchemicalProperty` model via the `PotionsAlchemicalProperty` join model. This model has [its own docs](/docs/in_game_items/potions-alchemical-property.md) but it is worth mentioning here as well. The join table contains attributes about the integer `strength` and `duration` of the property in that potion. There is a validation on the join model ensuring that no potion can have more than 4 alchemical effects.
+
+When a potion is matched with a `Canonical::Potion`, any alchemical properties present on the canonical potion but not the in-game potion will be added. In this case, the `added_automatically` attribute will be set to `true` on the join model. If the alchemical property is added to the potion by the user, this attribute will be set to `false`.

--- a/docs/in_game_items/potions-alchemical-property.md
+++ b/docs/in_game_items/potions-alchemical-property.md
@@ -9,3 +9,7 @@ In Skyrim, each potion's properties can have a `strength` and/or `duration` defi
 ## Matching Canonical Models
 
 This join model does not validate the presence of a corresponding canonical model when it's created, both to avoid expensive database queries and to reflect the fact that not all potions have corresponding canonical potions.
+
+## `added_automatically`
+
+This `PotionsAlchemicalProperty` join model has an attribute, `added_automatically`, to indicate when an alchemical property has been added to a potion automatically based on its canonical potion versus when it has been added by the user.

--- a/docs/in_game_items/weapon.md
+++ b/docs/in_game_items/weapon.md
@@ -16,6 +16,8 @@ The `Weapon` model represents in-game items of the `Canonical::Weapon` type.
 
 Because `Weapon` models may (at least theoretically) have user-added enchantments in addition to those present on the canonical model, the `Weapon` model has its own associations to `EnchantablesEnchantment` and `Enchantment`. The canonical model's enchantments will automatically be added to the `Weapon` model after save if it has a single matching `Canonical::Weapon` model. If additional enchantments are added, the `EnchantablesEnchantment` model validates that the canonical weapon either has the same enchantment or is `enchantable` before the join model is allowed to be created.
 
+When an enchantment is added to a `Weapon` model automatically from its `Canonical::Weapon` association, the `added_automatically` attribute will be set to `true` on the `EnchantablesEnchantment` join model. For associations added by the user, this attribute will be set to `false`.
+
 Like the [`Armor` model](/docs/in_game_items/armor.md), a weapon's `crafting_materials` and `tempering_materials` don't differ from the canonical model, so `Weapon`s don't have their own associations and instead pull crafting and tempering materials from the `Canonical::Weapon` model if they have one.
 
 ## Auto-Populated Fields

--- a/spec/models/armor_spec.rb
+++ b/spec/models/armor_spec.rb
@@ -287,6 +287,12 @@ RSpec.describe Armor, type: :model do
           expect(armor.enchantments.length).to eq 2
         end
 
+        it 'sets "added_automatically" to true on new associations' do
+          armor.save!
+
+          expect(armor.enchantables_enchantments.pluck(:added_automatically).uniq).to eq [true]
+        end
+
         it 'sets the correct strengths', :aggregate_failures do
           armor.save!
           matching_canonical.enchantables_enchantments.each do |join_model|
@@ -311,6 +317,11 @@ RSpec.describe Armor, type: :model do
 
         it "doesn't remove the existing enchantments" do
           expect(armor.enchantments.reload.length).to eq 4
+        end
+
+        it 'sets "added_automatically" only on the new associations' do
+          expect(armor.enchantables_enchantments.pluck(:added_automatically))
+            .to eq [true, true, false, false]
         end
       end
     end

--- a/spec/models/armor_spec.rb
+++ b/spec/models/armor_spec.rb
@@ -290,7 +290,8 @@ RSpec.describe Armor, type: :model do
         it 'sets "added_automatically" to true on new associations' do
           armor.save!
 
-          expect(armor.enchantables_enchantments.pluck(:added_automatically).uniq).to eq [true]
+          expect(armor.enchantables_enchantments.pluck(:added_automatically))
+            .to be_all(true)
         end
 
         it 'sets the correct strengths', :aggregate_failures do
@@ -443,6 +444,7 @@ RSpec.describe Armor, type: :model do
           :enchantables_enchantment,
           enchantable: armor,
           enchantment: Canonical::Armor.last.enchantments.first,
+          strength: Canonical::Armor.last.enchantments.first.strength,
         )
       end
 

--- a/spec/models/clothing_item_spec.rb
+++ b/spec/models/clothing_item_spec.rb
@@ -202,6 +202,12 @@ RSpec.describe ClothingItem, type: :model do
           expect(item.enchantments.length).to eq 2
         end
 
+        it 'sets "added_automatically" to true on new associations' do
+          item.save!
+
+          expect(item.enchantables_enchantments.pluck(:added_automatically).uniq).to eq [true]
+        end
+
         it 'sets the correct strengths', :aggregate_failures do
           item.save!
           matching_canonical.enchantables_enchantments.each do |join_model|
@@ -227,6 +233,13 @@ RSpec.describe ClothingItem, type: :model do
         it "doesn't remove the existing enchantments" do
           item.save!
           expect(item.enchantments.reload.length).to eq 4
+        end
+
+        it 'sets "added_automatically" only on the new associations' do
+          item.save!
+
+          expect(item.enchantables_enchantments.pluck(:added_automatically))
+            .to eq [true, true, false, false]
         end
       end
     end

--- a/spec/models/clothing_item_spec.rb
+++ b/spec/models/clothing_item_spec.rb
@@ -205,7 +205,8 @@ RSpec.describe ClothingItem, type: :model do
         it 'sets "added_automatically" to true on new associations' do
           item.save!
 
-          expect(item.enchantables_enchantments.pluck(:added_automatically).uniq).to eq [true]
+          expect(item.enchantables_enchantments.pluck(:added_automatically))
+            .to be_all(true)
         end
 
         it 'sets the correct strengths', :aggregate_failures do
@@ -350,6 +351,7 @@ RSpec.describe ClothingItem, type: :model do
           :enchantables_enchantment,
           enchantable: item,
           enchantment: Canonical::ClothingItem.last.enchantments.first,
+          strength: Canonical::ClothingItem.last.enchantments.first.strength,
         )
       end
 

--- a/spec/models/enchantables_enchantment_spec.rb
+++ b/spec/models/enchantables_enchantment_spec.rb
@@ -6,100 +6,185 @@ RSpec.describe EnchantablesEnchantment, type: :model do
   let(:enchantment) { create(:enchantment) }
 
   describe 'validations' do
+    subject(:validate) { model.validate }
+
     describe 'enchantable item and enchantment' do
       let(:armor) { create(:canonical_armor) }
 
+      let(:model) do
+        build(
+          :enchantables_enchantment,
+          enchantable: armor,
+          enchantment:,
+        )
+      end
+
       it 'must form a unique combination' do
         create(:enchantables_enchantment, :for_canonical_armor, enchantable: armor, enchantment:)
-        model = build(:enchantables_enchantment, :for_canonical_armor, enchantable: armor, enchantment:)
+        validate
 
-        model.validate
         expect(model.errors[:enchantment_id]).to include 'must form a unique combination with enchantable item'
       end
     end
 
-    describe 'polymorphic associations' do
-      subject(:enchantable_type) { described_class.new(enchantable: item, enchantment: create(:enchantment)).enchantable_type }
+    describe '#added_automatically' do
+      context 'when the association is not a canonical model' do
+        let(:model) { build(:enchantables_enchantment, :for_armor) }
 
-      context 'when the association is a canonical armor item' do
-        let(:item) { create(:canonical_armor) }
+        it 'can be true' do
+          model.added_automatically = true
+          validate
 
-        it 'sets the enchantable type' do
-          expect(enchantable_type).to eq 'Canonical::Armor'
+          expect(model.errors[:added_automatically]).to be_empty
+        end
+
+        it "doesn't change a true value" do
+          model.added_automatically = true
+
+          expect { validate }
+            .not_to change(model, :added_automatically)
+        end
+
+        it 'can be false' do
+          model.added_automatically = false
+          validate
+
+          expect(model.errors[:added_automatically]).to be_empty
+        end
+
+        it 'changes nil values' do
+          model.added_automatically = nil
+
+          expect { validate }
+            .to change(model, :added_automatically)
+                  .to(false)
         end
       end
 
-      context 'when the association is a canonical weapon' do
-        let(:item) { create(:canonical_weapon) }
+      context 'when the association is a canonical model' do
+        let(:model) { build(:enchantables_enchantment, :for_canonical_weapon) }
 
-        it 'sets the enchantable type' do
-          expect(enchantable_type).to eq 'Canonical::Weapon'
+        it 'is automatically changed to true if set to false' do
+          model.added_automatically = true
+          validate
+
+          expect(model.added_automatically).to be true
+        end
+
+        it 'is automatically changed to true if nil' do
+          model.added_automatically = nil
+          validate
+
+          expect(model.added_automatically).to be true
         end
       end
+    end
+  end
 
-      context 'when the association is a canonical jewelry item' do
-        let(:item) { create(:canonical_jewelry_item) }
+  describe 'polymorphic associations' do
+    subject(:enchantable_type) do
+      described_class
+        .new(enchantable: item, enchantment: create(:enchantment)).enchantable_type
+    end
 
-        it 'sets the enchantable type' do
-          expect(enchantable_type).to eq 'Canonical::JewelryItem'
-        end
+    context 'when the association is a canonical armor item' do
+      let(:item) { create(:canonical_armor) }
+
+      it 'sets the enchantable type' do
+        expect(enchantable_type).to eq 'Canonical::Armor'
+      end
+    end
+
+    context 'when the association is a canonical weapon' do
+      let(:item) { create(:canonical_weapon) }
+
+      it 'sets the enchantable type' do
+        expect(enchantable_type).to eq 'Canonical::Weapon'
+      end
+    end
+
+    context 'when the association is a canonical jewelry item' do
+      let(:item) { create(:canonical_jewelry_item) }
+
+      it 'sets the enchantable type' do
+        expect(enchantable_type).to eq 'Canonical::JewelryItem'
+      end
+    end
+
+    context 'when the association is a canonical clothing item' do
+      let(:item) { create(:canonical_clothing_item) }
+
+      it 'sets the enchantable type' do
+        expect(enchantable_type).to eq 'Canonical::ClothingItem'
+      end
+    end
+
+    context 'when the association is an armor item' do
+      let(:item) { create(:armor) }
+
+      before do
+        create(:canonical_armor)
       end
 
-      context 'when the association is a canonical clothing item' do
-        let(:item) { create(:canonical_clothing_item) }
+      it 'sets the enchantable type' do
+        expect(enchantable_type).to eq 'Armor'
+      end
+    end
 
-        it 'sets the enchantable type' do
-          expect(enchantable_type).to eq 'Canonical::ClothingItem'
-        end
+    context 'when the association is a clothing item' do
+      let(:item) { create(:clothing_item) }
+
+      before do
+        create(:canonical_clothing_item)
       end
 
-      context 'when the association is an armor item' do
-        let(:item) { create(:armor) }
+      it 'sets the enchantable type' do
+        expect(enchantable_type).to eq 'ClothingItem'
+      end
+    end
 
-        before do
-          create(:canonical_armor)
-        end
+    context 'when the association is a jewelry item' do
+      let(:item) { create(:jewelry_item) }
 
-        it 'sets the enchantable type' do
-          expect(enchantable_type).to eq 'Armor'
-        end
+      before do
+        create(:canonical_jewelry_item)
       end
 
-      context 'when the association is a clothing item' do
-        let(:item) { create(:clothing_item) }
+      it 'sets the enchantable type' do
+        expect(enchantable_type).to eq 'JewelryItem'
+      end
+    end
 
-        before do
-          create(:canonical_clothing_item)
-        end
+    context 'when the association is a weapon' do
+      let(:item) { create(:weapon) }
 
-        it 'sets the enchantable type' do
-          expect(enchantable_type).to eq 'ClothingItem'
-        end
+      before do
+        create(:canonical_weapon)
       end
 
-      context 'when the association is a jewelry item' do
-        let(:item) { create(:jewelry_item) }
-
-        before do
-          create(:canonical_jewelry_item)
-        end
-
-        it 'sets the enchantable type' do
-          expect(enchantable_type).to eq 'JewelryItem'
-        end
+      it 'sets the enchantable type' do
+        expect(enchantable_type).to eq 'Weapon'
       end
+    end
+  end
 
-      context 'when the association is a weapon' do
-        let(:item) { create(:weapon) }
+  describe '::added_manually scope' do
+    subject(:added_manually) { described_class.added_manually }
 
-        before do
-          create(:canonical_weapon)
-        end
+    let!(:included_models) do
+      [
+        create(:enchantables_enchantment, :for_armor, added_automatically: false),
+        create(:enchantables_enchantment, :for_weapon, added_automatically: false),
+      ]
+    end
 
-        it 'sets the enchantable type' do
-          expect(enchantable_type).to eq 'Weapon'
-        end
-      end
+    before do
+      create(:enchantables_enchantment, :for_canonical_armor)
+      create(:enchantables_enchantment, :for_armor, added_automatically: true)
+    end
+
+    it 'includes all models with #added_automatically set to false' do
+      expect(added_manually).to contain_exactly(*included_models)
     end
   end
 

--- a/spec/models/enchantables_enchantment_spec.rb
+++ b/spec/models/enchantables_enchantment_spec.rb
@@ -168,23 +168,23 @@ RSpec.describe EnchantablesEnchantment, type: :model do
     end
   end
 
-  describe '::added_manually scope' do
-    subject(:added_manually) { described_class.added_manually }
+  describe '::added_automatically scope' do
+    subject(:added_automatically) { described_class.added_automatically }
 
     let!(:included_models) do
       [
-        create(:enchantables_enchantment, :for_armor, added_automatically: false),
-        create(:enchantables_enchantment, :for_weapon, added_automatically: false),
+        create(:enchantables_enchantment, :for_armor, added_automatically: true),
+        create(:enchantables_enchantment, :for_weapon, added_automatically: true),
+        create(:enchantables_enchantment, :for_canonical_clothing),
       ]
     end
 
     before do
-      create(:enchantables_enchantment, :for_canonical_armor)
-      create(:enchantables_enchantment, :for_armor, added_automatically: true)
+      create(:enchantables_enchantment, :for_armor, added_automatically: false)
     end
 
-    it 'includes all models with #added_automatically set to false' do
-      expect(added_manually).to contain_exactly(*included_models)
+    it 'includes all models with #added_automatically set to true' do
+      expect(added_automatically).to contain_exactly(*included_models)
     end
   end
 

--- a/spec/models/jewelry_item_spec.rb
+++ b/spec/models/jewelry_item_spec.rb
@@ -451,7 +451,7 @@ RSpec.describe JewelryItem, type: :model do
     let(:item) { create(:jewelry_item, name: 'Gold Diamond Ring') }
 
     context 'when there is a single matching canonical model' do
-      before do
+      let!(:matching_canonical) do
         create(
           :canonical_jewelry_item,
           :with_enchantments,
@@ -459,8 +459,58 @@ RSpec.describe JewelryItem, type: :model do
         )
       end
 
-      it 'adds enchantments' do
-        expect(item.enchantments.length).to eq 2
+      context "when the new item doesn't have its own enchantments" do
+        let(:item) do
+          build(
+            :jewelry_item,
+            name: 'Gold diamond ring',
+          )
+        end
+
+        it 'adds enchantments from the canonical model' do
+          item.save!
+          expect(item.enchantments.length).to eq 2
+        end
+
+        it 'sets "added_automatically" to true on new associations' do
+          item.save!
+          expect(item.enchantables_enchantments.pluck(:added_automatically).uniq)
+            .to eq [true]
+        end
+
+        it 'sets the correct strengths', :aggregate_failures do
+          item.save!
+
+          matching_canonical.enchantables_enchantments.each do |join_model|
+            has_matching = item.enchantables_enchantments.any? do |model|
+              model.enchantment == join_model.enchantment && model.strength == join_model.strength
+            end
+
+            expect(has_matching).to be true
+          end
+        end
+      end
+
+      context 'when the new item has its own enchantments' do
+        let(:item) do
+          create(
+            :jewelry_item,
+            :with_enchantments,
+            name: 'Gold diamond ring',
+          )
+        end
+
+        it "doesn't remove the existing enchantments" do
+          item.save!
+          expect(item.enchantments.reload.length).to eq 4
+        end
+
+        it 'sets "added_automatically" only on the new associations' do
+          item.save!
+
+          expect(item.enchantables_enchantments.pluck(:added_automatically))
+            .to eq [true, true, false, false]
+        end
       end
     end
 

--- a/spec/models/jewelry_item_spec.rb
+++ b/spec/models/jewelry_item_spec.rb
@@ -258,6 +258,7 @@ RSpec.describe JewelryItem, type: :model do
           :enchantables_enchantment,
           enchantable: item,
           enchantment: Canonical::JewelryItem.last.enchantments.first,
+          strength: Canonical::JewelryItem.last.enchantments.first.strength,
         )
       end
 
@@ -474,8 +475,8 @@ RSpec.describe JewelryItem, type: :model do
 
         it 'sets "added_automatically" to true on new associations' do
           item.save!
-          expect(item.enchantables_enchantments.pluck(:added_automatically).uniq)
-            .to eq [true]
+          expect(item.enchantables_enchantments.pluck(:added_automatically))
+            .to be_all(true)
         end
 
         it 'sets the correct strengths', :aggregate_failures do

--- a/spec/models/potion_spec.rb
+++ b/spec/models/potion_spec.rb
@@ -572,7 +572,20 @@ RSpec.describe Potion, type: :model do
       it 'sets "added_automatically" to true on new associations' do
         potion.save!
 
-        expect(potion.potions_alchemical_properties.pluck(:added_automatically).uniq).to eq [true]
+        expect(potion.potions_alchemical_properties.pluck(:added_automatically))
+          .to be_all(true)
+      end
+
+      it 'sets the correct strength and duration', :aggregate_failures do
+        potion.save!
+
+        potion.canonical_potion.canonical_potions_alchemical_properties.each do |model|
+          has_match = potion.potions_alchemical_properties.any? do |join_model|
+            join_model.strength == model.strength && join_model.duration == model.duration
+          end
+
+          expect(has_match).to be true
+        end
       end
     end
 

--- a/spec/models/potions_alchemical_property_spec.rb
+++ b/spec/models/potions_alchemical_property_spec.rb
@@ -89,6 +89,42 @@ RSpec.describe PotionsAlchemicalProperty, type: :model do
       end
     end
 
+    describe '#added_automatically' do
+      it 'can be true' do
+        model.added_automatically = true
+
+        expect(model).to be_valid
+      end
+
+      it "doesn't change a true value" do
+        model.added_automatically = true
+
+        expect { model.validate }
+          .not_to change(model, :added_automatically)
+      end
+
+      it 'can be false' do
+        model.added_automatically = false
+
+        expect(model).to be_valid
+      end
+
+      it "doesn't change a false value" do
+        model.added_automatically = false
+
+        expect { model.validate }
+          .not_to change(model, :added_automatically)
+      end
+
+      it 'changes a nil value to false' do
+        model.added_automatically = nil
+
+        expect { model.validate }
+          .to change(model, :added_automatically)
+                .to(false)
+      end
+    end
+
     describe 'alchemical effects' do
       let(:potion) { create(:potion) }
       let(:model) { build(:potions_alchemical_property, potion:) }
@@ -126,6 +162,26 @@ RSpec.describe PotionsAlchemicalProperty, type: :model do
           expect(model.errors[:potion]).to include 'can have a maximum of 4 effects'
         end
       end
+    end
+  end
+
+  describe '::added_manually scope' do
+    subject(:added_manually) { described_class.added_manually }
+
+    let!(:included_models) do
+      create_list(
+        :potions_alchemical_property,
+        2,
+        added_automatically: false,
+      )
+    end
+
+    before do
+      create(:potions_alchemical_property, added_automatically: true)
+    end
+
+    it 'includes manually created models only' do
+      expect(added_manually).to contain_exactly(*included_models)
     end
   end
 end

--- a/spec/models/potions_alchemical_property_spec.rb
+++ b/spec/models/potions_alchemical_property_spec.rb
@@ -165,23 +165,23 @@ RSpec.describe PotionsAlchemicalProperty, type: :model do
     end
   end
 
-  describe '::added_manually scope' do
-    subject(:added_manually) { described_class.added_manually }
+  describe '::added_automatically scope' do
+    subject(:added_automatically) { described_class.added_automatically }
 
     let!(:included_models) do
       create_list(
         :potions_alchemical_property,
         2,
-        added_automatically: false,
+        added_automatically: true,
       )
     end
 
     before do
-      create(:potions_alchemical_property, added_automatically: true)
+      create(:potions_alchemical_property, added_automatically: false)
     end
 
-    it 'includes manually created models only' do
-      expect(added_manually).to contain_exactly(*included_models)
+    it 'includes automatically created models only' do
+      expect(added_automatically).to contain_exactly(*included_models)
     end
   end
 end

--- a/spec/models/potions_alchemical_property_spec.rb
+++ b/spec/models/potions_alchemical_property_spec.rb
@@ -165,23 +165,23 @@ RSpec.describe PotionsAlchemicalProperty, type: :model do
     end
   end
 
-  describe '::added_manually scope' do
-    subject(:added_manually) { described_class.added_manually }
+  describe '::added_automatically scope' do
+    subject(:added_automatically) { described_class.added_automatically }
 
     let!(:included_models) do
       create_list(
         :potions_alchemical_property,
         2,
-        added_automatically: false,
+        added_automatically: true,
       )
     end
 
     before do
-      create(:potions_alchemical_property, added_automatically: true)
+      create(:potions_alchemical_property, added_automatically: false)
     end
 
     it 'includes automatically created models only' do
-      expect(added_manually).to contain_exactly(*included_models)
+      expect(added_automatically).to contain_exactly(*included_models)
     end
   end
 end

--- a/spec/models/potions_alchemical_property_spec.rb
+++ b/spec/models/potions_alchemical_property_spec.rb
@@ -165,23 +165,23 @@ RSpec.describe PotionsAlchemicalProperty, type: :model do
     end
   end
 
-  describe '::added_automatically scope' do
-    subject(:added_automatically) { described_class.added_automatically }
+  describe '::added_manually scope' do
+    subject(:added_manually) { described_class.added_manually }
 
     let!(:included_models) do
       create_list(
         :potions_alchemical_property,
         2,
-        added_automatically: true,
+        added_automatically: false,
       )
     end
 
     before do
-      create(:potions_alchemical_property, added_automatically: false)
+      create(:potions_alchemical_property, added_automatically: true)
     end
 
     it 'includes automatically created models only' do
-      expect(added_automatically).to contain_exactly(*included_models)
+      expect(added_manually).to contain_exactly(*included_models)
     end
   end
 end

--- a/spec/models/weapon_spec.rb
+++ b/spec/models/weapon_spec.rb
@@ -379,110 +379,61 @@ RSpec.describe Weapon, type: :model do
 
   describe '::after_save' do
     context 'when there is one matching canonical model' do
-      subject(:save) { weapon.save! }
-
-      context 'when neither the canonical nor the in-game item have enchantments' do
-        let(:weapon) { build(:weapon, :with_matching_canonical) }
-
-        it "doesn't add enchantments" do
-          expect { save }
-            .not_to change(weapon, :enchantments)
-        end
+      let!(:matching_canonical) do
+        create(
+          :canonical_weapon,
+          :with_enchantments,
+          name: 'Elven War Axe',
+        )
       end
 
-      context 'when the canonical weapon is enchanted' do
-        subject(:add_enchantment) do
-          create(
-            :enchantables_enchantment,
-            enchantable: weapon,
-            enchantment: Canonical::Weapon.first.enchantments.first,
+      context "when the new weapon doesn't have its own enchantments" do
+        let(:weapon) do
+          build(
+            :weapon,
+            name: 'elven war axe',
           )
         end
 
-        let(:weapon) { build(:weapon, name: 'foobar') }
-
-        context 'when the in-game item is not enchanted' do
-          before do
-            matching_canonical = create(
-              :canonical_weapon,
-              name: 'Foobar',
-            )
-
-            # We need to save the weapon now so that it doesn't add enchantments
-            # from the matching canonical if we create/save it after the enchantments
-            # have been added to the canonical.
-            weapon.save!
-
-            create_list(
-              :enchantables_enchantment,
-              2,
-              enchantable: matching_canonical,
-            )
-          end
-
-          it 'adds enchantments from the canonical' do
-            add_enchantment
-            expect(weapon.reload.enchantments.length).to eq 2
-          end
+        it 'adds enchantments from the canonical weapon' do
+          weapon.save!
+          expect(weapon.enchantments.length).to eq 2
         end
 
-        context 'when the in-game item has matching enchantments' do
-          before do
-            create_list(
-              :canonical_weapon,
-              2,
-              :with_enchantments,
-              name: 'Foobar',
-              # Set enchantable to false, otherwise both canonicals
-              # will continue to match the weapon object even after
-              # enchantments are added
-              enchantable: false,
-            )
-          end
+        it 'sets "added_automatically" to true on new associations' do
+          weapon.save!
 
-          it 'adds missing enchantments' do
-            add_enchantment
-            expect(weapon.reload.enchantments.length).to eq 2
-          end
+          expect(weapon.enchantables_enchantments.pluck(:added_automatically).uniq).to eq [true]
         end
 
-        # We don't need to include sub-contexts for enchantable vs.
-        # non-enchantable canonicals, because if the canonicals are not
-        # enchantable then there will be no matching canonicals, which
-        # would be impossible to set up because SIM doesn't allow any
-        # weapon to be saved if no canonicals match.
-        context 'when the in-game item has non-matching enchantments' do
-          subject(:add_enchantment) { create(:enchantables_enchantment, enchantable: weapon) }
+        it 'sets the correct strengths', :aggregate_failures do
+          weapon.save!
+          matching_canonical.enchantables_enchantments.each do |join_model|
+            has_matching = weapon.enchantables_enchantments.any? do |model|
+              model.enchantment == join_model.enchantment && model.strength == join_model.strength
+            end
 
-          let(:weapon) { create(:weapon, name: 'foobar') }
-
-          before do
-            create(
-              :canonical_weapon,
-              :with_enchantments,
-              name: 'Foobar',
-              enchantable: true,
-            )
-
-            create(
-              :canonical_weapon,
-              :with_enchantments,
-              name: 'Foobar',
-              enchantable: false,
-            )
+            expect(has_matching).to be true
           end
+        end
+      end
 
-          it 'sets the canonical weapon' do
-            expect { add_enchantment }
-              .to change(weapon.reload, :canonical_weapon)
-                    .from(nil)
-                    .to(Canonical::Weapon.first)
-          end
+      context 'when the new weapon has its own enchantments' do
+        let(:weapon) do
+          create(
+            :weapon,
+            :with_enchantments,
+            name: 'elven war axe',
+          )
+        end
 
-          it 'adds any enchantments from the enchantable canonical' do
-            add_enchantment
-            expect(weapon.reload.enchantments.length).to eq 3
-          end
+        it "doesn't remove the existing enchantments" do
+          expect(weapon.enchantments.reload.length).to eq 4
+        end
+
+        it 'sets "added_automatically" only on the new associations' do
+          expect(weapon.enchantables_enchantments.pluck(:added_automatically))
+            .to eq [true, true, false, false]
         end
       end
     end

--- a/spec/models/weapon_spec.rb
+++ b/spec/models/weapon_spec.rb
@@ -403,7 +403,8 @@ RSpec.describe Weapon, type: :model do
         it 'sets "added_automatically" to true on new associations' do
           weapon.save!
 
-          expect(weapon.enchantables_enchantments.pluck(:added_automatically).uniq).to eq [true]
+          expect(weapon.enchantables_enchantments.pluck(:added_automatically))
+            .to be_all(true)
         end
 
         it 'sets the correct strengths', :aggregate_failures do
@@ -551,6 +552,7 @@ RSpec.describe Weapon, type: :model do
           :enchantables_enchantment,
           enchantable: weapon,
           enchantment: Canonical::Weapon.last.enchantments.first,
+          strength: Canonical::Weapon.last.enchantments.first.strength,
         )
       end
 

--- a/spec/support/factories/canonical/armors.rb
+++ b/spec/support/factories/canonical/armors.rb
@@ -15,7 +15,7 @@ FactoryBot.define do
 
     trait :with_enchantments do
       after(:create) do |armor|
-        create_list(:enchantables_enchantment, 2, enchantable: armor)
+        create_list(:enchantables_enchantment, 2, :with_strength, enchantable: armor)
       end
     end
   end

--- a/spec/support/factories/canonical/clothing_items.rb
+++ b/spec/support/factories/canonical/clothing_items.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
 
     trait :with_enchantments do
       after(:create) do |item|
-        create_list(:enchantables_enchantment, 2, enchantable: item)
+        create_list(:enchantables_enchantment, 2, :with_strength, enchantable: item)
       end
     end
   end

--- a/spec/support/factories/canonical/jewelry_items.rb
+++ b/spec/support/factories/canonical/jewelry_items.rb
@@ -23,7 +23,7 @@ FactoryBot.define do
 
     trait :with_enchantments do
       after(:create) do |model|
-        create_list(:enchantables_enchantment, 2, enchantable: model)
+        create_list(:enchantables_enchantment, 2, :with_strength, enchantable: model)
       end
     end
   end

--- a/spec/support/factories/canonical/potions.rb
+++ b/spec/support/factories/canonical/potions.rb
@@ -10,9 +10,9 @@ FactoryBot.define do
     rare_item { false }
     quest_item { false }
 
-    trait :with_association do
+    trait :with_associations do
       after(:create) do |potion|
-        create(:canonical_potions_alchemical_property, potion:)
+        create_list(:canonical_potions_alchemical_property, 2, potion:)
       end
     end
   end

--- a/spec/support/factories/canonical/weapons.rb
+++ b/spec/support/factories/canonical/weapons.rb
@@ -18,7 +18,7 @@ FactoryBot.define do
 
     trait :with_enchantments do
       after(:create) do |item|
-        create_list(:enchantables_enchantment, 2, enchantable: item)
+        create_list(:enchantables_enchantment, 2, :with_strength, enchantable: item)
       end
     end
 

--- a/spec/support/factories/enchantables_enchantments.rb
+++ b/spec/support/factories/enchantables_enchantments.rb
@@ -4,6 +4,8 @@ FactoryBot.define do
   factory :enchantables_enchantment do
     enchantment
 
+    added_automatically { false }
+
     trait :for_canonical_armor do
       association :enchantable, factory: :canonical_armor
     end
@@ -18,6 +20,14 @@ FactoryBot.define do
 
     trait :for_canonical_weapon do
       association :enchantable, factory: :canonical_weapon
+    end
+
+    trait :for_armor do
+      association :enchantable, factory: %i[armor with_matching_canonical]
+    end
+
+    trait :for_weapon do
+      association :enchantable, factory: %i[weapon with_matching_canonical]
     end
   end
 end

--- a/spec/support/factories/enchantables_enchantments.rb
+++ b/spec/support/factories/enchantables_enchantments.rb
@@ -29,5 +29,9 @@ FactoryBot.define do
     trait :for_weapon do
       association :enchantable, factory: %i[weapon with_matching_canonical]
     end
+
+    trait :with_strength do
+      strength { 20 }
+    end
   end
 end

--- a/spec/support/factories/jewelry_items.rb
+++ b/spec/support/factories/jewelry_items.rb
@@ -8,5 +8,11 @@ FactoryBot.define do
     trait :with_matching_canonical do
       association :canonical_jewelry_item, strategy: :create
     end
+
+    trait :with_enchantments do
+      after(:create) do |item|
+        create_list(:enchantables_enchantment, 2, enchantable: item)
+      end
+    end
   end
 end

--- a/spec/support/factories/potions.rb
+++ b/spec/support/factories/potions.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     name { 'My Potion' }
 
     trait :with_matching_canonical do
-      association :canonical_potion, factory: %i[canonical_potion with_association]
+      association :canonical_potion, factory: %i[canonical_potion with_associations]
 
       name { canonical_potion.name }
     end

--- a/spec/support/factories/potions_alchemical_properties.rb
+++ b/spec/support/factories/potions_alchemical_properties.rb
@@ -4,5 +4,7 @@ FactoryBot.define do
   factory :potions_alchemical_property do
     potion
     alchemical_property
+
+    added_automatically { false }
   end
 end

--- a/spec/support/factories/weapons.rb
+++ b/spec/support/factories/weapons.rb
@@ -10,6 +10,12 @@ FactoryBot.define do
       association :canonical_weapon, strategy: :create
     end
 
+    trait :with_enchantments do
+      after(:create) do |weapon|
+        create_list(:enchantables_enchantment, 2, enchantable: weapon)
+      end
+    end
+
     trait :with_enchanted_canonical do
       association :canonical_weapon,
                   factory: %i[canonical_weapon with_enchantments],


### PR DESCRIPTION
## Context

[**Ensure associations updated when canonical models rematched**](https://trello.com/c/9i7Z0bjc/345-ensure-associations-updated-when-canonical-models-rematched)

Certain in-game item models, when matched with a corresponding canonical model, can have any associations from those canonical models that don't currently exist on the in-game model added when the model is saved. For example, if a `Weapon` is matched with a `Canonical::Weapon` that has enchantments, any of the canonical weapon's enchantments that are missing from the in-game weapon will be added.

Models with this feature include:

* `Armor` (`Enchantment`)
* `ClothingItem` (`Enchantment`)
* `JewelryItem` (`Enchantment`)
* `Potion` (`AlchemicalProperty`)
* `Weapon` (`Enchantment`)

(Note that this PR also adds functionality to add alchemical properties to potions automatically, a feature that was missing.)

We have recently also added the capability for a canonical model to be changed (if a new one matches) or removed (if an update to the in-game item results in multiple possible canonical matches). However, these automatically-added associations are not removed or changed. Since canonical models are matched based on these associations in addition to attributes, this can prevent a new canonical model from being accurately identified. We want to remove associations added from a canonical model when that canonical model is removed as the canonical model for a given in-game item.

The fly in the ointment is that the user might've added some of the associations themselves. We assume that users do this based on knowledge they have about the item, so these associations should not be removed when a canonical model is changed. In order to differentiate, we needed to add an `added_automatically` attribute to the join models for these associations, which will be set to `true` when the association is added automatically and `false` otherwise. There will also be an `added_automatically` scope on each of these join models, which will enable us to more easily target them for removal when a canonical match changes.

## Changes

* Add boolean `added_automatically` column to `EnchantablesEnchantment` and `PotionsAlchemicalProperty` models
* Add `added_automatically` scope to join models to identify those added automatically
* Add alchemical properties from canonical potions when a non-canonical potion is saved
* Set `added_automatically` to `true` when a join model is created automatically based on a canonical model
* Set `added_automatically` to `false` otherwise
* Add tests for the above functionality
* Update docs

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

Note that this PR does not yet remove these associations when the canonical model changes. It only provides a mechanism for doing so.
