### PR TITLE
Fix environment variable access in CORS initializer

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -38,5 +38,9 @@ module SkyrimInventoryManagement
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+
+    # Set the CORS client origin to either the `CLIENT_ORIGIN` specified in
+    # environment variables (for prod environments) or localhost (for dev).
+    config.cors_client_origin = ENV['CLIENT_ORIGIN'].presence || 'http://localhost:5173'
   end
 end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -9,7 +9,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins ENV['CLIENT_ORIGIN'].presence || 'http://localhost:5173'
+    origins Rails.application.config.cors_client_origin
 
     resource '*',
              headers: :any,


### PR DESCRIPTION
## Context

[**Fix environment variable access in CORS config**](https://trello.com/c/htEBnBgR/369-fix-environment-variable-access-in-cors-config)

In #314, Dependabot updates rubocop-rails. Unfortunately, because of the new `Rails/EnvironmentVariableAccess` cop, the PR fails CI due to an environment variable, `CLIENT_ORIGIN`, being directly accessed in the CORS initializer. This is because best practice is to add this value to the Rails config and use that elsewhere in the app. That seemed reasonable, so rather than disabling the cop, we decided to simply fix the issue.

## Changes

* Move environment variable read from CORS initializer to Rails application config

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate
