### PR TITLE
Update Spring to 4.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,5 +60,5 @@ group :development do
   gem 'listen', '~> 3.9'
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
-  gem 'spring', '~> 4.1'
+  gem 'spring', '~> 4.2'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,7 +265,7 @@ GEM
     rubocop-rspec_rails (2.28.3)
       rubocop (~> 1.40)
     ruby-progressbar (1.13.0)
-    spring (4.1.3)
+    spring (4.2.1)
     stringio (3.1.0)
     strscan (3.1.0)
     thor (1.3.1)
@@ -308,7 +308,7 @@ DEPENDENCIES
   rubocop-performance (~> 1.21)
   rubocop-rails (~> 2.24)
   rubocop-rspec (~> 2.29)
-  spring (~> 4.1)
+  spring (~> 4.2)
   timecop (~> 0.9.8)
   webmock (~> 3.23)
 


### PR DESCRIPTION
## Context

In #326, Dependabot tried to update Spring to 4.2.1. However, there was some kind of conflict with the Gemfile.lock

## Changes

* Update Spring gem to 4.2.1
* Bump required Spring version to `"~> 4.2"`

### Required Changes

* [ ] ~~Added and updated RSpec tests as appropriate~~
* [ ] ~~Added and updated API docs and developer docs as appropriate~~