### PR TITLE
Rename ShoppingList and ShoppingListItem on the back end

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -119,8 +119,8 @@ Layout/ClassStructure:
   Exclude:
     - app/models/inventory_item.rb
     - app/models/inventory_list.rb
-    - app/models/shopping_list.rb
-    - app/models/shopping_list_item.rb
+    - app/models/wish_list.rb
+    - app/models/wish_list_item.rb
 Layout/ClosingHeredocIndentation:
   Description: 'Checks the indentation of here document closings.'
   Enabled: true

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Users are uniquely identified by the UID of the Google account they use to sign 
 
 ### Authenticating Resources
 
-All resources are scoped to the currently authenticated user. Requesting a resource that doesn't belong to the authenticated user will result in a 404, not a 401. So, if User 1 owns the `ShoppingList` with ID 24, requesting `/shopping_lists/24` with a valid token belonging to User 2 will simply result in the resource not being found, and not in a 401 response. All requests lacking a valid token will return 401 responses.
+All resources are scoped to the currently authenticated user. Requesting a resource that doesn't belong to the authenticated user will result in a 404, not a 401. So, if User 1 owns the `WishList` with ID 24, requesting `/shopping_lists/24` with a valid token belonging to User 2 will simply result in the resource not being found, and not in a 401 response. All requests lacking a valid token will return 401 responses.
 
 ## Resources
 
@@ -36,7 +36,7 @@ display_name: string or null
 
 ### RESTful Resources
 
-See the [API docs](/docs/api/README.md) for information about resources like games, shopping lists, and more. For information about models not exposed as RESTful resources, see docs on [canonical models](/docs/canonical_models/README.md).
+See the [API docs](/docs/api/README.md) for information about resources like games, wish lists, and more. For information about models not exposed as RESTful resources, see docs on [canonical models](/docs/canonical_models/README.md).
 
 ## Developer Info
 
@@ -69,7 +69,7 @@ bundle exec rspec spec/models
 bundle exec rspec spec/requests/shopping_lists_spec.rb
 
 # runs a specific spec on line 42 of the specified file
-bundle exec rspec spec/models/shopping_list_item_spec.rb:42
+bundle exec rspec spec/models/wish_list_item_spec.rb:42
 ```
 
 All pull requests should include whatever test updates are required to ensure the new code is thoroughly covered by quality, passing tests.
@@ -81,7 +81,7 @@ One caveat in testing is that timestamps may be treated differently in [GitHub A
 t = Time.zone.now + 3.days
 Timecop.freeze(t) do
   perform
-  expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+  expect(wish_list.reload.updated_at).to be_within(0.005.seconds).of(t)
 end
 ```
 

--- a/app/controller_services/shopping_list_items_controller/destroy_service.rb
+++ b/app/controller_services/shopping_list_items_controller/destroy_service.rb
@@ -7,7 +7,7 @@ require 'service/internal_server_error_result'
 
 class ShoppingListItemsController < ApplicationController
   class DestroyService
-    AGGREGATE_LIST_ERROR = 'Cannot manually delete list item from aggregate shopping list'
+    AGGREGATE_LIST_ERROR = 'Cannot manually delete list item from aggregate wish list'
 
     def initialize(user, item_id)
       @user = user
@@ -15,14 +15,14 @@ class ShoppingListItemsController < ApplicationController
     end
 
     def perform
-      return Service::MethodNotAllowedResult.new(errors: [AGGREGATE_LIST_ERROR]) if shopping_list.aggregate == true
+      return Service::MethodNotAllowedResult.new(errors: [AGGREGATE_LIST_ERROR]) if wish_list.aggregate == true
 
       ActiveRecord::Base.transaction do
-        shopping_list_item.destroy!
-        aggregate_list.remove_item_from_child_list(shopping_list_item.attributes)
+        wish_list_item.destroy!
+        aggregate_list.remove_item_from_child_list(wish_list_item.attributes)
       end
 
-      Service::OKResult.new(resource: [aggregate_list.reload, shopping_list.reload])
+      Service::OKResult.new(resource: [aggregate_list.reload, wish_list.reload])
     rescue ActiveRecord::RecordNotFound
       Service::NotFoundResult.new
     rescue StandardError => e
@@ -35,19 +35,19 @@ class ShoppingListItemsController < ApplicationController
     attr_reader :user, :item_id
 
     def game
-      @game ||= shopping_list.game
+      @game ||= wish_list.game
     end
 
     def aggregate_list
-      @aggregate_list ||= shopping_list.aggregate_list
+      @aggregate_list ||= wish_list.aggregate_list
     end
 
-    def shopping_list
-      @shopping_list = shopping_list_item.list
+    def wish_list
+      @wish_list = wish_list_item.list
     end
 
-    def shopping_list_item
-      @shopping_list_item ||= user.shopping_list_items.find(item_id)
+    def wish_list_item
+      @wish_list_item ||= user.wish_list_items.find(item_id)
     end
   end
 end

--- a/app/controller_services/shopping_list_items_controller/update_service.rb
+++ b/app/controller_services/shopping_list_items_controller/update_service.rb
@@ -8,7 +8,7 @@ require 'service/internal_server_error_result'
 
 class ShoppingListItemsController < ApplicationController
   class UpdateService
-    AGGREGATE_LIST_ERROR = 'Cannot manually update list items on an aggregate shopping list'
+    AGGREGATE_LIST_ERROR = 'Cannot manually update list items on an aggregate wish list'
 
     def initialize(user, item_id, params)
       @user = user
@@ -17,7 +17,7 @@ class ShoppingListItemsController < ApplicationController
     end
 
     def perform
-      return Service::MethodNotAllowedResult.new(errors: [AGGREGATE_LIST_ERROR]) if shopping_list.aggregate == true
+      return Service::MethodNotAllowedResult.new(errors: [AGGREGATE_LIST_ERROR]) if wish_list.aggregate == true
 
       changed_attributes = {}
       changed_attributes[:quantity] = { from: list_item.quantity, to: params[:quantity] } if quantity_changed?
@@ -48,16 +48,16 @@ class ShoppingListItemsController < ApplicationController
       @aggregate_list ||= list_item.list.aggregate_list
     end
 
-    def shopping_list
-      @shopping_list ||= list_item.list
+    def wish_list
+      @wish_list ||= list_item.list
     end
 
     def list_item
-      @list_item ||= user.shopping_list_items.find(item_id)
+      @list_item ||= user.wish_list_items.find(item_id)
     end
 
     def game
-      @game ||= shopping_list.game
+      @game ||= wish_list.game
     end
 
     def aggregate_list_item
@@ -73,7 +73,7 @@ class ShoppingListItemsController < ApplicationController
     end
 
     def all_matching_items
-      aggregate_list.game.shopping_list_items.where('description ILIKE ?', list_item.description)
+      aggregate_list.game.wish_list_items.where('description ILIKE ?', list_item.description)
     end
   end
 end

--- a/app/controller_services/shopping_lists_controller/create_service.rb
+++ b/app/controller_services/shopping_lists_controller/create_service.rb
@@ -9,7 +9,7 @@ require 'service/ok_result'
 
 class ShoppingListsController < ApplicationController
   class CreateService
-    AGGREGATE_LIST_ERROR = 'Cannot manually create an aggregate shopping list'
+    AGGREGATE_LIST_ERROR = 'Cannot manually create an aggregate wish list'
 
     def initialize(user, game_id, params)
       @user = user
@@ -20,13 +20,13 @@ class ShoppingListsController < ApplicationController
     def perform
       return Service::UnprocessableEntityResult.new(errors: [AGGREGATE_LIST_ERROR]) if params[:aggregate]
 
-      shopping_list = game.shopping_lists.new(params)
+      wish_list = game.wish_lists.new(params)
 
-      if shopping_list.save
-        resource = game_has_other_lists? ? Array.wrap(shopping_list) : game.shopping_lists.index_order
+      if wish_list.save
+        resource = game_has_other_lists? ? Array.wrap(wish_list) : game.wish_lists.index_order
         Service::CreatedResult.new(resource:)
       else
-        Service::UnprocessableEntityResult.new(errors: shopping_list.error_array)
+        Service::UnprocessableEntityResult.new(errors: wish_list.error_array)
       end
     rescue ActiveRecord::RecordNotFound
       Service::NotFoundResult.new
@@ -44,7 +44,7 @@ class ShoppingListsController < ApplicationController
     end
 
     def game_has_other_lists?
-      game.shopping_lists.count > 2
+      game.wish_lists.count > 2
     end
   end
 end

--- a/app/controller_services/shopping_lists_controller/destroy_service.rb
+++ b/app/controller_services/shopping_lists_controller/destroy_service.rb
@@ -7,7 +7,7 @@ require 'service/internal_server_error_result'
 
 class ShoppingListsController < ApplicationController
   class DestroyService
-    AGGREGATE_LIST_ERROR = 'Cannot manually delete an aggregate shopping list'
+    AGGREGATE_LIST_ERROR = 'Cannot manually delete an aggregate wish list'
 
     def initialize(user, list_id)
       @user = user
@@ -15,9 +15,9 @@ class ShoppingListsController < ApplicationController
     end
 
     def perform
-      return Service::MethodNotAllowedResult.new(errors: [AGGREGATE_LIST_ERROR]) if shopping_list.aggregate == true
+      return Service::MethodNotAllowedResult.new(errors: [AGGREGATE_LIST_ERROR]) if wish_list.aggregate == true
 
-      ids = game.shopping_lists.count == 2 ? [aggregate_list.id, shopping_list.id] : [shopping_list.id]
+      ids = game.wish_lists.count == 2 ? [aggregate_list.id, wish_list.id] : [wish_list.id]
 
       destroy_and_update_aggregate_list_items!
 
@@ -35,27 +35,27 @@ class ShoppingListsController < ApplicationController
 
     attr_reader :user, :list_id
 
-    def shopping_list
-      @shopping_list ||= user.shopping_lists.find(list_id)
+    def wish_list
+      @wish_list ||= user.wish_lists.find(list_id)
     end
 
     def aggregate_list
-      game.aggregate_shopping_list
+      game.aggregate_wish_list
     end
 
     def game
-      @game ||= shopping_list.game
+      @game ||= wish_list.game
     end
 
     def destroy_and_update_aggregate_list_items!
-      aggregate_list = shopping_list.aggregate_list
+      aggregate_list = wish_list.aggregate_list
 
-      list_items = shopping_list.list_items.map(&:attributes)
+      list_items = wish_list.list_items.map(&:attributes)
 
       ActiveRecord::Base.transaction do
-        # If shopping_list is the user's last regular shopping list, this will also
+        # If wish_list is the user's last regular wish list, this will also
         # destroy their aggregate list (see the Aggregatable concern)
-        shopping_list.destroy!
+        wish_list.destroy!
 
         list_items.each {|item_attributes| aggregate_list.remove_item_from_child_list(item_attributes) } if aggregate_list&.persisted?
       end

--- a/app/controller_services/shopping_lists_controller/index_service.rb
+++ b/app/controller_services/shopping_lists_controller/index_service.rb
@@ -12,7 +12,7 @@ class ShoppingListsController < ApplicationController
     end
 
     def perform
-      Service::OKResult.new(resource: game.shopping_lists.index_order)
+      Service::OKResult.new(resource: game.wish_lists.index_order)
     rescue ActiveRecord::RecordNotFound
       Service::NotFoundResult.new
     rescue StandardError => e

--- a/app/controller_services/shopping_lists_controller/update_service.rb
+++ b/app/controller_services/shopping_lists_controller/update_service.rb
@@ -8,8 +8,8 @@ require 'service/internal_server_error_result'
 
 class ShoppingListsController < ApplicationController
   class UpdateService
-    AGGREGATE_LIST_ERROR = 'Cannot manually update an aggregate shopping list'
-    DISALLOWED_UPDATE_ERROR = 'Cannot make a regular shopping list an aggregate list'
+    AGGREGATE_LIST_ERROR = 'Cannot manually update an aggregate wish list'
+    DISALLOWED_UPDATE_ERROR = 'Cannot make a regular wish list an aggregate list'
 
     def initialize(user, list_id, params)
       @user = user
@@ -18,13 +18,13 @@ class ShoppingListsController < ApplicationController
     end
 
     def perform
-      return Service::MethodNotAllowedResult.new(errors: [AGGREGATE_LIST_ERROR]) if shopping_list.aggregate == true
+      return Service::MethodNotAllowedResult.new(errors: [AGGREGATE_LIST_ERROR]) if wish_list.aggregate == true
       return Service::UnprocessableEntityResult.new(errors: [DISALLOWED_UPDATE_ERROR]) if params[:aggregate] == true
 
-      if shopping_list.update(params)
-        Service::OKResult.new(resource: shopping_list)
+      if wish_list.update(params)
+        Service::OKResult.new(resource: wish_list)
       else
-        Service::UnprocessableEntityResult.new(errors: shopping_list.error_array)
+        Service::UnprocessableEntityResult.new(errors: wish_list.error_array)
       end
     rescue ActiveRecord::RecordNotFound
       Service::NotFoundResult.new
@@ -37,8 +37,8 @@ class ShoppingListsController < ApplicationController
 
     attr_reader :user, :list_id, :params
 
-    def shopping_list
-      @shopping_list ||= user.shopping_lists.find(list_id)
+    def wish_list
+      @wish_list ||= user.wish_lists.find(list_id)
     end
   end
 end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -29,7 +29,7 @@ class Game < ApplicationRecord
   # before `dependent: :destroy` need to be defined before the
   # association is defined.
   before_destroy :destroy_aggregatable_child_models
-  has_many :shopping_lists, -> { index_order }, dependent: :destroy, inverse_of: :game
+  has_many :wish_lists, -> { index_order }, dependent: :destroy, inverse_of: :game
   has_many :inventory_lists, -> { index_order }, dependent: :destroy, inverse_of: :game
 
   validates :name,
@@ -41,16 +41,16 @@ class Game < ApplicationRecord
 
   scope :index_order, -> { order(updated_at: :desc) }
 
-  def aggregate_shopping_list
-    shopping_lists.find_by(aggregate: true)
+  def aggregate_wish_list
+    wish_lists.find_by(aggregate: true)
   end
 
   def aggregate_inventory_list
     inventory_lists.find_by(aggregate: true)
   end
 
-  def shopping_list_items
-    ShoppingListItem.belonging_to_game(self)
+  def wish_list_items
+    WishListItem.belonging_to_game(self)
   end
 
   def inventory_items
@@ -76,7 +76,7 @@ class Game < ApplicationRecord
   # Since there is no way to change the order in which the child models are
   # deleted, it's necessary to do it in a before hook.
   def destroy_aggregatable_child_models
-    shopping_lists.reverse.each(&:destroy)
+    wish_lists.reverse.each(&:destroy)
     inventory_lists.reverse.each(&:destroy)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,16 +16,16 @@ class User < ApplicationRecord
     end
   end
 
-  def shopping_lists
-    ShoppingList.belonging_to_user(self)
+  def wish_lists
+    WishList.belonging_to_user(self)
   end
 
   def inventory_lists
     InventoryList.belonging_to_user(self)
   end
 
-  def shopping_list_items
-    ShoppingListItem.belonging_to_user(self)
+  def wish_list_items
+    WishListItem.belonging_to_user(self)
   end
 
   def inventory_items

--- a/app/models/wish_list.rb
+++ b/app/models/wish_list.rb
@@ -2,9 +2,7 @@
 
 require 'titlecase'
 
-class ShoppingList < ApplicationRecord
-  self.table_name = 'wish_lists'
-
+class WishList < ApplicationRecord
   # Titles have to be unique per game as described in the API docs. They also can only
   # contain alphanumeric characters and spaces with no special characters or whitespace
   # other than spaces. Leading or trailing whitespace is stripped anyway so the validation
@@ -21,7 +19,7 @@ class ShoppingList < ApplicationRecord
   # This has to be defined before including AggregateListable because its `included` block
   # calls this method.
   def self.list_item_class_name
-    'ShoppingListItem'
+    'WishListItem'
   end
 
   include Aggregatable
@@ -35,7 +33,11 @@ class ShoppingList < ApplicationRecord
     return if aggregate
 
     if title.blank?
-      max_existing_number = game.shopping_lists.where("title LIKE 'My List %'").pluck(:title).map {|t| t.gsub('My List ', '').to_i }
+      max_existing_number = game
+                              .wish_lists
+                              .where("title LIKE 'My List %'")
+                              .pluck(:title)
+                              .map {|t| t.gsub('My List ', '').to_i }
                               .max || 0
       next_number = max_existing_number >= 0 ? max_existing_number + 1 : 1
       self.title = "My List #{next_number}"

--- a/app/models/wish_list_item.rb
+++ b/app/models/wish_list_item.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
-class ShoppingListItem < ApplicationRecord
-  self.table_name = 'wish_list_items'
-
+class WishListItem < ApplicationRecord
   def self.list_class
-    ShoppingList
+    WishList
   end
 
   def self.list_table_name

--- a/docs/aggregate-lists.md
+++ b/docs/aggregate-lists.md
@@ -29,16 +29,16 @@
 
 ## Overview
 
-Skyrim Inventory Management makes use of a concept called "aggregate lists". A model that represents a list of other models (e.g., `ShoppingList`, which is a list of `ShoppingListItem` models) can include the `Aggregatable` concern to incorporate aggregate list behaviour. Currently, the only such classes are `ShoppingList` and `InventoryList`. List item models can include the `Listable` concern.
+Skyrim Inventory Management makes use of a concept called "aggregate lists". A model that represents a list of other models (e.g., `WishList`, which is a list of `WishListItem` models) can include the `Aggregatable` concern to incorporate aggregate list behaviour. Currently, the only such classes are `WishList` and `InventoryList`. List item models can include the `Listable` concern.
 
 An aggregate list is a list that tracks and aggregates data from other lists (the child lists). When an item is added, removed, or modified on a child list, the corresponding item is added, removed, or modified on the aggregate list as well.
 
 Above where you include `Aggregatable` in the model code, you will need to define a class method called `self.list_item_class_name` that is the class name, as a string, of the class the list items for this type of list belong to:
 
 ```ruby
-class ShoppingList < ApplicationRecord
+class WishList < ApplicationRecord
   def self.list_item_class_name
-    'ShoppingListItem'
+    'WishListItem'
   end
 
   include Aggregatable
@@ -108,7 +108,7 @@ Best practice for aggregate lists is to never create or destroy an aggregate lis
 When a user creates their first regular list, an aggregate list will be automatically created for them and set as that list's aggregate list. Subsequent lists of the same class belonging to the same user should be created with that as the aggregate list:
 
 ```ruby
-game.aggregate_shopping_list.child_lists.create!(title: 'My Title')
+game.aggregate_wish_list.child_lists.create!(title: 'My Title')
 ```
 
 When a user destroys a regular list, and it is their last regular list of that class, the aggregate list will also be destroyed.
@@ -273,7 +273,7 @@ Arguments:
 
 #### `aggregate_list`
 
-Returns the aggregate list to which the shopping list belongs. Is `nil` for aggregate lists.
+Returns the aggregate list to which the wish list belongs. Is `nil` for aggregate lists.
 
 #### `child_lists`
 

--- a/spec/controller_services/shopping_list_items_controller/create_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/create_service_spec.rb
@@ -9,12 +9,12 @@ require 'service/internal_server_error_result'
 
 RSpec.describe ShoppingListItemsController::CreateService do
   describe '#perform' do
-    subject(:perform) { described_class.new(user, shopping_list.id, params).perform }
+    subject(:perform) { described_class.new(user, wish_list.id, params).perform }
 
     let(:user) { create(:user) }
     let(:game) { create(:game, user:) }
-    let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
-    let!(:shopping_list) { create(:shopping_list, game:, aggregate_list:) }
+    let!(:aggregate_list) { create(:aggregate_wish_list, game:) }
+    let!(:wish_list) { create(:wish_list, game:, aggregate_list:) }
 
     context 'when all goes well' do
       let(:params) { { description: 'Necklace', quantity: 2, notes: 'Hello world' } }
@@ -24,7 +24,7 @@ RSpec.describe ShoppingListItemsController::CreateService do
           context 'when unit weight is not set' do
             it 'creates a new item on the list' do
               expect { perform }
-                .to change(shopping_list.list_items, :count).from(0).to(1)
+                .to change(wish_list.list_items, :count).from(0).to(1)
             end
 
             it 'creates a new item on the aggregate list' do
@@ -36,8 +36,8 @@ RSpec.describe ShoppingListItemsController::CreateService do
               expect(perform).to be_a(Service::CreatedResult)
             end
 
-            it 'sets the resource to all the changed shopping lists' do
-              expect(perform.resource).to eq [aggregate_list, shopping_list]
+            it 'sets the resource to all the changed wish lists' do
+              expect(perform.resource).to eq [aggregate_list, wish_list]
             end
           end
 
@@ -46,7 +46,7 @@ RSpec.describe ShoppingListItemsController::CreateService do
 
             it 'creates a new item on the list' do
               expect { perform }
-                .to change(shopping_list.list_items, :count).from(0).to(1)
+                .to change(wish_list.list_items, :count).from(0).to(1)
             end
 
             it 'creates a new item on the aggregate list' do
@@ -58,19 +58,19 @@ RSpec.describe ShoppingListItemsController::CreateService do
               expect(perform).to be_a(Service::CreatedResult)
             end
 
-            it 'sets the resource to all the changed shopping lists' do
-              expect(perform.resource).to eq [aggregate_list, shopping_list]
+            it 'sets the resource to all the changed wish lists' do
+              expect(perform.resource).to eq [aggregate_list, wish_list]
             end
           end
         end
 
         context 'when there is an existing matching item on another list' do
-          let(:other_list) { create(:shopping_list, game: aggregate_list.game, aggregate_list:) }
-          let!(:other_item) { create(:shopping_list_item, list: other_list, description: 'Necklace', unit_weight: 1, quantity: 1) }
+          let(:other_list) { create(:wish_list, game: aggregate_list.game, aggregate_list:) }
+          let!(:other_item) { create(:wish_list_item, list: other_list, description: 'Necklace', unit_weight: 1, quantity: 1) }
 
           before do
             # This should not be included in the resource body
-            create(:shopping_list, game:)
+            create(:wish_list, game:)
 
             aggregate_list.add_item_from_child_list(other_item)
           end
@@ -78,12 +78,12 @@ RSpec.describe ShoppingListItemsController::CreateService do
           context 'when the unit_weight is not set' do
             it 'creates a new item on the list' do
               expect { perform }
-                .to change(shopping_list.list_items, :count).from(0).to eq 1
+                .to change(wish_list.list_items, :count).from(0).to eq 1
             end
 
             it 'sets the unit weight on the new item' do
               perform
-              expect(shopping_list.list_items.unscoped.last.unit_weight).to eq 1
+              expect(wish_list.list_items.unscoped.last.unit_weight).to eq 1
             end
 
             it 'updates the item on the aggregate list', :aggregate_failures do
@@ -97,8 +97,8 @@ RSpec.describe ShoppingListItemsController::CreateService do
               expect(perform).to be_a(Service::CreatedResult)
             end
 
-            it 'sets all the changed shopping lists as the resource' do
-              expect(perform.resource).to eq([aggregate_list, shopping_list])
+            it 'sets all the changed wish lists as the resource' do
+              expect(perform.resource).to eq([aggregate_list, wish_list])
             end
           end
 
@@ -107,7 +107,7 @@ RSpec.describe ShoppingListItemsController::CreateService do
 
             it 'creates a new item on the list' do
               expect { perform }
-                .to change(shopping_list.list_items, :count).from(0).to(1)
+                .to change(wish_list.list_items, :count).from(0).to(1)
             end
 
             it 'updates the item on the aggregate list', :aggregate_failures do
@@ -127,21 +127,21 @@ RSpec.describe ShoppingListItemsController::CreateService do
               expect(perform).to be_a(Service::CreatedResult)
             end
 
-            it 'sets all the changed shopping lists as the resource' do
-              expect(perform.resource).to eq([aggregate_list, other_list, shopping_list])
+            it 'sets all the changed wish lists as the resource' do
+              expect(perform.resource).to eq([aggregate_list, other_list, wish_list])
             end
           end
         end
       end
 
       context 'when there is an existing matching item on the same list' do
-        let(:other_list) { create(:shopping_list, game:) }
-        let!(:other_item) { create(:shopping_list_item, list: other_list, description: 'Necklace', quantity: 2) }
-        let!(:list_item) { create(:shopping_list_item, list: shopping_list, description: 'Necklace', quantity: 1) }
+        let(:other_list) { create(:wish_list, game:) }
+        let!(:other_item) { create(:wish_list_item, list: other_list, description: 'Necklace', quantity: 2) }
+        let!(:list_item) { create(:wish_list_item, list: wish_list, description: 'Necklace', quantity: 1) }
 
         before do
           # This should not be included in the resource body
-          create(:shopping_list, game:)
+          create(:wish_list, game:)
 
           aggregate_list.add_item_from_child_list(other_item)
           aggregate_list.add_item_from_child_list(list_item)
@@ -152,7 +152,7 @@ RSpec.describe ShoppingListItemsController::CreateService do
 
           it "doesn't create a new item" do
             expect { perform }
-              .not_to change(ShoppingListItem, :count)
+              .not_to change(WishListItem, :count)
           end
 
           it 'combines with the existing item' do
@@ -169,8 +169,8 @@ RSpec.describe ShoppingListItemsController::CreateService do
             expect(perform).to be_a(Service::OKResult)
           end
 
-          it 'sets all the changed shopping lists as the resource' do
-            expect(perform.resource).to eq([aggregate_list, shopping_list])
+          it 'sets all the changed wish lists as the resource' do
+            expect(perform.resource).to eq([aggregate_list, wish_list])
           end
         end
 
@@ -179,7 +179,7 @@ RSpec.describe ShoppingListItemsController::CreateService do
 
           it "doesn't create a new list item" do
             expect { perform }
-              .not_to change(ShoppingListItem, :count)
+              .not_to change(WishListItem, :count)
           end
 
           it 'combines the items', :aggregate_failures do
@@ -204,8 +204,8 @@ RSpec.describe ShoppingListItemsController::CreateService do
             expect(perform).to be_a(Service::OKResult)
           end
 
-          it 'sets all the changed shopping lists as the resource' do
-            expect(perform.resource).to eq([aggregate_list, other_list, shopping_list])
+          it 'sets all the changed wish lists as the resource' do
+            expect(perform.resource).to eq([aggregate_list, other_list, wish_list])
           end
         end
       end
@@ -213,7 +213,7 @@ RSpec.describe ShoppingListItemsController::CreateService do
 
     context "when the list doesn't exist" do
       let(:params) { { description: 'Necklace', quantity: 4, unit_weight: 0.5 } }
-      let(:shopping_list) { double(id: 234_980) }
+      let(:wish_list) { double(id: 234_980) }
 
       it 'returns a Service::NotFoundResult' do
         expect(perform).to be_a(Service::NotFoundResult)
@@ -227,11 +227,11 @@ RSpec.describe ShoppingListItemsController::CreateService do
 
     context 'when the list belongs to another user' do
       let(:params) { { description: 'Necklace', quantity: 4, unit_weight: 0.5 } }
-      let!(:shopping_list) { create(:shopping_list) }
+      let!(:wish_list) { create(:wish_list) }
 
       it "doesn't create a list item" do
         expect { perform }
-          .not_to change(ShoppingListItem, :count)
+          .not_to change(WishListItem, :count)
       end
 
       it 'returns a Service::NotFoundResult' do
@@ -257,12 +257,12 @@ RSpec.describe ShoppingListItemsController::CreateService do
     end
 
     context 'when the list is an aggregate list' do
-      let(:shopping_list) { aggregate_list }
+      let(:wish_list) { aggregate_list }
       let!(:params) { { description: 'Necklace', quantity: 2 } }
 
       it "doesn't create an item" do
         expect { perform }
-          .not_to change(ShoppingListItem, :count)
+          .not_to change(WishListItem, :count)
       end
 
       it 'returns a Service::MethodNotAllowedResult' do
@@ -270,7 +270,7 @@ RSpec.describe ShoppingListItemsController::CreateService do
       end
 
       it 'sets the errors' do
-        expect(perform.errors).to eq ['Cannot manually manage items on an aggregate shopping list']
+        expect(perform.errors).to eq ['Cannot manually manage items on an aggregate wish list']
       end
     end
 
@@ -278,7 +278,7 @@ RSpec.describe ShoppingListItemsController::CreateService do
       let!(:params) { { description: 'Necklace', quantity: 2 } }
 
       before do
-        allow(ShoppingList).to receive(:find).and_raise(StandardError.new('Something went horribly wrong'))
+        allow(WishList).to receive(:find).and_raise(StandardError.new('Something went horribly wrong'))
       end
 
       it 'returns a Service::InternalServerErrorResponse' do

--- a/spec/controller_services/shopping_list_items_controller/update_service_spec.rb
+++ b/spec/controller_services/shopping_list_items_controller/update_service_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe ShoppingListItemsController::UpdateService do
 
     let(:user) { create(:user) }
     let(:game) { create(:game, user:) }
-    let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
-    let!(:shopping_list) { create(:shopping_list, game:, aggregate_list:) }
+    let!(:aggregate_list) { create(:aggregate_wish_list, game:) }
+    let!(:wish_list) { create(:wish_list, game:, aggregate_list:) }
 
     context 'when all goes well' do
       context 'when there is no matching item on another list' do
-        let!(:list_item) { create(:shopping_list_item, list: shopping_list, description: 'Dwarven metal ingot', quantity: 2) }
+        let!(:list_item) { create(:wish_list_item, list: wish_list, description: 'Dwarven metal ingot', quantity: 2) }
         let(:aggregate_list_item) { aggregate_list.list_items.first }
         let(:params) { { quantity: 9, notes: 'To make bolts with' } }
 
@@ -42,15 +42,15 @@ RSpec.describe ShoppingListItemsController::UpdateService do
           expect(perform).to be_a(Service::OKResult)
         end
 
-        it 'returns the modified shopping list items as the resource' do
+        it 'returns the modified wish list items as the resource' do
           expect(perform.resource).to eq [aggregate_list_item, list_item.reload]
         end
       end
 
       context 'when there is a matching item on another list' do
-        let!(:list_item) { create(:shopping_list_item, list: shopping_list, quantity: 4, unit_weight: 1) }
-        let(:other_list) { create(:shopping_list, game:, aggregate_list:) }
-        let!(:other_item) { create(:shopping_list_item, description: list_item.description, list: other_list, unit_weight: 1, quantity: 3) }
+        let!(:list_item) { create(:wish_list_item, list: wish_list, quantity: 4, unit_weight: 1) }
+        let(:other_list) { create(:wish_list, game:, aggregate_list:) }
+        let!(:other_item) { create(:wish_list_item, description: list_item.description, list: other_list, unit_weight: 1, quantity: 3) }
         let(:aggregate_list_item) { aggregate_list.list_items.first }
 
         before do
@@ -142,7 +142,7 @@ RSpec.describe ShoppingListItemsController::UpdateService do
       end
     end
 
-    context "when the shopping list item doesn't exist" do
+    context "when the wish list item doesn't exist" do
       let(:list_item) { double(id: 3_459_250) }
       let(:params) { { quantity: 4 } }
 
@@ -156,8 +156,8 @@ RSpec.describe ShoppingListItemsController::UpdateService do
       end
     end
 
-    context 'when the shopping list item belongs to another user' do
-      let!(:list_item) { create(:shopping_list_item) }
+    context 'when the wish list item belongs to another user' do
+      let!(:list_item) { create(:wish_list_item) }
       let(:params) { { quantity: 4 } }
 
       it "doesn't update the item" do
@@ -176,7 +176,7 @@ RSpec.describe ShoppingListItemsController::UpdateService do
     end
 
     context 'when the item is on an aggregate list' do
-      let!(:list_item) { create(:shopping_list_item, list: aggregate_list) }
+      let!(:list_item) { create(:wish_list_item, list: aggregate_list) }
       let(:params) { { quantity: 5 } }
 
       it 'returns a Service::MethodNotAllowedResult' do
@@ -184,14 +184,14 @@ RSpec.describe ShoppingListItemsController::UpdateService do
       end
 
       it 'sets the errors' do
-        expect(perform.errors).to eq ['Cannot manually update list items on an aggregate shopping list']
+        expect(perform.errors).to eq ['Cannot manually update list items on an aggregate wish list']
       end
     end
 
     context 'when the attributes are invalid' do
-      let!(:list_item) { create(:shopping_list_item, list: shopping_list, quantity: 2) }
-      let(:other_list) { create(:shopping_list, game:) }
-      let!(:other_item) { create(:shopping_list_item, list: other_list, description: list_item.description, quantity: 1) }
+      let!(:list_item) { create(:wish_list_item, list: wish_list, quantity: 2) }
+      let(:other_list) { create(:wish_list, game:) }
+      let!(:other_item) { create(:wish_list_item, list: other_list, description: list_item.description, quantity: 1) }
       let(:aggregate_list_item) { aggregate_list.list_items.first }
       let(:params) { { quantity: -4, unit_weight: 2 } }
 
@@ -221,12 +221,12 @@ RSpec.describe ShoppingListItemsController::UpdateService do
     end
 
     context 'when there is an unexpected error' do
-      let!(:list_item) { create(:shopping_list_item, list: shopping_list) }
+      let!(:list_item) { create(:wish_list_item, list: wish_list) }
       let(:params) { { notes: 'Hello world' } }
 
       before do
         aggregate_list.add_item_from_child_list(list_item)
-        allow_any_instance_of(ShoppingList)
+        allow_any_instance_of(WishList)
           .to receive(:aggregate)
                 .and_raise(StandardError.new('Something went horribly wrong'))
       end

--- a/spec/controller_services/shopping_lists_controller/create_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/create_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ShoppingListsController::CreateService do
 
     context 'when the game is not found' do
       let(:game) { double(id: 898_243) }
-      let(:params) { { title: 'My Shopping List' } }
+      let(:params) { { title: 'My Wish List' } }
 
       it 'returns a Service::NotFoundResult' do
         expect(perform).to be_a(Service::NotFoundResult)
@@ -28,11 +28,11 @@ RSpec.describe ShoppingListsController::CreateService do
 
     context 'when the game belongs to another user' do
       let(:game) { create(:game) }
-      let(:params) { { title: 'My Shopping List' } }
+      let(:params) { { title: 'My Wish List' } }
 
-      it "doesn't create a shopping list" do
+      it "doesn't create a wish list" do
         expect { perform }
-          .not_to change(ShoppingList, :count)
+          .not_to change(WishList, :count)
       end
 
       it 'returns a Service::NotFoundResult' do
@@ -59,7 +59,7 @@ RSpec.describe ShoppingListsController::CreateService do
       end
 
       it 'sets an error' do
-        expect(perform.errors).to eq(['Cannot manually create an aggregate shopping list'])
+        expect(perform.errors).to eq(['Cannot manually create an aggregate wish list'])
       end
     end
 
@@ -67,14 +67,14 @@ RSpec.describe ShoppingListsController::CreateService do
       let!(:game) { create(:game, user:) }
       let(:params) { { title: 'Proudspire Manor' } }
 
-      context 'when the game has other shopping lists' do
+      context 'when the game has other wish lists' do
         before do
-          create(:shopping_list, game:)
+          create(:wish_list, game:)
         end
 
-        it 'creates a shopping list for the given game' do
+        it 'creates a wish list for the given game' do
           expect { perform }
-            .to change(game.shopping_lists, :count).from(2).to(3)
+            .to change(game.wish_lists, :count).from(2).to(3)
         end
 
         it 'returns a Service::CreatedResult' do
@@ -82,7 +82,7 @@ RSpec.describe ShoppingListsController::CreateService do
         end
 
         it 'sets the resource to the created list' do
-          expect(perform.resource).to eq [game.shopping_lists.find_by(title: 'Proudspire Manor')]
+          expect(perform.resource).to eq [game.wish_lists.find_by(title: 'Proudspire Manor')]
         end
 
         it 'updates the game' do
@@ -94,20 +94,20 @@ RSpec.describe ShoppingListsController::CreateService do
         end
       end
 
-      context "when the game doesn't have an aggregate shopping list" do
+      context "when the game doesn't have an aggregate wish list" do
         it 'creates two lists' do
           expect { perform }
-            .to change(game.shopping_lists, :count).from(0).to(2)
+            .to change(game.wish_lists, :count).from(0).to(2)
         end
 
-        it 'creates an aggregate shopping list for the given game' do
+        it 'creates an aggregate wish list for the given game' do
           perform
-          expect(game.aggregate_shopping_list).to be_present
+          expect(game.aggregate_wish_list).to be_present
         end
 
-        it 'creates a regular shopping list for the given game' do
+        it 'creates a regular wish list for the given game' do
           perform
-          expect(game.shopping_lists.last.title).to eq 'Proudspire Manor'
+          expect(game.wish_lists.last.title).to eq 'Proudspire Manor'
         end
 
         it 'updates the game' do
@@ -123,7 +123,7 @@ RSpec.describe ShoppingListsController::CreateService do
         end
 
         it 'sets the resource to include both lists' do
-          expect(perform.resource).to eq(game.shopping_lists.index_order)
+          expect(perform.resource).to eq(game.wish_lists.index_order)
         end
       end
     end
@@ -133,9 +133,9 @@ RSpec.describe ShoppingListsController::CreateService do
       let(:game_id) { game.id }
       let(:params) { { title: '|nvalid Tit|e' } }
 
-      it 'does not create a shopping list' do
+      it 'does not create a wish list' do
         expect { perform }
-          .not_to change(game.shopping_lists, :count)
+          .not_to change(game.wish_lists, :count)
       end
 
       it 'returns a Service::UnprocessableEntityResult' do
@@ -152,7 +152,9 @@ RSpec.describe ShoppingListsController::CreateService do
       let(:params) { { title: 'Foobar' } }
 
       before do
-        allow_any_instance_of(ShoppingList).to receive(:save).and_raise(StandardError, 'Something went horribly wrong')
+        allow_any_instance_of(WishList)
+          .to receive(:save)
+                .and_raise(StandardError, 'Something went horribly wrong')
       end
 
       it 'returns a Service::InternalServerErrorResult' do

--- a/spec/controller_services/shopping_lists_controller/index_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/index_service_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe ShoppingListsController::IndexService do
       end
     end
 
-    context 'when there are no shopping lists for that game' do
+    context 'when there are no wish lists for that game' do
       let(:game) { create(:game, user:) }
       let(:game_id) { game.id }
 
@@ -49,16 +49,16 @@ RSpec.describe ShoppingListsController::IndexService do
       end
     end
 
-    context 'when there are shopping lists for that game' do
-      let(:game) { create(:game_with_shopping_lists, user:) }
+    context 'when there are wish lists for that game' do
+      let(:game) { create(:game_with_wish_lists, user:) }
       let(:game_id) { game.id }
 
       it 'returns a Service::OKResult' do
         expect(perform).to be_a(Service::OKResult)
       end
 
-      it "sets the resource to the game's shopping lists" do
-        expect(perform.resource).to eq game.shopping_lists.index_order
+      it "sets the resource to the game's wish lists" do
+        expect(perform.resource).to eq game.wish_lists.index_order
       end
     end
 
@@ -67,7 +67,7 @@ RSpec.describe ShoppingListsController::IndexService do
       let(:game_id) { game.id }
 
       before do
-        allow_any_instance_of(Game).to receive(:shopping_lists).and_raise(StandardError, 'Something went horribly wrong')
+        allow_any_instance_of(Game).to receive(:wish_lists).and_raise(StandardError, 'Something went horribly wrong')
       end
 
       it 'returns a Service::InternalServerErrorResult' do

--- a/spec/controller_services/shopping_lists_controller/update_service_spec.rb
+++ b/spec/controller_services/shopping_lists_controller/update_service_spec.rb
@@ -9,27 +9,27 @@ require 'service/internal_server_error_result'
 
 RSpec.describe ShoppingListsController::UpdateService do
   describe '#perform' do
-    subject(:perform) { described_class.new(user, shopping_list.id, params).perform }
+    subject(:perform) { described_class.new(user, wish_list.id, params).perform }
 
-    let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
+    let!(:aggregate_list) { create(:aggregate_wish_list, game:) }
     let(:user) { create(:user) }
 
     context 'when all goes well' do
-      let(:shopping_list) { create(:shopping_list, game:, aggregate_list:) }
+      let(:wish_list) { create(:wish_list, game:, aggregate_list:) }
       let(:game) { create(:game, user:) }
       let(:params) { { title: 'My New Title' } }
 
-      it 'updates the shopping list' do
+      it 'updates the wish list' do
         perform
-        expect(shopping_list.reload.title).to eq 'My New Title'
+        expect(wish_list.reload.title).to eq 'My New Title'
       end
 
       it 'returns a Service::OKResult' do
         expect(perform).to be_a(Service::OKResult)
       end
 
-      it 'sets the resource to the updated shopping list' do
-        expect(perform.resource).to eq shopping_list
+      it 'sets the resource to the updated wish list' do
+        expect(perform.resource).to eq wish_list
       end
 
       it 'updates the game' do
@@ -42,7 +42,7 @@ RSpec.describe ShoppingListsController::UpdateService do
     end
 
     context 'when the params are invalid' do
-      let(:shopping_list) { create(:shopping_list, game:) }
+      let(:wish_list) { create(:wish_list, game:) }
       let(:game) { create(:game, user:) }
       let(:params) { { title: '|nvalid Tit|e' } }
 
@@ -55,8 +55,8 @@ RSpec.describe ShoppingListsController::UpdateService do
       end
     end
 
-    context "when the shopping list doesn't exist" do
-      let(:shopping_list) { double(id: 23_859) }
+    context "when the wish list doesn't exist" do
+      let(:wish_list) { double(id: 23_859) }
       let(:game) { create(:game) }
       let(:params) { { title: 'Valid New Title' } }
 
@@ -70,14 +70,14 @@ RSpec.describe ShoppingListsController::UpdateService do
       end
     end
 
-    context 'when the shopping list belongs to another user' do
-      let!(:shopping_list) { create(:shopping_list) }
+    context 'when the wish list belongs to another user' do
+      let!(:wish_list) { create(:wish_list) }
       let(:game) { create(:game) }
       let(:params) { { title: 'Valid New Title' } }
 
-      it "doesn't update the shopping list" do
+      it "doesn't update the wish list" do
         expect { perform }
-          .not_to change(shopping_list.reload, :title)
+          .not_to change(wish_list.reload, :title)
       end
 
       it 'returns a Service::NotFoundResult' do
@@ -90,8 +90,8 @@ RSpec.describe ShoppingListsController::UpdateService do
       end
     end
 
-    context 'when the shopping list is an aggregate shopping list' do
-      let(:shopping_list) { aggregate_list }
+    context 'when the wish list is an aggregate wish list' do
+      let(:wish_list) { aggregate_list }
       let(:game) { create(:game, user:) }
       let(:params) { { title: 'New Title' } }
 
@@ -100,12 +100,12 @@ RSpec.describe ShoppingListsController::UpdateService do
       end
 
       it 'sets the error message' do
-        expect(perform.errors).to eq(['Cannot manually update an aggregate shopping list'])
+        expect(perform.errors).to eq(['Cannot manually update an aggregate wish list'])
       end
     end
 
     context 'when the request tries to set aggregate to true' do
-      let(:shopping_list) { create(:shopping_list, game:) }
+      let(:wish_list) { create(:wish_list, game:) }
       let(:game) { create(:game, user:) }
       let(:params) { { aggregate: true } }
 
@@ -114,17 +114,19 @@ RSpec.describe ShoppingListsController::UpdateService do
       end
 
       it 'sets the error message' do
-        expect(perform.errors).to eq(['Cannot make a regular shopping list an aggregate list'])
+        expect(perform.errors).to eq(['Cannot make a regular wish list an aggregate list'])
       end
     end
 
     context 'when something unexpected goes wrong' do
-      let!(:shopping_list) { create(:shopping_list, game:) }
+      let!(:wish_list) { create(:wish_list, game:) }
       let(:game) { create(:game, user:) }
       let(:params) { { title: 'New Title' } }
 
       before do
-        allow_any_instance_of(ShoppingList).to receive(:update).and_raise(StandardError, 'Something went horribly wrong')
+        allow_any_instance_of(WishList)
+          .to receive(:update)
+                .and_raise(StandardError, 'Something went horribly wrong')
       end
 
       it 'returns a Service::InternalServerErrorResult' do

--- a/spec/lib/controller/response_spec.rb
+++ b/spec/lib/controller/response_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Controller::Response do
 
     context 'when there are errors' do
       let(:controller) { instance_double(ShoppingListsController, render: nil) }
-      let(:errors) { ['Cannot manually update an aggregate shopping list'] }
+      let(:errors) { ['Cannot manually update an aggregate wish list'] }
       let(:options) { {} }
       let(:result) { Service::MethodNotAllowedResult.new(errors:) }
 
@@ -70,7 +70,7 @@ RSpec.describe Controller::Response do
       context 'when there is a resource and errors' do
         let(:controller) { instance_double(ShoppingListsController, render: nil) }
         let(:options) { {} }
-        let(:errors) { ['Title is already taken', 'Cannot manually create or update an aggregate shopping list'] }
+        let(:errors) { ['Title is already taken', 'Cannot manually create or update an aggregate wish list'] }
         let(:result) { Service::UnprocessableEntityResult.new(errors:, resource: { foo: 'bar' }) }
 
         it 'renders the errors' do

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -60,21 +60,21 @@ RSpec.describe Game, type: :model do
     let!(:game) { create(:game_with_everything, user:) }
 
     # This is a regression test. Games were failing to be destroyed because, when
-    # destroying their shopping lists, the aggregate list wasn't necessarily
+    # destroying their wish lists, the aggregate list wasn't necessarily
     # destroyed last. The Aggregatable concern prevents aggregate lists from being
     # destroyed if they have child lists. However, since the index_order scope puts
     # the aggregate list first, it is the first list the game attempts to destroy.
     # We had to implement another `before_destroy` callback to ensure this behaviour
     # didn't make it impossible to destroy a game with Aggregatable child models.
 
-    it "destroys all the game's shopping lists" do
+    it "destroys all the game's wish lists" do
       expect { game.destroy! }
-        .to change(ShoppingList, :count).from(3).to(0)
+        .to change(WishList, :count).from(3).to(0)
     end
 
-    it "destroys all the game's shopping list items" do
+    it "destroys all the game's wish list items" do
       expect { game.destroy! }
-        .to change(ShoppingListItem, :count).from(8).to(0)
+        .to change(WishListItem, :count).from(8).to(0)
     end
 
     it "destroys all the game's inventory lists" do
@@ -168,18 +168,18 @@ RSpec.describe Game, type: :model do
     end
   end
 
-  describe '#aggregate_shopping_list' do
-    subject(:aggregate_shopping_list) { game.aggregate_shopping_list }
+  describe '#aggregate_wish_list' do
+    subject(:aggregate_wish_list) { game.aggregate_wish_list }
 
     let(:game) { create(:game) }
-    let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
+    let!(:aggregate_list) { create(:aggregate_wish_list, game:) }
 
     before do
-      create_list(:shopping_list, 2, game:)
+      create_list(:wish_list, 2, game:)
     end
 
-    it "returns that game's aggregate shopping list" do
-      expect(aggregate_shopping_list).to eq aggregate_list
+    it "returns that game's aggregate wish list" do
+      expect(aggregate_wish_list).to eq aggregate_list
     end
   end
 
@@ -198,22 +198,22 @@ RSpec.describe Game, type: :model do
     end
   end
 
-  describe '#shopping_list_items' do
-    subject(:shopping_list_items) { game.shopping_list_items.to_a.sort }
+  describe '#wish_list_items' do
+    subject(:wish_list_items) { game.wish_list_items.to_a.sort }
 
     let(:game) { create(:game, user:) }
 
     before do
-      create_list(:shopping_list_with_list_items, 2, game:)
-      create(:game_with_shopping_lists_and_items, user:) # one that shouldn't be included
+      create_list(:wish_list_with_list_items, 2, game:)
+      create(:game_with_wish_lists_and_items, user:) # one that shouldn't be included
     end
 
     it 'returns all list items belonging to the game' do
-      items = game.shopping_lists.map {|list| list.list_items.to_a }
+      items = game.wish_lists.map {|list| list.list_items.to_a }
       items.flatten!
       items.sort!
 
-      expect(shopping_list_items).to eq items
+      expect(wish_list_items).to eq items
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -47,25 +47,25 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe '#shopping_lists' do
+  describe '#wish_lists' do
     let(:user1) { create(:user) }
     let(:user2) { create(:user) }
 
     let(:game1) { create(:game, user: user1) }
     let(:game2) { create(:game, user: user1) }
-    let(:game3) { create(:game_with_shopping_lists, user: user2) }
+    let(:game3) { create(:game_with_wish_lists, user: user2) }
 
-    let!(:shopping_list1) { create(:aggregate_shopping_list, game: game1) }
-    let!(:shopping_list2) { create(:shopping_list, game: game1) }
-    let!(:shopping_list3) { create(:aggregate_shopping_list, game: game2) }
-    let!(:shopping_list4) { create(:shopping_list, game: game2) }
+    let!(:wish_list1) { create(:aggregate_wish_list, game: game1) }
+    let!(:wish_list2) { create(:wish_list, game: game1) }
+    let!(:wish_list3) { create(:aggregate_wish_list, game: game2) }
+    let!(:wish_list4) { create(:wish_list, game: game2) }
 
-    it "returns all the shopping lists for the user's games" do
-      expect(user1.shopping_lists).to eq([
-        shopping_list4,
-        shopping_list3,
-        shopping_list2,
-        shopping_list1,
+    it "returns all the wish lists for the user's games" do
+      expect(user1.wish_lists).to eq([
+        wish_list4,
+        wish_list3,
+        wish_list2,
+        wish_list1,
       ])
     end
   end
@@ -93,21 +93,21 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe '#shopping_list_items' do
-    subject(:shopping_list_items) { user1.shopping_list_items.to_a.sort }
+  describe '#wish_list_items' do
+    subject(:wish_list_items) { user1.wish_list_items.to_a.sort }
 
     let(:user1) { create(:user) }
     let(:user2) { create(:user) }
 
-    let(:game1) { create(:game_with_shopping_lists_and_items, user: user1) }
-    let(:game2) { create(:game_with_shopping_lists_and_items, user: user1) }
-    let(:game3) { create(:game_with_shopping_lists_and_items, user: user2) }
+    let(:game1) { create(:game_with_wish_lists_and_items, user: user1) }
+    let(:game2) { create(:game_with_wish_lists_and_items, user: user1) }
+    let(:game3) { create(:game_with_wish_lists_and_items, user: user2) }
 
-    it 'includes the shopping list items belonging to that user' do
-      user1_list_items = game1.shopping_list_items.to_a + game2.shopping_list_items.to_a
+    it 'includes the wish list items belonging to that user' do
+      user1_list_items = game1.wish_list_items.to_a + game2.wish_list_items.to_a
       user1_list_items.sort!
 
-      expect(shopping_list_items).to eq user1_list_items
+      expect(wish_list_items).to eq user1_list_items
     end
   end
 

--- a/spec/models/wish_list_item_spec.rb
+++ b/spec/models/wish_list_item_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe WishListItem, type: :model do
     let(:list_item) { create(:wish_list_item, list: wish_list) }
 
     describe '#game' do
-      it 'returns the game its ShoppingList belongs to' do
+      it 'returns the game its WishList belongs to' do
         expect(list_item.game).to eq game
       end
     end

--- a/spec/models/wish_list_item_spec.rb
+++ b/spec/models/wish_list_item_spec.rb
@@ -2,13 +2,13 @@
 
 require 'rails_helper'
 
-RSpec.describe ShoppingListItem, type: :model do
+RSpec.describe WishListItem, type: :model do
   let!(:game) { create(:game) }
-  let(:aggregate_list) { create(:aggregate_shopping_list, game:) }
-  let(:shopping_list) { create(:shopping_list, game:, aggregate_list:) }
+  let(:aggregate_list) { create(:aggregate_wish_list, game:) }
+  let(:wish_list) { create(:wish_list, game:, aggregate_list:) }
 
   describe 'validation' do
-    let(:item) { build(:shopping_list_item) }
+    let(:item) { build(:wish_list_item) }
 
     it 'is invalid with a quantity less than 1' do
       item.quantity = 0
@@ -59,7 +59,7 @@ RSpec.describe ShoppingListItem, type: :model do
   end
 
   describe 'delegation' do
-    let(:list_item) { create(:shopping_list_item, list: shopping_list) }
+    let(:list_item) { create(:wish_list_item, list: wish_list) }
 
     describe '#game' do
       it 'returns the game its ShoppingList belongs to' do
@@ -76,11 +76,11 @@ RSpec.describe ShoppingListItem, type: :model do
 
   describe 'scopes' do
     describe '::index_order' do
-      let!(:list_item1) { create(:shopping_list_item, list:) }
-      let!(:list_item2) { create(:shopping_list_item, list:) }
-      let!(:list_item3) { create(:shopping_list_item, list:) }
+      let!(:list_item1) { create(:wish_list_item, list:) }
+      let!(:list_item2) { create(:wish_list_item, list:) }
+      let!(:list_item3) { create(:wish_list_item, list:) }
 
-      let(:list) { create(:shopping_list, game:) }
+      let(:list) { create(:wish_list, game:) }
 
       before do
         list_item2.update!(quantity: 3)
@@ -92,14 +92,14 @@ RSpec.describe ShoppingListItem, type: :model do
     end
 
     describe '::belonging_to_game' do
-      let!(:list1) { create(:shopping_list_with_list_items, game:, aggregate_list:) }
-      let!(:list2) { create(:shopping_list_with_list_items, game:, aggregate_list:) }
-      let!(:list3) { create(:shopping_list_with_list_items, game:, aggregate_list:) }
+      let!(:list1) { create(:wish_list_with_list_items, game:, aggregate_list:) }
+      let!(:list2) { create(:wish_list_with_list_items, game:, aggregate_list:) }
+      let!(:list3) { create(:wish_list_with_list_items, game:, aggregate_list:) }
 
       before do
         # There should be some that don't belong to the game to make sure they
         # don't also get included
-        create(:shopping_list_with_list_items)
+        create(:wish_list_with_list_items)
       end
 
       it 'returns all list items from all the lists for the given game' do
@@ -122,15 +122,15 @@ RSpec.describe ShoppingListItem, type: :model do
       let(:user) { game.user }
 
       before do
-        create(:shopping_list_with_list_items, game:, aggregate_list:)
-        create(:game_with_shopping_lists_and_items, user:)
-        create(:game_with_shopping_lists_and_items, user:)
-        create(:shopping_list_with_list_items) # one from a different user
+        create(:wish_list_with_list_items, game:, aggregate_list:)
+        create(:game_with_wish_lists_and_items, user:)
+        create(:game_with_wish_lists_and_items, user:)
+        create(:wish_list_with_list_items) # one from a different user
       end
 
       it 'returns all the list items belonging to the user', :aggregate_failures do
         all_items = []
-        user.shopping_lists.each {|list| all_items << list.list_items }
+        user.wish_lists.each {|list| all_items << list.list_items }
         all_items.flatten!.sort!
 
         expect(belonging_to_user).to eq all_items
@@ -144,18 +144,18 @@ RSpec.describe ShoppingListItem, type: :model do
         described_class.combine_or_create!(
           description: 'existing item',
           quantity: 1,
-          list: shopping_list,
+          list: wish_list,
           notes: notes2,
         )
       end
 
       let!(:existing_item) do
         create(
-          :shopping_list_item,
+          :wish_list_item,
           description: 'ExIsTiNg ItEm',
           quantity: 2,
           unit_weight: 0.3,
-          list: shopping_list,
+          list: wish_list,
           notes: notes1,
         )
       end
@@ -165,7 +165,7 @@ RSpec.describe ShoppingListItem, type: :model do
 
       it "doesn't create a new list item" do
         expect { combine_or_create }
-          .not_to change(shopping_list.list_items, :count)
+          .not_to change(wish_list.list_items, :count)
       end
 
       it 'adds the quantity to the existing item' do
@@ -190,7 +190,7 @@ RSpec.describe ShoppingListItem, type: :model do
           described_class.combine_or_create!(
             description: 'existing item',
             quantity: 1,
-            list: shopping_list,
+            list: wish_list,
             unit_weight: 0.2,
             notes: notes2,
           )
@@ -203,13 +203,13 @@ RSpec.describe ShoppingListItem, type: :model do
       end
 
       context 'when the list is an aggregate list' do
-        let(:shopping_list) { aggregate_list }
+        let(:wish_list) { aggregate_list }
         let(:notes1) { nil }
         let(:notes2) { 'notes 2' }
 
         it 'leaves the notes as nil' do
           combine_or_create
-          expect(shopping_list.list_items.last.reload.notes).to be_nil
+          expect(wish_list.list_items.last.reload.notes).to be_nil
         end
       end
     end
@@ -219,21 +219,21 @@ RSpec.describe ShoppingListItem, type: :model do
         described_class.combine_or_create!(
           description: 'New Item',
           quantity: 1,
-          list: shopping_list,
+          list: wish_list,
           unit_weight:,
         )
       end
 
       let!(:other_item) do
         create(
-          :shopping_list_item,
+          :wish_list_item,
           description: 'New Item',
           list: other_list,
           unit_weight: 1,
         )
       end
 
-      let(:other_list) { create(:shopping_list, game:, aggregate_list:) }
+      let(:other_list) { create(:wish_list, game:, aggregate_list:) }
 
       before do
         aggregate_list.add_item_from_child_list(other_item)
@@ -255,18 +255,18 @@ RSpec.describe ShoppingListItem, type: :model do
         described_class.combine_or_new(
           description: 'existing item',
           quantity: 1,
-          list: shopping_list,
+          list: wish_list,
           notes: 'notes 2',
         )
       end
 
       let!(:existing_item) do
         create(
-          :shopping_list_item,
+          :wish_list_item,
           description: 'ExIsTiNg ItEm',
           quantity: 2,
           unit_weight: 0.3,
-          list: shopping_list,
+          list: wish_list,
           notes: 'notes 1',
         )
       end
@@ -297,7 +297,7 @@ RSpec.describe ShoppingListItem, type: :model do
       end
 
       context 'when the new item has a unit_weight' do
-        subject(:combine_or_new) { described_class.combine_or_new(description: 'existing item', quantity: 1, unit_weight: 0.2, list: shopping_list, notes: 'notes 2') }
+        subject(:combine_or_new) { described_class.combine_or_new(description: 'existing item', quantity: 1, unit_weight: 0.2, list: wish_list, notes: 'notes 2') }
 
         it 'updates the unit_weight' do
           expect(combine_or_new.unit_weight).to eq 0.2
@@ -310,7 +310,7 @@ RSpec.describe ShoppingListItem, type: :model do
         described_class.combine_or_new(
           description: 'new item',
           quantity: 1,
-          list: shopping_list,
+          list: wish_list,
         )
       end
 
@@ -318,19 +318,19 @@ RSpec.describe ShoppingListItem, type: :model do
         allow(described_class).to receive(:new).and_call_original
       end
 
-      it 'instantiates a new shopping list item' do
+      it 'instantiates a new wish list item' do
         combine_or_new
         expect(described_class).to have_received(:new)
       end
 
-      it "doesn't save the shopping list item yet" do
+      it "doesn't save the wish list item yet" do
         expect { combine_or_new }
-          .not_to change(shopping_list.list_items, :count)
+          .not_to change(wish_list.list_items, :count)
       end
 
       context 'when unit weight is nil and there are matching items on other lists' do
-        let!(:other_list) { create(:shopping_list, game:, aggregate_list:) }
-        let!(:other_item) { create(:shopping_list_item, description: 'new item', list: other_list, unit_weight: 1) }
+        let!(:other_list) { create(:wish_list, game:, aggregate_list:) }
+        let!(:other_item) { create(:wish_list_item, description: 'new item', list: other_list, unit_weight: 1) }
 
         before do
           aggregate_list.add_item_from_child_list(other_item)
@@ -380,7 +380,7 @@ RSpec.describe ShoppingListItem, type: :model do
   end
 
   describe '#update!' do
-    let!(:list_item) { create(:shopping_list_item, quantity: 1, list: shopping_list) }
+    let!(:list_item) { create(:wish_list_item, quantity: 1, list: wish_list) }
 
     context 'when updating quantity' do
       subject(:update_item) { list_item.update!(quantity: 4) }
@@ -403,15 +403,15 @@ RSpec.describe ShoppingListItem, type: :model do
 
   describe 'notes field' do
     it 'cleans up leading and trailing dashes or whitespace' do
-      shopping_list_item = build(:shopping_list_item, notes: ' -- some notes --')
-      expect { shopping_list_item.save }
-        .to change(shopping_list_item, :notes).to('some notes')
+      wish_list_item = build(:wish_list_item, notes: ' -- some notes --')
+      expect { wish_list_item.save }
+        .to change(wish_list_item, :notes).to('some notes')
     end
 
     it 'saves as nil if it consists only of dashes' do
-      shopping_list_item = build(:shopping_list_item, notes: '--')
-      expect { shopping_list_item.save }
-        .to change(shopping_list_item, :notes).to(nil)
+      wish_list_item = build(:wish_list_item, notes: '--')
+      expect { wish_list_item.save }
+        .to change(wish_list_item, :notes).to(nil)
     end
   end
 end

--- a/spec/models/wish_list_spec.rb
+++ b/spec/models/wish_list_spec.rb
@@ -2,70 +2,70 @@
 
 require 'rails_helper'
 
-RSpec.describe ShoppingList, type: :model do
+RSpec.describe WishList, type: :model do
   describe 'scopes' do
     describe '::index_order' do
-      subject(:index_order) { game.shopping_lists.index_order.to_a }
+      subject(:index_order) { game.wish_lists.index_order.to_a }
 
       let!(:game) { create(:game) }
-      let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
-      let!(:shopping_list1) { create(:shopping_list, game:) }
-      let!(:shopping_list2) { create(:shopping_list, game:) }
-      let!(:shopping_list3) { create(:shopping_list, game:) }
+      let!(:aggregate_list) { create(:aggregate_wish_list, game:) }
+      let!(:wish_list1) { create(:wish_list, game:) }
+      let!(:wish_list2) { create(:wish_list, game:) }
+      let!(:wish_list3) { create(:wish_list, game:) }
 
       before do
-        shopping_list2.update!(title: 'Windstad Manor')
+        wish_list2.update!(title: 'Windstad Manor')
       end
 
       it 'is in reverse chronological order by updated_at with aggregate before anything' do
-        expect(index_order).to eq([aggregate_list, shopping_list2, shopping_list3, shopping_list1])
+        expect(index_order).to eq([aggregate_list, wish_list2, wish_list3, wish_list1])
       end
     end
 
     # Aggregatable
     describe '::includes_items' do
-      subject(:includes_items) { game.shopping_lists.includes_items }
+      subject(:includes_items) { game.wish_lists.includes_items }
 
       let!(:game) { create(:game) }
-      let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
-      let!(:lists) { create_list(:shopping_list_with_list_items, 2, game:) }
+      let!(:aggregate_list) { create(:aggregate_wish_list, game:) }
+      let!(:lists) { create_list(:wish_list_with_list_items, 2, game:) }
 
-      it 'includes the shopping list items' do
-        expect(includes_items).to eq game.shopping_lists.includes(:list_items)
+      it 'includes the wish list items' do
+        expect(includes_items).to eq game.wish_lists.includes(:list_items)
       end
     end
 
     # Aggregatable
     describe '::aggregates_first' do
-      subject(:aggregate_first) { game.shopping_lists.aggregate_first.to_a }
+      subject(:aggregate_first) { game.wish_lists.aggregate_first.to_a }
 
       let!(:game) { create(:game) }
-      let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
-      let!(:shopping_list) { create(:shopping_list, game:) }
+      let!(:aggregate_list) { create(:aggregate_wish_list, game:) }
+      let!(:wish_list) { create(:wish_list, game:) }
 
-      it 'returns the shopping lists with the aggregate list first' do
-        expect(aggregate_first).to eq([aggregate_list, shopping_list])
+      it 'returns the wish lists with the aggregate list first' do
+        expect(aggregate_first).to eq([aggregate_list, wish_list])
       end
     end
 
     describe '::belongs_to_user' do
       let(:user) { create(:user) }
-      let!(:game1) { create(:game_with_shopping_lists, user:) }
-      let!(:game2) { create(:game_with_shopping_lists, user:) }
-      let!(:game3) { create(:game_with_shopping_lists, user:) }
+      let!(:game1) { create(:game_with_wish_lists, user:) }
+      let!(:game2) { create(:game_with_wish_lists, user:) }
+      let!(:game3) { create(:game_with_wish_lists, user:) }
 
       before do
-        create(:game_with_shopping_lists)
+        create(:game_with_wish_lists)
       end
 
-      it "returns all the shopping lists from all the user's games" do
-        # These are going to be rearranged in the output since game.shopping_lists
+      it "returns all the wish lists from all the user's games" do
+        # These are going to be rearranged in the output since game.wish_lists
         # comes back aggregate list first and the scope will return them in descending
         # updated_at order. There was no easy programmatic way to rearrange them so
         # I just have to pull them all out and reorder them in the expectation.
-        agg_list1, game1_list1, game1_list2 = game1.shopping_lists.to_a
-        agg_list2, game2_list1, game2_list2 = game2.shopping_lists.to_a
-        agg_list3, game3_list1, game3_list2 = game3.shopping_lists.to_a
+        agg_list1, game1_list1, game1_list2 = game1.wish_lists.to_a
+        agg_list2, game2_list1, game2_list2 = game2.wish_lists.to_a
+        agg_list3, game3_list1, game3_list2 = game3.wish_lists.to_a
 
         expect(described_class.belonging_to_user(user).to_a).to eq([
           game3_list1,
@@ -87,7 +87,7 @@ RSpec.describe ShoppingList, type: :model do
     describe 'aggregate lists' do
       context 'when there are no aggregate lists' do
         let(:game) { create(:game) }
-        let(:aggregate_list) { build(:aggregate_shopping_list, game:) }
+        let(:aggregate_list) { build(:aggregate_wish_list, game:) }
 
         it 'is valid' do
           expect(aggregate_list).to be_valid
@@ -96,11 +96,11 @@ RSpec.describe ShoppingList, type: :model do
 
       context 'when there is an existing aggregate list belonging to another game' do
         let(:game) { create(:game) }
-        let(:aggregate_list) { build(:aggregate_shopping_list, game:) }
+        let(:aggregate_list) { build(:aggregate_wish_list, game:) }
 
         before do
           other_game = create(:game, user: game.user)
-          create(:aggregate_shopping_list, game: other_game)
+          create(:aggregate_wish_list, game: other_game)
         end
 
         it 'is valid' do
@@ -110,10 +110,10 @@ RSpec.describe ShoppingList, type: :model do
 
       context 'when the game already has an aggregate list' do
         let(:game) { create(:game) }
-        let(:aggregate_list) { build(:aggregate_shopping_list, game:) }
+        let(:aggregate_list) { build(:aggregate_wish_list, game:) }
 
         before do
-          create(:aggregate_shopping_list, game:)
+          create(:aggregate_wish_list, game:)
         end
 
         it 'is invalid', :aggregate_failures do
@@ -127,12 +127,12 @@ RSpec.describe ShoppingList, type: :model do
       # Aggregatable
       context 'when the title is "all items"' do
         it 'is allowed for an aggregate list' do
-          list = build(:aggregate_shopping_list, title: 'All Items')
+          list = build(:aggregate_wish_list, title: 'All Items')
           expect(list).to be_valid
         end
 
         it 'is not allowed for a regular list', :aggregate_failures do
-          list = build(:shopping_list, title: 'all items')
+          list = build(:wish_list, title: 'all items')
           expect(list).not_to be_valid
           expect(list.errors[:title]).to include 'cannot be "All Items"'
         end
@@ -140,38 +140,38 @@ RSpec.describe ShoppingList, type: :model do
 
       context 'when the title contains "all items" as well as other characters' do
         it 'is valid' do
-          list = build(:shopping_list, title: 'aLL iTems the seQUel')
+          list = build(:wish_list, title: 'aLL iTems the seQUel')
           expect(list).to be_valid
         end
       end
 
       describe 'allowed characters' do
         it 'allows alphanumeric characters, spaces, commas, apostrophes, and hyphens' do
-          list = build(:shopping_list, title: "aB 61 ,'-")
+          list = build(:wish_list, title: "aB 61 ,'-")
           expect(list).to be_valid
         end
 
         it "doesn't allow newlines", :aggregate_failures do
-          list = build(:shopping_list, title: "My\nList 1  ")
+          list = build(:wish_list, title: "My\nList 1  ")
           expect(list).not_to be_valid
           expect(list.errors[:title]).to include "can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')"
         end
 
         it "doesn't allow other non-space whitespace", :aggregate_failures do
-          list = build(:shopping_list, title: "My\tList 1")
+          list = build(:wish_list, title: "My\tList 1")
           expect(list).not_to be_valid
           expect(list.errors[:title]).to include "can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')"
         end
 
         it "doesn't allow special characters", :aggregate_failures do
-          list = build(:shopping_list, title: 'My^List&1')
+          list = build(:wish_list, title: 'My^List&1')
           expect(list).not_to be_valid
           expect(list.errors[:title]).to include "can only contain alphanumeric characters, spaces, commas (,), hyphens (-), and apostrophes (')"
         end
 
         # Leading and trailing whitespace characters will be stripped anyway so no need to validate
         it 'ignores leading or trailing whitespace characters' do
-          list = build(:shopping_list, title: "My List 1\n\t")
+          list = build(:wish_list, title: "My List 1\n\t")
           expect(list).to be_valid
         end
       end
@@ -180,11 +180,11 @@ RSpec.describe ShoppingList, type: :model do
 
   # Aggregatable
   describe '#aggregate_list' do
-    let!(:aggregate_list) { create(:aggregate_shopping_list) }
-    let(:shopping_list) { create(:shopping_list, game: aggregate_list.game) }
+    let!(:aggregate_list) { create(:aggregate_wish_list) }
+    let(:wish_list) { create(:wish_list, game: aggregate_list.game) }
 
     it 'returns the aggregate list that tracks it' do
-      expect(shopping_list.aggregate_list).to eq aggregate_list
+      expect(wish_list.aggregate_list).to eq aggregate_list
     end
   end
 
@@ -196,7 +196,7 @@ RSpec.describe ShoppingList, type: :model do
       # it sets values for certain attributes and I don't want those to get in the way.
       context 'when the list is not an aggregate list' do
         context 'when the user has set a title' do
-          subject(:title) { game.shopping_lists.create!(title: 'Heljarchen Hall').title }
+          subject(:title) { game.wish_lists.create!(title: 'Heljarchen Hall').title }
 
           let(:game) { create(:game) }
 
@@ -206,14 +206,14 @@ RSpec.describe ShoppingList, type: :model do
         end
 
         context 'when the user has not set a title' do
-          subject(:title) { game.shopping_lists.create!.title }
+          subject(:title) { game.wish_lists.create!.title }
 
           context 'when the game has all default-titled regular lists' do
             before do
               # Create lists for a different game to make sure the name of this game's
               # list isn't affected by them
-              create_list(:shopping_list, 2, title: nil)
-              create_list(:shopping_list, 2, title: nil, game:)
+              create_list(:wish_list, 2, title: nil)
+              create_list(:wish_list, 2, title: nil, game:)
             end
 
             it 'sets the title based on the highest numbered default title' do
@@ -223,10 +223,10 @@ RSpec.describe ShoppingList, type: :model do
 
           context 'when the game has differently titled regular lists' do
             before do
-              create(:shopping_list, title: nil)
-              create(:shopping_list, game:, title: nil)
-              create(:shopping_list, game:, title: 'Windstad Manor')
-              create(:shopping_list, game:, title: nil)
+              create(:wish_list, title: nil)
+              create(:wish_list, game:, title: nil)
+              create(:wish_list, game:, title: 'Windstad Manor')
+              create(:wish_list, game:, title: nil)
             end
 
             it 'uses the next highest number in default lists' do
@@ -234,10 +234,10 @@ RSpec.describe ShoppingList, type: :model do
             end
           end
 
-          context 'when the game has a shopping list with a similar title' do
+          context 'when the game has a wish list with a similar title' do
             before do
-              create(:shopping_list, game:, title: 'This List is Called My List 4')
-              create_list(:shopping_list, 2, game:, title: nil)
+              create(:wish_list, game:, title: 'This List is Called My List 4')
+              create_list(:wish_list, 2, game:, title: nil)
             end
 
             it 'sets the title based on the highest numbered list called "My List N"' do
@@ -245,10 +245,10 @@ RSpec.describe ShoppingList, type: :model do
             end
           end
 
-          context 'when there is a shopping list called "My List <non-integer>"' do
+          context 'when there is a wish list called "My List <non-integer>"' do
             before do
-              create(:shopping_list, game:, title: 'My List Is the Best List')
-              create_list(:shopping_list, 2, game:, title: nil)
+              create(:wish_list, game:, title: 'My List Is the Best List')
+              create_list(:wish_list, 2, game:, title: nil)
             end
 
             it 'sets the title based on the highest numbered list called "My List N"' do
@@ -256,9 +256,9 @@ RSpec.describe ShoppingList, type: :model do
             end
           end
 
-          context 'when there is a shopping list called "My List <negative integer>"' do
+          context 'when there is a wish list called "My List <negative integer>"' do
             before do
-              create(:shopping_list, game:, title: 'My List -4')
+              create(:wish_list, game:, title: 'My List -4')
             end
 
             it 'ignores the list title with the negative integer' do
@@ -271,7 +271,7 @@ RSpec.describe ShoppingList, type: :model do
       # Aggregatable
       context 'when the list is an aggregate list' do
         context 'when the user has set a title' do
-          subject(:title) { game.shopping_lists.create!(aggregate: true, title: 'Something other than all items').title }
+          subject(:title) { game.wish_lists.create!(aggregate: true, title: 'Something other than all items').title }
 
           it 'overrides the title the user has set' do
             expect(title).to eq 'All Items'
@@ -279,7 +279,7 @@ RSpec.describe ShoppingList, type: :model do
         end
 
         context 'when the user has not set a title' do
-          subject(:title) { game.shopping_lists.create!(aggregate: true).title }
+          subject(:title) { game.wish_lists.create!(aggregate: true).title }
 
           it 'sets the title to "All Items"' do
             expect(title).to eq 'All Items'
@@ -290,45 +290,45 @@ RSpec.describe ShoppingList, type: :model do
 
     context 'when the request includes sloppy data' do
       it 'uses intelligent title capitalisation' do
-        list = create(:shopping_list, title: 'lord oF thE rIngs')
+        list = create(:wish_list, title: 'lord oF thE rIngs')
         expect(list.title).to eq 'Lord of the Rings'
       end
 
       it 'strips trailing and leading whitespace' do
-        list = create(:shopping_list, title: " lord oF tHe RiNgs\n")
+        list = create(:wish_list, title: " lord oF tHe RiNgs\n")
         expect(list.title).to eq 'Lord of the Rings'
       end
     end
   end
 
   describe 'associations' do
-    subject(:items) { shopping_list.list_items }
+    subject(:items) { wish_list.list_items }
 
-    let!(:aggregate_list) { create(:aggregate_shopping_list) }
-    let(:shopping_list) { create(:shopping_list, game: aggregate_list.game, aggregate_list_id: aggregate_list.id) }
-    let!(:item1) { create(:shopping_list_item, list: shopping_list) }
-    let!(:item2) { create(:shopping_list_item, list: shopping_list) }
-    let!(:item3) { create(:shopping_list_item, list: shopping_list) }
+    let!(:aggregate_list) { create(:aggregate_wish_list) }
+    let(:wish_list) { create(:wish_list, game: aggregate_list.game, aggregate_list_id: aggregate_list.id) }
+    let!(:item1) { create(:wish_list_item, list: wish_list) }
+    let!(:item2) { create(:wish_list_item, list: wish_list) }
+    let!(:item3) { create(:wish_list_item, list: wish_list) }
 
     before do
       item2.update!(quantity: 2)
     end
 
     it 'keeps child models in descending order of updated_at' do
-      expect(shopping_list.list_items.to_a).to eq([item2, item3, item1])
+      expect(wish_list.list_items.to_a).to eq([item2, item3, item1])
     end
   end
 
   describe 'before destroy hook' do
     # Aggregatable
     context 'when trying to destroy the aggregate list' do
-      subject(:destroy_list) { shopping_list.destroy! }
+      subject(:destroy_list) { wish_list.destroy! }
 
-      let(:shopping_list) { create(:aggregate_shopping_list) }
+      let(:wish_list) { create(:aggregate_wish_list) }
 
       context 'when the game has regular lists' do
         before do
-          create(:shopping_list, game: shopping_list.game, aggregate_list: shopping_list)
+          create(:wish_list, game: wish_list.game, aggregate_list: wish_list)
         end
 
         it 'raises an error and does not destroy the list' do
@@ -340,7 +340,7 @@ RSpec.describe ShoppingList, type: :model do
       context 'when the game has no regular lists' do
         it 'destroys the aggregate list' do
           expect { destroy_list }
-            .to change(shopping_list.game.shopping_lists, :count).from(1).to(0)
+            .to change(wish_list.game.wish_lists, :count).from(1).to(0)
         end
       end
     end
@@ -348,27 +348,27 @@ RSpec.describe ShoppingList, type: :model do
 
   # Aggregatable
   describe 'after destroy hook' do
-    subject(:destroy_list) { shopping_list.destroy! }
+    subject(:destroy_list) { wish_list.destroy! }
 
-    let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
-    let!(:shopping_list) { create(:shopping_list, game:) }
+    let!(:aggregate_list) { create(:aggregate_wish_list, game:) }
+    let!(:wish_list) { create(:wish_list, game:) }
     let(:game) { create(:game) }
 
     context 'when the user has additional regular lists' do
       before do
-        create(:shopping_list, game:)
+        create(:wish_list, game:)
       end
 
       it "doesn't destroy the aggregate list" do
         expect { destroy_list }
-          .not_to change(game, :aggregate_shopping_list)
+          .not_to change(game, :aggregate_wish_list)
       end
     end
 
     context 'when the user has no additional regular lists' do
       it 'destroys the aggregate list' do
         expect { destroy_list }
-          .to change(game.shopping_lists, :count).from(2).to(0)
+          .to change(game.wish_lists, :count).from(2).to(0)
       end
     end
   end
@@ -377,12 +377,12 @@ RSpec.describe ShoppingList, type: :model do
     describe '#add_item_from_child_list' do
       subject(:add_item) { aggregate_list.add_item_from_child_list(list_item) }
 
-      let(:aggregate_list) { create(:aggregate_shopping_list) }
+      let(:aggregate_list) { create(:aggregate_wish_list) }
 
       context 'when there is no matching item on the aggregate list' do
         let(:list_item) do
           create(
-            :shopping_list_item,
+            :wish_list_item,
             quantity: 3,
             unit_weight: 4,
             notes: "shouldn't be on aggregate list",
@@ -406,11 +406,11 @@ RSpec.describe ShoppingList, type: :model do
       end
 
       context 'when there is a matching item on the aggregate list' do
-        let(:other_list) { create(:shopping_list, game: aggregate_list.game, aggregate_list:) }
+        let(:other_list) { create(:wish_list, game: aggregate_list.game, aggregate_list:) }
 
         let!(:item_on_other_list) do
           create(
-            :shopping_list_item,
+            :wish_list_item,
             description: 'Dwarven metal ingot',
             list: other_list,
             unit_weight: 0.3,
@@ -418,11 +418,11 @@ RSpec.describe ShoppingList, type: :model do
         end
 
         context 'when the new item has notes' do
-          let!(:existing_list_item) { create(:shopping_list_item, list: aggregate_list, quantity: 3) }
+          let!(:existing_list_item) { create(:wish_list_item, list: aggregate_list, quantity: 3) }
 
           let(:list_item) do
             create(
-              :shopping_list_item,
+              :wish_list_item,
               description: existing_list_item.description,
               quantity: 2,
               notes: 'foobar',
@@ -439,7 +439,7 @@ RSpec.describe ShoppingList, type: :model do
         context "when the new item doesn't have a unit weight" do
           let!(:existing_list_item) do
             create(
-              :shopping_list_item,
+              :wish_list_item,
               description: 'Dwarven metal ingot',
               list: aggregate_list,
               unit_weight: 0.3,
@@ -448,7 +448,7 @@ RSpec.describe ShoppingList, type: :model do
 
           let(:list_item) do
             create(
-              :shopping_list_item,
+              :wish_list_item,
               description: existing_list_item.description,
               quantity: 2,
               unit_weight: nil,
@@ -469,7 +469,7 @@ RSpec.describe ShoppingList, type: :model do
         context 'when the new item has a unit weight' do
           let!(:existing_list_item) do
             create(
-              :shopping_list_item,
+              :wish_list_item,
               description: 'Dwarven metal ingot',
               unit_weight: 0.3,
               list: aggregate_list,
@@ -478,7 +478,7 @@ RSpec.describe ShoppingList, type: :model do
 
           let(:list_item) do
             create(
-              :shopping_list_item,
+              :wish_list_item,
               description: 'Dwarven metal ingot',
               quantity: 2,
               unit_weight: 0.2,
@@ -498,8 +498,8 @@ RSpec.describe ShoppingList, type: :model do
       end
 
       context 'when called on a non-aggregate list' do
-        let(:aggregate_list) { create(:shopping_list) }
-        let(:list_item) { create(:shopping_list_item) }
+        let(:aggregate_list) { create(:wish_list) }
+        let(:list_item) { create(:wish_list_item) }
 
         it 'raises an AggregateListError' do
           expect { add_item }
@@ -512,7 +512,7 @@ RSpec.describe ShoppingList, type: :model do
       subject(:remove_item) { aggregate_list.remove_item_from_child_list(item_attrs) }
 
       context 'when there is no matching item on the aggregate list' do
-        let(:aggregate_list) { create(:aggregate_shopping_list) }
+        let(:aggregate_list) { create(:aggregate_wish_list) }
         let(:item_attrs) { { description: 'Necklace', quantity: 3, notes: 'some notes' } }
 
         it 'raises an error' do
@@ -522,7 +522,7 @@ RSpec.describe ShoppingList, type: :model do
       end
 
       context 'when the quantity is greater than the quantity on the aggregate list' do
-        let(:aggregate_list) { create(:aggregate_shopping_list) }
+        let(:aggregate_list) { create(:aggregate_wish_list) }
         let(:item_attrs) { { 'description' => 'Necklace', 'quantity' => 3, 'notes' => 'some notes' } }
 
         before do
@@ -536,7 +536,7 @@ RSpec.describe ShoppingList, type: :model do
       end
 
       context 'when the quantity is equal to the quantity on the aggregate list' do
-        let(:aggregate_list) { create(:aggregate_shopping_list) }
+        let(:aggregate_list) { create(:aggregate_wish_list) }
         let(:item_attrs) { { 'description' => 'Necklace', 'quantity' => 3, 'notes' => 'some notes' } }
 
         before do
@@ -550,7 +550,7 @@ RSpec.describe ShoppingList, type: :model do
       end
 
       context 'when the quantity is less than the quantity on the aggregate list' do
-        let(:aggregate_list) { create(:aggregate_shopping_list) }
+        let(:aggregate_list) { create(:aggregate_wish_list) }
         let(:item_attrs) { { 'description' => 'Necklace', 'quantity' => 3, 'notes' => 'notes 2' } }
 
         before do
@@ -564,7 +564,7 @@ RSpec.describe ShoppingList, type: :model do
       end
 
       context 'when called on a non-aggregate list' do
-        let(:aggregate_list) { create(:shopping_list) }
+        let(:aggregate_list) { create(:wish_list) }
         let(:item_attrs) { { description: 'Necklace', quantity: 3, notes: 'some notes' } }
 
         it 'raises an error' do
@@ -575,7 +575,7 @@ RSpec.describe ShoppingList, type: :model do
     end
 
     describe '#update_item_from_child_list' do
-      let(:aggregate_list) { create(:aggregate_shopping_list) }
+      let(:aggregate_list) { create(:aggregate_wish_list) }
       let(:description) { 'Corundum ingot' }
 
       context 'when adjusting quantity up' do
@@ -631,9 +631,9 @@ RSpec.describe ShoppingList, type: :model do
           )
         end
 
-        let!(:item_on_other_list) { create(:shopping_list_item, list: other_list, description:, unit_weight: 1) }
-        let!(:aggregate_list_item) { create(:shopping_list_item, list: aggregate_list, description:, quantity: 3, unit_weight: 1) }
-        let(:other_list) { create(:shopping_list, game: aggregate_list.game, aggregate_list:) }
+        let!(:item_on_other_list) { create(:wish_list_item, list: other_list, description:, unit_weight: 1) }
+        let!(:aggregate_list_item) { create(:wish_list_item, list: aggregate_list, description:, quantity: 3, unit_weight: 1) }
+        let(:other_list) { create(:wish_list, game: aggregate_list.game, aggregate_list:) }
 
         it 'unsets the unit weight on the aggregate list' do
           update_item
@@ -656,9 +656,9 @@ RSpec.describe ShoppingList, type: :model do
           )
         end
 
-        let!(:item_on_other_list) { create(:shopping_list_item, list: other_list, description:, unit_weight: 1) }
-        let!(:aggregate_list_item) { create(:shopping_list_item, list: aggregate_list, description:, quantity: 3, unit_weight: 1) }
-        let(:other_list) { create(:shopping_list, game: aggregate_list.game, aggregate_list:) }
+        let!(:item_on_other_list) { create(:wish_list_item, list: other_list, description:, unit_weight: 1) }
+        let!(:aggregate_list_item) { create(:wish_list_item, list: aggregate_list, description:, quantity: 3, unit_weight: 1) }
+        let(:other_list) { create(:wish_list, game: aggregate_list.game, aggregate_list:) }
 
         it 'unsets the unit weight on the aggregate list' do
           update_item
@@ -779,7 +779,7 @@ RSpec.describe ShoppingList, type: :model do
           )
         end
 
-        let(:list) { create(:shopping_list) }
+        let(:list) { create(:wish_list) }
 
         it 'raises an error' do
           expect { update_item }
@@ -789,10 +789,10 @@ RSpec.describe ShoppingList, type: :model do
     end
 
     describe '#user' do
-      let(:shopping_list) { create(:shopping_list) }
+      let(:wish_list) { create(:wish_list) }
 
       it 'delegates to the game' do
-        expect(shopping_list.user).to eq(shopping_list.game.user)
+        expect(wish_list.user).to eq(wish_list.game.user)
       end
     end
 

--- a/spec/requests/shopping_list_items_spec.rb
+++ b/spec/requests/shopping_list_items_spec.rb
@@ -12,13 +12,13 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
   describe 'POST /shopping_lists/:shopping_list_id/shopping_list_items' do
     subject(:create_item) do
-      post "/shopping_lists/#{shopping_list.id}/shopping_list_items", params:, headers:
+      post "/shopping_lists/#{wish_list.id}/shopping_list_items", params:, headers:
     end
 
     let!(:user) { create(:authenticated_user) }
     let(:game) { create(:game, user:) }
-    let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
-    let!(:shopping_list) { create(:shopping_list, aggregate_list:, game:) }
+    let!(:aggregate_list) { create(:aggregate_wish_list, game:) }
+    let!(:wish_list) { create(:wish_list, aggregate_list:, game:) }
 
     context 'when authenticated' do
       before do
@@ -33,7 +33,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
             context 'when unit weight is not set' do
               it 'creates a new item on the requested list' do
                 expect { create_item }
-                  .to change(shopping_list.list_items, :count).from(0).to(1)
+                  .to change(wish_list.list_items, :count).from(0).to(1)
               end
 
               it 'creates a new item on the aggregate list' do
@@ -46,9 +46,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
                 expect(response.status).to eq 201
               end
 
-              it 'returns all changed shopping lists for the same game' do
+              it 'returns all changed wish lists for the same game' do
                 create_item
-                expect(response.body).to eq(game.shopping_lists.to_json)
+                expect(response.body).to eq(game.wish_lists.to_json)
               end
             end
 
@@ -57,7 +57,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
               it 'creates a new item on the requested list' do
                 expect { create_item }
-                  .to change(shopping_list.list_items, :count).from(0).to(1)
+                  .to change(wish_list.list_items, :count).from(0).to(1)
               end
 
               it 'creates a new item on the aggregate list' do
@@ -70,21 +70,21 @@ RSpec.describe 'ShoppingListItems', type: :request do
                 expect(response.status).to eq 201
               end
 
-              it 'returns all changed shopping lists for the same game' do
+              it 'returns all changed wish lists for the same game' do
                 create_item
-                expect(response.body).to eq(game.shopping_lists.to_json)
+                expect(response.body).to eq(game.wish_lists.to_json)
               end
             end
           end
 
           context 'when there is an existing matching item on another list' do
-            let(:other_list) { create(:shopping_list, game:) }
-            let!(:other_item) { create(:shopping_list_item, list: other_list, description: 'Corundum ingot', quantity: 2) }
+            let(:other_list) { create(:wish_list, game:) }
+            let!(:other_item) { create(:wish_list_item, list: other_list, description: 'Corundum ingot', quantity: 2) }
 
             before do
               # This list has nothing to do with things and should not be included in the
               # response bodies.
-              create(:shopping_list, game:)
+              create(:wish_list, game:)
 
               aggregate_list.add_item_from_child_list(other_item)
             end
@@ -94,7 +94,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
               it 'creates a new item on the requested list' do
                 expect { create_item }
-                  .to change(shopping_list.list_items, :count).from(0).to(1)
+                  .to change(wish_list.list_items, :count).from(0).to(1)
               end
 
               it 'updates the item on the aggregate list' do
@@ -107,9 +107,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
                 expect(response.status).to eq 201
               end
 
-              it 'returns all changed shopping lists from the same game' do
+              it 'returns all changed wish lists from the same game' do
                 create_item
-                expect(response.body).to eq(game.shopping_lists.where(id: [aggregate_list.id, shopping_list.id]).to_json)
+                expect(response.body).to eq(game.wish_lists.where(id: [aggregate_list.id, wish_list.id]).to_json)
               end
             end
 
@@ -118,7 +118,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
               it 'creates a new item on the requested list' do
                 expect { create_item }
-                  .to change(shopping_list.list_items, :count).from(0).to(1)
+                  .to change(wish_list.list_items, :count).from(0).to(1)
               end
 
               it 'updates the item on the aggregate list', :aggregate_failures do
@@ -138,12 +138,12 @@ RSpec.describe 'ShoppingListItems', type: :request do
                 expect(response.status).to eq 201
               end
 
-              it 'returns all changed shopping lists for the same game' do
+              it 'returns all changed wish lists for the same game' do
                 create_item
                 expect(response.body).to eq(
                   game
-                    .shopping_lists
-                    .where(id: [aggregate_list.id, shopping_list.id, other_list.id])
+                    .wish_lists
+                    .where(id: [aggregate_list.id, wish_list.id, other_list.id])
                     .to_json,
                 )
               end
@@ -152,14 +152,14 @@ RSpec.describe 'ShoppingListItems', type: :request do
         end
 
         context 'when there is an existing matching item on the same list' do
-          let(:other_list) { create(:shopping_list, game: aggregate_list.game, aggregate_list:) }
-          let!(:other_item) { create(:shopping_list_item, list: other_list, description: 'Corundum ingot', quantity: 2) }
-          let!(:list_item) { create(:shopping_list_item, list: shopping_list, description: 'Corundum ingot', quantity: 3) }
+          let(:other_list) { create(:wish_list, game: aggregate_list.game, aggregate_list:) }
+          let!(:other_item) { create(:wish_list_item, list: other_list, description: 'Corundum ingot', quantity: 2) }
+          let!(:list_item) { create(:wish_list_item, list: wish_list, description: 'Corundum ingot', quantity: 3) }
 
           before do
             # This list has nothing to do with things and should not be included in the
             # response bodies.
-            create(:shopping_list, game:)
+            create(:wish_list, game:)
 
             aggregate_list.add_item_from_child_list(other_item)
             aggregate_list.add_item_from_child_list(list_item)
@@ -168,7 +168,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
           context "when unit weight isn't updated" do
             it "doesn't create a new item" do
               expect { create_item }
-                .not_to change(ShoppingListItem, :count)
+                .not_to change(WishListItem, :count)
             end
 
             it 'combines with the existing item' do
@@ -186,9 +186,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
               expect(response.status).to eq 200
             end
 
-            it 'returns all changed shopping lists for the same game' do
+            it 'returns all changed wish lists for the same game' do
               create_item
-              expect(response.body).to eq(game.shopping_lists.where(id: [aggregate_list.id, shopping_list.id]).to_json)
+              expect(response.body).to eq(game.wish_lists.where(id: [aggregate_list.id, wish_list.id]).to_json)
             end
           end
 
@@ -197,7 +197,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
             it "doesn't create a new list item" do
               expect { create_item }
-                .not_to change(ShoppingListItem, :count)
+                .not_to change(WishListItem, :count)
             end
 
             it 'combines it with the existing item', :aggregate_failures do
@@ -223,12 +223,12 @@ RSpec.describe 'ShoppingListItems', type: :request do
               expect(response.status).to eq 200
             end
 
-            it 'returns all changed shopping lists for the same game' do
+            it 'returns all changed wish lists for the same game' do
               create_item
               expect(response.body).to eq(
                 game
-                  .shopping_lists
-                  .where(id: [aggregate_list.id, shopping_list.id, other_list.id])
+                  .wish_lists
+                  .where(id: [aggregate_list.id, wish_list.id, other_list.id])
                   .to_json,
               )
             end
@@ -238,7 +238,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
       context "when the list doesn't exist" do
         let(:params) { { description: 'Necklace', quantity: 2, unit_weight: 0.5 }.to_json }
-        let(:shopping_list) { double(id: 23_498) }
+        let(:wish_list) { double(id: 23_498) }
 
         it 'returns status 404' do
           create_item
@@ -253,11 +253,11 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
       context 'when the list belongs to another user' do
         let(:params) { { description: 'Necklace', quantity: 2, unit_weight: 0.5 }.to_json }
-        let!(:shopping_list) { create(:shopping_list) }
+        let!(:wish_list) { create(:wish_list) }
 
         it "doesn't create a list item" do
           expect { create_item }
-            .not_to change(ShoppingListItem, :count)
+            .not_to change(WishListItem, :count)
         end
 
         it 'returns status 404' do
@@ -276,7 +276,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
         it "doesn't create the item" do
           expect { create_item }
-            .not_to change(ShoppingListItem, :count)
+            .not_to change(WishListItem, :count)
         end
 
         it 'returns status 422' do
@@ -291,12 +291,12 @@ RSpec.describe 'ShoppingListItems', type: :request do
       end
 
       context 'when the list is an aggregate list' do
-        let(:shopping_list) { aggregate_list }
+        let(:wish_list) { aggregate_list }
         let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 4 } }.to_json }
 
         it "doesn't create an item" do
           expect { create_item }
-            .not_to change(ShoppingListItem, :count)
+            .not_to change(WishListItem, :count)
         end
 
         it 'returns status 405' do
@@ -307,7 +307,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
         it 'returns the error' do
           create_item
           expect(JSON.parse(response.body))
-            .to eq({ 'errors' => ['Cannot manually manage items on an aggregate shopping list'] })
+            .to eq({ 'errors' => ['Cannot manually manage items on an aggregate wish list'] })
         end
       end
 
@@ -315,7 +315,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
         let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 4 } }.to_json }
 
         before do
-          allow(ShoppingList).to receive(:find).and_raise(StandardError.new('Something went horribly wrong'))
+          allow(WishList)
+            .to receive(:find)
+                  .and_raise(StandardError.new('Something went horribly wrong'))
         end
 
         it 'returns status 500' do
@@ -337,9 +339,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
         stub_unsuccessful_login
       end
 
-      it "doesn't create a shopping list item" do
+      it "doesn't create a wish list item" do
         expect { create_item }
-          .not_to change(ShoppingListItem, :count)
+          .not_to change(WishListItem, :count)
       end
 
       it 'returns status 401' do
@@ -359,8 +361,8 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
     let!(:user) { create(:authenticated_user) }
     let(:game) { create(:game, user:) }
-    let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
-    let!(:shopping_list) { create(:shopping_list, game:, aggregate_list:) }
+    let!(:aggregate_list) { create(:aggregate_wish_list, game:) }
+    let!(:wish_list) { create(:wish_list, game:, aggregate_list:) }
 
     context 'when authenticated' do
       before do
@@ -369,7 +371,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
       context 'when all goes well' do
         context 'when there is no matching item on another list' do
-          let!(:list_item) { create(:shopping_list_item, list: shopping_list, description: 'Dwarven metal ingot', quantity: 5) }
+          let!(:list_item) { create(:wish_list_item, list: wish_list, description: 'Dwarven metal ingot', quantity: 5) }
           let(:aggregate_list_item) { aggregate_list.list_items.first }
           let(:params) { { shopping_list_item: { description: 'Dwarven metal ingot', quantity: 10 } }.to_json }
 
@@ -391,7 +393,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
             t = Time.zone.now + 3.days
             Timecop.freeze(t) do
               update_item
-              expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+              expect(wish_list.reload.updated_at).to be_within(0.005.seconds).of(t)
             end
           end
 
@@ -416,16 +418,16 @@ RSpec.describe 'ShoppingListItems', type: :request do
             expect(response.status).to eq 200
           end
 
-          it 'returns the modified shopping list items' do
+          it 'returns the modified wish list items' do
             update_item
             expect(response.body).to eq([aggregate_list_item, list_item.reload].to_json)
           end
         end
 
         context 'when there is a matching item on another list' do
-          let!(:list_item) { create(:shopping_list_item, list: shopping_list, unit_weight: 1) }
-          let!(:other_list) { create(:shopping_list, game:, aggregate_list:) }
-          let!(:other_item) { create(:shopping_list_item, list: other_list, description: list_item.description, quantity: 4, unit_weight: 1) }
+          let!(:list_item) { create(:wish_list_item, list: wish_list, unit_weight: 1) }
+          let!(:other_list) { create(:wish_list, game:, aggregate_list:) }
+          let!(:other_item) { create(:wish_list_item, list: other_list, description: list_item.description, quantity: 4, unit_weight: 1) }
           let(:aggregate_list_item) { aggregate_list.list_items.first }
 
           before do
@@ -450,7 +452,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
               t = Time.zone.now + 3.days
               Timecop.freeze(t) do
                 update_item
-                expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+                expect(wish_list.reload.updated_at).to be_within(0.005.seconds).of(t)
               end
             end
 
@@ -506,7 +508,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
               t = Time.zone.now + 3.days
               Timecop.freeze(t) do
                 update_item
-                expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+                expect(wish_list.reload.updated_at).to be_within(0.005.seconds).of(t)
               end
             end
 
@@ -570,7 +572,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
               t = Time.zone.now + 3.days
               Timecop.freeze(t) do
                 update_item
-                expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+                expect(wish_list.reload.updated_at).to be_within(0.005.seconds).of(t)
               end
             end
 
@@ -611,7 +613,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
         end
       end
 
-      context "when the shopping list item doesn't exist" do
+      context "when the wish list item doesn't exist" do
         let(:list_item) { double(id: 234_567) }
         let(:params) { { quantity: 4, unit_weight: 0.3 }.to_json }
 
@@ -626,8 +628,8 @@ RSpec.describe 'ShoppingListItems', type: :request do
         end
       end
 
-      context 'when the shopping list item belongs to another user' do
-        let!(:list_item) { create(:shopping_list_item) }
+      context 'when the wish list item belongs to another user' do
+        let!(:list_item) { create(:wish_list_item) }
         let(:params) { { quantity: 4, unit_weight: 0.3 }.to_json }
 
         it "doesn't update the item" do
@@ -647,7 +649,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
       end
 
       context 'when the list item is on an aggregate list' do
-        let!(:list_item) { create(:shopping_list_item, list: aggregate_list) }
+        let!(:list_item) { create(:wish_list_item, list: aggregate_list) }
         let(:params) { { shopping_list_item: { quantity: 10 } }.to_json }
 
         it 'returns status 405' do
@@ -657,14 +659,14 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
         it 'returns an error array' do
           update_item
-          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Cannot manually update list items on an aggregate shopping list'] })
+          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Cannot manually update list items on an aggregate wish list'] })
         end
       end
 
       context 'when the attributes are invalid' do
-        let!(:list_item) { create(:shopping_list_item, list: shopping_list, quantity: 2) }
-        let(:other_list) { create(:shopping_list, game:) }
-        let!(:other_item) { create(:shopping_list_item, list: other_list, description: list_item.description, quantity: 1) }
+        let!(:list_item) { create(:wish_list_item, list: wish_list, quantity: 2) }
+        let(:other_list) { create(:wish_list, game:) }
+        let!(:other_item) { create(:wish_list_item, list: other_list, description: list_item.description, quantity: 1) }
         let(:aggregate_list_item) { aggregate_list.list_items.first }
         let(:params) { { shopping_list_item: { quantity: -4, unit_weight: 2 } }.to_json }
 
@@ -696,12 +698,12 @@ RSpec.describe 'ShoppingListItems', type: :request do
       end
 
       context 'when something unexpected goes wrong' do
-        let!(:list_item) { create(:shopping_list_item, list: shopping_list) }
+        let!(:list_item) { create(:wish_list_item, list: wish_list) }
         let(:params) { { notes: 'Hello world' }.to_json }
 
         before do
           aggregate_list.add_item_from_child_list(list_item)
-          allow_any_instance_of(ShoppingList)
+          allow_any_instance_of(WishList)
             .to receive(:aggregate)
                   .and_raise(StandardError.new('Something went horribly wrong'))
         end
@@ -719,14 +721,14 @@ RSpec.describe 'ShoppingListItems', type: :request do
     end
 
     context 'when unauthenticated' do
-      let!(:list_item) { create(:shopping_list_item, list: shopping_list) }
+      let!(:list_item) { create(:wish_list_item, list: wish_list) }
       let(:params) { { shopping_list_item: { quantity: 16 } } }
 
       before do
         stub_unsuccessful_login
       end
 
-      it "doesn't update the shopping list item" do
+      it "doesn't update the wish list item" do
         expect { update_item }
           .not_to change(list_item.reload, :quantity)
       end
@@ -748,8 +750,8 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
     let!(:user) { create(:authenticated_user) }
     let(:game) { create(:game, user:) }
-    let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
-    let!(:shopping_list) { create(:shopping_list, game:, aggregate_list:) }
+    let!(:aggregate_list) { create(:aggregate_wish_list, game:) }
+    let!(:wish_list) { create(:wish_list, game:, aggregate_list:) }
 
     context 'when authenticated' do
       before do
@@ -758,7 +760,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
       context 'when all goes well' do
         context 'when there is no matching item on another list' do
-          let!(:list_item) { create(:shopping_list_item, list: shopping_list, description: 'Dwarven metal ingot', quantity: 5) }
+          let!(:list_item) { create(:wish_list_item, list: wish_list, description: 'Dwarven metal ingot', quantity: 5) }
           let(:aggregate_list_item) { aggregate_list.list_items.first }
           let(:params) { { shopping_list_item: { description: 'Dwarven metal ingot', quantity: 10 } }.to_json }
 
@@ -780,7 +782,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
             t = Time.zone.now + 3.days
             Timecop.freeze(t) do
               update_item
-              expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+              expect(wish_list.reload.updated_at).to be_within(0.005.seconds).of(t)
             end
           end
 
@@ -805,16 +807,16 @@ RSpec.describe 'ShoppingListItems', type: :request do
             expect(response.status).to eq 200
           end
 
-          it 'returns the modified shopping list items' do
+          it 'returns the modified wish list items' do
             update_item
             expect(response.body).to eq([aggregate_list_item, list_item.reload].to_json)
           end
         end
 
         context 'when there is a matching item on another list' do
-          let!(:list_item) { create(:shopping_list_item, list: shopping_list, unit_weight: 1) }
-          let!(:other_list) { create(:shopping_list, game:, aggregate_list:) }
-          let!(:other_item) { create(:shopping_list_item, list: other_list, description: list_item.description, quantity: 4, unit_weight: 1) }
+          let!(:list_item) { create(:wish_list_item, list: wish_list, unit_weight: 1) }
+          let!(:other_list) { create(:wish_list, game:, aggregate_list:) }
+          let!(:other_item) { create(:wish_list_item, list: other_list, description: list_item.description, quantity: 4, unit_weight: 1) }
           let(:aggregate_list_item) { aggregate_list.list_items.first }
 
           before do
@@ -839,7 +841,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
               t = Time.zone.now + 3.days
               Timecop.freeze(t) do
                 update_item
-                expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+                expect(wish_list.reload.updated_at).to be_within(0.005.seconds).of(t)
               end
             end
 
@@ -895,7 +897,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
               t = Time.zone.now + 3.days
               Timecop.freeze(t) do
                 update_item
-                expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+                expect(wish_list.reload.updated_at).to be_within(0.005.seconds).of(t)
               end
             end
 
@@ -959,7 +961,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
               t = Time.zone.now + 3.days
               Timecop.freeze(t) do
                 update_item
-                expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+                expect(wish_list.reload.updated_at).to be_within(0.005.seconds).of(t)
               end
             end
 
@@ -1000,7 +1002,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
         end
       end
 
-      context "when the shopping list item doesn't exist" do
+      context "when the wish list item doesn't exist" do
         let(:list_item) { double(id: 234_567) }
         let(:params) { { quantity: 4, unit_weight: 0.3 }.to_json }
 
@@ -1015,8 +1017,8 @@ RSpec.describe 'ShoppingListItems', type: :request do
         end
       end
 
-      context 'when the shopping list item belongs to another user' do
-        let!(:list_item) { create(:shopping_list_item) }
+      context 'when the wish list item belongs to another user' do
+        let!(:list_item) { create(:wish_list_item) }
         let(:params) { { quantity: 4, unit_weight: 0.3 }.to_json }
 
         it "doesn't update the item" do
@@ -1036,7 +1038,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
       end
 
       context 'when the list item is on an aggregate list' do
-        let!(:list_item) { create(:shopping_list_item, list: aggregate_list) }
+        let!(:list_item) { create(:wish_list_item, list: aggregate_list) }
         let(:params) { { shopping_list_item: { quantity: 10 } }.to_json }
 
         it 'returns status 405' do
@@ -1046,14 +1048,14 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
         it 'returns an error array' do
           update_item
-          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Cannot manually update list items on an aggregate shopping list'] })
+          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Cannot manually update list items on an aggregate wish list'] })
         end
       end
 
       context 'when the attributes are invalid' do
-        let!(:list_item) { create(:shopping_list_item, list: shopping_list, quantity: 2) }
-        let(:other_list) { create(:shopping_list, game:) }
-        let!(:other_item) { create(:shopping_list_item, list: other_list, description: list_item.description, quantity: 1) }
+        let!(:list_item) { create(:wish_list_item, list: wish_list, quantity: 2) }
+        let(:other_list) { create(:wish_list, game:) }
+        let!(:other_item) { create(:wish_list_item, list: other_list, description: list_item.description, quantity: 1) }
         let(:aggregate_list_item) { aggregate_list.list_items.first }
         let(:params) { { shopping_list_item: { quantity: -4, unit_weight: 2 } }.to_json }
 
@@ -1085,12 +1087,12 @@ RSpec.describe 'ShoppingListItems', type: :request do
       end
 
       context 'when something unexpected goes wrong' do
-        let!(:list_item) { create(:shopping_list_item, list: shopping_list) }
+        let!(:list_item) { create(:wish_list_item, list: wish_list) }
         let(:params) { { notes: 'Hello world' }.to_json }
 
         before do
           aggregate_list.add_item_from_child_list(list_item)
-          allow_any_instance_of(ShoppingList)
+          allow_any_instance_of(WishList)
             .to receive(:aggregate)
                   .and_raise(StandardError.new('Something went horribly wrong'))
         end
@@ -1108,14 +1110,14 @@ RSpec.describe 'ShoppingListItems', type: :request do
     end
 
     context 'when unauthenticated' do
-      let!(:list_item) { create(:shopping_list_item, list: shopping_list) }
+      let!(:list_item) { create(:wish_list_item, list: wish_list) }
       let(:params) { { shopping_list_item: { quantity: 16 } } }
 
       before do
         stub_unsuccessful_login
       end
 
-      it "doesn't update the shopping list item" do
+      it "doesn't update the wish list item" do
         expect { update_item }
           .not_to change(list_item.reload, :quantity)
       end
@@ -1137,8 +1139,8 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
     context 'when authenticated' do
       let!(:user) { create(:authenticated_user) }
-      let!(:aggregate_list) { create(:aggregate_shopping_list, game:) }
-      let!(:shopping_list) { create(:shopping_list, game:, aggregate_list:) }
+      let!(:aggregate_list) { create(:aggregate_wish_list, game:) }
+      let!(:wish_list) { create(:wish_list, game:, aggregate_list:) }
       let(:game) { create(:game, user:) }
 
       before do
@@ -1146,7 +1148,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
       end
 
       context 'when all goes well' do
-        let(:list_item) { create(:shopping_list_item, list: shopping_list, quantity: 3, notes: 'foo') }
+        let(:list_item) { create(:wish_list_item, list: wish_list, quantity: 3, notes: 'foo') }
 
         before do
           aggregate_list.add_item_from_child_list(list_item)
@@ -1155,7 +1157,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
         context 'when the quantity on the regular list equals that on the aggregate list' do
           it 'destroys the item on the regular list' do
             destroy_item
-            expect { ShoppingListItem.find(list_item.id) }
+            expect { WishListItem.find(list_item.id) }
               .to raise_error ActiveRecord::RecordNotFound
           end
 
@@ -1168,7 +1170,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
             t = Time.zone.now + 3.days
             Timecop.freeze(t) do
               destroy_item
-              expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+              expect(wish_list.reload.updated_at).to be_within(0.005.seconds).of(t)
             end
           end
 
@@ -1195,16 +1197,16 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
           it 'returns the aggregate list and the regular list' do
             destroy_item
-            expect(response.body).to eq([aggregate_list.reload, shopping_list.reload].to_json)
+            expect(response.body).to eq([aggregate_list.reload, wish_list.reload].to_json)
           end
         end
 
         context 'when the quantity on the aggregate list exceeds that on the regular list' do
-          let(:second_list) { create(:shopping_list, game:) }
+          let(:second_list) { create(:wish_list, game:) }
 
           let(:second_item) do
             create(
-              :shopping_list_item,
+              :wish_list_item,
               list: second_list,
               description: list_item.description,
               quantity: 2,
@@ -1218,7 +1220,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
           it 'destroys the item on the regular list' do
             destroy_item
-            expect { ShoppingListItem.find(list_item.id) }
+            expect { WishListItem.find(list_item.id) }
               .to raise_error ActiveRecord::RecordNotFound
           end
 
@@ -1231,7 +1233,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
             t = Time.zone.now + 3.days
             Timecop.freeze(t) do
               destroy_item
-              expect(shopping_list.reload.updated_at).to be_within(0.005.seconds).of(t)
+              expect(wish_list.reload.updated_at).to be_within(0.005.seconds).of(t)
             end
           end
 
@@ -1258,7 +1260,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
           it 'returns the aggregate list and the regular list' do
             destroy_item
-            expect(response.body).to eq([aggregate_list.reload, shopping_list.reload].to_json)
+            expect(response.body).to eq([aggregate_list.reload, wish_list.reload].to_json)
           end
         end
       end
@@ -1278,11 +1280,11 @@ RSpec.describe 'ShoppingListItems', type: :request do
       end
 
       context 'when the specified list item belongs to another user' do
-        let!(:list_item) { create(:shopping_list_item) }
+        let!(:list_item) { create(:wish_list_item) }
 
         it "doesn't destroy the item" do
           expect { destroy_item }
-            .not_to change(ShoppingListItem, :count)
+            .not_to change(WishListItem, :count)
         end
 
         it 'returns status 404' do
@@ -1297,7 +1299,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
       end
 
       context 'when the specified list item is on an aggregate list' do
-        let(:list_item) { create(:shopping_list_item, list: aggregate_list) }
+        let(:list_item) { create(:wish_list_item, list: aggregate_list) }
 
         it 'returns status 405' do
           destroy_item
@@ -1306,15 +1308,17 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
         it 'returns a helpful error message' do
           destroy_item
-          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Cannot manually delete list item from aggregate shopping list'] })
+          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Cannot manually delete list item from aggregate wish list'] })
         end
       end
 
       context 'when something unexpected goes wrong' do
-        let!(:list_item) { create(:shopping_list_item, list: shopping_list) }
+        let!(:list_item) { create(:wish_list_item, list: wish_list) }
 
         before do
-          allow_any_instance_of(ShoppingList).to receive(:aggregate).and_raise(StandardError.new('Something went horribly wrong'))
+          allow_any_instance_of(WishList)
+            .to receive(:aggregate)
+                  .and_raise(StandardError.new('Something went horribly wrong'))
         end
 
         it 'returns status 500' do
@@ -1330,7 +1334,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
     end
 
     context 'when unauthenticated' do
-      let!(:list_item) { create(:shopping_list_item) }
+      let!(:list_item) { create(:wish_list_item) }
 
       before do
         stub_unsuccessful_login
@@ -1338,7 +1342,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
       it "doesn't destroy the list item" do
         expect { destroy_item }
-          .not_to change(ShoppingListItem, :count)
+          .not_to change(WishListItem, :count)
       end
 
       it 'returns status 401' do

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'ShoppingLists', type: :request do
   end
 
   describe 'POST games/:game_id/shopping_lists' do
-    subject(:create_shopping_list) { post "/games/#{game.id}/shopping_lists", params: { shopping_list: {} }.to_json, headers: }
+    subject(:create_wish_list) { post "/games/#{game.id}/shopping_lists", params: { shopping_list: {} }.to_json, headers: }
 
     context 'when authenticated' do
       let!(:user) { create(:authenticated_user) }
@@ -24,59 +24,59 @@ RSpec.describe 'ShoppingLists', type: :request do
         let(:game) { create(:game, user:) }
 
         context 'when an aggregate list has also been created' do
-          it 'creates a new shopping list' do
-            expect { create_shopping_list }
-              .to change(game.shopping_lists, :count).from(0).to(2) # because of the aggregate list
+          it 'creates a new wish list' do
+            expect { create_wish_list }
+              .to change(game.wish_lists, :count).from(0).to(2) # because of the aggregate list
           end
 
-          it 'returns both shopping lists' do
-            create_shopping_list
-            expect(response.body).to eq(game.shopping_lists.index_order.to_json)
+          it 'returns both wish lists' do
+            create_wish_list
+            expect(response.body).to eq(game.wish_lists.index_order.to_json)
           end
 
           it 'returns status 201' do
-            create_shopping_list
+            create_wish_list
             expect(response.status).to eq 201
           end
         end
 
-        context 'when only the new shopping list has been created' do
+        context 'when only the new wish list has been created' do
           before do
-            create(:shopping_list, game:)
+            create(:wish_list, game:)
           end
 
           it 'creates one list' do
-            expect { create_shopping_list }
-              .to change(game.shopping_lists, :count).from(2).to(3)
+            expect { create_wish_list }
+              .to change(game.wish_lists, :count).from(2).to(3)
           end
 
           it 'returns only the created list' do
-            create_shopping_list
-            expect(response.body).to eq([game.shopping_lists.unscoped.last].to_json)
+            create_wish_list
+            expect(response.body).to eq([game.wish_lists.unscoped.last].to_json)
           end
 
           it 'returns status 201' do
-            create_shopping_list
+            create_wish_list
             expect(response.status).to eq 201
           end
         end
 
         context 'when the request does not include a body' do
-          subject(:create_shopping_list) { post "/games/#{game.id}/shopping_lists", headers: }
+          subject(:create_wish_list) { post "/games/#{game.id}/shopping_lists", headers: }
 
           before do
             # let's not have this request create an aggregate list too
-            create(:aggregate_shopping_list, game:)
+            create(:aggregate_wish_list, game:)
           end
 
           it 'returns status 201' do
-            create_shopping_list
+            create_wish_list
             expect(response.status).to eq 201
           end
 
-          it 'creates the shopping list with a default title' do
-            create_shopping_list
-            expect(game.shopping_lists.last.title).to eq 'My List 1'
+          it 'creates the wish list with a default title' do
+            create_wish_list
+            expect(game.wish_lists.last.title).to eq 'My List 1'
           end
         end
       end
@@ -85,12 +85,12 @@ RSpec.describe 'ShoppingLists', type: :request do
         let(:game) { double(id: 84_968_294) }
 
         it 'returns status 404' do
-          create_shopping_list
+          create_wish_list
           expect(response.status).to eq 404
         end
 
         it "doesn't return any data" do
-          create_shopping_list
+          create_wish_list
           expect(response.body).to be_empty
         end
       end
@@ -98,57 +98,69 @@ RSpec.describe 'ShoppingLists', type: :request do
       context 'when the game belongs to another user' do
         let(:game) { create(:game) }
 
-        it "doesn't create a shopping list" do
-          expect { create_shopping_list }
-            .not_to change(ShoppingList, :count)
+        it "doesn't create a wish list" do
+          expect { create_wish_list }
+            .not_to change(WishList, :count)
         end
 
         it 'returns status 404' do
-          create_shopping_list
+          create_wish_list
           expect(response.status).to eq 404
         end
 
         it "doesn't return any data" do
-          create_shopping_list
+          create_wish_list
           expect(response.body).to be_empty
         end
       end
 
       context 'when the params are invalid' do
-        subject(:create_shopping_list) { post "/games/#{game.id}/shopping_lists", params: { shopping_list: { title: existing_list.title } }.to_json, headers: }
+        subject(:create_wish_list) do
+          post "/games/#{game.id}/shopping_lists",
+               params: {
+                 shopping_list: { title: existing_list.title },
+               }.to_json,
+               headers:
+        end
 
         let(:game) { create(:game, user:) }
-        let(:existing_list) { create(:shopping_list, game:) }
+        let(:existing_list) { create(:wish_list, game:) }
 
         it 'returns status 422' do
-          create_shopping_list
+          create_wish_list
           expect(response.status).to eq 422
         end
 
         it 'returns the errors' do
-          create_shopping_list
+          create_wish_list
           expect(JSON.parse(response.body)).to eq({ 'errors' => ['Title must be unique per game'] })
         end
       end
 
       context 'when the client attempts to create an aggregate list' do
-        subject(:create_shopping_list) { post "/games/#{game.id}/shopping_lists", params: { shopping_list: { aggregate: true } }.to_json, headers: }
+        subject(:create_wish_list) do
+          post "/games/#{game.id}/shopping_lists",
+               params: {
+                 shopping_list: { aggregate: true },
+               }.to_json,
+               headers:
+        end
 
         let(:game) { create(:game, user:) }
 
         it "doesn't create a list" do
-          expect { create_shopping_list }
-            .not_to change(game.shopping_lists, :count)
+          expect { create_wish_list }
+            .not_to change(game.wish_lists, :count)
         end
 
         it 'returns an error' do
-          create_shopping_list
+          create_wish_list
           expect(response.status).to eq 422
         end
 
         it 'returns a helpful error body' do
-          create_shopping_list
-          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Cannot manually create an aggregate shopping list'] })
+          create_wish_list
+          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Cannot manually create an aggregate wish list'] })
         end
       end
     end
@@ -160,25 +172,25 @@ RSpec.describe 'ShoppingLists', type: :request do
         stub_unsuccessful_login
       end
 
-      it "doesn't create a shopping list" do
-        expect { create_shopping_list }
-          .not_to change(ShoppingList, :count)
+      it "doesn't create a wish list" do
+        expect { create_wish_list }
+          .not_to change(WishList, :count)
       end
 
       it 'returns status 401' do
-        create_shopping_list
+        create_wish_list
         expect(response.status).to eq 401
       end
 
       it "doesn't return any data" do
-        create_shopping_list
+        create_wish_list
         expect(JSON.parse(response.body)).to eq({ 'errors' => ['Token validation response did not include a user'] })
       end
     end
   end
 
   describe 'PUT /shopping_lists/:id' do
-    subject(:update_shopping_list) { put "/shopping_lists/#{list_id}", params:, headers: }
+    subject(:update_wish_list) { put "/shopping_lists/#{list_id}", params:, headers: }
 
     let(:params) { { shopping_list: { title: 'Severin Manor' } }.to_json }
 
@@ -190,26 +202,26 @@ RSpec.describe 'ShoppingLists', type: :request do
       end
 
       context 'when all goes well' do
-        let!(:shopping_list) { create(:shopping_list, game:) }
+        let!(:wish_list) { create(:wish_list, game:) }
         let(:game) { create(:game, user:) }
-        let(:list_id) { shopping_list.id }
+        let(:list_id) { wish_list.id }
 
         context 'when the request body sets a valid title' do
           it 'updates the title' do
-            update_shopping_list
-            expect(shopping_list.reload.title).to eq 'Severin Manor'
+            update_wish_list
+            expect(wish_list.reload.title).to eq 'Severin Manor'
           end
 
           it 'returns the updated list' do
-            update_shopping_list
+            update_wish_list
             # This ugly hack is needed because if we don't parse the JSON, it'll make an error
-            # if everything isn't in the exact same order, but if we just use shopping_list.attributes
+            # if everything isn't in the exact same order, but if we just use wish_list.attributes
             # it won't include the list_items. Ugly.
-            expect(JSON.parse(response.body)).to eq(JSON.parse(shopping_list.reload.to_json))
+            expect(JSON.parse(response.body)).to eq(JSON.parse(wish_list.reload.to_json))
           end
 
           it 'returns status 200' do
-            update_shopping_list
+            update_wish_list
             expect(response.status).to eq 200
           end
         end
@@ -218,20 +230,20 @@ RSpec.describe 'ShoppingLists', type: :request do
           let(:params) { { shopping_list: { title: nil } }.to_json }
 
           it 'sets a default title' do
-            update_shopping_list
-            expect(shopping_list.reload.title).to eq 'My List 1'
+            update_wish_list
+            expect(wish_list.reload.title).to eq 'My List 1'
           end
 
           it 'returns the updated list' do
-            update_shopping_list
+            update_wish_list
             # This ugly hack is needed because if we don't parse the JSON, it'll make an error
-            # if everything isn't in the exact same order, but if we just use shopping_list.attributes
+            # if everything isn't in the exact same order, but if we just use wish_list.attributes
             # it won't include the list_items. Ugly.
-            expect(JSON.parse(response.body)).to eq(JSON.parse(shopping_list.reload.to_json))
+            expect(JSON.parse(response.body)).to eq(JSON.parse(wish_list.reload.to_json))
           end
 
           it 'returns status 200' do
-            update_shopping_list
+            update_wish_list
             expect(response.status).to eq 200
           end
         end
@@ -240,20 +252,20 @@ RSpec.describe 'ShoppingLists', type: :request do
           let(:params) { { shopping_list: {} }.to_json }
 
           it "doesn't change the attributes" do
-            expect { update_shopping_list }
-              .not_to change(shopping_list.reload, :attributes)
+            expect { update_wish_list }
+              .not_to change(wish_list.reload, :attributes)
           end
 
           it 'returns the updated list' do
-            update_shopping_list
+            update_wish_list
             # This ugly hack is needed because if we don't parse the JSON, it'll make an error
-            # if everything isn't in the exact same order, but if we just use shopping_list.attributes
+            # if everything isn't in the exact same order, but if we just use wish_list.attributes
             # it won't include the list_items. Ugly.
-            expect(JSON.parse(response.body)).to eq(JSON.parse(shopping_list.reload.to_json))
+            expect(JSON.parse(response.body)).to eq(JSON.parse(wish_list.reload.to_json))
           end
 
           it 'returns status 200' do
-            update_shopping_list
+            update_wish_list
             expect(response.status).to eq 200
           end
         end
@@ -262,40 +274,46 @@ RSpec.describe 'ShoppingLists', type: :request do
           let(:params) { nil }
 
           it "doesn't change the attributes" do
-            expect { update_shopping_list }
-              .not_to change(shopping_list.reload, :attributes)
+            expect { update_wish_list }
+              .not_to change(wish_list.reload, :attributes)
           end
 
           it 'returns the updated list' do
-            update_shopping_list
+            update_wish_list
             # This ugly hack is needed because if we don't parse the JSON, it'll make an error
-            # if everything isn't in the exact same order, but if we just use shopping_list.attributes
+            # if everything isn't in the exact same order, but if we just use wish_list.attributes
             # it won't include the list_items. Ugly.
-            expect(JSON.parse(response.body)).to eq(JSON.parse(shopping_list.reload.to_json))
+            expect(JSON.parse(response.body)).to eq(JSON.parse(wish_list.reload.to_json))
           end
 
           it 'returns status 200' do
-            update_shopping_list
+            update_wish_list
             expect(response.status).to eq 200
           end
         end
       end
 
       context 'when the params are invalid' do
-        subject(:update_shopping_list) { put "/shopping_lists/#{list_id}", params: { shopping_list: { title: other_list.title } }.to_json, headers: }
+        subject(:update_wish_list) do
+          put "/shopping_lists/#{list_id}",
+              params: {
+                shopping_list: { title: other_list.title },
+              }.to_json,
+              headers:
+        end
 
-        let!(:shopping_list) { create(:shopping_list, game:) }
+        let!(:wish_list) { create(:wish_list, game:) }
         let(:game) { create(:game, user:) }
-        let(:list_id) { shopping_list.id }
-        let(:other_list) { create(:shopping_list, game:) }
+        let(:list_id) { wish_list.id }
+        let(:other_list) { create(:wish_list, game:) }
 
         it 'returns status 422' do
-          update_shopping_list
+          update_wish_list
           expect(response.status).to eq 422
         end
 
         it 'returns the errors' do
-          update_shopping_list
+          update_wish_list
           expect(JSON.parse(response.body)).to eq({ 'errors' => ['Title must be unique per game'] })
         end
       end
@@ -304,129 +322,149 @@ RSpec.describe 'ShoppingLists', type: :request do
         let(:list_id) { 245_285 }
 
         it 'returns status 404' do
-          update_shopping_list
+          update_wish_list
           expect(response.status).to eq 404
         end
 
         it "doesn't return data" do
-          update_shopping_list
+          update_wish_list
           expect(response.body).to be_blank
         end
       end
 
       context 'when the list belongs to another user' do
-        let!(:shopping_list) { create(:shopping_list) }
-        let(:list_id) { shopping_list.id }
+        let!(:wish_list) { create(:wish_list) }
+        let(:list_id) { wish_list.id }
 
-        it "doesn't update the shopping list" do
-          expect { update_shopping_list }
-            .not_to change(shopping_list.reload, :title)
+        it "doesn't update the wish list" do
+          expect { update_wish_list }
+            .not_to change(wish_list.reload, :title)
         end
 
         it 'returns status 404' do
-          update_shopping_list
+          update_wish_list
           expect(response.status).to eq 404
         end
 
         it "doesn't return data" do
-          update_shopping_list
+          update_wish_list
           expect(response.body).to be_blank
         end
       end
 
       context 'when the client attempts to update an aggregate list' do
-        subject(:update_shopping_list) { put "/shopping_lists/#{shopping_list.id}", params: { shopping_list: { title: 'Foo' } }.to_json, headers: }
+        subject(:update_wish_list) do
+          put "/shopping_lists/#{shopping_list.id}",
+              params: {
+                shopping_list: { title: 'Foo' },
+              }.to_json,
+              headers:
+        end
 
-        let!(:shopping_list) { create(:aggregate_shopping_list, game:) }
+        let!(:wish_list) { create(:aggregate_wish_list, game:) }
         let(:game) { create(:game, user:) }
 
         it "doesn't update the list" do
-          update_shopping_list
-          expect(shopping_list.reload.title).to eq 'All Items'
+          update_wish_list
+          expect(wish_list.reload.title).to eq 'All Items'
         end
 
         it 'returns status 405 (method not allowed)' do
-          update_shopping_list
+          update_wish_list
           expect(response.status).to eq 405
         end
 
         it 'returns a helpful error body' do
-          update_shopping_list
-          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Cannot manually update an aggregate shopping list'] })
+          update_wish_list
+          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Cannot manually update an aggregate wish list'] })
         end
       end
 
       context 'when the client attempts to change a regular list to an aggregate list' do
-        subject(:update_shopping_list) { put "/shopping_lists/#{shopping_list.id}", params: { shopping_list: { aggregate: true } }.to_json, headers: }
+        subject(:update_wish_list) do
+          put "/shopping_lists/#{shopping_list.id}",
+              params: {
+                shopping_list: { aggregate: true },
+              }.to_json,
+              headers:
+        end
 
-        let!(:shopping_list) { create(:shopping_list, game:) }
+        let!(:wish_list) { create(:wish_list, game:) }
         let(:game) { create(:game, user:) }
 
         it "doesn't update the list" do
-          update_shopping_list
-          expect(shopping_list.reload.aggregate).to eq false
+          update_wish_list
+          expect(wish_list.reload.aggregate).to eq false
         end
 
         it 'returns status 422' do
-          update_shopping_list
+          update_wish_list
           expect(response.status).to eq 422
         end
 
         it 'returns a helpful error body' do
-          update_shopping_list
-          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Cannot make a regular shopping list an aggregate list'] })
+          update_wish_list
+          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Cannot make a regular wish list an aggregate list'] })
         end
       end
 
       context 'when something unexpected goes wrong' do
-        subject(:update_shopping_list) { put "/shopping_lists/#{shopping_list.id}", params: { shopping_list: { title: 'Some New Title' } }.to_json, headers: }
+        subject(:update_wish_list) do
+          put "/shopping_lists/#{wish_list.id}",
+              params: {
+                shopping_list: { title: 'Some New Title' },
+              }.to_json,
+              headers:
+        end
 
-        let!(:shopping_list) { create(:shopping_list, game:) }
+        let!(:wish_list) { create(:wish_list, game:) }
         let(:game) { create(:game, user:) }
 
         before do
-          allow_any_instance_of(User).to receive(:shopping_lists).and_raise(StandardError, 'Something went catastrophically wrong')
+          allow_any_instance_of(User)
+            .to receive(:wish_lists)
+                  .and_raise(StandardError, 'Something went catastrophically wrong')
         end
 
         it 'returns status 500' do
-          update_shopping_list
+          update_wish_list
           expect(response.status).to eq 500
         end
 
         it 'returns the error in the body' do
-          update_shopping_list
+          update_wish_list
           expect(response.body).to eq({ errors: ['Something went catastrophically wrong'] }.to_json)
         end
       end
     end
 
     context 'when unauthenticated' do
-      let!(:shopping_list) { create(:shopping_list) }
-      let(:list_id) { shopping_list.id }
+      let!(:wish_list) { create(:wish_list) }
+      let(:list_id) { wish_list.id }
 
       before do
         stub_unsuccessful_login
       end
 
-      it "doesn't update the shopping list" do
-        expect { update_shopping_list }
-          .not_to change(shopping_list.reload, :title)
+      it "doesn't update the wish list" do
+        expect { update_wish_list }
+          .not_to change(wish_list.reload, :title)
       end
 
       it 'returns status 401' do
-        update_shopping_list
+        update_wish_list
         expect(response.status).to eq 401
       end
 
       it "doesn't return any data" do
-        update_shopping_list
+        update_wish_list
         expect(JSON.parse(response.body)).to eq({ 'errors' => ['Token validation response did not include a user'] })
       end
     end
   end
 
   describe 'PATCH /shopping_lists/:id' do
-    subject(:update_shopping_list) { patch "/shopping_lists/#{list_id}", params:, headers: }
+    subject(:update_wish_list) { patch "/shopping_lists/#{list_id}", params:, headers: }
 
     let(:params) { { shopping_list: { title: 'Severin Manor' } }.to_json }
 
@@ -438,26 +476,26 @@ RSpec.describe 'ShoppingLists', type: :request do
       end
 
       context 'when all goes well' do
-        let!(:shopping_list) { create(:shopping_list, game:) }
+        let!(:wish_list) { create(:wish_list, game:) }
         let(:game) { create(:game, user:) }
-        let(:list_id) { shopping_list.id }
+        let(:list_id) { wish_list.id }
 
         context 'when the request body sets a valid title' do
           it 'updates the title' do
-            update_shopping_list
-            expect(shopping_list.reload.title).to eq 'Severin Manor'
+            update_wish_list
+            expect(wish_list.reload.title).to eq 'Severin Manor'
           end
 
           it 'returns the updated list' do
-            update_shopping_list
+            update_wish_list
             # This ugly hack is needed because if we don't parse the JSON, it'll make an error
-            # if everything isn't in the exact same order, but if we just use shopping_list.attributes
+            # if everything isn't in the exact same order, but if we just use wish_list.attributes
             # it won't include the list_items. Ugly.
-            expect(JSON.parse(response.body)).to eq(JSON.parse(shopping_list.reload.to_json))
+            expect(JSON.parse(response.body)).to eq(JSON.parse(wish_list.reload.to_json))
           end
 
           it 'returns status 200' do
-            update_shopping_list
+            update_wish_list
             expect(response.status).to eq 200
           end
         end
@@ -466,20 +504,20 @@ RSpec.describe 'ShoppingLists', type: :request do
           let(:params) { { shopping_list: { title: nil } }.to_json }
 
           it 'sets a default title' do
-            update_shopping_list
-            expect(shopping_list.reload.title).to eq 'My List 1'
+            update_wish_list
+            expect(wish_list.reload.title).to eq 'My List 1'
           end
 
           it 'returns the updated list' do
-            update_shopping_list
+            update_wish_list
             # This ugly hack is needed because if we don't parse the JSON, it'll make an error
-            # if everything isn't in the exact same order, but if we just use shopping_list.attributes
+            # if everything isn't in the exact same order, but if we just use wish_list.attributes
             # it won't include the list_items. Ugly.
-            expect(JSON.parse(response.body)).to eq(JSON.parse(shopping_list.reload.to_json))
+            expect(JSON.parse(response.body)).to eq(JSON.parse(wish_list.reload.to_json))
           end
 
           it 'returns status 200' do
-            update_shopping_list
+            update_wish_list
             expect(response.status).to eq 200
           end
         end
@@ -488,20 +526,20 @@ RSpec.describe 'ShoppingLists', type: :request do
           let(:params) { { shopping_list: {} }.to_json }
 
           it "doesn't change the attributes" do
-            expect { update_shopping_list }
-              .not_to change(shopping_list.reload, :attributes)
+            expect { update_wish_list }
+              .not_to change(wish_list.reload, :attributes)
           end
 
           it 'returns the updated list' do
-            update_shopping_list
+            update_wish_list
             # This ugly hack is needed because if we don't parse the JSON, it'll make an error
-            # if everything isn't in the exact same order, but if we just use shopping_list.attributes
+            # if everything isn't in the exact same order, but if we just use wish_list.attributes
             # it won't include the list_items. Ugly.
-            expect(JSON.parse(response.body)).to eq(JSON.parse(shopping_list.reload.to_json))
+            expect(JSON.parse(response.body)).to eq(JSON.parse(wish_list.reload.to_json))
           end
 
           it 'returns status 200' do
-            update_shopping_list
+            update_wish_list
             expect(response.status).to eq 200
           end
         end
@@ -510,40 +548,46 @@ RSpec.describe 'ShoppingLists', type: :request do
           let(:params) { nil }
 
           it "doesn't change the attributes" do
-            expect { update_shopping_list }
-              .not_to change(shopping_list.reload, :attributes)
+            expect { update_wish_list }
+              .not_to change(wish_list.reload, :attributes)
           end
 
           it 'returns the updated list' do
-            update_shopping_list
+            update_wish_list
             # This ugly hack is needed because if we don't parse the JSON, it'll make an error
-            # if everything isn't in the exact same order, but if we just use shopping_list.attributes
+            # if everything isn't in the exact same order, but if we just use wish_list.attributes
             # it won't include the list_items. Ugly.
-            expect(JSON.parse(response.body)).to eq(JSON.parse(shopping_list.reload.to_json))
+            expect(JSON.parse(response.body)).to eq(JSON.parse(wish_list.reload.to_json))
           end
 
           it 'returns status 200' do
-            update_shopping_list
+            update_wish_list
             expect(response.status).to eq 200
           end
         end
       end
 
       context 'when the params are invalid' do
-        subject(:update_shopping_list) { patch "/shopping_lists/#{list_id}", params: { shopping_list: { title: other_list.title } }.to_json, headers: }
+        subject(:update_wish_list) do
+          patch "/shopping_lists/#{list_id}",
+                params: {
+                  shopping_list: { title: other_list.title },
+                }.to_json,
+                headers:
+        end
 
-        let!(:shopping_list) { create(:shopping_list, game:) }
+        let!(:wish_list) { create(:wish_list, game:) }
         let(:game) { create(:game, user:) }
-        let(:list_id) { shopping_list.id }
-        let(:other_list) { create(:shopping_list, game:) }
+        let(:list_id) { wish_list.id }
+        let(:other_list) { create(:wish_list, game:) }
 
         it 'returns status 422' do
-          update_shopping_list
+          update_wish_list
           expect(response.status).to eq 422
         end
 
         it 'returns the errors' do
-          update_shopping_list
+          update_wish_list
           expect(JSON.parse(response.body)).to eq({ 'errors' => ['Title must be unique per game'] })
         end
       end
@@ -552,122 +596,136 @@ RSpec.describe 'ShoppingLists', type: :request do
         let(:list_id) { 245_285 }
 
         it 'returns status 404' do
-          update_shopping_list
+          update_wish_list
           expect(response.status).to eq 404
         end
 
         it "doesn't return data" do
-          update_shopping_list
+          update_wish_list
           expect(response.body).to be_blank
         end
       end
 
       context 'when the list belongs to another user' do
-        let!(:shopping_list) { create(:shopping_list) }
-        let(:list_id) { shopping_list.id }
+        let!(:wish_list) { create(:wish_list) }
+        let(:list_id) { wish_list.id }
 
-        it "doesn't update the shopping list" do
-          expect { update_shopping_list }
-            .not_to change(shopping_list.reload, :title)
+        it "doesn't update the wish list" do
+          expect { update_wish_list }
+            .not_to change(wish_list.reload, :title)
         end
 
         it 'returns status 404' do
-          update_shopping_list
+          update_wish_list
           expect(response.status).to eq 404
         end
 
         it "doesn't return data" do
-          update_shopping_list
+          update_wish_list
           expect(response.body).to be_blank
         end
       end
 
       context 'when the client attempts to update an aggregate list' do
-        subject(:update_shopping_list) { patch "/shopping_lists/#{shopping_list.id}", params: { shopping_list: { title: 'Foo' } }.to_json, headers: }
+        subject(:update_wish_list) do
+          patch "/shopping_lists/#{wish_list.id}",
+                params: { shopping_list: { title: 'Foo' } }.to_json,
+                headers:
+        end
 
-        let!(:shopping_list) { create(:aggregate_shopping_list, game:) }
+        let!(:wish_list) { create(:aggregate_wish_list, game:) }
         let(:game) { create(:game, user:) }
 
         it "doesn't update the list" do
-          update_shopping_list
-          expect(shopping_list.reload.title).to eq 'All Items'
+          update_wish_list
+          expect(wish_list.reload.title).to eq 'All Items'
         end
 
         it 'returns status 405 (method not allowed)' do
-          update_shopping_list
+          update_wish_list
           expect(response.status).to eq 405
         end
 
         it 'returns a helpful error body' do
-          update_shopping_list
-          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Cannot manually update an aggregate shopping list'] })
+          update_wish_list
+          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Cannot manually update an aggregate wish list'] })
         end
       end
 
       context 'when the client attempts to change a regular list to an aggregate list' do
-        subject(:update_shopping_list) { patch "/shopping_lists/#{shopping_list.id}", params: { shopping_list: { aggregate: true } }.to_json, headers: }
+        subject(:update_wish_list) do
+          patch "/shopping_lists/#{wish_list.id}",
+                params: { shopping_list: { aggregate: true } }.to_json,
+                headers:
+        end
 
-        let!(:shopping_list) { create(:shopping_list, game:) }
+        let!(:wish_list) { create(:wish_list, game:) }
         let(:game) { create(:game, user:) }
 
         it "doesn't update the list" do
-          update_shopping_list
-          expect(shopping_list.reload.aggregate).to eq false
+          update_wish_list
+          expect(wish_list.reload.aggregate).to eq false
         end
 
         it 'returns status 422' do
-          update_shopping_list
+          update_wish_list
           expect(response.status).to eq 422
         end
 
         it 'returns a helpful error body' do
-          update_shopping_list
-          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Cannot make a regular shopping list an aggregate list'] })
+          update_wish_list
+          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Cannot make a regular wish list an aggregate list'] })
         end
       end
 
       context 'when something unexpected goes wrong' do
-        subject(:update_shopping_list) { patch "/shopping_lists/#{shopping_list.id}", params: { shopping_list: { title: 'Some New Title' } }.to_json, headers: }
+        subject(:update_wish_list) do
+          patch "/shopping_lists/#{wish_list.id}",
+                params: { shopping_list: { title: 'Some New Title' } }.to_json,
+                headers:
+        end
 
-        let!(:shopping_list) { create(:shopping_list, game:) }
+        let!(:wish_list) { create(:wish_list, game:) }
         let(:game) { create(:game, user:) }
 
         before do
-          allow_any_instance_of(User).to receive(:shopping_lists).and_raise(StandardError, 'Something went catastrophically wrong')
+          allow_any_instance_of(User)
+            .to receive(:wish_lists)
+                  .and_raise(StandardError, 'Something went catastrophically wrong')
         end
 
         it 'returns status 500' do
-          update_shopping_list
+          update_wish_list
           expect(response.status).to eq 500
         end
 
         it 'returns the error in the body' do
-          update_shopping_list
+          update_wish_list
           expect(response.body).to eq({ errors: ['Something went catastrophically wrong'] }.to_json)
         end
       end
     end
 
     context 'when unauthenticated' do
-      let!(:shopping_list) { create(:shopping_list) }
-      let(:list_id) { shopping_list.id }
+      let!(:wish_list) { create(:wish_list) }
+      let(:list_id) { wish_list.id }
 
       before do
         stub_unsuccessful_login
       end
 
-      it "doesn't update the shopping list" do
-        expect { update_shopping_list }
-          .not_to change(shopping_list.reload, :title)
+      it "doesn't update the wish list" do
+        expect { update_wish_list }
+          .not_to change(wish_list.reload, :title)
       end
 
       it 'returns status 401' do
-        update_shopping_list
+        update_wish_list
         expect(response.status).to eq 401
       end
 
       it "doesn't return any data" do
-        update_shopping_list
+        update_wish_list
         expect(JSON.parse(response.body)).to eq({ 'errors' => ['Token validation response did not include a user'] })
       end
     end
@@ -711,7 +769,7 @@ RSpec.describe 'ShoppingLists', type: :request do
         end
       end
 
-      context 'when there are no shopping lists for that game' do
+      context 'when there are no wish lists for that game' do
         let(:game) { create(:game, user:) }
 
         it 'returns status 200' do
@@ -725,17 +783,17 @@ RSpec.describe 'ShoppingLists', type: :request do
         end
       end
 
-      context 'when there are shopping lists for that game' do
-        let(:game) { create(:game_with_shopping_lists, user:) }
+      context 'when there are wish lists for that game' do
+        let(:game) { create(:game_with_wish_lists, user:) }
 
         it 'returns status 200' do
           get_index
           expect(response.status).to eq 200
         end
 
-        it 'returns the shopping lists in index order' do
+        it 'returns the wish lists in index order' do
           get_index
-          expect(response.body).to eq game.shopping_lists.index_order.to_json
+          expect(response.body).to eq game.wish_lists.index_order.to_json
         end
       end
     end
@@ -760,7 +818,7 @@ RSpec.describe 'ShoppingLists', type: :request do
   end
 
   describe 'DELETE /shopping_lists/:id' do
-    subject(:delete_shopping_list) { delete "/shopping_lists/#{shopping_list.id}", headers: }
+    subject(:delete_wish_list) { delete "/shopping_lists/#{wish_list.id}", headers: }
 
     context 'when authenticated' do
       let!(:user) { create(:authenticated_user) }
@@ -770,136 +828,136 @@ RSpec.describe 'ShoppingLists', type: :request do
         stub_successful_login
       end
 
-      context 'when the shopping list exists' do
-        let!(:shopping_list) { create(:shopping_list, game:) }
-        let!(:shopping_list_id) { shopping_list.id }
+      context 'when the wish list exists' do
+        let!(:wish_list) { create(:wish_list, game:) }
+        let!(:wish_list_id) { wish_list.id }
 
-        context "when this is the game's last regular shopping list" do
-          let!(:aggregate_list_id) { game.aggregate_shopping_list.id }
+        context "when this is the game's last regular wish list" do
+          let!(:aggregate_list_id) { game.aggregate_wish_list.id }
 
           let(:expected_response_body) do
             {
-              deleted: [aggregate_list_id, shopping_list_id],
+              deleted: [aggregate_list_id, wish_list_id],
             }.to_json
           end
 
-          it 'deletes the shopping list and the aggregate list' do
-            expect { delete_shopping_list }
-              .to change(game.shopping_lists, :count).from(2).to(0)
+          it 'deletes the wish list and the aggregate list' do
+            expect { delete_wish_list }
+              .to change(game.wish_lists, :count).from(2).to(0)
           end
 
           it 'returns status 200' do
-            delete_shopping_list
+            delete_wish_list
             expect(response.status).to eq 200
           end
 
           it 'returns the IDs of the deleted lists' do
-            delete_shopping_list
+            delete_wish_list
             expect(response.body).to eq expected_response_body
           end
         end
 
-        context "when this is not the game's last regular shopping list" do
+        context "when this is not the game's last regular wish list" do
           let(:expected_response_body) do
             {
-              'deleted': [shopping_list_id],
-              'aggregate': game.aggregate_shopping_list,
+              'deleted': [wish_list_id],
+              'aggregate': game.aggregate_wish_list,
             }.to_json
           end
 
           before do
-            create(:shopping_list, game:)
+            create(:wish_list, game:)
           end
 
-          it 'deletes the requested shopping list' do
-            expect { delete_shopping_list }
-              .to change(game.shopping_lists, :count).from(3).to(2)
+          it 'deletes the requested wish list' do
+            expect { delete_wish_list }
+              .to change(game.wish_lists, :count).from(3).to(2)
           end
 
           it 'returns status 200' do
-            delete_shopping_list
+            delete_wish_list
             expect(response.status).to eq 200
           end
 
           it 'returns the deleted list ID and the aggregate list' do
-            delete_shopping_list
+            delete_wish_list
             expect(response.body).to eq(expected_response_body)
           end
         end
       end
 
-      context 'when the shopping list does not exist' do
-        let(:shopping_list) { double(id: 24_588) }
+      context 'when the wish list does not exist' do
+        let(:wish_list) { double(id: 24_588) }
 
         it 'returns 404' do
-          delete_shopping_list
+          delete_wish_list
           expect(response.status).to eq 404
         end
 
         it "doesn't return any data" do
-          delete_shopping_list
+          delete_wish_list
           expect(response.body).to be_blank
         end
       end
 
-      context 'when the shopping list belongs to another user' do
-        let!(:shopping_list) { create(:shopping_list) }
+      context 'when the wish list belongs to another user' do
+        let!(:wish_list) { create(:wish_list) }
 
-        it "doesn't destroy the shopping list" do
-          expect { delete_shopping_list }
-            .not_to change(ShoppingList, :count)
+        it "doesn't destroy the wish list" do
+          expect { delete_wish_list }
+            .not_to change(WishList, :count)
         end
 
         it 'returns 404' do
-          delete_shopping_list
+          delete_wish_list
           expect(response.status).to eq 404
         end
 
         it "doesn't return any data" do
-          delete_shopping_list
+          delete_wish_list
           expect(response.body).to be_blank
         end
       end
 
       context 'when attempting to delete the aggregate list' do
-        let!(:shopping_list) { create(:aggregate_shopping_list, game:) }
+        let!(:wish_list) { create(:aggregate_wish_list, game:) }
 
         it "doesn't delete the list" do
-          expect { delete_shopping_list }
-            .not_to change(ShoppingList, :count)
+          expect { delete_wish_list }
+            .not_to change(WishList, :count)
         end
 
         it 'returns status 405' do
-          delete_shopping_list
+          delete_wish_list
           expect(response.status).to eq 405
         end
 
         it 'returns an "errors" array' do
-          delete_shopping_list
-          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Cannot manually delete an aggregate shopping list'] })
+          delete_wish_list
+          expect(JSON.parse(response.body)).to eq({ 'errors' => ['Cannot manually delete an aggregate wish list'] })
         end
       end
     end
 
     context 'when unauthenticated' do
-      let!(:shopping_list) { create(:shopping_list) }
+      let!(:wish_list) { create(:wish_list) }
 
       before do
         stub_unsuccessful_login
       end
 
-      it "doesn't destroy the shopping list" do
-        expect { delete_shopping_list }
-          .not_to change(ShoppingList, :count)
+      it "doesn't destroy the wish list" do
+        expect { delete_wish_list }
+          .not_to change(WishList, :count)
       end
 
       it 'returns status 401' do
-        delete_shopping_list
+        delete_wish_list
         expect(response.status).to eq 401
       end
 
       it "doesn't return any data" do
-        delete_shopping_list
+        delete_wish_list
         expect(JSON.parse(response.body)).to eq({ 'errors' => ['Token validation response did not include a user'] })
       end
     end

--- a/spec/requests/shopping_lists_spec.rb
+++ b/spec/requests/shopping_lists_spec.rb
@@ -354,7 +354,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       context 'when the client attempts to update an aggregate list' do
         subject(:update_wish_list) do
-          put "/shopping_lists/#{shopping_list.id}",
+          put "/shopping_lists/#{wish_list.id}",
               params: {
                 shopping_list: { title: 'Foo' },
               }.to_json,
@@ -382,7 +382,7 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       context 'when the client attempts to change a regular list to an aggregate list' do
         subject(:update_wish_list) do
-          put "/shopping_lists/#{shopping_list.id}",
+          put "/shopping_lists/#{wish_list.id}",
               params: {
                 shopping_list: { aggregate: true },
               }.to_json,

--- a/spec/support/factories/games.rb
+++ b/spec/support/factories/games.rb
@@ -6,26 +6,26 @@ FactoryBot.define do
 
     sequence(:name) {|n| "Skyrim Game #{n}" }
 
-    factory :game_with_shopping_lists do
+    factory :game_with_wish_lists do
       transient do
-        shopping_list_count { 2 }
+        wish_list_count { 2 }
       end
 
       after(:create) do |game, evaluator|
-        create(:aggregate_shopping_list, game:)
-        create_list(:shopping_list, evaluator.shopping_list_count, game:)
+        create(:aggregate_wish_list, game:)
+        create_list(:wish_list, evaluator.wish_list_count, game:)
       end
     end
 
-    factory :game_with_shopping_lists_and_items do
+    factory :game_with_wish_lists_and_items do
       transient do
-        shopping_list_count { 2 }
+        wish_list_count { 2 }
       end
 
       after(:create) do |game, evaluator|
-        shopping_lists = create_list(:shopping_list_with_list_items, evaluator.shopping_list_count, game:)
+        wish_lists = create_list(:wish_list_with_list_items, evaluator.wish_list_count, game:)
 
-        shopping_lists.each do |list|
+        wish_lists.each do |list|
           list.list_items.each do |item|
             list.aggregate_list.add_item_from_child_list(item)
           end
@@ -62,7 +62,7 @@ FactoryBot.define do
 
     factory :game_with_everything do
       transient do
-        shopping_list_count { 2 }
+        wish_list_count { 2 }
         inventory_list_count { 2 }
       end
 
@@ -75,9 +75,9 @@ FactoryBot.define do
           end
         end
 
-        shopping_lists = create_list(:shopping_list_with_list_items, evaluator.shopping_list_count, game:)
+        wish_lists = create_list(:wish_list_with_list_items, evaluator.wish_list_count, game:)
 
-        shopping_lists.each do |list|
+        wish_lists.each do |list|
           list.list_items.each do |item|
             list.aggregate_list.add_item_from_child_list(item)
           end

--- a/spec/support/factories/wish_list_items.rb
+++ b/spec/support/factories/wish_list_items.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :shopping_list_item do
-    association :list, factory: :shopping_list
+  factory :wish_list_item do
+    association :list, factory: :wish_list
 
     sequence(:description) {|n| "Item #{n}" }
     quantity { 1 }

--- a/spec/support/factories/wish_lists.rb
+++ b/spec/support/factories/wish_lists.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :wish_list do
     game
 
-    sequence(:title) {|n| "Shopping List #{n}" }
+    sequence(:title) {|n| "Wish List #{n}" }
 
     factory :aggregate_wish_list do
       aggregate { true }

--- a/spec/support/factories/wish_lists.rb
+++ b/spec/support/factories/wish_lists.rb
@@ -1,24 +1,24 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :shopping_list do
+  factory :wish_list do
     game
 
     sequence(:title) {|n| "Shopping List #{n}" }
 
-    factory :aggregate_shopping_list do
+    factory :aggregate_wish_list do
       aggregate { true }
       title { 'All Items' }
       aggregate_list_id { nil }
     end
 
-    factory :shopping_list_with_list_items do
+    factory :wish_list_with_list_items do
       transient do
         list_item_count { 2 }
       end
 
       after(:create) do |list, evaluator|
-        create_list(:shopping_list_item, evaluator.list_item_count, list:)
+        create_list(:wish_list_item, evaluator.list_item_count, list:)
       end
     end
   end


### PR DESCRIPTION
## Context

* [**Rename ShoppingList model on the back end**](https://trello.com/c/BbLH9Edj/358-rename-shoppinglist-on-the-back-end)
* [**Rename ShoppingListItem model on the back end**](https://trello.com/c/W7u7Jczr/359-rename-shoppinglistitem-model-on-the-back-end)

We're in the process of renaming `ShoppingList`s to `WishList`s. There were two separate cards for renaming the `ShoppingList` and `ShoppingListItem` models, however, I forgot about that and renamed both models in one big PR. Oops.

## Changes

* Rename `ShoppingList` model to `WishList`
* Rename `ShoppingListItem` model to `WishListItem`
* Update nomenclature throughout codebase
* Update tests and factories to use new names
* Update docs

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

We have decided to wait to change the names of controllers and endpoints until the very end of the [associated epic](https://trello.com/c/tQDepPq7/354-rename-shoppinglist-to-wishlist). This way, we can limit the number of deploys we need to coordinate between front and back end. This being the case, API docs for shopping lists and shopping list items have not changed, nor have expected request bodies. This means that, for example, a `PATCH` request to `/shopping_lists/:id` will have a `shopping_list` key in the JSON request body. This will be changed towards the end of the epic.
