### PR TITLE
Make Berit's Ashes a non-unique ingredient since it respawns

### DIFF
--- a/lib/tasks/canonical_models/canonical_ingredients.json
+++ b/lib/tasks/canonical_models/canonical_ingredients.json
@@ -4258,7 +4258,7 @@
       "unit_weight": 0.2,
       "purchasable": false,
       "purchase_requires_perk": null,
-      "unique_item": true,
+      "unique_item": false,
       "rare_item": true,
       "quest_item": true
     },


### PR DESCRIPTION
## Context

[**Don't consider respawning items unique**](https://trello.com/c/x5bBR50K/342-dont-consider-respawning-items-unique)

Some of the canonical models we have designated as unique are not exactly unique after all. Whether due to features or bugs, it is possible to obtain multiple instances of certain items considered unique. We want SIM not to consider these items unique, to prevent the situation where a user obtains another instance of the object and validations prevent them from adding it to SIM.

Due to the number of unique models in the database, we've decided to fix this for each canonical model class individually. In the case of `Canonical::Ingredient` models, there is only one "unique" item that respawns.

## Changes

* Update canonical data for Berit's Ashes to indicate the item is not unique