### PR TITLE
Rename ShoppingListsController and endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Users are uniquely identified by the UID of the Google account they use to sign 
 
 ### Authenticating Resources
 
-All resources are scoped to the currently authenticated user. Requesting a resource that doesn't belong to the authenticated user will result in a 404, not a 401. So, if User 1 owns the `WishList` with ID 24, requesting `/shopping_lists/24` with a valid token belonging to User 2 will simply result in the resource not being found, and not in a 401 response. All requests lacking a valid token will return 401 responses.
+All resources are scoped to the currently authenticated user. Requesting a resource that doesn't belong to the authenticated user will result in a 404, not a 401. So, if User 1 owns the `WishList` with ID 24, requesting `/wish_lists/24` with a valid token belonging to User 2 will simply result in the resource not being found, and not in a 401 response. All requests lacking a valid token will return 401 responses.
 
 ## Resources
 
@@ -66,7 +66,7 @@ If you'd like to run only a specific subset of specs, these options are the way 
 bundle exec rspec spec/models
 
 # runs only one spec file
-bundle exec rspec spec/requests/shopping_lists_spec.rb
+bundle exec rspec spec/requests/wish_lists_spec.rb
 
 # runs a specific spec on line 42 of the specified file
 bundle exec rspec spec/models/wish_list_item_spec.rb:42

--- a/app/controller_services/wish_list_items_controller/create_service.rb
+++ b/app/controller_services/wish_list_items_controller/create_service.rb
@@ -7,7 +7,7 @@ require 'service/unprocessable_entity_result'
 require 'service/method_not_allowed_result'
 require 'service/internal_server_error_result'
 
-class ShoppingListItemsController < ApplicationController
+class WishListItemsController < ApplicationController
   class CreateService
     AGGREGATE_LIST_ERROR = 'Cannot manually manage items on an aggregate wish list'
 

--- a/app/controller_services/wish_list_items_controller/destroy_service.rb
+++ b/app/controller_services/wish_list_items_controller/destroy_service.rb
@@ -5,7 +5,7 @@ require 'service/not_found_result'
 require 'service/method_not_allowed_result'
 require 'service/internal_server_error_result'
 
-class ShoppingListItemsController < ApplicationController
+class WishListItemsController < ApplicationController
   class DestroyService
     AGGREGATE_LIST_ERROR = 'Cannot manually delete list item from aggregate wish list'
 

--- a/app/controller_services/wish_list_items_controller/update_service.rb
+++ b/app/controller_services/wish_list_items_controller/update_service.rb
@@ -6,7 +6,7 @@ require 'service/unprocessable_entity_result'
 require 'service/method_not_allowed_result'
 require 'service/internal_server_error_result'
 
-class ShoppingListItemsController < ApplicationController
+class WishListItemsController < ApplicationController
   class UpdateService
     AGGREGATE_LIST_ERROR = 'Cannot manually update list items on an aggregate wish list'
 

--- a/app/controller_services/wish_lists_controller/create_service.rb
+++ b/app/controller_services/wish_lists_controller/create_service.rb
@@ -7,7 +7,7 @@ require 'service/method_not_allowed_result'
 require 'service/internal_server_error_result'
 require 'service/ok_result'
 
-class ShoppingListsController < ApplicationController
+class WishListsController < ApplicationController
   class CreateService
     AGGREGATE_LIST_ERROR = 'Cannot manually create an aggregate wish list'
 

--- a/app/controller_services/wish_lists_controller/destroy_service.rb
+++ b/app/controller_services/wish_lists_controller/destroy_service.rb
@@ -5,7 +5,7 @@ require 'service/not_found_result'
 require 'service/ok_result'
 require 'service/internal_server_error_result'
 
-class ShoppingListsController < ApplicationController
+class WishListsController < ApplicationController
   class DestroyService
     AGGREGATE_LIST_ERROR = 'Cannot manually delete an aggregate wish list'
 

--- a/app/controller_services/wish_lists_controller/index_service.rb
+++ b/app/controller_services/wish_lists_controller/index_service.rb
@@ -4,7 +4,7 @@ require 'service/ok_result'
 require 'service/not_found_result'
 require 'service/internal_server_error_result'
 
-class ShoppingListsController < ApplicationController
+class WishListsController < ApplicationController
   class IndexService
     def initialize(user, game_id)
       @user = user

--- a/app/controller_services/wish_lists_controller/update_service.rb
+++ b/app/controller_services/wish_lists_controller/update_service.rb
@@ -6,7 +6,7 @@ require 'service/not_found_result'
 require 'service/unprocessable_entity_result'
 require 'service/internal_server_error_result'
 
-class ShoppingListsController < ApplicationController
+class WishListsController < ApplicationController
   class UpdateService
     AGGREGATE_LIST_ERROR = 'Cannot manually update an aggregate wish list'
     DISALLOWED_UPDATE_ERROR = 'Cannot make a regular wish list an aggregate list'

--- a/app/controllers/wish_list_items_controller.rb
+++ b/app/controllers/wish_list_items_controller.rb
@@ -2,9 +2,9 @@
 
 require 'controller/response'
 
-class ShoppingListItemsController < ApplicationController
+class WishListItemsController < ApplicationController
   def create
-    result = CreateService.new(current_user, params[:shopping_list_id], list_item_params).perform
+    result = CreateService.new(current_user, params[:wish_list_id], list_item_params).perform
 
     ::Controller::Response.new(self, result).execute
   end
@@ -24,7 +24,7 @@ class ShoppingListItemsController < ApplicationController
   private
 
   def list_item_params
-    params.require(:shopping_list_item).permit(
+    params.require(:wish_list_item).permit(
       :description,
       :quantity,
       :notes,

--- a/app/controllers/wish_lists_controller.rb
+++ b/app/controllers/wish_lists_controller.rb
@@ -2,7 +2,7 @@
 
 require 'controller/response'
 
-class ShoppingListsController < ApplicationController
+class WishListsController < ApplicationController
   def index
     result = IndexService.new(current_user, params[:game_id]).perform
 
@@ -10,13 +10,13 @@ class ShoppingListsController < ApplicationController
   end
 
   def create
-    result = CreateService.new(current_user, params[:game_id], shopping_list_params).perform
+    result = CreateService.new(current_user, params[:game_id], wish_list_params).perform
 
     ::Controller::Response.new(self, result).execute
   end
 
   def update
-    result = UpdateService.new(current_user, params[:id], shopping_list_params).perform
+    result = UpdateService.new(current_user, params[:id], wish_list_params).perform
 
     ::Controller::Response.new(self, result).execute
   end
@@ -29,7 +29,7 @@ class ShoppingListsController < ApplicationController
 
   private
 
-  def shopping_list_params
-    params[:shopping_list].present? ? params.require(:shopping_list).permit(:title, :aggregate) : {}
+  def wish_list_params
+    params[:wish_list].present? ? params.require(:wish_list).permit(:title, :aggregate) : {}
   end
 end

--- a/app/models/concerns/aggregatable.rb
+++ b/app/models/concerns/aggregatable.rb
@@ -22,10 +22,10 @@
 #    | game_id           | bigint  | null: false                 |
 #
 # There are a few other assumptions made:
-# - There is a `#list_item_class_name` method defined. For the `ShoppingList` model,
-#   this would be `'ShoppingListItem'`.
+# - There is a `#list_item_class_name` method defined. For the `WishList` model,
+#   this would be `'WishListItem'`.
 # - There is a scope on the child model class called `:index_order` that defines
-#   the order in which the child models should appear. For example, `ShoppingListItem`
+#   the order in which the child models should appear. For example, `WishListItem`
 #   models are in descending `:updated_at` order.
 
 module Aggregatable

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -6,7 +6,7 @@ class Property < ApplicationRecord
   belongs_to :game
   belongs_to :canonical_property, class_name: 'Canonical::Property'
 
-  has_many :shopping_lists, dependent: nil
+  has_many :wish_lists, dependent: nil
   has_many :inventory_lists, dependent: nil
 
   validates :canonical_property,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,8 +4,8 @@ Rails.application.routes.draw do
   root to: 'health_checks#index'
 
   resources :games do
-    resources :shopping_lists, shallow: true, except: %i[show] do
-      resources :shopping_list_items, shallow: true, except: %i[index show]
+    resources :wish_lists, shallow: true, except: %i[show] do
+      resources :wish_list_items, shallow: true, except: %i[index show]
     end
 
     resources :inventory_lists, shallow: true, except: %i[show] do

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -21,9 +21,9 @@ The SIM API makes the following RESTful resources available to the client. Note 
 * [Games](/docs/api/resources/games.md)
 * [Inventory List Items](/docs/api/resources/inventory-list-items.md)
 * [Inventory Lists](/docs/api/resources/inventory-lists.md)
-* [Shopping List Items](/docs/api/resources/shopping-list-items.md)
-* [Shopping Lists](/docs/api/resources/shopping-lists.md)
+* [Wish List Items](/docs/api/resources/wish-list-items.md)
+* [Wish Lists](/docs/api/resources/wish-lists.md)
 
 ### Object Modelling Hierarchy
 
-In SIM, users can have any number of games, which can each have any number of shopping lists, which can each have any number of shopping list items. An authenticated user can create, access, update, and destroy resources belonging to them. There are currently no admin routes or any way to access resources not belonging to the currently authenticated user (except through direct database access).
+In SIM, users can have any number of games, which can each have any number of wish lists, which can each have any number of wish list items. An authenticated user can create, access, update, and destroy resources belonging to them. There are currently no admin routes or any way to access resources not belonging to the currently authenticated user (except through direct database access).

--- a/docs/api/resources/games.md
+++ b/docs/api/resources/games.md
@@ -1,6 +1,6 @@
 # Games
 
-Each user in Skyrim Inventory Management can have many games. The game is the base resource that owns other resources a user may create, such as shopping lists and shopping list items. All game routes are scoped to the currently authenticated user. There are no admin routes or any way to access, create, remove, or modify data for a user that is not currently authenticated.
+Each user in Skyrim Inventory Management can have many games. The game is the base resource that owns other resources a user may create, such as wish lists and wish list items. All game routes are scoped to the currently authenticated user. There are no admin routes or any way to access, create, remove, or modify data for a user that is not currently authenticated.
 
 ## Endpoints
 

--- a/docs/api/resources/wish-list-items.md
+++ b/docs/api/resources/wish-list-items.md
@@ -1,14 +1,14 @@
-# Shopping List Items
+# Wish List Items
 
-Shopping list items represent the items on a [shopping list](/docs/api/resources/shopping-lists.md). Shopping list items on regular lists can be created, updated, and destroyed through the API. Shopping list items on aggregate shopping lists are managed automatically as the items on their child lists change. Each shopping list item belongs to a particular list and will be destroyed if the list is destroyed.
+Wish list items represent the items on a [wish list](/docs/api/resources/wish-lists.md). Wish list items on regular lists can be created, updated, and destroyed through the API. Wish list items on aggregate wish lists are managed automatically as the items on their child lists change. Each wish list item belongs to a particular list and will be destroyed if the list is destroyed.
 
-There are no read routes (`GET /shopping_list_items`, `GET /shopping_list/:shopping_list_id/shopping_list_items`, or `GET /shopping_list_items/:id`) for shopping list items since all shopping list items are returned with the lists they are on when requests are made to the list routes. There are, however, routes to create, update, and destroy shopping list items.
+There are no read routes (`GET /wish_list_items`, `GET /wish_list/:wish_list_id/wish_list_items`, or `GET /wish_list_items/:id`) for wish list items since all wish list items are returned with the lists they are on when requests are made to the list routes. There are, however, routes to create, update, and destroy wish list items.
 
-All requests to shopping list item endpoints must be [authenticated](/docs/api/resources/authorization.md).
+All requests to wish list item endpoints must be [authenticated](/docs/api/resources/authorization.md).
 
 ## Automatically Managed Aggregate Lists
 
-Skyrim Inventory Management makes use of automatically managed aggregate lists to help users track an aggregate of what items they need for different properties or purposes in each game. The aggregate list is created automatically when the client creates a the first regular shopping list for a game, and is destroyed automatically when the client deletes the game's last regular shopping list. When items are added, updated, or destroyed from any of a game's regular lists, aggregate list items are updated as described in this section.
+Skyrim Inventory Management makes use of automatically managed aggregate lists to help users track an aggregate of what items they need for different properties or purposes in each game. The aggregate list is created automatically when the client creates a the first regular wish list for a game, and is destroyed automatically when the client deletes the game's last regular wish list. When items are added, updated, or destroyed from any of a game's regular lists, aggregate list items are updated as described in this section.
 
 (Ensuring automatic management of aggregate lists does require some work on the part of SIM developers. If you are working on lists in SIM and would like information on how to keep them synced, head over to the [`Aggregatable` docs](/docs/aggregate-lists.md).)
 
@@ -37,29 +37,29 @@ When a client updates a list item on a regular list for a given game, one (or mo
 
 ### Destroying a List Item
 
-When a client destroys a list item on a regular shopping list, one of the following things will happen:
+When a client destroys a list item on a regular wish list, one of the following things will happen:
 
-* If the quantity of the item on the aggregate shopping list for the same game is higher than the quantity of the item deleted (i.e., if there is another matching item on a different list), the aggregate list item's quantity will be decreased by the amount of the quantity of the deleted item.
-* If the quantity on the aggregate shopping list is equal to the quantity of the item deleted (i.e., if there is not another matching item on a different list), the item on the aggregate shopping list will be deleted as well.
+* If the quantity of the item on the aggregate wish list for the same game is higher than the quantity of the item deleted (i.e., if there is another matching item on a different list), the aggregate list item's quantity will be decreased by the amount of the quantity of the deleted item.
+* If the quantity on the aggregate wish list is equal to the quantity of the item deleted (i.e., if there is not another matching item on a different list), the item on the aggregate wish list will be deleted as well.
 
 ## Endpoints
 
-The following endpoints are available to manage shopping list items:
+The following endpoints are available to manage wish list items:
 
-* [`POST /shopping_lists/:shopping_list_id/shopping_list_items`](#post-shopping_listsshopping_list_idshopping_list_items)
-* [`PATCH|PUT /shopping_list_items/:id`](#patchput-shopping_list_itemsid)
-* [`DELETE /shopping_list_items/:id`](#delete-shopping_list_itemsid)
+* [`POST /wish_lists/:wish_list_id/wish_list_items`](#post-wish_listswish_list_idwish_list_items)
+* [`PATCH|PUT /wish_list_items/:id`](#patchput-wish_list_itemsid)
+* [`DELETE /wish_list_items/:id`](#delete-wish_list_itemsid)
 
-## POST /shopping_lists/:shopping_list_id/shopping_list_items
+## POST /wish_lists/:wish_list_id/wish_list_items
 
-Creates a shopping list item on the given list if the shopping list with the given ID:
+Creates a wish list item on the given list if the wish list with the given ID:
 
 1. Exists
 2. Belongs to the authenticated user
 3. Is not an aggregate list AND
-4. Does not have an existing shopping list item with the same description
+4. Does not have an existing wish list item with the same description
 
-If the first three conditions are met but the list does have an existing shopping list item with a matching description, `quantity` and `notes` are updated on the existing item to aggregate the values. If the value of `unit_weight` differs from the value on the existing item and is not `null`, the existing item and any other items with the same description belonging to the same game will have their `unit_weight` updated.
+If the first three conditions are met but the list does have an existing wish list item with a matching description, `quantity` and `notes` are updated on the existing item to aggregate the values. If the value of `unit_weight` differs from the value on the existing item and is not `null`, the existing item and any other items with the same description belonging to the same game will have their `unit_weight` updated.
 
 In both cases, the aggregate list for the same game is also updated to reflect the new `quantity` and `unit_weight`. Again, aggregate lists do not track `notes`.
 
@@ -70,12 +70,12 @@ Allowed fields are:
 * `notes` (string, optional): Any notes about the item or what it is for
 * `unit_weight` (decimal, optional): The unit weight of the item as given in the game, precise to one decimal place
 
-A successful response will return a JSON array of all changed shopping lists for the game to which the created or updated list item ultimately belongs, including all the list items on each list.
+A successful response will return a JSON array of all changed wish lists for the game to which the created or updated list item ultimately belongs, including all the list items on each list.
 
 ### Example Request
 
 ```
-POST /shopping_lists/72/shopping_list_items
+POST /wish_lists/72/wish_list_items
 Authorization: Bearer xxxxxxxxxxx
 Content-Type: application/json
 {
@@ -94,9 +94,9 @@ Content-Type: application/json
 
 #### Example Body
 
-If there is no item with a matching description on the requested shopping list, a new item will be created and the server will return a 201 response. If there is an item with a matching description, its notes and quantity will be combined with the notes and quantity in the client request and a 200 response will be returned.
+If there is no item with a matching description on the requested wish list, a new item will be created and the server will return a 201 response. If there is an item with a matching description, its notes and quantity will be combined with the notes and quantity in the client request and a 200 response will be returned.
 
-The body for both responses is a JSON array containing all _changed_ shopping lists for the game to which the created or updated list item ultimately belongs, i.e., those that have had items added, updated, or removed. Each shopping list includes its list items.
+The body for both responses is a JSON array containing all _changed_ wish lists for the game to which the created or updated list item ultimately belongs, i.e., those that have had items added, updated, or removed. Each wish list includes its list items.
 
 ```json
 [
@@ -174,12 +174,12 @@ Four error responses are possible.
 
 #### Example Bodies
 
-No body will be returned with a 404 error, which is returned if the specified shopping list doesn't exist or doesn't belong to the authenticated user.
+No body will be returned with a 404 error, which is returned if the specified wish list doesn't exist or doesn't belong to the authenticated user.
 
-A 405 error, which is returned if the specified shopping list is an aggregate shopping list, comes with the following body:
+A 405 error, which is returned if the specified wish list is an aggregate wish list, comes with the following body:
 ```json
 {
-  "errors": ["Cannot manually manage items on an aggregate shopping list"]
+  "errors": ["Cannot manually manage items on an aggregate wish list"]
 }
 ```
 
@@ -201,9 +201,9 @@ A 500 error response, which is always a result of an unforeseen problem, include
 }
 ```
 
-## PATCH|PUT /shopping_list_items/:id
+## PATCH|PUT /wish_list_items/:id
 
-Updates a given shopping list item provided the list the item is on:
+Updates a given wish list item provided the list the item is on:
 
 1. Exists
 2. Belongs to the authenticated user AND
@@ -219,13 +219,13 @@ Requests may specify up to three fields to update:
 
 Requests attempting to update `description` will result in a validation error.
 
-When updating `unit_weight`, the `unit_weight` value will be updated for all shopping list items belonging to the same game and matching the description. This is to prevent the aggregate list from getting out of sync with the values on its child list items.
+When updating `unit_weight`, the `unit_weight` value will be updated for all wish list items belonging to the same game and matching the description. This is to prevent the aggregate list from getting out of sync with the values on its child list items.
 
 This route supports both `PATCH` and `PUT` requests. Application behaviour does not differ depending on which method is used.
 
 ### Example Requests
 
-Request bodies must contain a `"shopping_list_item"` key containing attributes to be changed. Request bodies lacking this key may result in an error or unexpected behaviour. If the `"shopping_list_item"` object is empty, the item will not be changed. Attributes that can be changed include:
+Request bodies must contain a `"wish_list_item"` key containing attributes to be changed. Request bodies lacking this key may result in an error or unexpected behaviour. If the `"wish_list_item"` object is empty, the item will not be changed. Attributes that can be changed include:
 
 * `quantity` (integer greater than zero)
 * `notes` (string)
@@ -234,11 +234,11 @@ Request bodies must contain a `"shopping_list_item"` key containing attributes t
 #### PATCH Requests
 
 ```
-PATCH /shopping_list_items/72
+PATCH /wish_list_items/72
 Authorization: Bearer xxxxxxxxxxx
 Content-Type: application/json
 {
-  "shopping_list_item": {
+  "wish_list_item": {
     "quantity": 7,
     "notes": "To enchant with 'Absorb Health'"
   }
@@ -248,11 +248,11 @@ Content-Type: application/json
 #### PUT Requests
 
 ```
-PUT /shopping_list_items/72
+PUT /wish_list_items/72
 Authorization: Bearer xxxxxxxxxxx
 Content-Type: application/json
 {
-  "shopping_list_item": {
+  "wish_list_item": {
     "quantity": 7,
     "notes": "To enchant with 'Absorb Health'"
   }
@@ -267,7 +267,7 @@ Content-Type: application/json
 
 #### Example Body
 
-The body is a JSON array containing all shopping list items modified in the course of handling the request. Clients should take note of each item's `list_id` value to associate the item to a shopping list. Note that, if an item's unit weight is updated, this weight will be updated on any lists with a corresponding list item, so there may be more than two list items included in the response.
+The body is a JSON array containing all wish list items modified in the course of handling the request. Clients should take note of each item's `list_id` value to associate the item to a wish list. Note that, if an item's unit weight is updated, this weight will be updated on any lists with a corresponding list item, so there may be more than two list items included in the response.
 
 ```json
 [
@@ -306,13 +306,13 @@ Four error responses are possible.
 
 #### Example Bodies
 
-No body will be returned with a 404 error, which is returned if the specified shopping list item doesn't exist or doesn't belong to the authenticated user.
+No body will be returned with a 404 error, which is returned if the specified wish list item doesn't exist or doesn't belong to the authenticated user.
 
-A 405 error, which is returned if the specified shopping list item is on an aggregate shopping list, comes with the following body:
+A 405 error, which is returned if the specified wish list item is on an aggregate wish list, comes with the following body:
 
 ```json
 {
-  "errors": ["Cannot manually update list items on an aggregate shopping list"]
+  "errors": ["Cannot manually update list items on an aggregate wish list"]
 }
 ```
 
@@ -334,9 +334,9 @@ A 500 error response, which is always a result of an unforeseen problem, include
 }
 ```
 
-## DELETE /shopping_list_items/:id
+## DELETE /wish_list_items/:id
 
-Deletes the given shopping list item provided the item exists and the list it is on:
+Deletes the given wish list item provided the item exists and the list it is on:
 
 1. Belongs to the authenticated user AND
 2. Is not an aggregate list
@@ -346,7 +346,7 @@ When this happens, the corresponding list item on the aggregate list is also aut
 ### Example Request
 
 ```
-DELETE /shopping_list_items/5651
+DELETE /wish_list_items/5651
 Authorization: Bearer xxxxxxxxxxx
 ```
 
@@ -358,7 +358,7 @@ Authorization: Bearer xxxxxxxxxxx
 
 #### Example Body
 
-The response body includes the shopping list from which the item was deleted as well as the aggregate list, with the aggregate list first.
+The response body includes the wish list from which the item was deleted as well as the aggregate list, with the aggregate list first.
 
 ```json
 [
@@ -435,13 +435,13 @@ Three error responses are possible.
 
 #### Example Bodies
 
-No body will be returned with a 404 error, which is returned if the specified shopping list item doesn't exist or doesn't belong to the authenticated user.
+No body will be returned with a 404 error, which is returned if the specified wish list item doesn't exist or doesn't belong to the authenticated user.
 
-A 405 error, which is returned if the specified shopping list item is on an aggregate shopping list, comes with the following body:
+A 405 error, which is returned if the specified wish list item is on an aggregate wish list, comes with the following body:
 
 ```json
 {
-  "errors": ["Cannot manually delete an item from an aggregate shopping list"]
+  "errors": ["Cannot manually delete an item from an aggregate wish list"]
 }
 ```
 

--- a/docs/api/resources/wish-lists.md
+++ b/docs/api/resources/wish-lists.md
@@ -1,10 +1,10 @@
-# Shopping Lists
+# Wish Lists
 
-Shopping lists represent lists of items a user needs in a given game. Users can have different lists corresponding to different property locations within each game. Games with shopping lists also have an aggregate list that includes the combined list items and quantities from all the other lists for that game. Aggregate lists are created, updated, and destroyed automatically. They cannot be created, updated, or destroyed through the API (including to change attributes or to add, remove, or update list items).
+Wish lists represent lists of items a user needs in a given game. Users can have different lists corresponding to different property locations within each game. Games with wish lists also have an aggregate list that includes the combined list items and quantities from all the other lists for that game. Aggregate lists are created, updated, and destroyed automatically. They cannot be created, updated, or destroyed through the API (including to change attributes or to add, remove, or update list items).
 
-Each list contains [shopping list items](/docs/api/resources/shopping-list-items.md), which are returned with each response that includes the list.
+Each list contains [wish list items](/docs/api/resources/wish-list-items.md), which are returned with each response that includes the list.
 
-When making requests to update the title of a shopping list, there are some validations and automatic transformations to keep in mind:
+When making requests to update the title of a wish list, there are some validations and automatic transformations to keep in mind:
 
 * Titles must be unique per game - you cannot name two lists the same thing within the same game
 * Only an aggregate list can be called "All Items"
@@ -14,23 +14,23 @@ When making requests to update the title of a shopping list, there are some vali
 * Leading and trailing whitespace will be stripped from titles before they are saved, so " My List 2  " becomes "My List 2"
 * Titles may only contain alphanumeric characters, spaces, hyphens, apostrophes, and commas - any other characters (that aren't leading or trailing whitespace, which will be stripped regardless) cause the API to return a 422 response
 
-Like other resources in SIM, shopping lists are scoped to the authenticated user. There is no way to retrieve or manage shopping lists for any other user through the API.
+Like other resources in SIM, wish lists are scoped to the authenticated user. There is no way to retrieve or manage wish lists for any other user through the API.
 
 ## Endpoints
 
-* [`GET /games/:game_id/shopping_lists`](#get-gamesgame_idshopping_lists)
-* [`POST /games/:game_id/shopping_lists`](#post-gamesgame_idshopping_lists)
-* [`PATCH|PUT /shopping_lists/:id`](#patchput-shopping_listsid)
-* [`DELETE /shopping_lists/:id`](#delete-shopping_listsid)
+* [`GET /games/:game_id/wish_lists`](#get-gamesgame_idwish_lists)
+* [`POST /games/:game_id/wish_lists`](#post-gamesgame_idwish_lists)
+* [`PATCH|PUT /wish_lists/:id`](#patchput-wish_listsid)
+* [`DELETE /wish_lists/:id`](#delete-wish_listsid)
 
-## GET /games/:game_id/shopping_lists
+## GET /games/:game_id/wish_lists
 
-Returns all shopping lists for the game indicated by the `:game_id` param, provided the game exists and is owned by the authenticated user. The aggregate shopping list will be returned first, followed by the game's other shopping lists in reverse chronological order by `updated_at` (i.e., the lists that were edited most recently will be on top).
+Returns all wish lists for the game indicated by the `:game_id` param, provided the game exists and is owned by the authenticated user. The aggregate wish list will be returned first, followed by the game's other wish lists in reverse chronological order by `updated_at` (i.e., the lists that were edited most recently will be on top).
 
 ### Example Request
 
 ```
-GET /shopping_lists
+GET /wish_lists
 Authorization: Bearer xxxxxxxxxxxxx
 ```
 
@@ -156,11 +156,11 @@ A 500 error response, which is always a result of an unforeseen problem, include
 }
 ```
 
-## POST /games/:game_id/shopping_lists
+## POST /games/:game_id/wish_lists
 
-Creates a new shopping list for the specified game if it exists and belongs to the authenticated user. If the game does not already have an aggregate list, an aggregate list will also be created automatically. The response is an array that includes all shopping lists that were created. The shopping lists are returned with the aggregate list first, if one was created while handling this request, and the regular list the user requested.
+Creates a new wish list for the specified game if it exists and belongs to the authenticated user. If the game does not already have an aggregate list, an aggregate list will also be created automatically. The response is an array that includes all wish lists that were created. The wish lists are returned with the aggregate list first, if one was created while handling this request, and the regular list the user requested.
 
-The request does not have to include a body. If it does, the body should include a `"shopping_list"` object with an optional `"title"` key, the only attribute that can be set on a shopping list via this or any endpoint. If you don't include a title, your list will be titled "My List N", where _N_ is an integer equal to one plus the highest numbered default list title you have. For example, if you have lists titled "My List 1", "My List 3", and "My List 4" and you don't specify a title for your new list, your new list will be titled "My List 5".
+The request does not have to include a body. If it does, the body should include a `"wish_list"` object with an optional `"title"` key, the only attribute that can be set on a wish list via this or any endpoint. If you don't include a title, your list will be titled "My List N", where _N_ is an integer equal to one plus the highest numbered default list title you have. For example, if you have lists titled "My List 1", "My List 3", and "My List 4" and you don't specify a title for your new list, your new list will be titled "My List 5".
 
 There are a few validations and automatic changes made to titles:
 
@@ -174,11 +174,11 @@ There are a few validations and automatic changes made to titles:
 
 Request specifying a title:
 ```
-POST games/1455/shopping_lists
+POST games/1455/wish_lists
 Authorization: Bearer xxxxxxxxxx
 Content-Type: application/json
 {
-  "shopping_list": {
+  "wish_list": {
     "title": "Custom Title"
   }
 }
@@ -186,15 +186,15 @@ Content-Type: application/json
 
 Request not specifying a title (list will be given a default title as defined above):
 ```
-POST /games/8928/shopping_lists
+POST /games/8928/wish_lists
 Authorization: Bearer xxxxxxxxxx
 Content-Type: application/json
-{ "shopping_list": {} }
+{ "wish_list": {} }
 ```
 
 Request with no request body (the list will be given a default title as defined above):
 ```
-POST /games/8928/shopping_lists
+POST /games/8928/wish_lists
 Authorization: Bearer xxxxxxxxxx
 ```
 
@@ -272,7 +272,7 @@ If duplicate title is given:
 If request attempts to create an aggregate list:
 ```json
 {
-  "errors": ["Cannot manually create an aggregate shopping list"]
+  "errors": ["Cannot manually create an aggregate wish list"]
 }
 ```
 
@@ -283,24 +283,24 @@ A 500 error response, which is always a result of an unforeseen problem, include
 }
 ```
 
-## PATCH|PUT /shopping_lists/:id
+## PATCH|PUT /wish_lists/:id
 
-If the specified shopping list exists, belongs to the authenticated user, and is not an aggregate list, updates the title and returns the shopping list. Title is the only shopping list attribute that can be modified using this endpoint. This endpoint also supports the `PUT` method. There is no  difference in application behaviour whether `PATCH` or `PUT` is used.
+If the specified wish list exists, belongs to the authenticated user, and is not an aggregate list, updates the title and returns the wish list. Title is the only wish list attribute that can be modified using this endpoint. This endpoint also supports the `PUT` method. There is no  difference in application behaviour whether `PATCH` or `PUT` is used.
 
 ### Example Requests
 
-Requests should include a `"shopping_list"` object with a `"title"` key. The `"title"` may be `null`; in this case, a default title will be assigned as described [above](#post-gamesgame_idshopping_lists). If the `"shopping_list"` object is empty or nonexistent, or if no request body is given, the list will not be updated but will be returned as-is. `"title"` is the only attribute that may be set on shopping lists via the SIM API.
+Requests should include a `"wish_list"` object with a `"title"` key. The `"title"` may be `null`; in this case, a default title will be assigned as described [above](#post-gamesgame_idwish_lists). If the `"wish_list"` object is empty or nonexistent, or if no request body is given, the list will not be updated but will be returned as-is. `"title"` is the only attribute that may be set on wish lists via the SIM API.
 
 #### PATCH Requests
 
 Normal usage:
 
 ```
-PATCH /shopping_lists/3
+PATCH /wish_lists/3
 Authorization: Bearer xxxxxxxxxx
 Content-Type: application/json
 {
-  "shopping_list": {
+  "wish_list": {
     "title": "New List Title"
   }
 }
@@ -309,24 +309,24 @@ Content-Type: application/json
 Null title (will result in a default title being assigned):
 
 ```
-PATCH /shopping_lists/3
+PATCH /wish_lists/3
 Authorization: Bearer xxxxxxxxxx
 Content-Type: application/json
 {
-  "shopping_list": {
+  "wish_list": {
     "title": null
   }
 }
 ```
 
-Empty `"shopping_list"` object (shopping list will be returned as-is):
+Empty `"wish_list"` object (wish list will be returned as-is):
 
 ```
-PATCH /shopping_lists/3
+PATCH /wish_lists/3
 Authorization: Bearer xxxxxxxxxx
 Content-Type: application/json
 {
-  "shopping_list": {}
+  "wish_list": {}
 }
 ```
 
@@ -335,11 +335,11 @@ Content-Type: application/json
 Normal usage:
 
 ```
-PUT /shopping_lists/3
+PUT /wish_lists/3
 Authorization: Bearer xxxxxxxxxx
 Content-Type: application/json
 {
-  "shopping_list": {
+  "wish_list": {
     "title": "New List Title"
   }
 }
@@ -348,24 +348,24 @@ Content-Type: application/json
 Null title (will result in a default title being assigned):
 
 ```
-PUT /shopping_lists/3
+PUT /wish_lists/3
 Authorization: Bearer xxxxxxxxxx
 Content-Type: application/json
 {
-  "shopping_list": {
+  "wish_list": {
     "title": null
   }
 }
 ```
 
-Empty `"shopping_list"` object (shopping list will be returned as-is):
+Empty `"wish_list"` object (wish list will be returned as-is):
 
 ```
-PUT /shopping_lists/3
+PUT /wish_lists/3
 Authorization: Bearer xxxxxxxxxx
 Content-Type: application/json
 {
-  "shopping_list": {}
+  "wish_list": {}
 }
 ```
 
@@ -426,7 +426,7 @@ For a 405 response due to attempting to update an aggregate list or convert a re
 
 ```json
 {
-  "errors": ["Cannot manually update an aggregate shopping list"]
+  "errors": ["Cannot manually update an aggregate wish list"]
 }
 ```
 
@@ -438,14 +438,14 @@ A 500 error response, which is always a result of an unforeseen problem, include
 }
 ```
 
-## DELETE /shopping_lists/:id
+## DELETE /wish_lists/:id
 
-Destroys the given shopping list, and any shopping list items on it, if it exists and belongs to the authenticated user. If the list to be destroyed is the user's only regular (non-aggregate) shopping list, the aggregate list will also be destroyed. The body of a successful response includes an array of deleted list IDs and the updated aggregate list (unless it was also deleted).
+Destroys the given wish list, and any wish list items on it, if it exists and belongs to the authenticated user. If the list to be destroyed is the user's only regular (non-aggregate) wish list, the aggregate list will also be destroyed. The body of a successful response includes an array of deleted list IDs and the updated aggregate list (unless it was also deleted).
 
 ### Example Request
 
 ```
-DELETE /shopping_lists/428
+DELETE /wish_lists/428
 Authorization: Bearer xxxxxxxxxxxx
 ```
 
@@ -457,7 +457,7 @@ Authorization: Bearer xxxxxxxxxxxx
 
 #### Example Bodies
 
-The response body will be a JSON object with a `"deleted"` key pointing to an array of deleted lists. If only the target list was destroyed, this array will include one member. If the target list was the game's last regular shopping list and the aggregate list was therefore also destroyed, the array will include two members. If the aggregate list was not destroyed, it will be returned as well, with its updated list items, under the `"aggregate"` key.
+The response body will be a JSON object with a `"deleted"` key pointing to an array of deleted lists. If only the target list was destroyed, this array will include one member. If the target list was the game's last regular wish list and the aggregate list was therefore also destroyed, the array will include two members. If the aggregate list was not destroyed, it will be returned as well, with its updated list items, under the `"aggregate"` key.
 
 Body including an aggregate list that was not destroyed:
 
@@ -514,7 +514,7 @@ For a 405 response:
 
 ```json
 {
-  "errors": ["Cannot manually delete an aggregate shopping list"]
+  "errors": ["Cannot manually delete an aggregate wish list"]
 }
 ```
 

--- a/docs/canonical_models/canonical-property.md
+++ b/docs/canonical_models/canonical-property.md
@@ -44,6 +44,6 @@ Each homestead also has one outdoor element unique to it:
 Properties are different from other types of "items" in SIM in two ways:
 
 1. Each property is also a location (often with sublocations)
-2. Properties are an organising element in SIM - users will be able to associate inventory and shopping lists with specific properties
+2. Properties are an organising element in SIM - users will be able to associate inventory and wish lists with specific properties
 
 The implications of both of these factors are being uncovered as we continue building out the back end.

--- a/docs/controller-services.md
+++ b/docs/controller-services.md
@@ -26,7 +26,7 @@ Existing result classes are:
 An example of their use might be (inside a controller service's `#perform` method):
 ```ruby
 def perform
-  return Service::NotFoundResult.new(errors: ['Could not find shopping list']) unless shopping_list.present?
+  return Service::NotFoundResult.new(errors: ['Could not find wish list']) unless wish_list.present?
 end
 ```
 
@@ -35,16 +35,16 @@ end
 The `Controller::Response` object lives in the `/lib/controller` directory. The response takes a controller and a result object as an argument and makes the response indicated in the result object using the controller passed in. This usually happens in the controller itself:
 
 ```ruby
-# /app/controllers/shopping_lists_controller.rb
+# /app/controllers/wish_lists_controller.rb
 
 require 'controller/response'
 
-class ShoppingListsController < ApplicationController
+class WishListsController < ApplicationController
   def create
     # The CreateService needs to know who to create a list for and what
     # params to do it with. If successful, it will return a
     # Service::CreatedResponse object.
-    result = CreateService.new(current_user, shopping_list_params).perform
+    result = CreateService.new(current_user, wish_list_params).perform
 
     # Renders the right JSON response and status code
     response = ::Controller::Response.new(self, result).execute

--- a/spec/controller_services/wish_list_items_controller/create_service_spec.rb
+++ b/spec/controller_services/wish_list_items_controller/create_service_spec.rb
@@ -7,7 +7,7 @@ require 'service/not_found_result'
 require 'service/method_not_allowed_result'
 require 'service/internal_server_error_result'
 
-RSpec.describe ShoppingListItemsController::CreateService do
+RSpec.describe WishListItemsController::CreateService do
   describe '#perform' do
     subject(:perform) { described_class.new(user, wish_list.id, params).perform }
 

--- a/spec/controller_services/wish_list_items_controller/destroy_service_spec.rb
+++ b/spec/controller_services/wish_list_items_controller/destroy_service_spec.rb
@@ -6,7 +6,7 @@ require 'service/not_found_result'
 require 'service/method_not_allowed_result'
 require 'service/internal_server_error_result'
 
-RSpec.describe ShoppingListItemsController::DestroyService do
+RSpec.describe WishListItemsController::DestroyService do
   describe '#perform' do
     subject(:perform) { described_class.new(user, list_item.id).perform }
 

--- a/spec/controller_services/wish_list_items_controller/update_service_spec.rb
+++ b/spec/controller_services/wish_list_items_controller/update_service_spec.rb
@@ -7,7 +7,7 @@ require 'service/unprocessable_entity_result'
 require 'service/method_not_allowed_result'
 require 'service/internal_server_error_result'
 
-RSpec.describe ShoppingListItemsController::UpdateService do
+RSpec.describe WishListItemsController::UpdateService do
   describe '#perform' do
     subject(:perform) { described_class.new(user, list_item.id, params).perform }
 

--- a/spec/controller_services/wish_lists_controller/create_service_spec.rb
+++ b/spec/controller_services/wish_lists_controller/create_service_spec.rb
@@ -6,7 +6,7 @@ require 'service/not_found_result'
 require 'service/unprocessable_entity_result'
 require 'service/internal_server_error_result'
 
-RSpec.describe ShoppingListsController::CreateService do
+RSpec.describe WishListsController::CreateService do
   describe '#perform' do
     subject(:perform) { described_class.new(user, game.id, params).perform }
 

--- a/spec/controller_services/wish_lists_controller/destroy_service_spec.rb
+++ b/spec/controller_services/wish_lists_controller/destroy_service_spec.rb
@@ -5,7 +5,7 @@ require 'service/method_not_allowed_result'
 require 'service/not_found_result'
 require 'service/ok_result'
 
-RSpec.describe ShoppingListsController::DestroyService do
+RSpec.describe WishListsController::DestroyService do
   describe '#perform' do
     subject(:perform) { described_class.new(user, wish_list.id).perform }
 

--- a/spec/controller_services/wish_lists_controller/index_service_spec.rb
+++ b/spec/controller_services/wish_lists_controller/index_service_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 require 'service/ok_result'
 require 'service/not_found_result'
 
-RSpec.describe ShoppingListsController::IndexService do
+RSpec.describe WishListsController::IndexService do
   describe '#perform' do
     subject(:perform) { described_class.new(user, game_id).perform }
 

--- a/spec/controller_services/wish_lists_controller/update_service_spec.rb
+++ b/spec/controller_services/wish_lists_controller/update_service_spec.rb
@@ -7,7 +7,7 @@ require 'service/not_found_result'
 require 'service/unprocessable_entity_result'
 require 'service/internal_server_error_result'
 
-RSpec.describe ShoppingListsController::UpdateService do
+RSpec.describe WishListsController::UpdateService do
   describe '#perform' do
     subject(:perform) { described_class.new(user, wish_list.id, params).perform }
 

--- a/spec/lib/controller/response_spec.rb
+++ b/spec/lib/controller/response_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Controller::Response do
     subject(:execute) { described_class.new(controller, result, options).execute }
 
     context 'when the result has no resource and the errors are empty' do
-      let(:controller) { instance_double(ShoppingListsController, head: nil) }
+      let(:controller) { instance_double(WishListsController, head: nil) }
       let(:options) { {} }
       let(:result) { Service::NoContentResult.new(resource: nil, errors: []) }
 
@@ -23,7 +23,7 @@ RSpec.describe Controller::Response do
     end
 
     context 'when the resource is present but empty' do
-      let(:controller) { instance_double(ShoppingListsController, render: nil) }
+      let(:controller) { instance_double(WishListsController, render: nil) }
       let(:options) { {} }
       let(:result) { Service::OKResult.new(resource: []) }
 
@@ -34,7 +34,7 @@ RSpec.describe Controller::Response do
     end
 
     context 'when there is a resource' do
-      let(:controller) { instance_double(ShoppingListsController, render: nil) }
+      let(:controller) { instance_double(WishListsController, render: nil) }
       let(:options) { {} }
       let(:result) { Service::OKResult.new(resource:) }
 
@@ -55,7 +55,7 @@ RSpec.describe Controller::Response do
     end
 
     context 'when there are errors' do
-      let(:controller) { instance_double(ShoppingListsController, render: nil) }
+      let(:controller) { instance_double(WishListsController, render: nil) }
       let(:errors) { ['Cannot manually update an aggregate wish list'] }
       let(:options) { {} }
       let(:result) { Service::MethodNotAllowedResult.new(errors:) }
@@ -68,7 +68,7 @@ RSpec.describe Controller::Response do
 
     describe 'unexpected cases' do
       context 'when there is a resource and errors' do
-        let(:controller) { instance_double(ShoppingListsController, render: nil) }
+        let(:controller) { instance_double(WishListsController, render: nil) }
         let(:options) { {} }
         let(:errors) { ['Title is already taken', 'Cannot manually create or update an aggregate wish list'] }
         let(:result) { Service::UnprocessableEntityResult.new(errors:, resource: { foo: 'bar' }) }

--- a/spec/requests/wish_list_items_spec.rb
+++ b/spec/requests/wish_list_items_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'ShoppingListItems', type: :request do
+RSpec.describe 'WishListItems', type: :request do
   let(:headers) do
     {
       'Content-Type' => 'application/json',
@@ -10,9 +10,9 @@ RSpec.describe 'ShoppingListItems', type: :request do
     }
   end
 
-  describe 'POST /shopping_lists/:shopping_list_id/shopping_list_items' do
+  describe 'POST /wish_lists/:wish_list_id/wish_list_items' do
     subject(:create_item) do
-      post "/shopping_lists/#{wish_list.id}/shopping_list_items", params:, headers:
+      post "/wish_lists/#{wish_list.id}/wish_list_items", params:, headers:
     end
 
     let!(:user) { create(:authenticated_user) }
@@ -26,7 +26,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
       end
 
       context 'when all goes well' do
-        let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 5, notes: 'To make locks' } }.to_json }
+        let(:params) { { wish_list_item: { description: 'Corundum ingot', quantity: 5, notes: 'To make locks' } }.to_json }
 
         context 'when there is no existing matching item on the same list' do
           context 'when there is no existing matching item on any list' do
@@ -53,7 +53,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
             end
 
             context 'when unit weight is set' do
-              let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 5, notes: 'To make locks' } }.to_json }
+              let(:params) { { wish_list_item: { description: 'Corundum ingot', quantity: 5, notes: 'To make locks' } }.to_json }
 
               it 'creates a new item on the requested list' do
                 expect { create_item }
@@ -90,7 +90,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
             end
 
             context "when unit weight isn't set" do
-              let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 5 } }.to_json }
+              let(:params) { { wish_list_item: { description: 'Corundum ingot', quantity: 5 } }.to_json }
 
               it 'creates a new item on the requested list' do
                 expect { create_item }
@@ -114,7 +114,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
             end
 
             context 'when unit weight is set' do
-              let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 5, unit_weight: 1 } }.to_json }
+              let(:params) { { wish_list_item: { description: 'Corundum ingot', quantity: 5, unit_weight: 1 } }.to_json }
 
               it 'creates a new item on the requested list' do
                 expect { create_item }
@@ -193,7 +193,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
           end
 
           context 'when unit weight is updated' do
-            let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 2, unit_weight: 1 } }.to_json }
+            let(:params) { { wish_list_item: { description: 'Corundum ingot', quantity: 2, unit_weight: 1 } }.to_json }
 
             it "doesn't create a new list item" do
               expect { create_item }
@@ -272,7 +272,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
       end
 
       context 'when the params are invalid' do
-        let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: -2 } }.to_json }
+        let(:params) { { wish_list_item: { description: 'Corundum ingot', quantity: -2 } }.to_json }
 
         it "doesn't create the item" do
           expect { create_item }
@@ -292,7 +292,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
       context 'when the list is an aggregate list' do
         let(:wish_list) { aggregate_list }
-        let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 4 } }.to_json }
+        let(:params) { { wish_list_item: { description: 'Corundum ingot', quantity: 4 } }.to_json }
 
         it "doesn't create an item" do
           expect { create_item }
@@ -312,7 +312,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
       end
 
       context 'when something unexpected goes wrong' do
-        let(:params) { { shopping_list_item: { description: 'Corundum ingot', quantity: 4 } }.to_json }
+        let(:params) { { wish_list_item: { description: 'Corundum ingot', quantity: 4 } }.to_json }
 
         before do
           allow(WishList)
@@ -333,7 +333,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
     end
 
     context 'when unauthenticated' do
-      let(:params) { { shopping_list_item: { description: 'Dwarven Metal Ingot', quantity: 1 } } }
+      let(:params) { { wish_list_item: { description: 'Dwarven Metal Ingot', quantity: 1 } } }
 
       before do
         stub_unsuccessful_login
@@ -356,8 +356,8 @@ RSpec.describe 'ShoppingListItems', type: :request do
     end
   end
 
-  describe 'PATCH /shopping_list_items/:id' do
-    subject(:update_item) { patch "/shopping_list_items/#{list_item.id}", headers:, params: }
+  describe 'PATCH /wish_list_items/:id' do
+    subject(:update_item) { patch "/wish_list_items/#{list_item.id}", headers:, params: }
 
     let!(:user) { create(:authenticated_user) }
     let(:game) { create(:game, user:) }
@@ -373,7 +373,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
         context 'when there is no matching item on another list' do
           let!(:list_item) { create(:wish_list_item, list: wish_list, description: 'Dwarven metal ingot', quantity: 5) }
           let(:aggregate_list_item) { aggregate_list.list_items.first }
-          let(:params) { { shopping_list_item: { description: 'Dwarven metal ingot', quantity: 10 } }.to_json }
+          let(:params) { { wish_list_item: { description: 'Dwarven metal ingot', quantity: 10 } }.to_json }
 
           before do
             aggregate_list.add_item_from_child_list(list_item)
@@ -436,7 +436,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
           end
 
           context 'when unit_weight is not changed' do
-            let(:params) { { shopping_list_item: { quantity: 10 } }.to_json }
+            let(:params) { { wish_list_item: { quantity: 10 } }.to_json }
 
             it 'updates the list item' do
               update_item
@@ -484,7 +484,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
           end
 
           context 'when unit_weight is changed' do
-            let(:params) { { shopping_list_item: { quantity: 10, unit_weight: 2 } }.to_json }
+            let(:params) { { wish_list_item: { quantity: 10, unit_weight: 2 } }.to_json }
 
             it 'updates the list item', :aggregate_failures do
               update_item
@@ -548,7 +548,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
           end
 
           context 'when unit_weight is set to nil' do
-            let(:params) { { shopping_list_item: { quantity: 10, unit_weight: nil } }.to_json }
+            let(:params) { { wish_list_item: { quantity: 10, unit_weight: nil } }.to_json }
 
             it 'updates the list item', :aggregate_failures do
               update_item
@@ -650,7 +650,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
       context 'when the list item is on an aggregate list' do
         let!(:list_item) { create(:wish_list_item, list: aggregate_list) }
-        let(:params) { { shopping_list_item: { quantity: 10 } }.to_json }
+        let(:params) { { wish_list_item: { quantity: 10 } }.to_json }
 
         it 'returns status 405' do
           update_item
@@ -668,7 +668,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
         let(:other_list) { create(:wish_list, game:) }
         let!(:other_item) { create(:wish_list_item, list: other_list, description: list_item.description, quantity: 1) }
         let(:aggregate_list_item) { aggregate_list.list_items.first }
-        let(:params) { { shopping_list_item: { quantity: -4, unit_weight: 2 } }.to_json }
+        let(:params) { { wish_list_item: { quantity: -4, unit_weight: 2 } }.to_json }
 
         before do
           aggregate_list.add_item_from_child_list(list_item)
@@ -722,7 +722,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
     context 'when unauthenticated' do
       let!(:list_item) { create(:wish_list_item, list: wish_list) }
-      let(:params) { { shopping_list_item: { quantity: 16 } } }
+      let(:params) { { wish_list_item: { quantity: 16 } } }
 
       before do
         stub_unsuccessful_login
@@ -745,8 +745,8 @@ RSpec.describe 'ShoppingListItems', type: :request do
     end
   end
 
-  describe 'PUT /shopping_list_items/:id' do
-    subject(:update_item) { put "/shopping_list_items/#{list_item.id}", headers:, params: }
+  describe 'PUT /wish_list_items/:id' do
+    subject(:update_item) { put "/wish_list_items/#{list_item.id}", headers:, params: }
 
     let!(:user) { create(:authenticated_user) }
     let(:game) { create(:game, user:) }
@@ -762,7 +762,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
         context 'when there is no matching item on another list' do
           let!(:list_item) { create(:wish_list_item, list: wish_list, description: 'Dwarven metal ingot', quantity: 5) }
           let(:aggregate_list_item) { aggregate_list.list_items.first }
-          let(:params) { { shopping_list_item: { description: 'Dwarven metal ingot', quantity: 10 } }.to_json }
+          let(:params) { { wish_list_item: { description: 'Dwarven metal ingot', quantity: 10 } }.to_json }
 
           before do
             aggregate_list.add_item_from_child_list(list_item)
@@ -825,7 +825,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
           end
 
           context 'when unit_weight is not changed' do
-            let(:params) { { shopping_list_item: { quantity: 10 } }.to_json }
+            let(:params) { { wish_list_item: { quantity: 10 } }.to_json }
 
             it 'updates the list item' do
               update_item
@@ -873,7 +873,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
           end
 
           context 'when unit_weight is changed' do
-            let(:params) { { shopping_list_item: { quantity: 10, unit_weight: 2 } }.to_json }
+            let(:params) { { wish_list_item: { quantity: 10, unit_weight: 2 } }.to_json }
 
             it 'updates the list item', :aggregate_failures do
               update_item
@@ -937,7 +937,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
           end
 
           context 'when unit_weight is set to nil' do
-            let(:params) { { shopping_list_item: { quantity: 10, unit_weight: nil } }.to_json }
+            let(:params) { { wish_list_item: { quantity: 10, unit_weight: nil } }.to_json }
 
             it 'updates the list item', :aggregate_failures do
               update_item
@@ -1039,7 +1039,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
       context 'when the list item is on an aggregate list' do
         let!(:list_item) { create(:wish_list_item, list: aggregate_list) }
-        let(:params) { { shopping_list_item: { quantity: 10 } }.to_json }
+        let(:params) { { wish_list_item: { quantity: 10 } }.to_json }
 
         it 'returns status 405' do
           update_item
@@ -1057,7 +1057,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
         let(:other_list) { create(:wish_list, game:) }
         let!(:other_item) { create(:wish_list_item, list: other_list, description: list_item.description, quantity: 1) }
         let(:aggregate_list_item) { aggregate_list.list_items.first }
-        let(:params) { { shopping_list_item: { quantity: -4, unit_weight: 2 } }.to_json }
+        let(:params) { { wish_list_item: { quantity: -4, unit_weight: 2 } }.to_json }
 
         before do
           aggregate_list.add_item_from_child_list(list_item)
@@ -1111,7 +1111,7 @@ RSpec.describe 'ShoppingListItems', type: :request do
 
     context 'when unauthenticated' do
       let!(:list_item) { create(:wish_list_item, list: wish_list) }
-      let(:params) { { shopping_list_item: { quantity: 16 } } }
+      let(:params) { { wish_list_item: { quantity: 16 } } }
 
       before do
         stub_unsuccessful_login
@@ -1134,8 +1134,8 @@ RSpec.describe 'ShoppingListItems', type: :request do
     end
   end
 
-  describe 'DELETE /shopping_list_items/:id' do
-    subject(:destroy_item) { delete "/shopping_list_items/#{list_item.id}", headers: }
+  describe 'DELETE /wish_list_items/:id' do
+    subject(:destroy_item) { delete "/wish_list_items/#{list_item.id}", headers: }
 
     context 'when authenticated' do
       let!(:user) { create(:authenticated_user) }

--- a/spec/requests/wish_lists_spec.rb
+++ b/spec/requests/wish_lists_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'ShoppingLists', type: :request do
+RSpec.describe 'WishLists', type: :request do
   let(:headers) do
     {
       'Content-Type' => 'application/json',
@@ -10,8 +10,8 @@ RSpec.describe 'ShoppingLists', type: :request do
     }
   end
 
-  describe 'POST games/:game_id/shopping_lists' do
-    subject(:create_wish_list) { post "/games/#{game.id}/shopping_lists", params: { shopping_list: {} }.to_json, headers: }
+  describe 'POST games/:game_id/wish_lists' do
+    subject(:create_wish_list) { post "/games/#{game.id}/wish_lists", params: { wish_list: {} }.to_json, headers: }
 
     context 'when authenticated' do
       let!(:user) { create(:authenticated_user) }
@@ -62,7 +62,7 @@ RSpec.describe 'ShoppingLists', type: :request do
         end
 
         context 'when the request does not include a body' do
-          subject(:create_wish_list) { post "/games/#{game.id}/shopping_lists", headers: }
+          subject(:create_wish_list) { post "/games/#{game.id}/wish_lists", headers: }
 
           before do
             # let's not have this request create an aggregate list too
@@ -116,9 +116,9 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       context 'when the params are invalid' do
         subject(:create_wish_list) do
-          post "/games/#{game.id}/shopping_lists",
+          post "/games/#{game.id}/wish_lists",
                params: {
-                 shopping_list: { title: existing_list.title },
+                 wish_list: { title: existing_list.title },
                }.to_json,
                headers:
         end
@@ -139,9 +139,9 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       context 'when the client attempts to create an aggregate list' do
         subject(:create_wish_list) do
-          post "/games/#{game.id}/shopping_lists",
+          post "/games/#{game.id}/wish_lists",
                params: {
-                 shopping_list: { aggregate: true },
+                 wish_list: { aggregate: true },
                }.to_json,
                headers:
         end
@@ -189,10 +189,10 @@ RSpec.describe 'ShoppingLists', type: :request do
     end
   end
 
-  describe 'PUT /shopping_lists/:id' do
-    subject(:update_wish_list) { put "/shopping_lists/#{list_id}", params:, headers: }
+  describe 'PUT /wish_lists/:id' do
+    subject(:update_wish_list) { put "/wish_lists/#{list_id}", params:, headers: }
 
-    let(:params) { { shopping_list: { title: 'Severin Manor' } }.to_json }
+    let(:params) { { wish_list: { title: 'Severin Manor' } }.to_json }
 
     context 'when authenticated' do
       let!(:user) { create(:authenticated_user) }
@@ -227,7 +227,7 @@ RSpec.describe 'ShoppingLists', type: :request do
         end
 
         context 'when the params include a null title' do
-          let(:params) { { shopping_list: { title: nil } }.to_json }
+          let(:params) { { wish_list: { title: nil } }.to_json }
 
           it 'sets a default title' do
             update_wish_list
@@ -248,8 +248,8 @@ RSpec.describe 'ShoppingLists', type: :request do
           end
         end
 
-        context 'when the "shopping_list" param is empty"' do
-          let(:params) { { shopping_list: {} }.to_json }
+        context 'when the "wish_list" param is empty"' do
+          let(:params) { { wish_list: {} }.to_json }
 
           it "doesn't change the attributes" do
             expect { update_wish_list }
@@ -295,9 +295,9 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       context 'when the params are invalid' do
         subject(:update_wish_list) do
-          put "/shopping_lists/#{list_id}",
+          put "/wish_lists/#{list_id}",
               params: {
-                shopping_list: { title: other_list.title },
+                wish_list: { title: other_list.title },
               }.to_json,
               headers:
         end
@@ -354,9 +354,9 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       context 'when the client attempts to update an aggregate list' do
         subject(:update_wish_list) do
-          put "/shopping_lists/#{wish_list.id}",
+          put "/wish_lists/#{wish_list.id}",
               params: {
-                shopping_list: { title: 'Foo' },
+                wish_list: { title: 'Foo' },
               }.to_json,
               headers:
         end
@@ -382,9 +382,9 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       context 'when the client attempts to change a regular list to an aggregate list' do
         subject(:update_wish_list) do
-          put "/shopping_lists/#{wish_list.id}",
+          put "/wish_lists/#{wish_list.id}",
               params: {
-                shopping_list: { aggregate: true },
+                wish_list: { aggregate: true },
               }.to_json,
               headers:
         end
@@ -410,9 +410,9 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       context 'when something unexpected goes wrong' do
         subject(:update_wish_list) do
-          put "/shopping_lists/#{wish_list.id}",
+          put "/wish_lists/#{wish_list.id}",
               params: {
-                shopping_list: { title: 'Some New Title' },
+                wish_list: { title: 'Some New Title' },
               }.to_json,
               headers:
         end
@@ -463,10 +463,10 @@ RSpec.describe 'ShoppingLists', type: :request do
     end
   end
 
-  describe 'PATCH /shopping_lists/:id' do
-    subject(:update_wish_list) { patch "/shopping_lists/#{list_id}", params:, headers: }
+  describe 'PATCH /wish_lists/:id' do
+    subject(:update_wish_list) { patch "/wish_lists/#{list_id}", params:, headers: }
 
-    let(:params) { { shopping_list: { title: 'Severin Manor' } }.to_json }
+    let(:params) { { wish_list: { title: 'Severin Manor' } }.to_json }
 
     context 'when authenticated' do
       let!(:user) { create(:authenticated_user) }
@@ -501,7 +501,7 @@ RSpec.describe 'ShoppingLists', type: :request do
         end
 
         context 'when the params include a null title' do
-          let(:params) { { shopping_list: { title: nil } }.to_json }
+          let(:params) { { wish_list: { title: nil } }.to_json }
 
           it 'sets a default title' do
             update_wish_list
@@ -522,8 +522,8 @@ RSpec.describe 'ShoppingLists', type: :request do
           end
         end
 
-        context 'when the "shopping_list" param is empty"' do
-          let(:params) { { shopping_list: {} }.to_json }
+        context 'when the "wish_list" param is empty"' do
+          let(:params) { { wish_list: {} }.to_json }
 
           it "doesn't change the attributes" do
             expect { update_wish_list }
@@ -569,9 +569,9 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       context 'when the params are invalid' do
         subject(:update_wish_list) do
-          patch "/shopping_lists/#{list_id}",
+          patch "/wish_lists/#{list_id}",
                 params: {
-                  shopping_list: { title: other_list.title },
+                  wish_list: { title: other_list.title },
                 }.to_json,
                 headers:
         end
@@ -628,8 +628,8 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       context 'when the client attempts to update an aggregate list' do
         subject(:update_wish_list) do
-          patch "/shopping_lists/#{wish_list.id}",
-                params: { shopping_list: { title: 'Foo' } }.to_json,
+          patch "/wish_lists/#{wish_list.id}",
+                params: { wish_list: { title: 'Foo' } }.to_json,
                 headers:
         end
 
@@ -654,8 +654,8 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       context 'when the client attempts to change a regular list to an aggregate list' do
         subject(:update_wish_list) do
-          patch "/shopping_lists/#{wish_list.id}",
-                params: { shopping_list: { aggregate: true } }.to_json,
+          patch "/wish_lists/#{wish_list.id}",
+                params: { wish_list: { aggregate: true } }.to_json,
                 headers:
         end
 
@@ -680,8 +680,8 @@ RSpec.describe 'ShoppingLists', type: :request do
 
       context 'when something unexpected goes wrong' do
         subject(:update_wish_list) do
-          patch "/shopping_lists/#{wish_list.id}",
-                params: { shopping_list: { title: 'Some New Title' } }.to_json,
+          patch "/wish_lists/#{wish_list.id}",
+                params: { wish_list: { title: 'Some New Title' } }.to_json,
                 headers:
         end
 
@@ -731,8 +731,8 @@ RSpec.describe 'ShoppingLists', type: :request do
     end
   end
 
-  describe 'GET games/:game_id/shopping_lists' do
-    subject(:get_index) { get "/games/#{game.id}/shopping_lists", headers: }
+  describe 'GET games/:game_id/wish_lists' do
+    subject(:get_index) { get "/games/#{game.id}/wish_lists", headers: }
 
     context 'when authenticated' do
       let!(:user) { create(:authenticated_user) }
@@ -817,8 +817,8 @@ RSpec.describe 'ShoppingLists', type: :request do
     end
   end
 
-  describe 'DELETE /shopping_lists/:id' do
-    subject(:delete_wish_list) { delete "/shopping_lists/#{wish_list.id}", headers: }
+  describe 'DELETE /wish_lists/:id' do
+    subject(:delete_wish_list) { delete "/wish_lists/#{wish_list.id}", headers: }
 
     context 'when authenticated' do
       let!(:user) { create(:authenticated_user) }


### PR DESCRIPTION
## Context

[**Rename ShoppingListsController and endpoints**](https://trello.com/c/IhFZ9p1P/356-rename-shoppinglistscontroller-and-endpoints)

This PR corresponds to danascheider/skyrim_inventory_management_frontend#246 and the two PRs will need to be merged and deployed at the same time.

We are renaming `ShoppingList`/`ShoppingListItem` models to `WishList`/`WishListItem`. The final step of this migration is to update the API itself. This PR updates routes and controllers and removes any other references to "shopping" lists or list items in the code, comments, tests, and docs.

## Changes

* Rename `ShoppingListsController` to `WishListsController`
* Rename `ShoppingListItemsController` to `WishListItemsController`
* Rename routes to point to correct controllers
* Update tests to reflect new names
* Update API and other miscellaneous docs to remove references to shopping lists or shopping list items

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate

## Considerations

These changes have been tested manually in a local environment according to the manual test cases set out in the linked front-end PR. There were no issues with local testing.
