### PR TITLE
Tweak methods in Book model to see if they fix the flaky test

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -39,11 +39,11 @@ class Book < InGameItem
                      )
     end
 
-    canonicals
+    Canonical::Book.where(id: canonicals.ids)
   end
 
   def recipe?
-    canonical_models.any? {|model| model.book_type == 'recipe' }
+    canonical_models.where(book_type: 'recipe').any?
   end
 
   private

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -181,6 +181,20 @@ RSpec.describe Book, type: :model do
 
     let(:book) { create(:book, title: 'foo') }
 
+    context 'when all matching canonicals are recipes' do
+      before do
+        create_list(
+          :canonical_recipe,
+          2,
+          title: 'Foo',
+        )
+      end
+
+      it 'returns true' do
+        expect(recipe).to be true
+      end
+    end
+
     context 'when at least one matching canonical is a recipe' do
       before do
         create(:canonical_recipe, title: 'Foo')


### PR DESCRIPTION
## Context

[**Investigate flaky RSpec test**](https://trello.com/c/OvOe2TgY/343-investigate-flaky-rspec-test)

There's an [RSpec test](https://github.com/danascheider/skyrim_inventory_management/blob/c02988762bbfb0aee8d2c4766a09a918a7672216/spec/models/book_spec.rb#L190-L192) that is inconsistently failing. It tests that a `Book` model with multiple matching canonicals qualifies as a recipe if at least one of the matching canonicals counts as a recipe. We have determined that the sporadic failures do not have to do with the order in which the tests are running, as running with the same seed locally didn't lead to a failure in a local environment. This test has never wrongly failed in a local environment.

While we aren't sure what could be causing this test to be flaky, I did notice some improvements to be made in the `Book` class's `#canonical_models` and `#recipe?` methods. Specifically, the `#canonical_models` method, as it was before this PR, returned canonicals with their associated `:recipes_canonical_ingredients`, and the `#recipe?` method iterated through these canonicals using Ruby methods instead of refining them with an ActiveRecord query. This PR changes both of these things. Hopefully they will help with the test, but they are improvements either way.

## Changes

* Ensure canonical books are returned uniquely and without join models
* Use ActiveRecord query to test whether any canonicals are recipes

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [ ] ~~Added and updated API docs and developer docs as appropriate~~ 