### PR TITLE
Correct clothing items falsely marked as unique

### DIFF
--- a/lib/tasks/canonical_models/canonical_clothing.json
+++ b/lib/tasks/canonical_models/canonical_clothing.json
@@ -3088,7 +3088,7 @@
       "unit_weight": 0.5,
       "purchasable": false,
       "quest_item": true,
-      "unique_item": true,
+      "unique_item": false,
       "rare_item": true,
       "enchantable": false,
       "quest_reward": false
@@ -3109,7 +3109,7 @@
       "unit_weight": 0.5,
       "purchasable": false,
       "quest_item": true,
-      "unique_item": true,
+      "unique_item": false,
       "rare_item": true,
       "enchantable": false,
       "quest_reward": false
@@ -3208,7 +3208,7 @@
       "unit_weight": 2,
       "purchasable": false,
       "quest_item": false,
-      "unique_item": true,
+      "unique_item": false,
       "rare_item": true,
       "enchantable": true,
       "quest_reward": false
@@ -3296,6 +3296,22 @@
       "magical_effects": null,
       "body_slot": "feet",
       "unit_weight": 1,
+      "purchasable": false,
+      "quest_item": false,
+      "unique_item": true,
+      "rare_item": true,
+      "enchantable": true,
+      "quest_reward": false
+    },
+    "enchantments": []
+  },
+  {
+    "attributes": {
+      "name": "Ulfric's Bracers",
+      "item_code": "0006230B",
+      "magical_effects": null,
+      "body_slot": "hands",
+      "unit_weight": 0.5,
       "purchasable": false,
       "quest_item": false,
       "unique_item": true,
@@ -3427,6 +3443,22 @@
       "purchasable": false,
       "quest_item": true,
       "unique_item": true,
+      "rare_item": true,
+      "enchantable": true,
+      "quest_reward": false
+    },
+    "enchantments": []
+  },
+  {
+    "attributes": {
+      "name": "Wedding Wreath",
+      "item_code": "0008895A",
+      "magical_effects": null,
+      "body_slot": "head",
+      "unit_weight": 1,
+      "purchasable": false,
+      "quest_item": false,
+      "unique_item": false,
       "rare_item": true,
       "enchantable": true,
       "quest_reward": false

--- a/lib/tasks/canonical_models/canonical_jewelry.json
+++ b/lib/tasks/canonical_models/canonical_jewelry.json
@@ -8351,23 +8351,6 @@
   },
   {
     "attributes": {
-      "name": "Wedding Wreath",
-      "item_code": "0008895A",
-      "jewelry_type": "circlet",
-      "unit_weight": 0.5,
-      "magical_effects": null,
-      "purchasable": false,
-      "unique_item": true,
-      "rare_item": true,
-      "quest_item": false,
-      "enchantable": false,
-      "quest_reward": false
-    },
-    "enchantments": [],
-    "crafting_materials": []
-  },
-  {
-    "attributes": {
       "name": "Yisra's Necklace",
       "item_code": "000D4FF7",
       "jewelry_type": "amulet",


### PR DESCRIPTION
## Context

[**Don't consider respawning items unique**](https://trello.com/c/x5bBR50K/342-dont-consider-respawning-items-unique)

There are certain instances in which multiple copies of items designated as "unique" in the SIM database can actually be obtained in the game. Since SIM prevents duplicates of unique items from being created, this causes bad UX. Because there are quite a few unique canonical models, we've decided to break the changes down into one PR for each type of item.

## Changes

* Remove `unique_item` designation for items that respawn or are obtainable multiple times
* Move `Wedding Wreath` from jewelry items to clothing items since it is considered a clothing item
* Add `Ulfric's Bracers` to canonical clothing item data