### PR TITLE
Correct place where skill_name was updated instead of max_quantity

### DIFF
--- a/lib/tasks/canonical_models/canonical_books.json
+++ b/lib/tasks/canonical_models/canonical_books.json
@@ -6354,9 +6354,9 @@
       "authors": [
         "Lyrin Telleno"
       ],
-      "skill_name": 10,
+      "skill_name": null,
       "add_on": "dragonborn",
-      "max_quantity": null,
+      "max_quantity": 10,
       "purchasable": false,
       "collectible": true,
       "unique_item": false,


### PR DESCRIPTION
## Context

[**Add new attributes to all canonical models**](https://trello.com/c/wQbjkOgB/353-add-new-attributes-to-all-canonical-models)

When we updated canonical data for the `Canonical::Book` model, not all the data was valid and it broke when syncing the models in production. This PR fixes broken data.

## Changes

* Correct place where `skill_name` was updated instead of `max_quantity`

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~

## Considerations

This time we have tested syncing in the local environment.
