### PR TITLE
Validate names of player created potions

### DIFF
--- a/docs/in_game_items/potion.md
+++ b/docs/in_game_items/potion.md
@@ -4,7 +4,7 @@ The `Potion` model represents in-game items of the `Canonical::Potion` type. Lik
 
 ## Matching to Canonical Models
 
-Potions differ from some in-game items in that they may or may not have a corresponding canonical version. User-created potions do not have this, since there are a nearly infinite number of possible combinations of [strength and duration](/docs/in_game_items/potions-alchemical-property.md) for each alchemical property.
+Potions differ from some in-game items in that they may or may not have a corresponding canonical version. User-created potions do not have this, since there are a nearly infinite number of possible combinations of [strength and duration](/docs/in_game_items/potions-alchemical-property.md) for each alchemical property. However, there are a limited number of names of player-created potions. Thus, if no canonical models match, potions are validated to ensure that the potion is a valid player-created potion.
 
 When a `Potion` is created, it is then matched to a subset of canonical potions by its `name`, `unit_weight` and `magical_effects` attributes (if defined). The `name` and `magical_effects` attributes are matched case-insensitively. If the potion has alchemical properties, the results are further narrowed down based on those associations, checking for the `alchemical_property_id`, `strength` and `duration` defined on the [`PotionsAlchemicalProperty`](/docs/in_game_items/potions-alchemical-property.md) model. If these match for all defined alchemical properties, it is considered a match.
 

--- a/spec/models/potion_spec.rb
+++ b/spec/models/potion_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Potion, type: :model do
         data.each do |object|
           AlchemicalProperty.create!(object[:attributes])
         rescue ActiveRecord::RecordInvalid
-          # noop
+          next
         end
       end
 

--- a/spec/models/potion_spec.rb
+++ b/spec/models/potion_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Potion, type: :model do
     let(:potion) { build(:potion) }
 
     before do
-      create(:alchemical_property, name: 'Cure Disease', effect_type: 'potion')
+      create(:alchemical_property, name: 'Fortify Destruction', effect_type: 'potion')
     end
 
     describe '#name' do

--- a/spec/models/potions_alchemical_property_spec.rb
+++ b/spec/models/potions_alchemical_property_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe PotionsAlchemicalProperty, type: :model do
     end
 
     describe 'alchemical effects' do
-      let(:potion) { create(:potion) }
+      let(:potion) { create(:potion, :with_matching_canonical) }
       let(:model) { build(:potions_alchemical_property, potion:) }
 
       context 'when the potion has fewer than 4 effects' do

--- a/spec/support/factories/canonical/potions.rb
+++ b/spec/support/factories/canonical/potions.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :canonical_potion, class: Canonical::Potion do
-    name { 'My Potion' }
+    name { 'Potion of Fortify Destruction' }
     sequence(:item_code) {|n| "xx123x#{n}" }
     unit_weight { 0.5 }
     purchasable { true }

--- a/spec/support/factories/potions.rb
+++ b/spec/support/factories/potions.rb
@@ -4,12 +4,16 @@ FactoryBot.define do
   factory :potion do
     game
 
-    name { 'My Potion' }
+    name { 'Potion of Fortify Destruction' }
 
     trait :with_matching_canonical do
-      association :canonical_potion, factory: %i[canonical_potion with_associations]
+      association :canonical_potion, strategy: :create
+    end
 
-      name { canonical_potion.name }
+    trait :with_canonical_and_alchemical_properties do
+      association :canonical_potion,
+                  factory: %i[canonical_potion with_associations],
+                  strategy: :create
     end
   end
 end

--- a/spec/support/factories/potions_alchemical_properties.rb
+++ b/spec/support/factories/potions_alchemical_properties.rb
@@ -2,8 +2,8 @@
 
 FactoryBot.define do
   factory :potions_alchemical_property do
-    potion
     alchemical_property
+    association :potion, factory: %i[potion with_matching_canonical]
 
     added_automatically { false }
     strength { 20 }


### PR DESCRIPTION
## Context

[**Validate names of player-created potions**](https://trello.com/c/mE7TPsJ3/346-validate-names-of-player-created-potions)

Because player-created potions can have a nearly infinite combination of `strength` and `duration` values for their alchemical properties, the `Potion` model is the only in-game item model that is not required to match at least one canonical model. However, we should still be validating that potions being created are possible potions that can exist in the game. This PR ensures that, if there are no canonical matches for a potion, its name is that of a valid player-created potion.

## Changes

* Add validation for names of player-created potions
* Tweak factories so new validations pass
* Add tests for new behaviour
* Update docs

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

Because potion names are created according to the formula `"#{effect_type} of #{alchemical_property_name}", and there are only 56 alchemical properties, it didn't make sense to focus excessively on performance optimisations when creating a list of these possible names in memory. However, the list is memoised so the database operation doesn't have to be run again during the life of the instance.
