### PR TITLE
Update factory_bot_rails to 6.4.0 from 6.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ group :development, :test do
   gem 'database_cleaner-active_record', '~> 2.1'
 
   # Use FactoryBot to create models for tests
-  gem 'factory_bot_rails', '~> 6.2.0'
+  gem 'factory_bot_rails', '~> 6.4.0'
 
   # Use Rubocop to enforce style guide
   gem 'rubocop-rails', '~> 2.22', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,10 +99,10 @@ GEM
     drb (2.2.0)
       ruby2_keywords
     erubi (1.12.0)
-    factory_bot (6.2.1)
+    factory_bot (6.4.1)
       activesupport (>= 5.0.0)
-    factory_bot_rails (6.2.0)
-      factory_bot (~> 6.2.0)
+    factory_bot_rails (6.4.0)
+      factory_bot (~> 6.4)
       railties (>= 5.0.0)
     faraday (2.7.11)
       base64
@@ -291,7 +291,7 @@ DEPENDENCIES
   byebug (~> 11.1)
   database_cleaner-active_record (~> 2.1)
   dotenv (~> 2.8)
-  factory_bot_rails (~> 6.2.0)
+  factory_bot_rails (~> 6.4.0)
   faraday (~> 2.7.11)
   listen (~> 3.7)
   pg (~> 1.5)


### PR DESCRIPTION
## Context

In #244 Dependbot tried to update the factory_bot_rails package. However, in that PR, the transitive dependency on `factory_bot` is locked at v6.4.0 and it seems to be causing weird failures in the database step of GitHub Actions. In this PR, the transitive dependency is locked at v6.4.1 and hopefully that's a patch that fixes this issue.

## Changes

* Update `factory_bot_rails` from 6.2.0 to 6.4.0
* Ensure `factory_bot` dependency is at 6.4.1

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~