### PR TITLE
Correct errors in canonical misc item data

### DIFF
--- a/lib/tasks/canonical_models/canonical_books.json
+++ b/lib/tasks/canonical_models/canonical_books.json
@@ -4945,7 +4945,7 @@
       ],
       "skill_name": null,
       "purchasable": false,
-      "unique_item": true,
+      "unique_item": false,
       "rare_item": true,
       "solstheim_only": true,
       "quest_item": false,

--- a/lib/tasks/canonical_models/canonical_misc_items.json
+++ b/lib/tasks/canonical_models/canonical_misc_items.json
@@ -9,7 +9,7 @@
       ],
       "description": null,
       "purchasable": false,
-      "unique_item": true,
+      "unique_item": false,
       "rare_item": true,
       "quest_item": true,
       "quest_reward": true
@@ -153,7 +153,7 @@
       ],
       "description": null,
       "purchasable": false,
-      "unique_item": true,
+      "unique_item": false,
       "rare_item": true,
       "quest_item": false,
       "quest_reward": false
@@ -185,7 +185,7 @@
       ],
       "description": null,
       "purchasable": false,
-      "unique_item": true,
+      "unique_item": false,
       "rare_item": true,
       "quest_item": true,
       "quest_reward": false
@@ -297,7 +297,7 @@
       ],
       "description": "Live monarch butterfly in a jar",
       "purchasable": false,
-      "unique_item": true,
+      "unique_item": false,
       "rare_item": true,
       "quest_item": false,
       "quest_reward": false
@@ -393,7 +393,7 @@
       ],
       "description": null,
       "purchasable": true,
-      "unique_item": true,
+      "unique_item": false,
       "rare_item": true,
       "quest_item": true,
       "quest_reward": false
@@ -827,7 +827,7 @@
       ],
       "description": null,
       "purchasable": false,
-      "unique_item": true,
+      "unique_item": false,
       "rare_item": true,
       "quest_item": true,
       "quest_reward": false
@@ -843,7 +843,7 @@
       ],
       "description": null,
       "purchasable": false,
-      "unique_item": true,
+      "unique_item": false,
       "rare_item": true,
       "quest_item": false,
       "quest_reward": false
@@ -1339,7 +1339,7 @@
       ],
       "description": "Live luna moth in a jar",
       "purchasable": false,
-      "unique_item": true,
+      "unique_item": false,
       "rare_item": true,
       "quest_item": false,
       "quest_reward": false
@@ -1387,39 +1387,7 @@
       ],
       "description": null,
       "purchasable": false,
-      "unique_item": true,
-      "rare_item": true,
-      "quest_item": true,
-      "quest_reward": false
-    }
-  },
-  {
-    "attributes": {
-      "name": "Opaque Vessel",
-      "item_code": "0003E6BB",
-      "unit_weight": 0,
-      "item_types": [
-        "miscellaneous"
-      ],
-      "description": null,
-      "purchasable": false,
-      "unique_item": true,
-      "rare_item": true,
-      "quest_item": true,
-      "quest_reward": false
-    }
-  },
-  {
-    "attributes": {
-      "name": "Opaque Vessel",
-      "item_code": "0008D770",
-      "unit_weight": 0,
-      "item_types": [
-        "miscellaneous"
-      ],
-      "description": null,
-      "purchasable": false,
-      "unique_item": true,
+      "unique_item": false,
       "rare_item": true,
       "quest_item": true,
       "quest_reward": false
@@ -1547,39 +1515,7 @@
       ],
       "description": null,
       "purchasable": false,
-      "unique_item": true,
-      "rare_item": true,
-      "quest_item": true,
-      "quest_reward": false
-    }
-  },
-  {
-    "attributes": {
-      "name": "Reaper Gem Fragment",
-      "item_code": "XX0066F5",
-      "unit_weight": 0.1,
-      "item_types": [
-        "miscellaneous"
-      ],
-      "description": null,
-      "purchasable": false,
-      "unique_item": true,
-      "rare_item": true,
-      "quest_item": true,
-      "quest_reward": false
-    }
-  },
-  {
-    "attributes": {
-      "name": "Reaper Gem Fragment",
-      "item_code": "XX0066F6",
-      "unit_weight": 0.1,
-      "item_types": [
-        "miscellaneous"
-      ],
-      "description": null,
-      "purchasable": false,
-      "unique_item": true,
+      "unique_item": false,
       "rare_item": true,
       "quest_item": true,
       "quest_reward": false
@@ -1787,7 +1723,7 @@
       ],
       "description": null,
       "purchasable": false,
-      "unique_item": true,
+      "unique_item": false,
       "rare_item": true,
       "quest_item": true,
       "quest_reward": false
@@ -1795,7 +1731,7 @@
   },
   {
     "attributes": {
-      "name": "Silver Hand Strategem",
+      "name": "Silver Hand Stratagem",
       "item_code": "000F1491",
       "unit_weight": 0,
       "item_types": [
@@ -1963,7 +1899,7 @@
       ],
       "description": null,
       "purchasable": false,
-      "unique_item": true,
+      "unique_item": false,
       "rare_item": true,
       "quest_item": true,
       "quest_reward": false
@@ -2011,7 +1947,7 @@
       ],
       "description": "Live torchbug in a jar",
       "purchasable": false,
-      "unique_item": true,
+      "unique_item": false,
       "rare_item": true,
       "quest_item": false,
       "quest_reward": false
@@ -2123,39 +2059,7 @@
       ],
       "description": null,
       "purchasable": false,
-      "unique_item": true,
-      "rare_item": true,
-      "quest_item": true,
-      "quest_reward": false
-    }
-  },
-  {
-    "attributes": {
-      "name": "Werewolf Totem",
-      "item_code": "000E3147",
-      "unit_weight": 0.5,
-      "item_types": [
-        "miscellaneous"
-      ],
-      "description": null,
-      "purchasable": false,
-      "unique_item": true,
-      "rare_item": true,
-      "quest_item": true,
-      "quest_reward": false
-    }
-  },
-  {
-    "attributes": {
-      "name": "Werewolf Totem",
-      "item_code": "000E3148",
-      "unit_weight": 0.5,
-      "item_types": [
-        "miscellaneous"
-      ],
-      "description": null,
-      "purchasable": false,
-      "unique_item": true,
+      "unique_item": false,
       "rare_item": true,
       "quest_item": true,
       "quest_reward": false
@@ -2203,7 +2107,7 @@
       ],
       "description": null,
       "purchasable": false,
-      "unique_item": true,
+      "unique_item": false,
       "rare_item": true,
       "quest_item": false,
       "quest_reward": false


### PR DESCRIPTION
## Context

[**Don't consider respawning items unique**](https://trello.com/c/x5bBR50K/342-dont-consider-respawning-items-unique)

Because SIM prevents unique items from being created multiple times in the same game, it's critical that all items designated as canonically unique actually be unique and not, under any circumstances, obtainable multiple times. Oftentimes, supposedly "unique" items are, in fact, obtainable multiple times, either through glitches or respawning. Because of the large number of canonical models with `unique_item` set to `true`, we've decided to make these changes on a one-model-per-PR basis. This PR handles misc items. However, there is a change to one book that was discovered to be non-unique during the course of researching the misc items.

## Changes

* Correct inaccurate data on canonical misc items, especially around uniqueness
* Mark the book "Glover's Letter" as non-unique since it respawns