### PR TITLE
Ensure staves that respawn are not classified as unique

### DIFF
--- a/lib/tasks/canonical_models/canonical_staves.json
+++ b/lib/tasks/canonical_models/canonical_staves.json
@@ -1,7 +1,7 @@
 [
   {
     "attributes": {
-      "name": "Dragon Priest Staff (Wall of Fire)",
+      "name": "Dragon Priest Staff",
       "item_code": "0007E5BB",
       "unit_weight": 8,
       "base_damage": 0,
@@ -26,7 +26,7 @@
   },
   {
     "attributes": {
-      "name": "Dragon Priest Staff (Wall of Lightning)",
+      "name": "Dragon Priest Staff",
       "item_code": "0004DE5B",
       "unit_weight": 8,
       "base_damage": 2,
@@ -150,7 +150,7 @@
       "enemy": null,
       "daedric": false,
       "purchasable": false,
-      "unique_item": true,
+      "unique_item": false,
       "quest_item": true,
       "rare_item": true,
       "leveled": false,
@@ -225,7 +225,7 @@
       "enemy": "Halldir",
       "daedric": false,
       "purchasable": false,
-      "unique_item": true,
+      "unique_item": false,
       "rare_item": true,
       "quest_item": true,
       "leveled": false,
@@ -1118,7 +1118,7 @@
       "enemy": "Morokei",
       "daedric": false,
       "purchasable": false,
-      "unique_item": true,
+      "unique_item": false,
       "rare_item": true,
       "quest_item": true,
       "leveled": false,


### PR DESCRIPTION
## Context

[**Don't consider respawning items unique**](https://trello.com/c/x5bBR50K/342-dont-consider-respawning-items-unique)

SIM validates that, if a canonical model is unique, it can only have one in-game item associated per `Game`. However, this is bad UX if the item respawns or the user can otherwise obtain multiple copies. This PR updates canonical data for staves to mark such items as non-unique. It also updates the names of the two Dragon Priest Staves, which are both called "Dragon Priest Staff" from the user's point of view but were in the canonical data with parenthetical explanations of their differences. This would also be bad UX since the user would never enter a name enabling a canonical match.

## Changes

* Fix names of Dragon Priest Staff
* Mark staves of which multiple copies may be obtained as non-unique
