### PR TITLE
Correct errors in canonical data for weapons

### DIFF
--- a/lib/tasks/canonical_models/canonical_weapons.json
+++ b/lib/tasks/canonical_models/canonical_weapons.json
@@ -98,7 +98,7 @@
       "magical_effects": null,
       "smithing_perks": null,
       "purchasable": false,
-      "unique_item": true,
+      "unique_item": false,
       "rare_item": true,
       "quest_item": true,
       "leveled": false,
@@ -879,7 +879,7 @@
       "magical_effects": "In the quest \"Boethiah's Calling\", kills a follower in one strike, otherwise acts as ebony dagger",
       "smithing_perks": null,
       "purchasable": false,
-      "unique_item": true,
+      "unique_item": false,
       "rare_item": true,
       "quest_item": true,
       "leveled": false,
@@ -909,7 +909,7 @@
         "Arcane Blacksmith"
       ],
       "purchasable": false,
-      "unique_item": true,
+      "unique_item": false,
       "rare_item": true,
       "quest_item": true,
       "leveled": false,
@@ -12828,7 +12828,7 @@
       "magical_effects": "If killing undead, a chance to cause a fiery explosion that turns or destroys nearby undead",
       "smithing_perks": null,
       "purchasable": false,
-      "unique_item": true,
+      "unique_item": false,
       "rare_item": true,
       "quest_item": true,
       "leveled": false,
@@ -13460,7 +13460,7 @@
       "magical_effects": null,
       "smithing_perks": null,
       "purchasable": false,
-      "unique_item": true,
+      "unique_item": false,
       "rare_item": true,
       "quest_item": true,
       "leveled": false,
@@ -43733,7 +43733,7 @@
         "Arcane Blacksmith"
       ],
       "purchasable": false,
-      "unique_item": true,
+      "unique_item": false,
       "rare_item": true,
       "quest_item": false,
       "leveled": false,
@@ -43769,7 +43769,7 @@
         "Dwarven Smithing"
       ],
       "purchasable": false,
-      "unique_item": true,
+      "unique_item": false,
       "rare_item": true,
       "quest_item": true,
       "leveled": true,
@@ -53565,7 +53565,7 @@
         "Glass Smithing"
       ],
       "purchasable": false,
-      "unique_item": true,
+      "unique_item": false,
       "rare_item": true,
       "quest_item": true,
       "leveled": false,
@@ -56014,7 +56014,7 @@
       "magical_effects": "Targets have a small chance of being frozen solid",
       "smithing_perks": null,
       "purchasable": false,
-      "unique_item": true,
+      "unique_item": false,
       "rare_item": true,
       "quest_item": false,
       "leveled": false,
@@ -57453,11 +57453,11 @@
         "Steel Smithing"
       ],
       "purchasable": false,
-      "unique_item": true,
+      "unique_item": false,
       "rare_item": true,
       "quest_item": false,
       "leveled": false,
-      "enchantable": false,
+      "enchantable": true,
       "quest_reward": false
     },
     "enchantments": [],
@@ -65690,12 +65690,12 @@
         "Arcane Blacksmith"
       ],
       "purchasable": false,
-      "unique_item": true,
+      "unique_item": false,
       "rare_item": true,
-      "quest_item": true,
+      "quest_item": false,
       "leveled": true,
       "enchantable": false,
-      "quest_reward": false
+      "quest_reward": true
     },
     "enchantments": [
       {
@@ -65731,10 +65731,10 @@
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
-      "quest_item": true,
+      "quest_item": false,
       "leveled": true,
       "enchantable": false,
-      "quest_reward": false
+      "quest_reward": true
     },
     "enchantments": [],
     "crafting_materials": [],
@@ -85521,7 +85521,7 @@
         "Dwarven Smithing"
       ],
       "purchasable": false,
-      "unique_item": true,
+      "unique_item": false,
       "rare_item": true,
       "quest_item": true,
       "leveled": false,
@@ -85551,7 +85551,7 @@
         "Steel Smithing"
       ],
       "purchasable": false,
-      "unique_item": true,
+      "unique_item": false,
       "rare_item": true,
       "quest_item": true,
       "leveled": false,
@@ -87729,7 +87729,7 @@
       "rare_item": true,
       "quest_item": true,
       "leveled": false,
-      "enchantable": false,
+      "enchantable": true,
       "quest_reward": false
     },
     "enchantments": [],
@@ -105382,7 +105382,7 @@
         "Arcane Blacksmith"
       ],
       "purchasable": false,
-      "unique_item": true,
+      "unique_item": false,
       "rare_item": true,
       "quest_item": false,
       "leveled": false,
@@ -105463,7 +105463,7 @@
         "Orcish Smithing"
       ],
       "purchasable": false,
-      "unique_item": true,
+      "unique_item": false,
       "rare_item": true,
       "quest_item": false,
       "leveled": false,
@@ -105538,7 +105538,7 @@
       "quest_item": true,
       "leveled": false,
       "enchantable": false,
-      "quest_reward": false
+      "quest_reward": true
     },
     "enchantments": [
       {
@@ -105621,7 +105621,7 @@
         "Steel Smithing"
       ],
       "purchasable": false,
-      "unique_item": true,
+      "unique_item": false,
       "rare_item": true,
       "quest_item": true,
       "leveled": false,


### PR DESCRIPTION
## Context

[**Don't consider respawning items unique**](https://trello.com/c/x5bBR50K/342-dont-consider-respawning-items-unique)

We want to ensure that canonical models are only designated as `unique_item` if it is absolutely impossible to obtain a second copy of the item. This is because when a non-canonical item is matched with a unique canonical, no other in-game items can be created for that canonical. That leads to bad UX when, due to respawning or bugs, a user is able to obtain multiple copies of a "uniqe" weapon.

In the course of finding "unique" weapons that are not actually unique, we also discovered additional errors with some of the canonical data, such as `quest_reward`s being defined as `quest_item`s instead.

## Changes

* Update canonical weapon JSON data setting `"unique_item": false` for any items that respawn or can be obtained multiple times
