### PR TITLE
Remove dotenv as a dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,4 @@ group :development do
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring', '~> 4.1'
-
-  # Load environment variables in dev
-  gem 'dotenv', '~> 3.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,6 @@ GEM
     database_cleaner-core (2.0.1)
     date (3.3.4)
     diff-lcs (1.5.0)
-    dotenv (3.0.2)
     drb (2.2.0)
       ruby2_keywords
     erubi (1.12.0)
@@ -293,7 +292,6 @@ DEPENDENCIES
   bootsnap (~> 1.18)
   byebug (~> 11.1)
   database_cleaner-active_record (~> 2.1)
-  dotenv (~> 3.0)
   factory_bot_rails (~> 6.4.3)
   faraday (~> 2.9.0)
   listen (~> 3.7)


### PR DESCRIPTION
## Context

[**Remove dotenv as a dependency**](https://trello.com/c/OgmO7fZD/367-remove-dotenv-as-a-dependency)

Initially, we used the [`dotenv` gem](https://rubygems.org/gems/dotenv/versions/2.1.1) and Configatron to get config from environment variables, specifically the Google API key for Google login. Now, this is handled through the `credentials.yml` file, so we don't need environment variables and are no longer using `dotenv`. This PR removes it from the `Gemfile` and `Gemfile.lock`.

## Changes

* Remove dotenv as a dependency

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~

## Considerations

Explain any design or implementation decisions you've made here, as well as any alternatives you considered or tried. Justify your approach. Include links to any blog posts, documentation, or other materials readers may find useful to understand your implementation or the alternatives.
