### PR TITLE
Update GitHub Actions checkout to v3 in attempt to fix deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         env:


### PR DESCRIPTION
## Context

Sometimes, when running GitHub Actions, we get a warning that checkout v2 uses Node 12 and will be deprecated. This PR attempts to update to GitHub Actions checkout v3. We'll see if it works when CI runs - or doesn't run.

## Changes

* Use actions/checkout@v3