### PR TITLE
Change name of shopping_lists and shopping_list_items tables

### DIFF
--- a/app/models/shopping_list.rb
+++ b/app/models/shopping_list.rb
@@ -3,6 +3,8 @@
 require 'titlecase'
 
 class ShoppingList < ApplicationRecord
+  self.table_name = 'wish_lists'
+
   # Titles have to be unique per game as described in the API docs. They also can only
   # contain alphanumeric characters and spaces with no special characters or whitespace
   # other than spaces. Leading or trailing whitespace is stripped anyway so the validation
@@ -25,7 +27,7 @@ class ShoppingList < ApplicationRecord
   include Aggregatable
 
   scope :index_order, -> { includes_items.aggregate_first.order(updated_at: :desc) }
-  scope :belonging_to_user, ->(user) { joins(:game).where(games: { user_id: user.id }).order('shopping_lists.updated_at DESC') }
+  scope :belonging_to_user, ->(user) { joins(:game).where(games: { user_id: user.id }).order('wish_lists.updated_at DESC') }
 
   private
 

--- a/app/models/shopping_list_item.rb
+++ b/app/models/shopping_list_item.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 class ShoppingListItem < ApplicationRecord
+  self.table_name = 'wish_list_items'
+
   def self.list_class
     ShoppingList
   end
 
   def self.list_table_name
-    'shopping_lists'
+    'wish_lists'
   end
 
   include Listable

--- a/db/migrate/20231201050320_rename_shopping_list_and_shopping_list_item_tables.rb
+++ b/db/migrate/20231201050320_rename_shopping_list_and_shopping_list_item_tables.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class RenameShoppingListAndShoppingListItemTables < ActiveRecord::Migration[7.1]
+  def change
+    # Remove the foreign key constraint because it will point to the wrong table name
+    remove_foreign_key :shopping_list_items, :shopping_lists
+
+    rename_table :shopping_lists, :wish_lists
+    rename_table :shopping_list_items, :wish_list_items
+
+    # Update foreign key reference
+    add_foreign_key :wish_list_items, :wish_lists, column: :list_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_11_205621) do
+ActiveRecord::Schema[7.1].define(version: 2023_12_01_050320) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -513,30 +513,6 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_11_205621) do
     t.index ["recipe_id"], name: "index_recipes_canonical_ingredients_on_recipe_id"
   end
 
-  create_table "shopping_list_items", force: :cascade do |t|
-    t.string "description", null: false
-    t.string "notes"
-    t.integer "quantity", default: 1, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.bigint "list_id", null: false
-    t.decimal "unit_weight", precision: 5, scale: 1
-    t.index ["description", "list_id"], name: "index_shopping_list_items_on_description_and_list_id", unique: true
-    t.index ["list_id"], name: "index_shopping_list_items_on_list_id"
-  end
-
-  create_table "shopping_lists", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.boolean "aggregate", default: false
-    t.string "title", null: false
-    t.bigint "game_id", null: false
-    t.bigint "aggregate_list_id"
-    t.index ["aggregate_list_id"], name: "index_shopping_lists_on_aggregate_list_id"
-    t.index ["game_id"], name: "index_shopping_lists_on_game_id"
-    t.index ["title", "game_id"], name: "index_shopping_lists_on_title_and_game_id", unique: true
-  end
-
   create_table "spells", force: :cascade do |t|
     t.string "name", null: false
     t.string "description", null: false
@@ -587,6 +563,30 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_11_205621) do
     t.index ["game_id"], name: "index_weapons_on_game_id"
   end
 
+  create_table "wish_list_items", force: :cascade do |t|
+    t.string "description", null: false
+    t.string "notes"
+    t.integer "quantity", default: 1, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "list_id", null: false
+    t.decimal "unit_weight", precision: 5, scale: 1
+    t.index ["description", "list_id"], name: "index_wish_list_items_on_description_and_list_id", unique: true
+    t.index ["list_id"], name: "index_wish_list_items_on_list_id"
+  end
+
+  create_table "wish_lists", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "aggregate", default: false
+    t.string "title", null: false
+    t.bigint "game_id", null: false
+    t.bigint "aggregate_list_id"
+    t.index ["aggregate_list_id"], name: "index_wish_lists_on_aggregate_list_id"
+    t.index ["game_id"], name: "index_wish_lists_on_game_id"
+    t.index ["title", "game_id"], name: "index_wish_lists_on_title_and_game_id", unique: true
+  end
+
   add_foreign_key "armors", "canonical_armors"
   add_foreign_key "armors", "games"
   add_foreign_key "books", "canonical_books"
@@ -622,11 +622,11 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_11_205621) do
   add_foreign_key "properties", "canonical_properties"
   add_foreign_key "properties", "games"
   add_foreign_key "recipes_canonical_ingredients", "canonical_ingredients", column: "ingredient_id"
-  add_foreign_key "shopping_list_items", "shopping_lists", column: "list_id"
-  add_foreign_key "shopping_lists", "games"
-  add_foreign_key "shopping_lists", "shopping_lists", column: "aggregate_list_id"
   add_foreign_key "staves", "canonical_staves"
   add_foreign_key "staves", "games"
   add_foreign_key "weapons", "canonical_weapons"
   add_foreign_key "weapons", "games"
+  add_foreign_key "wish_list_items", "wish_lists", column: "list_id"
+  add_foreign_key "wish_lists", "games"
+  add_foreign_key "wish_lists", "wish_lists", column: "aggregate_list_id"
 end


### PR DESCRIPTION
## Context

[**Rename database tables to use "wish list" nomenclature**](https://trello.com/c/BZmS5zT5/355-rename-database-tables-to-use-wishlist-nomenclature)

We've decided that "wish list" is a much better name than "shopping list", and that the best time to make a sweeping change like this is ASAP. The first part of the change - one of the least risky parts - is to rename the database tables involved. This PR changes the names of the `shopping_lists` and `shopping_list_items` tables to `wish_lists` and `wish_list_items`. Note that the `shopping_list_id` foreign key has not been renamed but has been updated to point to the `wish_lists` table.

Application code has also been changed to point to the new table names.

## Changes

* Change `shopping_lists` table to `wish_lists`
* Change `shopping_list_items` table to `wish_list_items`
* Point `shopping_list_id` foreign key to `wish_lists` table
* Update code to connect model classes to correct tables.

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~

## Considerations

This is not a change that should affect application behaviour, and indeed, during development, errors were caught by existing RSpec coverage. Therefore, changes to test code were not required. Additionally, docs do not reference table names, so they didn't need to be updated either.