### PR TITLE
Add abstract InGameItem superclass to extract functionality from in-game item classes

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -23,9 +23,10 @@ class Book < ApplicationRecord
               allow_nil: true,
             }
 
+  validate :validate_unique_canonical
+
   before_validation :set_canonical_book
   before_validation :set_values_from_canonical
-  before_validation :validate_unique_canonical
 
   DUPLICATE_MATCH = 'is a duplicate of a unique in-game item'
 

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-class Book < ApplicationRecord
-  belongs_to :game
+class Book < InGameItem
   belongs_to :canonical_book,
              optional: true,
              class_name: 'Canonical::Book',
@@ -17,16 +16,6 @@ class Book < ApplicationRecord
            source: :ingredient
 
   validates :title, presence: true
-  validates :unit_weight,
-            numericality: {
-              greater_than_or_equal_to: 0,
-              allow_nil: true,
-            }
-
-  validate :validate_unique_canonical
-
-  before_validation :set_canonical_book
-  before_validation :set_values_from_canonical
 
   DUPLICATE_MATCH = 'is a duplicate of a unique in-game item'
 
@@ -40,7 +29,7 @@ class Book < ApplicationRecord
     canonicals = Canonical::Book.where('title ILIKE :title OR :title ILIKE ANY(title_variants)', title:)
     canonicals = canonicals.where(**attributes_to_match) if attributes_to_match.any?
 
-    return canonicals unless canonical_ingredients.any?
+    return canonicals if canonicals.none? || canonical_ingredients.none?
 
     recipes_canonical_ingredients.each do |join_model|
       canonicals = canonicals
@@ -61,39 +50,36 @@ class Book < ApplicationRecord
 
   private
 
-  def set_canonical_book
-    canonicals = canonical_models
+  alias_method :canonical_model=, :canonical_book=
 
-    unless canonicals.count == 1
-      clear_canonical_book
-      return
-    end
+  def canonical_class
+    Canonical::Book
+  end
 
-    self.canonical_book = canonicals.first
+  def canonical_table
+    'canonical_books'
+  end
+
+  def canonical_model_id
+    canonical_book_id
+  end
+
+  def canonical_model_id_changed?
+    canonical_book_id_changed?
+  end
+
+  def inverse_relationship_name
+    :books
   end
 
   def set_values_from_canonical
-    return if canonical_book.nil?
+    return if canonical_model.nil?
+    return unless canonical_model_id_changed?
 
-    self.title = canonical_book.title
-    self.authors = canonical_book.authors
-    self.unit_weight = canonical_book.unit_weight
-    self.skill_name = canonical_book.skill_name
-  end
-
-  def validate_unique_canonical
-    return unless canonical_book&.unique_item
-
-    books = canonical_book.books.where(game_id:)
-
-    return if books.count < 1
-    return if books.count == 1 && books.first == self
-
-    errors.add(:base, DUPLICATE_MATCH)
-  end
-
-  def clear_canonical_book
-    self.canonical_book_id = nil
+    self.title = canonical_model.title
+    self.authors = canonical_model.authors
+    self.unit_weight = canonical_model.unit_weight
+    self.skill_name = canonical_model.skill_name
   end
 
   def canonical_model_matches?

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -84,11 +84,15 @@ class Book < InGameItem
 
   def canonical_model_matches?
     return false if canonical_model.nil?
-    return false unless title.casecmp(canonical_model.title).zero?
+    return false unless title.casecmp(canonical_model.title).zero? || title_matches_variant?
     return false unless unit_weight.nil? || unit_weight == canonical_model.unit_weight
     return false unless skill_name.nil? || skill_name == canonical_model.skill_name
 
     true
+  end
+
+  def title_matches_variant?
+    canonical_model&.title_variants&.any? {|variant| title.casecmp(variant).zero? }
   end
 
   def attributes_to_match

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -17,8 +17,6 @@ class Book < InGameItem
 
   validates :title, presence: true
 
-  DUPLICATE_MATCH = 'is a duplicate of a unique in-game item'
-
   def canonical_model
     canonical_book
   end

--- a/app/models/enchantable_in_game_item.rb
+++ b/app/models/enchantable_in_game_item.rb
@@ -3,8 +3,6 @@
 class EnchantableInGameItem < InGameItem
   self.abstract_class = true
 
-  belongs_to :game
-
   has_many :enchantables_enchantments,
            dependent: :destroy,
            as: :enchantable
@@ -13,16 +11,7 @@ class EnchantableInGameItem < InGameItem
            through: :enchantables_enchantments,
            source: :enchantment
 
-  validate :validate_unique_canonical
-  validate :ensure_canonicals_exist
-
-  before_validation :set_canonical_model
-  before_validation :set_values_from_canonical
-
   after_create :set_enchantments, if: -> { canonical_model.present? }
-
-  DUPLICATE_MATCH = 'is a duplicate of a unique in-game item'
-  DOES_NOT_MATCH = "doesn't match any item that exists in Skyrim"
 
   def canonical_models
     return canonical_class.where(id: canonical_model_id) if canonical_model_matches?

--- a/app/models/enchantable_in_game_item.rb
+++ b/app/models/enchantable_in_game_item.rb
@@ -21,7 +21,6 @@ class EnchantableInGameItem < InGameItem
 
   after_create :set_enchantments, if: -> { canonical_model.present? }
 
-  MUST_DEFINE = 'Models inheriting from EnchantableInGameItem must define a'
   DUPLICATE_MATCH = 'is a duplicate of a unique in-game item'
   DOES_NOT_MATCH = "doesn't match any item that exists in Skyrim"
 

--- a/app/models/enchantable_in_game_item.rb
+++ b/app/models/enchantable_in_game_item.rb
@@ -3,10 +3,6 @@
 class EnchantableInGameItem < ApplicationRecord
   self.abstract_class = true
 
-  MUST_DEFINE = 'Models inheriting from EnchantableInGameItem must define a'
-  DUPLICATE_MATCH = 'is a duplicate of a unique in-game item'
-  DOES_NOT_MATCH = "doesn't match any item that exists in Skyrim"
-
   belongs_to :game
 
   has_many :enchantables_enchantments,
@@ -24,6 +20,10 @@ class EnchantableInGameItem < ApplicationRecord
   before_validation :set_values_from_canonical
 
   after_create :set_enchantments, if: -> { canonical_model.present? }
+
+  MUST_DEFINE = 'Models inheriting from EnchantableInGameItem must define a'
+  DUPLICATE_MATCH = 'is a duplicate of a unique in-game item'
+  DOES_NOT_MATCH = "doesn't match any item that exists in Skyrim"
 
   def canonical_model
     raise NotImplementedError.new("#{MUST_DEFINE} public #canonical_model method")

--- a/app/models/enchantable_in_game_item.rb
+++ b/app/models/enchantable_in_game_item.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class EnchantableInGameItem < ApplicationRecord
+class EnchantableInGameItem < InGameItem
   self.abstract_class = true
 
   belongs_to :game
@@ -24,10 +24,6 @@ class EnchantableInGameItem < ApplicationRecord
   MUST_DEFINE = 'Models inheriting from EnchantableInGameItem must define a'
   DUPLICATE_MATCH = 'is a duplicate of a unique in-game item'
   DOES_NOT_MATCH = "doesn't match any item that exists in Skyrim"
-
-  def canonical_model
-    raise NotImplementedError.new("#{MUST_DEFINE} public #canonical_model method")
-  end
 
   def canonical_models
     return canonical_class.where(id: canonical_model_id) if canonical_model_matches?
@@ -60,41 +56,6 @@ class EnchantableInGameItem < ApplicationRecord
 
   private
 
-  def canonical_class
-    raise NotImplementedError.new("#{MUST_DEFINE} private #canonical_class method")
-  end
-
-  def canonical_model=(_other)
-    raise NotImplementedError.new("#{MUST_DEFINE} private #canonical_model= method")
-  end
-
-  def canonical_table
-    raise NotImplementedError.new("#{MUST_DEFINE} private #canonical_table method")
-  end
-
-  def canonical_model_id
-    raise NotImplementedError.new("#{MUST_DEFINE} private #canonical_model_id method")
-  end
-
-  def canonical_model_id_changed?
-    raise NotImplementedError.new("#{MUST_DEFINE} private #canonical_model_id_changed? method")
-  end
-
-  def inverse_relationship_name
-    raise NotImplementedError.new("#{MUST_DEFINE} private #inverse_relationship_name method")
-  end
-
-  def set_canonical_model
-    canonicals = canonical_models
-
-    unless canonicals.count == 1
-      clear_canonical_model
-      return
-    end
-
-    self.canonical_model = canonicals.first
-  end
-
   def clear_canonical_model
     self.canonical_model = nil
     remove_automatically_added_enchantments!
@@ -102,10 +63,6 @@ class EnchantableInGameItem < ApplicationRecord
 
   def remove_automatically_added_enchantments!
     enchantables_enchantments.added_automatically.find_each(&:destroy!)
-  end
-
-  def set_values_from_canonical
-    raise NotImplementedError.new("#{MUST_DEFINE} private #set_values_from_canonical method")
   end
 
   def set_enchantments
@@ -119,24 +76,5 @@ class EnchantableInGameItem < ApplicationRecord
         strength: model.strength,
       ) {|new_model| new_model.added_automatically = true }
     end
-  end
-
-  def validate_unique_canonical
-    return unless canonical_model&.unique_item
-
-    items = canonical_model.public_send(inverse_relationship_name).where(game_id:)
-
-    return if items.count < 1
-    return if items.count == 1 && items.first == self
-
-    errors.add(:base, DUPLICATE_MATCH)
-  end
-
-  def ensure_canonicals_exist
-    errors.add(:base, DOES_NOT_MATCH) if canonical_models.none?
-  end
-
-  def attributes_to_match
-    raise NotImplementedError.new("#{MUST_DEFINE} private #attributes_to_match method")
   end
 end

--- a/app/models/in_game_item.rb
+++ b/app/models/in_game_item.rb
@@ -26,10 +26,20 @@ class InGameItem < ApplicationRecord
   end
 
   def canonical_models
-    raise NotImplementedError.new("#{MUST_DEFINE} public #canonical_models method")
+    return canonical_class.where(id: canonical_model_id) if canonical_model_matches?
+
+    query = 'name ILIKE :name'
+    query += ' AND (magical_effects ILIKE :magical_effects)' if model_has_magical_effects?
+
+    canonicals = canonical_class.where(query, name:, magical_effects:)
+    attributes_to_match.any? ? canonicals.where(**attributes_to_match) : canonicals
   end
 
   private
+
+  def model_has_magical_effects?
+    respond_to?(:magical_effects) && !magical_effects.nil?
+  end
 
   def canonical_class
     raise NotImplementedError.new("#{MUST_DEFINE} private #canonical_class method")

--- a/app/models/in_game_item.rb
+++ b/app/models/in_game_item.rb
@@ -43,6 +43,10 @@ class InGameItem < ApplicationRecord
     raise NotImplementedError.new("#{MUST_DEFINE} private #canonical_table method")
   end
 
+  def canonical_model_matches?
+    raise NotImplementedError.new("#{MUST_DEFINE} private #canonical_model_matches? method")
+  end
+
   def canonical_model_id
     raise NotImplementedError.new("#{MUST_DEFINE} private #canonical_model_id method")
   end

--- a/app/models/in_game_item.rb
+++ b/app/models/in_game_item.rb
@@ -31,6 +31,8 @@ class InGameItem < ApplicationRecord
     query = 'name ILIKE :name'
     query += ' AND (magical_effects ILIKE :magical_effects)' if model_has_magical_effects?
 
+    magical_effects = respond_to?(:magical_effects) ? self.magical_effects : nil
+
     canonicals = canonical_class.where(query, name:, magical_effects:)
     attributes_to_match.any? ? canonicals.where(**attributes_to_match) : canonicals
   end

--- a/app/models/in_game_item.rb
+++ b/app/models/in_game_item.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+class InGameItem < ApplicationRecord
+  self.abstract_class = true
+
+  belongs_to :game
+
+  validates :unit_weight,
+            numericality: {
+              greater_than_or_equal_to: 0,
+              allow_nil: true,
+            }
+
+  validate :validate_unique_canonical
+  validate :ensure_canonicals_exist
+
+  before_validation :set_canonical_model
+  before_validation :set_values_from_canonical
+
+  MUST_DEFINE = 'Models inheriting from InGameItem must define a'
+  DUPLICATE_MATCH = 'is a duplicate of a unique in-game item'
+  DOES_NOT_MATCH = "doesn't match any item that exists in Skyrim"
+
+  def canonical_model
+    raise NotImplementedError.new("#{MUST_DEFINE} public #canonical_model method")
+  end
+
+  def canonical_models
+    raise NotImplementedError.new("#{MUST_DEFINE} public #canonical_models method")
+  end
+
+  private
+
+  def canonical_class
+    raise NotImplementedError.new("#{MUST_DEFINE} private #canonical_class method")
+  end
+
+  def canonical_model=(_other)
+    raise NotImplementedError.new("#{MUST_DEFINE} private #canonical_model= method")
+  end
+
+  def canonical_table
+    raise NotImplementedError.new("#{MUST_DEFINE} private #canonical_table method")
+  end
+
+  def canonical_model_id
+    raise NotImplementedError.new("#{MUST_DEFINE} private #canonical_model_id method")
+  end
+
+  def canonical_model_id_changed?
+    raise NotImplementedError.new("#{MUST_DEFINE} private #canonical_model_id_changed? method")
+  end
+
+  def inverse_relationship_name
+    raise NotImplementedError.new("#{MUST_DEFINE} private #inverse_relationship_name method")
+  end
+
+  def set_values_from_canonical
+    raise NotImplementedError.new("#{MUST_DEFINE} private #set_values_from_canonical method")
+  end
+
+  def attributes_to_match
+    raise NotImplementedError.new("#{MUST_DEFINE} private #attributes_to_match method")
+  end
+
+  def set_canonical_model
+    canonicals = canonical_models
+
+    unless canonicals.count == 1
+      clear_canonical_model
+      return
+    end
+
+    self.canonical_model = canonicals.first
+  end
+
+  def clear_canonical_model
+    self.canonical_model = nil
+  end
+
+  def validate_unique_canonical
+    return unless canonical_model&.unique_item == true
+
+    items = canonical_model.public_send(inverse_relationship_name).where(game_id:)
+
+    return if items.count < 1
+    return if items.count == 1 && items.first == self
+
+    errors.add(:base, DUPLICATE_MATCH)
+  end
+
+  def ensure_canonicals_exist
+    errors.add(:base, DOES_NOT_MATCH) if canonical_models.none?
+  end
+end

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -13,10 +13,6 @@ class Ingredient < InGameItem
 
   validates :name, presence: true
 
-  validate :validate_unique_canonical
-
-  before_validation :set_values_from_canonical
-
   DOES_NOT_MATCH = "doesn't match an ingredient that exists in Skyrim"
   DUPLICATE_MATCH = 'is a duplicate of a unique in-game item'
 

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -75,17 +75,6 @@ class Ingredient < InGameItem
     self.unit_weight = canonical_model.unit_weight
   end
 
-  def validate_unique_canonical
-    return unless canonical_ingredient&.unique_item
-
-    ingredients = canonical_ingredient.ingredients.where(game_id:)
-
-    return if ingredients.count < 1
-    return if ingredients.count == 1 && ingredients.first == self
-
-    errors.add(:base, DUPLICATE_MATCH)
-  end
-
   def canonical_model_matches?
     return false if canonical_model.nil?
     return false unless name.casecmp(canonical_model.name).zero?

--- a/app/models/misc_item.rb
+++ b/app/models/misc_item.rb
@@ -8,7 +8,11 @@ class MiscItem < ApplicationRecord
              class_name: 'Canonical::MiscItem'
 
   validates :name, presence: true
-  validates :unit_weight, numericality: { greater_than_or_equal_to: 0, allow_nil: true }
+  validates :unit_weight,
+            numericality: {
+              greater_than_or_equal_to: 0,
+              allow_nil: true,
+            }
 
   validate :validate_association
   validate :validate_unique_canonical

--- a/app/models/misc_item.rb
+++ b/app/models/misc_item.rb
@@ -1,75 +1,47 @@
 # frozen_string_literal: true
 
-class MiscItem < ApplicationRecord
-  belongs_to :game
+class MiscItem < InGameItem
   belongs_to :canonical_misc_item,
              optional: true,
              inverse_of: :misc_items,
              class_name: 'Canonical::MiscItem'
 
   validates :name, presence: true
-  validates :unit_weight,
-            numericality: {
-              greater_than_or_equal_to: 0,
-              allow_nil: true,
-            }
-
-  validate :validate_association
-  validate :validate_unique_canonical
-
-  before_validation :set_canonical_misc_item
-
-  DUPLICATE_MATCH = 'is a duplicate of a unique in-game item'
-  DOES_NOT_MATCH = "doesn't match any item that exists in Skyrim"
 
   def canonical_model
     canonical_misc_item
   end
 
-  def canonical_models
-    return Canonical::MiscItem.where(id: canonical_misc_item_id) if canonical_model_matches?
-
-    canonicals = Canonical::MiscItem.where('name ILIKE ?', name)
-
-    attributes_to_match.any? ? canonicals.where(**attributes_to_match) : canonicals
-  end
-
   private
 
-  def set_canonical_misc_item
-    canonicals = canonical_models
+  alias_method :canonical_model=, :canonical_misc_item=
 
-    unless canonicals.count == 1
-      clear_canonical_misc_item
-      return
-    end
+  def canonical_class
+    Canonical::MiscItem
+  end
 
-    self.canonical_misc_item = canonicals.first
+  def canonical_table
+    'canonical_misc_items'
+  end
+
+  def canonical_model_id
+    canonical_misc_item_id
+  end
+
+  def canonical_model_id_changed?
+    canonical_misc_item_id_changed?
+  end
+
+  def inverse_relationship_name
+    :misc_items
+  end
+
+  def set_values_from_canonical
+    return if canonical_model.nil?
+    return unless canonical_model_id_changed?
+
     self.name = canonical_misc_item.name
     self.unit_weight = canonical_misc_item.unit_weight
-  end
-
-  def validate_association
-    return unless canonical_misc_item.nil?
-    return if canonical_models.count > 1 && unit_weight.blank?
-
-    error_msg = canonical_models.any? ? DUPLICATE_MATCH : DOES_NOT_MATCH
-    errors.add(:base, error_msg)
-  end
-
-  def validate_unique_canonical
-    return unless canonical_misc_item&.unique_item
-
-    items = canonical_misc_item.misc_items.where(game_id:)
-
-    return if items.count < 1
-    return if items.count == 1 && items.first == self
-
-    errors.add(:base, DUPLICATE_MATCH)
-  end
-
-  def clear_canonical_misc_item
-    self.canonical_misc_item_id = nil
   end
 
   def canonical_model_matches?

--- a/app/models/potion.rb
+++ b/app/models/potion.rb
@@ -2,7 +2,10 @@
 
 class Potion < ApplicationRecord
   belongs_to :game
-  belongs_to :canonical_potion, optional: true, class_name: 'Canonical::Potion'
+  belongs_to :canonical_potion,
+             optional: true,
+             class_name: 'Canonical::Potion',
+             inverse_of: :potions
 
   has_many :potions_alchemical_properties, dependent: :destroy, inverse_of: :potion
   has_many :alchemical_properties, through: :potions_alchemical_properties

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -9,21 +9,45 @@ class Property < ApplicationRecord
   has_many :shopping_lists, dependent: nil
   has_many :inventory_lists, dependent: nil
 
-  validates :canonical_property, uniqueness: { scope: :game_id, message: 'must be unique per game' }
+  validates :canonical_property,
+            uniqueness: {
+              scope: :game_id,
+              message: 'must be unique per game',
+            }
 
   validates :name,
             presence: true,
-            inclusion: { in: Canonical::Property::VALID_NAMES, message: "must be an ownable property in Skyrim, or the Arch-Mage's Quarters" },
-            uniqueness: { scope: :game_id, message: 'must be unique per game' }
+            inclusion: {
+              in: Canonical::Property::VALID_NAMES,
+              message: "must be an ownable property in Skyrim, or the Arch-Mage's Quarters",
+            },
+            uniqueness: {
+              scope: :game_id,
+              message: 'must be unique per game',
+            }
 
   validates :hold,
             presence: true,
-            inclusion: { in: Skyrim::HOLDS, message: 'must be one of the nine Skyrim holds, or Solstheim' },
-            uniqueness: { scope: :game_id, message: 'must be unique per game' }
+            inclusion: {
+              in: Skyrim::HOLDS,
+              message: 'must be one of the nine Skyrim holds, or Solstheim',
+            },
+            uniqueness: {
+              scope: :game_id,
+              message: 'must be unique per game',
+            }
 
   validates :city,
-            inclusion: { in: Canonical::Property::VALID_CITIES, message: 'must be a Skyrim city in which an ownable property is located', allow_blank: true },
-            uniqueness: { scope: :game_id, message: 'must be unique per game if present', allow_nil: true }
+            inclusion: {
+              in: Canonical::Property::VALID_CITIES,
+              message: 'must be a Skyrim city in which an ownable property is located',
+              allow_blank: true,
+            },
+            uniqueness: {
+              scope: :game_id,
+              message: 'must be unique per game if present',
+              allow_nil: true,
+            }
 
   validate :ensure_max, on: :create, if: :count_is_max
   validate :ensure_alchemy_lab_available, if: -> { has_alchemy_lab == true && canonical_property&.alchemy_lab_available == false }

--- a/app/models/staff.rb
+++ b/app/models/staff.rb
@@ -2,7 +2,10 @@
 
 class Staff < ApplicationRecord
   belongs_to :game
-  belongs_to :canonical_staff, optional: true, class_name: 'Canonical::Staff'
+  belongs_to :canonical_staff,
+             optional: true,
+             class_name: 'Canonical::Staff',
+             inverse_of: :staves
 
   validates :name, presence: true
   validates :unit_weight,

--- a/app/models/staff.rb
+++ b/app/models/staff.rb
@@ -1,26 +1,12 @@
 # frozen_string_literal: true
 
-class Staff < ApplicationRecord
-  belongs_to :game
+class Staff < InGameItem
   belongs_to :canonical_staff,
              optional: true,
              class_name: 'Canonical::Staff',
              inverse_of: :staves
 
   validates :name, presence: true
-  validates :unit_weight,
-            numericality: {
-              greater_than_or_equal_to: 0,
-              allow_nil: true,
-            }
-
-  validate :validate_canonical_models
-  validate :validate_unique_canonical
-
-  before_validation :set_canonical_staff
-
-  DUPLICATE_MATCH = 'is a duplicate of a unique in-game item'
-  DOES_NOT_MATCH = "doesn't match any item that exists in Skyrim"
 
   def spells
     canonical_staff&.spells || Spell.none
@@ -34,54 +20,41 @@ class Staff < ApplicationRecord
     canonical_staff
   end
 
-  def canonical_models
-    return Canonical::Staff.where(id: canonical_staff_id) if canonical_model_matches?
-
-    query = 'name ILIKE :name'
-    query += ' AND (magical_effects ILIKE :magical_effects)' unless magical_effects.nil?
-
-    canonicals = Canonical::Staff.where(query, name:, magical_effects:)
-    attributes_to_match.any? ? canonicals.where(**attributes_to_match) : canonicals
-  end
-
   private
 
-  def set_canonical_staff
-    canonicals = canonical_models
+  alias_method :canonical_model=, :canonical_staff=
 
-    unless canonicals.count == 1
-      clear_canonical_staff
-      return
-    end
+  def canonical_class
+    Canonical::Staff
+  end
 
-    self.canonical_staff = canonicals.first
-    self.name = canonical_staff.name
-    self.unit_weight = canonical_staff.unit_weight
-    self.magical_effects = canonical_staff.magical_effects
+  def canonical_table
+    'canonical_staves'
+  end
+
+  def canonical_model_id
+    canonical_staff_id
+  end
+
+  def canonical_model_id_changed?
+    canonical_staff_id_changed?
+  end
+
+  def inverse_relationship_name
+    :staves
+  end
+
+  def set_values_from_canonical
+    return if canonical_model.nil?
+    return unless canonical_model_id_changed?
+
+    self.name = canonical_model.name
+    self.unit_weight = canonical_model.unit_weight
+    self.magical_effects = canonical_model.magical_effects
   end
 
   def attributes_to_match
     { unit_weight: }.compact
-  end
-
-  def validate_unique_canonical
-    return unless canonical_staff&.unique_item
-
-    staves = canonical_staff.staves.where(game_id:)
-
-    return if staves.count < 1
-    return if staves.count == 1 && staves.last == self
-
-    errors.add(:base, DUPLICATE_MATCH)
-  end
-
-  def validate_canonical_models
-    errors.add(:base, DOES_NOT_MATCH) if canonical_models.none?
-    errors.add(:base, DUPLICATE_MATCH) if canonical_staff.nil? && canonical_models.count == 1
-  end
-
-  def clear_canonical_staff
-    self.canonical_staff_id = nil
   end
 
   def canonical_model_matches?

--- a/app/models/weapon.rb
+++ b/app/models/weapon.rb
@@ -8,12 +8,6 @@ class Weapon < EnchantableInGameItem
 
   validates :name, presence: true
 
-  validates :unit_weight,
-            numericality: {
-              greater_than_or_equal_to: 0,
-              allow_nil: true,
-            }
-
   validates :category,
             inclusion: {
               in: Canonical::Weapon::VALID_WEAPON_TYPES.keys,

--- a/docs/in_game_items/in-game-items.md
+++ b/docs/in_game_items/in-game-items.md
@@ -16,6 +16,10 @@ The following non-[canonical](/docs/canonical_models/README.md) in-game item mod
 
 Non-canonical in-game items represent individual item instances. For the purpose of inventory lists, they can also represent sets of items with identical characteristics whose quantities are then implied by the `quantity` field on the inventory item. (Note that, at this writing, inventory list functionality is not yet fully implemented.)
 
+## Inheritance
+
+With the exception of `Potion` and `Property`, which have unique considerations, and join models, all other in-game item models inherit from `InGameItem`, an abstract superclass that provides all the common functionality below. Four models - `Armor`, `ClothingItem`, `JewelryItem`, and `Weapon` - also inherit from `EnchantedInGameItem`, an abstract subclass of `InGameItem` that handles logic around adding, removing, an matching on enchantments.
+
 ## Common Characteristics
 
 ### Matching with Canonical Models

--- a/spec/models/ingredient_spec.rb
+++ b/spec/models/ingredient_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Ingredient, type: :model do
     context 'when there are no matching canonical ingredients' do
       it 'is invalid' do
         validate
-        expect(ingredient.errors[:base]).to include "doesn't match an ingredient that exists in Skyrim"
+        expect(ingredient.errors[:base]).to include "doesn't match any item that exists in Skyrim"
       end
     end
 

--- a/spec/support/factories/misc_items.rb
+++ b/spec/support/factories/misc_items.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     name { "Wylandria's Soul Gem" }
 
     trait :with_matching_canonical do
-      association :canonical_misc_item
+      association :canonical_misc_item, strategy: :create
     end
   end
 end


### PR DESCRIPTION
## Context

[**Review in-game item classes to ensure consistency**](https://trello.com/c/KXA86ONy/324-review-in-game-item-classes-to-ensure-consistency)

There was a lot of duplication in our in-game item classes - and therefore a lot of opportunities for bugs to sneak in. In #254, I added a class for the four enchantable in-game items: `Armor`, `ClothingItem`, `JewelryItem`, and `Weapon`. However, there was still a lot of duplication in the other classes, including duplication with the new `EnchantableInGameItem` superclass. This PR extracts this logic to a second abstract superclass, `InGameItem`, from which `EnchantableInGameItem` and most other in-game item models inherit (see considerations).

## Changes

* Create new `InGameItem` abstract model class
* Extract logic from all in-game model classes (including `EnchantableInGameItem` and excluding `Potion` and `Property`) into `InGameItem`
* Fix bug where canonical book matches were deemed not to match when the in-game item's `title` matched one of the `title_variants` of the canonical model but not the `title` itself
* Fix broken tests where required
* Add note to docs

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

The `Potion` and `Property` models had unique considerations to where it made more sense to leave them as they were and not extract their logic into a superclass or attempt to make them subclasses of `InGameItem`. They would have, at best, ended up just overwriting every method and at worst been wholly incompatible.
