### PR TITLE
Add new attributes to Canonical::MiscItem

### DIFF
--- a/app/models/canonical/book.rb
+++ b/app/models/canonical/book.rb
@@ -118,6 +118,7 @@ module Canonical
 
     def validate_uniqueness
       errors.add(:unique_item, 'must be true if max quantity is 1') if max_quantity == 1 && !unique_item
+      errors.add(:unique_item, 'must correspond to a max quantity of 1') if unique_item == true && max_quantity != 1
       errors.add(:rare_item, 'must be true if item is unique') unless rare_item == true
     end
 

--- a/app/models/canonical/book.rb
+++ b/app/models/canonical/book.rb
@@ -94,7 +94,7 @@ module Canonical
               }
 
     validate :validate_skill_name_presence
-    validate :verify_unique_item_rare, if: -> { unique_item == true }
+    validate :validate_uniqueness, if: -> { unique_item == true || max_quantity == 1 }
 
     before_validation :upcase_item_code, if: :item_code_changed?
 
@@ -116,7 +116,8 @@ module Canonical
       end
     end
 
-    def verify_unique_item_rare
+    def validate_uniqueness
+      errors.add(:unique_item, 'must be true if max quantity is 1') if max_quantity == 1 && !unique_item
       errors.add(:rare_item, 'must be true if item is unique') unless rare_item == true
     end
 

--- a/app/models/canonical/clothing_item.rb
+++ b/app/models/canonical/clothing_item.rb
@@ -76,7 +76,7 @@ module Canonical
                 message: BOOLEAN_VALIDATION_MESSAGE,
               }
 
-    validate :validate_unique_item_also_rare, if: -> { unique_item == true }
+    validate :validate_uniqueness, if: -> { unique_item == true || max_quantity == 1 }
 
     before_validation :upcase_item_code, if: :item_code_changed?
 
@@ -86,7 +86,8 @@ module Canonical
 
     private
 
-    def validate_unique_item_also_rare
+    def validate_uniqueness
+      errors.add(:unique_item, 'must be true if max quantity is 1') if max_quantity == 1 && !unique_item
       errors.add(:rare_item, 'must be true if item is unique') unless rare_item == true
     end
 

--- a/app/models/canonical/clothing_item.rb
+++ b/app/models/canonical/clothing_item.rb
@@ -88,6 +88,7 @@ module Canonical
 
     def validate_uniqueness
       errors.add(:unique_item, 'must be true if max quantity is 1') if max_quantity == 1 && !unique_item
+      errors.add(:unique_item, 'must correspond to a max quantity of 1') if unique_item == true && max_quantity != 1
       errors.add(:rare_item, 'must be true if item is unique') unless rare_item == true
     end
 

--- a/app/models/canonical/ingredient.rb
+++ b/app/models/canonical/ingredient.rb
@@ -112,6 +112,7 @@ module Canonical
 
     def validate_uniqueness
       errors.add(:unique_item, 'must be true if max quantity is 1') if max_quantity == 1 && !unique_item
+      errors.add(:unique_item, 'must correspond to a max quantity of 1') if unique_item == true && max_quantity != 1
       errors.add(:rare_item, 'must be true if item is unique') unless rare_item == true
     end
 

--- a/app/models/canonical/ingredient.rb
+++ b/app/models/canonical/ingredient.rb
@@ -88,7 +88,7 @@ module Canonical
     validate :validate_ingredient_type_not_set, if: -> { purchasable == false }
     validate :validate_ingredient_type_set, if: -> { purchasable == true }
     validate :validate_purchase_requires_perk
-    validate :validate_unique_item_also_rare, if: -> { unique_item == true }
+    validate :validate_uniqueness, if: -> { unique_item == true || max_quantity == 1 }
 
     before_validation :upcase_item_code, if: :item_code_changed?
 
@@ -110,7 +110,8 @@ module Canonical
       errors.add(:purchase_requires_perk, "can't be set if purchasable is false") if purchasable == false && !purchase_requires_perk.nil?
     end
 
-    def validate_unique_item_also_rare
+    def validate_uniqueness
+      errors.add(:unique_item, 'must be true if max quantity is 1') if max_quantity == 1 && !unique_item
       errors.add(:rare_item, 'must be true if item is unique') unless rare_item == true
     end
 

--- a/app/models/canonical/jewelry_item.rb
+++ b/app/models/canonical/jewelry_item.rb
@@ -91,7 +91,7 @@ module Canonical
                 message: BOOLEAN_VALIDATION_MESSAGE,
               }
 
-    validate :validate_unique_item_also_rare, if: -> { unique_item == true }
+    validate :validate_uniqueness, if: -> { unique_item == true || max_quantity == 1 }
 
     before_validation :upcase_item_code, if: :item_code_changed?
 
@@ -101,7 +101,8 @@ module Canonical
 
     private
 
-    def validate_unique_item_also_rare
+    def validate_uniqueness
+      errors.add(:unique_item, 'must be true if max quantity is 1') if max_quantity == 1 && !unique_item
       errors.add(:rare_item, 'must be true if item is unique') unless rare_item == true
     end
 

--- a/app/models/canonical/jewelry_item.rb
+++ b/app/models/canonical/jewelry_item.rb
@@ -103,6 +103,7 @@ module Canonical
 
     def validate_uniqueness
       errors.add(:unique_item, 'must be true if max quantity is 1') if max_quantity == 1 && !unique_item
+      errors.add(:unique_item, 'must correspond to a max quantity of 1') if unique_item == true && max_quantity != 1
       errors.add(:rare_item, 'must be true if item is unique') unless rare_item == true
     end
 

--- a/app/models/canonical/misc_item.rb
+++ b/app/models/canonical/misc_item.rb
@@ -50,7 +50,7 @@ module Canonical
 
     validate :validate_item_types
     validate :validate_boolean_values
-    validate :verify_unique_item_also_rare, if: -> { unique_item == true }
+    validate :validate_uniqueness
 
     before_validation :upcase_item_code, if: -> { item_code_changed? }
 
@@ -74,8 +74,11 @@ module Canonical
       errors.add(:quest_reward, BOOLEAN_VALIDATION_MESSAGE) unless boolean?(quest_reward)
     end
 
-    def verify_unique_item_also_rare
-      errors.add(:rare_item, 'must be true if item is unique') unless rare_item == true
+    def validate_uniqueness
+      return if unique_item == false && (max_quantity.nil? || max_quantity > 1)
+
+      errors.add(:unique_item, 'must be true if max quantity is 1') if unique_item == false && max_quantity == 1
+      errors.add(:rare_item, 'must be true if item is unique') if unique_item == true && !rare_item
     end
 
     def upcase_item_code

--- a/app/models/canonical/misc_item.rb
+++ b/app/models/canonical/misc_item.rb
@@ -34,6 +34,19 @@ module Canonical
               presence: true,
               numericality: { greater_than_or_equal_to: 0 }
     validates :item_types, presence: true
+    validates :add_on,
+              presence: true,
+              inclusion: {
+                in: SUPPORTED_ADD_ONS,
+                message: UNSUPPORTED_ADD_ON_MESSAGE,
+              }
+    validates :max_quantity,
+              numericality: {
+                greater_than_or_equal_to: 1,
+                only_integer: true,
+                message: 'must be an integer of at least 1',
+                allow_nil: true,
+              }
 
     validate :validate_item_types
     validate :validate_boolean_values
@@ -53,10 +66,12 @@ module Canonical
     end
 
     def validate_boolean_values
+      errors.add(:collectible, BOOLEAN_VALIDATION_MESSAGE) unless boolean?(collectible)
       errors.add(:purchasable, BOOLEAN_VALIDATION_MESSAGE) unless boolean?(purchasable)
       errors.add(:unique_item, BOOLEAN_VALIDATION_MESSAGE) unless boolean?(unique_item)
       errors.add(:rare_item, BOOLEAN_VALIDATION_MESSAGE) unless boolean?(rare_item)
       errors.add(:quest_item, BOOLEAN_VALIDATION_MESSAGE) unless boolean?(quest_item)
+      errors.add(:quest_reward, BOOLEAN_VALIDATION_MESSAGE) unless boolean?(quest_reward)
     end
 
     def verify_unique_item_also_rare

--- a/app/models/canonical/misc_item.rb
+++ b/app/models/canonical/misc_item.rb
@@ -50,7 +50,7 @@ module Canonical
 
     validate :validate_item_types
     validate :validate_boolean_values
-    validate :validate_uniqueness
+    validate :validate_uniqueness, if: -> { unique_item == true || max_quantity == 1 }
 
     before_validation :upcase_item_code, if: -> { item_code_changed? }
 
@@ -75,10 +75,9 @@ module Canonical
     end
 
     def validate_uniqueness
-      return if unique_item == false && (max_quantity.nil? || max_quantity > 1)
-
       errors.add(:unique_item, 'must be true if max quantity is 1') if unique_item == false && max_quantity == 1
-      errors.add(:rare_item, 'must be true if item is unique') if unique_item == true && !rare_item
+      errors.add(:unique_item, 'must correspond to a max quantity of 1') if unique_item == true && max_quantity != 1
+      errors.add(:rare_item, 'must be true if item is unique') unless rare_item == true
     end
 
     def upcase_item_code

--- a/app/models/canonical/potion.rb
+++ b/app/models/canonical/potion.rb
@@ -59,6 +59,7 @@ module Canonical
 
     def validate_uniqueness
       errors.add(:unique_item, 'must be true if max quantity is 1') if max_quantity == 1 && !unique_item
+      errors.add(:unique_item, 'must correspond to max quantity of 1') if unique_item == true && max_quantity != 1
       errors.add(:rare_item, 'must be true if item is unique') unless rare_item == true
     end
 

--- a/app/models/canonical/potion.rb
+++ b/app/models/canonical/potion.rb
@@ -37,7 +37,7 @@ module Canonical
               }
 
     validate :validate_boolean_values
-    validate :validate_unique_item_also_rare, if: -> { unique_item == true }
+    validate :validate_uniqueness, if: -> { unique_item == true || max_quantity == 1 }
 
     before_validation :upcase_item_code, if: :item_code_changed?
 
@@ -57,7 +57,8 @@ module Canonical
       errors.add(:collectible, BOOLEAN_VALIDATION_MESSAGE) unless boolean?(collectible)
     end
 
-    def validate_unique_item_also_rare
+    def validate_uniqueness
+      errors.add(:unique_item, 'must be true if max quantity is 1') if max_quantity == 1 && !unique_item
       errors.add(:rare_item, 'must be true if item is unique') unless rare_item == true
     end
 

--- a/db/migrate/20240602034625_add_new_fields_to_canonical_misc_item.rb
+++ b/db/migrate/20240602034625_add_new_fields_to_canonical_misc_item.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AddNewFieldsToCanonicalMiscItem < ActiveRecord::Migration[7.1]
+  def change
+    add_column :canonical_misc_items,
+               :add_on,
+               :string
+    add_column :canonical_misc_items,
+               :max_quantity,
+               :integer
+    add_column :canonical_misc_items,
+               :collectible,
+               :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_02_003206) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_02_034625) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -197,6 +197,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_02_003206) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "quest_reward", default: false
+    t.string "add_on"
+    t.integer "max_quantity"
+    t.boolean "collectible"
     t.index ["item_code"], name: "index_canonical_misc_items_on_item_code", unique: true
   end
 

--- a/lib/tasks/canonical_models/canonical_misc_items.json
+++ b/lib/tasks/canonical_models/canonical_misc_items.json
@@ -8,6 +8,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "dawnguard",
+      "max_quantity": null,
+      "collectible": true,
       "purchasable": false,
       "unique_item": false,
       "rare_item": true,
@@ -24,6 +27,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "dawnguard",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -40,6 +46,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "dawnguard",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -56,6 +65,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "dawnguard",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -72,6 +84,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "dawnguard",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -88,6 +103,9 @@
         "animal part"
       ],
       "description": null,
+      "add_on": "dragonborn",
+      "max_quantity": null,
+      "collectible": true,
       "purchasable": false,
       "unique_item": false,
       "rare_item": true,
@@ -104,6 +122,9 @@
         "dragon claw"
       ],
       "description": null,
+      "add_on": "dragonborn",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -120,6 +141,9 @@
         "dragon claw"
       ],
       "description": null,
+      "add_on": "dragonborn",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -136,8 +160,11 @@
         "paragon"
       ],
       "description": null,
+      "add_on": "dawnguard",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
-      "unique_item": false,
+      "unique_item": true,
       "rare_item": true,
       "quest_item": true,
       "quest_reward": false
@@ -152,6 +179,9 @@
         "animal part"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": null,
+      "collectible": true,
       "purchasable": false,
       "unique_item": false,
       "rare_item": true,
@@ -168,6 +198,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -184,6 +217,9 @@
         "Dwemer artifact"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 2,
+      "collectible": true,
       "purchasable": false,
       "unique_item": false,
       "rare_item": true,
@@ -200,6 +236,9 @@
         "daedric artifact"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -216,6 +255,9 @@
         "miscellaneous"
       ],
       "description": "Live bee in a jar",
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -232,6 +274,9 @@
         "Dwemer artifact"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -248,6 +293,9 @@
         "animal part"
       ],
       "description": null,
+      "add_on": "dawnguard",
+      "max_quantity": null,
+      "collectible": true,
       "purchasable": false,
       "unique_item": false,
       "rare_item": true,
@@ -264,6 +312,9 @@
         "daedric artifact"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -280,6 +331,9 @@
         "larceny trophy"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -296,6 +350,9 @@
         "miscellaneous"
       ],
       "description": "Live monarch butterfly in a jar",
+      "add_on": "base",
+      "max_quantity": null,
+      "collectible": true,
       "purchasable": false,
       "unique_item": false,
       "rare_item": true,
@@ -312,6 +369,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -328,6 +388,9 @@
         "Dwemer artifact"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": null,
+      "collectible": true,
       "purchasable": false,
       "unique_item": false,
       "rare_item": true,
@@ -337,29 +400,16 @@
   },
   {
     "attributes": {
-      "name": "Charcoal (Chunk)",
-      "item_code": "000BFB09",
-      "unit_weight": 0.5,
-      "item_types": [
-        "miscellaneous"
-      ],
-      "description": null,
-      "purchasable": false,
-      "unique_item": false,
-      "rare_item": true,
-      "quest_item": false,
-      "quest_reward": false
-    }
-  },
-  {
-    "attributes": {
-      "name": "Charcoal (Stick)",
+      "name": "Charcoal",
       "item_code": "00033760",
       "unit_weight": 0.5,
       "item_types": [
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": null,
+      "collectible": true,
       "purchasable": true,
       "unique_item": false,
       "rare_item": false,
@@ -376,6 +426,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "hearthfire",
+      "max_quantity": null,
+      "collectible": true,
       "purchasable": true,
       "unique_item": false,
       "rare_item": false,
@@ -392,6 +445,9 @@
         "dragon claw"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": null,
+      "collectible": true,
       "purchasable": true,
       "unique_item": false,
       "rare_item": true,
@@ -408,6 +464,9 @@
         "larceny trophy"
       ],
       "description": "Crown of Barenziah (no stones)",
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -424,6 +483,9 @@
         "larceny trophy"
       ],
       "description": "Crown of Barenziah (with stones)",
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -440,6 +502,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -456,6 +521,9 @@
         "animal part"
       ],
       "description": null,
+      "add_on": "dragonborn",
+      "max_quantity": null,
+      "collectible": true,
       "purchasable": false,
       "unique_item": false,
       "rare_item": true,
@@ -472,6 +540,9 @@
         "dragon claw"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -488,6 +559,9 @@
         "paragon"
       ],
       "description": null,
+      "add_on": "dawnguard",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -504,25 +578,12 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": null,
+      "collectible": true,
       "purchasable": false,
       "unique_item": false,
       "rare_item": true,
-      "quest_item": false,
-      "quest_reward": false
-    }
-  },
-  {
-    "attributes": {
-      "name": "Do Not Delete",
-      "item_code": "C7316",
-      "unit_weight": 0.5,
-      "item_types": [
-        "miscellaneous"
-      ],
-      "description": null,
-      "purchasable": false,
-      "unique_item": false,
-      "rare_item": false,
       "quest_item": false,
       "quest_reward": false
     }
@@ -536,6 +597,9 @@
         "animal part"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": null,
+      "collectible": true,
       "purchasable": false,
       "unique_item": false,
       "rare_item": true,
@@ -552,6 +616,9 @@
         "miscellaneous"
       ],
       "description": "Live orange dartwing in a jar",
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -568,6 +635,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -584,6 +654,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "dawnguard",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -600,6 +673,9 @@
         "Dwemer artifact"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": null,
+      "collectible": true,
       "purchasable": false,
       "unique_item": false,
       "rare_item": true,
@@ -616,6 +692,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "dawnguard",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -632,6 +711,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "dawnguard",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -648,6 +730,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "dawnguard",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -664,6 +749,9 @@
         "Dwemer artifact"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": null,
+      "collectible": true,
       "purchasable": false,
       "unique_item": false,
       "rare_item": true,
@@ -681,6 +769,9 @@
         "Dwemer artifact"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -698,6 +789,9 @@
         "map"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -714,6 +808,9 @@
         "dragon claw"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -730,6 +827,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -740,12 +840,15 @@
   {
     "attributes": {
       "name": "Emerald Dragon Claw",
-      "item_code": "000ed417",
+      "item_code": "000ED417",
       "unit_weight": 0.5,
       "item_types": [
         "dragon claw"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -762,6 +865,9 @@
         "paragon"
       ],
       "description": null,
+      "add_on": "dawnguard",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -778,6 +884,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": null,
+      "collectible": true,
       "purchasable": false,
       "unique_item": false,
       "rare_item": false,
@@ -794,6 +903,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "dawnguard",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -810,6 +922,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "dawnguard",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -826,6 +941,9 @@
         "Dwemer artifact"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": null,
+      "collectible": true,
       "purchasable": false,
       "unique_item": false,
       "rare_item": true,
@@ -842,6 +960,9 @@
         "gemstone"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": null,
+      "collectible": true,
       "purchasable": false,
       "unique_item": false,
       "rare_item": true,
@@ -858,6 +979,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -874,6 +998,9 @@
         "Dwemer artifact"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -890,6 +1017,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -906,6 +1036,9 @@
         "dragon claw"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -922,6 +1055,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": null,
+      "collectible": true,
       "purchasable": false,
       "unique_item": false,
       "rare_item": true,
@@ -938,6 +1074,9 @@
         "dragon claw"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -954,6 +1093,9 @@
         "larceny trophy"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": null,
+      "collectible": false,
       "purchasable": false,
       "unique_item": false,
       "rare_item": true,
@@ -970,6 +1112,9 @@
         "larceny trophy"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": null,
+      "collectible": false,
       "purchasable": false,
       "unique_item": false,
       "rare_item": true,
@@ -986,6 +1131,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -1002,6 +1150,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "dragonborn",
+      "max_quantity": null,
+      "collectible": true,
       "purchasable": false,
       "unique_item": false,
       "rare_item": false,
@@ -1018,6 +1169,9 @@
         "larceny trophy"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -1034,6 +1188,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -1050,6 +1207,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "dragonborn",
+      "max_quantity": 2,
+      "collectible": true,
       "purchasable": false,
       "unique_item": false,
       "rare_item": true,
@@ -1066,6 +1226,9 @@
         "dragon claw"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -1082,6 +1245,9 @@
         "dragon claw"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -1098,6 +1264,9 @@
         "larceny trophy"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": null,
+      "collectible": false,
       "purchasable": false,
       "unique_item": false,
       "rare_item": true,
@@ -1114,6 +1283,9 @@
         "larceny trophy"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": null,
+      "collectible": false,
       "purchasable": false,
       "unique_item": false,
       "rare_item": true,
@@ -1130,6 +1302,9 @@
         "larceny trophy"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": null,
+      "collectible": false,
       "purchasable": false,
       "unique_item": false,
       "rare_item": true,
@@ -1146,6 +1321,9 @@
         "larceny trophy"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": null,
+      "collectible": false,
       "purchasable": false,
       "unique_item": false,
       "rare_item": true,
@@ -1162,6 +1340,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 5,
+      "collectible": true,
       "purchasable": true,
       "unique_item": false,
       "rare_item": true,
@@ -1178,6 +1359,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -1194,6 +1378,9 @@
         "larceny trophy"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -1210,6 +1397,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": null,
+      "collectible": true,
       "purchasable": true,
       "unique_item": false,
       "rare_item": false,
@@ -1226,6 +1416,9 @@
         "animal part"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": null,
+      "collectible": true,
       "purchasable": false,
       "unique_item": false,
       "rare_item": false,
@@ -1242,6 +1435,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -1258,6 +1454,9 @@
         "book"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -1274,6 +1473,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -1290,6 +1492,9 @@
         "daedric artifact"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -1306,6 +1511,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -1322,6 +1530,9 @@
         "larceny trophy"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -1338,6 +1549,9 @@
         "miscellaneous"
       ],
       "description": "Live luna moth in a jar",
+      "add_on": "base",
+      "max_quantity": null,
+      "collectible": true,
       "purchasable": false,
       "unique_item": false,
       "rare_item": true,
@@ -1354,6 +1568,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -1370,6 +1587,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -1386,6 +1606,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": null,
+      "collectible": false,
       "purchasable": false,
       "unique_item": false,
       "rare_item": true,
@@ -1402,6 +1625,9 @@
         "larceny trophy"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": null,
+      "collectible": false,
       "purchasable": false,
       "unique_item": false,
       "rare_item": true,
@@ -1418,6 +1644,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -1434,6 +1663,9 @@
         "animal part"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -1450,6 +1682,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -1466,6 +1701,9 @@
         "animal part"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -1482,6 +1720,9 @@
         "larceny trophy"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": null,
+      "collectible": true,
       "purchasable": false,
       "unique_item": false,
       "rare_item": true,
@@ -1498,6 +1739,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -1514,6 +1758,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "dawnguard",
+      "max_quantity": null,
+      "collectible": true,
       "purchasable": false,
       "unique_item": false,
       "rare_item": true,
@@ -1530,6 +1777,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -1546,6 +1796,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -1562,6 +1815,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": null,
+      "collectible": true,
       "purchasable": false,
       "unique_item": false,
       "rare_item": true,
@@ -1578,6 +1834,9 @@
         "dragon claw"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -1594,6 +1853,9 @@
         "paragon"
       ],
       "description": null,
+      "add_on": "dawnguard",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -1610,6 +1872,9 @@
         "book"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": null,
+      "collectible": true,
       "purchasable": false,
       "unique_item": false,
       "rare_item": false,
@@ -1626,6 +1891,9 @@
         "Dwemer artifact"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -1642,6 +1910,9 @@
         "key"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -1658,6 +1929,9 @@
         "dragon claw"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -1674,6 +1948,9 @@
         "paragon"
       ],
       "description": null,
+      "add_on": "dawnguard",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -1690,6 +1967,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -1706,6 +1986,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -1722,6 +2005,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": null,
+      "collectible": true,
       "purchasable": false,
       "unique_item": false,
       "rare_item": true,
@@ -1738,6 +2024,9 @@
         "book"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -1754,6 +2043,9 @@
         "animal part"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -1770,6 +2062,9 @@
         "animal part"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": null,
+      "collectible": true,
       "purchasable": true,
       "unique_item": false,
       "rare_item": false,
@@ -1786,6 +2081,9 @@
         "animal part"
       ],
       "description": "Skull covered in carvings",
+      "add_on": "dragonborn",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -1802,6 +2100,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "dragonborn",
+      "max_quantity": null,
+      "collectible": false,
       "purchasable": false,
       "unique_item": false,
       "rare_item": true,
@@ -1818,6 +2119,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -1834,6 +2138,9 @@
         "gemstone"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 24,
+      "collectible": false,
       "purchasable": false,
       "unique_item": false,
       "rare_item": true,
@@ -1850,6 +2157,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -1866,11 +2176,14 @@
         "daedric artifact"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
       "quest_item": true,
-      "quest_reward": false
+      "quest_reward": true
     }
   },
   {
@@ -1882,6 +2195,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -1898,6 +2214,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": null,
+      "collectible": false,
       "purchasable": false,
       "unique_item": false,
       "rare_item": true,
@@ -1914,6 +2233,9 @@
         "key"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -1930,6 +2252,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": null,
+      "collectible": true,
       "purchasable": false,
       "unique_item": false,
       "rare_item": false,
@@ -1946,6 +2271,9 @@
         "miscellaneous"
       ],
       "description": "Live torchbug in a jar",
+      "add_on": "base",
+      "max_quantity": null,
+      "collectible": true,
       "purchasable": false,
       "unique_item": false,
       "rare_item": true,
@@ -1962,6 +2290,9 @@
         "key"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -1978,6 +2309,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -1994,6 +2328,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -2010,6 +2347,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -2026,6 +2366,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -2042,6 +2385,9 @@
         "pelt"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": null,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -2058,6 +2404,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 3,
+      "collectible": true,
       "purchasable": false,
       "unique_item": false,
       "rare_item": true,
@@ -2074,6 +2423,9 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -2090,6 +2442,9 @@
         "Dwemer artifact"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
@@ -2106,6 +2461,9 @@
         "Dwemer artifact"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": null,
+      "collectible": true,
       "purchasable": false,
       "unique_item": false,
       "rare_item": true,

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe Book, type: :model do
         let(:canonical_book) do
           create(
             :canonical_book,
+            max_quantity: 1,
             unique_item: true,
             rare_item: true,
           )

--- a/spec/models/canonical/book_spec.rb
+++ b/spec/models/canonical/book_spec.rb
@@ -153,6 +153,15 @@ RSpec.describe Canonical::Book, type: :model do
 
         expect(book.errors[:unique_item]).to include 'must be true if max quantity is 1'
       end
+
+      it 'must be false if max quantity is not 1' do
+        book.max_quantity = nil
+        book.unique_item = true
+
+        validate
+
+        expect(book.errors[:unique_item]).to include 'must correspond to a max quantity of 1'
+      end
     end
 
     describe 'rare_item' do

--- a/spec/models/canonical/book_spec.rb
+++ b/spec/models/canonical/book_spec.rb
@@ -144,6 +144,15 @@ RSpec.describe Canonical::Book, type: :model do
         validate
         expect(book.errors[:unique_item]).to include 'must be true or false'
       end
+
+      it 'must be true if max quantity is 1' do
+        book.max_quantity = 1
+        book.unique_item = false
+
+        validate
+
+        expect(book.errors[:unique_item]).to include 'must be true if max quantity is 1'
+      end
     end
 
     describe 'rare_item' do

--- a/spec/models/canonical/clothing_item_spec.rb
+++ b/spec/models/canonical/clothing_item_spec.rb
@@ -151,6 +151,15 @@ RSpec.describe Canonical::ClothingItem, type: :model do
 
         expect(model.errors[:unique_item]).to include 'must be true or false'
       end
+
+      it 'must be true if max quantity is 1' do
+        model.max_quantity = 1
+        model.unique_item = false
+
+        validate
+
+        expect(model.errors[:unique_item]).to include 'must be true if max quantity is 1'
+      end
     end
 
     describe 'rare_item' do

--- a/spec/models/canonical/clothing_item_spec.rb
+++ b/spec/models/canonical/clothing_item_spec.rb
@@ -160,6 +160,15 @@ RSpec.describe Canonical::ClothingItem, type: :model do
 
         expect(model.errors[:unique_item]).to include 'must be true if max quantity is 1'
       end
+
+      it 'must be false if max quantity is not 1' do
+        model.max_quantity = nil
+        model.unique_item = true
+
+        validate
+
+        expect(model.errors[:unique_item]).to include 'must correspond to a max quantity of 1'
+      end
     end
 
     describe 'rare_item' do

--- a/spec/models/canonical/ingredient_spec.rb
+++ b/spec/models/canonical/ingredient_spec.rb
@@ -200,6 +200,15 @@ RSpec.describe Canonical::Ingredient, type: :model do
 
         expect(model.errors[:unique_item]).to include 'must be true or false'
       end
+
+      it 'must be true if max quantity is 1' do
+        model.max_quantity = 1
+        model.unique_item = false
+
+        validate
+
+        expect(model.errors[:unique_item]).to include 'must be true if max quantity is 1'
+      end
     end
 
     describe 'rare_item' do

--- a/spec/models/canonical/ingredient_spec.rb
+++ b/spec/models/canonical/ingredient_spec.rb
@@ -209,6 +209,15 @@ RSpec.describe Canonical::Ingredient, type: :model do
 
         expect(model.errors[:unique_item]).to include 'must be true if max quantity is 1'
       end
+
+      it 'must be false if max quantity is not 1' do
+        model.max_quantity = 3
+        model.unique_item = true
+
+        validate
+
+        expect(model.errors[:unique_item]).to include 'must correspond to a max quantity of 1'
+      end
     end
 
     describe 'rare_item' do

--- a/spec/models/canonical/jewelry_item_spec.rb
+++ b/spec/models/canonical/jewelry_item_spec.rb
@@ -151,6 +151,15 @@ RSpec.describe Canonical::JewelryItem, type: :model do
 
         expect(model.errors[:unique_item]).to include 'must be true if max quantity is 1'
       end
+
+      it 'must be false if max quantity is not 1' do
+        model.max_quantity = 3
+        model.unique_item = true
+
+        validate
+
+        expect(model.errors[:unique_item]).to include 'must correspond to a max quantity of 1'
+      end
     end
 
     describe 'rare_item' do

--- a/spec/models/canonical/jewelry_item_spec.rb
+++ b/spec/models/canonical/jewelry_item_spec.rb
@@ -142,6 +142,15 @@ RSpec.describe Canonical::JewelryItem, type: :model do
 
         expect(model.errors[:unique_item]).to include 'must be true or false'
       end
+
+      it 'must be true if max quantity is 1' do
+        model.max_quantity = 1
+        model.unique_item = false
+
+        validate
+
+        expect(model.errors[:unique_item]).to include 'must be true if max quantity is 1'
+      end
     end
 
     describe 'rare_item' do

--- a/spec/models/canonical/misc_item_spec.rb
+++ b/spec/models/canonical/misc_item_spec.rb
@@ -155,6 +155,15 @@ RSpec.describe Canonical::MiscItem, type: :model do
 
         expect(model.errors[:unique_item]).to include 'must be true if max quantity is 1'
       end
+
+      it 'must be false if max quantity is not 1' do
+        model.max_quantity = nil
+        model.unique_item = true
+
+        validate
+
+        expect(model.errors[:unique_item]).to include 'must correspond to a max quantity of 1'
+      end
     end
 
     describe 'rare_item' do

--- a/spec/models/canonical/misc_item_spec.rb
+++ b/spec/models/canonical/misc_item_spec.rb
@@ -4,118 +4,182 @@ require 'rails_helper'
 
 RSpec.describe Canonical::MiscItem, type: :model do
   describe 'validations' do
+    subject(:validate) { model.validate }
+
+    let(:model) { build(:canonical_misc_item) }
+
     describe 'name' do
       it "can't be blank" do
-        model = build(:canonical_misc_item, name: nil)
+        model.name = nil
+        validate
 
-        model.validate
         expect(model.errors[:name]).to include "can't be blank"
       end
     end
 
     describe 'item_code' do
       it "can't be blank" do
-        model = build(:canonical_misc_item, item_code: nil)
+        model.item_code = nil
+        validate
 
-        model.validate
         expect(model.errors[:item_code]).to include "can't be blank"
       end
 
       it 'must be unique' do
         create(:canonical_misc_item, item_code: 'foo')
-        model = build(:canonical_misc_item, item_code: 'foo')
+        model.item_code = 'foo'
+        validate
 
-        model.validate
         expect(model.errors[:item_code]).to include 'must be unique'
       end
     end
 
     describe 'unit_weight' do
       it "can't be blank" do
-        model = build(:canonical_misc_item, unit_weight: nil)
+        model.unit_weight = nil
+        validate
 
-        model.validate
         expect(model.errors[:unit_weight]).to include "can't be blank"
       end
 
       it 'must be a number' do
-        model = build(:canonical_misc_item, unit_weight: 'foo')
+        model.unit_weight = 'foo'
+        validate
 
-        model.validate
         expect(model.errors[:unit_weight]).to include 'is not a number'
       end
 
       it 'must be at least zero' do
-        model = build(:canonical_misc_item, unit_weight: -2)
+        model.unit_weight = -2
+        validate
 
-        model.validate
         expect(model.errors[:unit_weight]).to include 'must be greater than or equal to 0'
       end
     end
 
     describe 'item_types' do
       it "can't be blank" do
-        model = build(:canonical_misc_item, item_types: nil)
+        model.item_types = nil
+        validate
 
-        model.validate
         expect(model.errors[:item_types]).to include "can't be blank"
       end
 
       it 'must include at least one valid type' do
-        model = build(:canonical_misc_item, item_types: [])
+        model.item_types = []
+        validate
 
-        model.validate
         expect(model.errors[:item_types]).to include 'must include at least one item type'
       end
 
       it 'must include only valid types' do
-        model = build(:canonical_misc_item, item_types: ['Dwemer artifact', 'industrial equipment'])
+        model.item_types = [
+          'Dwemer artifact',
+          'industrial equipment',
+        ]
+        validate
 
-        model.validate
         expect(model.errors[:item_types]).to include 'can only include valid item types'
+      end
+    end
+
+    describe 'add_on' do
+      it "can't be blank" do
+        model.add_on = nil
+        validate
+
+        expect(model.errors[:add_on]).to include "can't be blank"
+      end
+
+      it 'must be a supported add-on' do
+        model.add_on = 'fishing'
+        validate
+
+        expect(model.errors[:add_on]).to include 'must be a SIM-supported add-on or DLC'
+      end
+    end
+
+    describe 'max_quantity' do
+      it 'can be nil' do
+        model.max_quantity = nil
+
+        expect(model).to be_valid
+      end
+
+      it 'must be at least 1' do
+        model.max_quantity = 0
+        validate
+
+        expect(model.errors[:max_quantity]).to include 'must be an integer of at least 1'
+      end
+
+      it 'must be an integer' do
+        model.max_quantity = 2.7
+        validate
+
+        expect(model.errors[:max_quantity]).to include 'must be an integer of at least 1'
       end
     end
 
     describe 'purchasable' do
       it "can't be blank" do
-        model = build(:canonical_misc_item, purchasable: nil)
+        model.purchasable = nil
+        validate
 
-        model.validate
         expect(model.errors[:purchasable]).to include 'must be true or false'
+      end
+    end
+
+    describe 'collectible' do
+      it "can't be blank" do
+        model.collectible = nil
+        validate
+
+        expect(model.errors[:collectible]).to include 'must be true or false'
       end
     end
 
     describe 'unique_item' do
       it "can't be blank" do
-        model = build(:canonical_misc_item, unique_item: nil)
+        model.unique_item = nil
+        validate
 
-        model.validate
         expect(model.errors[:unique_item]).to include 'must be true or false'
       end
     end
 
     describe 'rare_item' do
       it "can't be blank" do
-        model = build(:canonical_misc_item, rare_item: nil)
+        model.rare_item = nil
+        validate
 
-        model.validate
         expect(model.errors[:rare_item]).to include 'must be true or false'
       end
 
       it 'must be true if unique_item is true' do
-        model = build(:canonical_misc_item, unique_item: true, rare_item: false)
+        model.unique_item = true
+        model.rare_item = false
+        validate
 
-        model.validate
         expect(model.errors[:rare_item]).to include 'must be true if item is unique'
       end
     end
 
     describe 'quest_item' do
       it "can't be blank" do
-        model = build(:canonical_misc_item, quest_item: nil)
+        model.quest_item = nil
+        validate
 
-        model.validate
         expect(model.errors[:quest_item]).to include 'must be true or false'
+      end
+    end
+
+    describe 'quest_reward' do
+      it "can't be blank" do
+        model.quest_reward = nil
+        validate
+
+        expect(model.errors[:quest_reward]).to include 'must be true or false'
       end
     end
   end

--- a/spec/models/canonical/misc_item_spec.rb
+++ b/spec/models/canonical/misc_item_spec.rb
@@ -146,6 +146,15 @@ RSpec.describe Canonical::MiscItem, type: :model do
 
         expect(model.errors[:unique_item]).to include 'must be true or false'
       end
+
+      it 'must be true if max_quantity is 1' do
+        model.unique_item = false
+        model.max_quantity = 1
+
+        validate
+
+        expect(model.errors[:unique_item]).to include 'must be true if max quantity is 1'
+      end
     end
 
     describe 'rare_item' do

--- a/spec/models/canonical/potion_spec.rb
+++ b/spec/models/canonical/potion_spec.rb
@@ -66,6 +66,15 @@ RSpec.describe Canonical::Potion, type: :model do
         validate
         expect(potion.errors[:unique_item]).to include 'must be true or false'
       end
+
+      it 'must be true if max quantity is 1' do
+        potion.max_quantity = 1
+        potion.unique_item = false
+
+        validate
+
+        expect(potion.errors[:unique_item]).to include 'must be true if max quantity is 1'
+      end
     end
 
     describe 'rare_item' do

--- a/spec/models/canonical/potion_spec.rb
+++ b/spec/models/canonical/potion_spec.rb
@@ -75,6 +75,15 @@ RSpec.describe Canonical::Potion, type: :model do
 
         expect(potion.errors[:unique_item]).to include 'must be true if max quantity is 1'
       end
+
+      it 'cannot be true if max quantity is not 1' do
+        potion.max_quantity = nil
+        potion.unique_item = true
+
+        validate
+
+        expect(potion.errors[:unique_item]).to include 'must correspond to max quantity of 1'
+      end
     end
 
     describe 'rare_item' do

--- a/spec/models/clothing_item_spec.rb
+++ b/spec/models/clothing_item_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe ClothingItem, type: :model do
         let(:canonical_clothing_item) do
           create(
             :canonical_clothing_item,
+            max_quantity: 1,
             unique_item: true,
             rare_item: true,
           )

--- a/spec/models/ingredient_spec.rb
+++ b/spec/models/ingredient_spec.rb
@@ -82,6 +82,7 @@ RSpec.describe Ingredient, type: :model do
         let(:canonical_ingredient) do
           create(
             :canonical_ingredient,
+            max_quantity: 1,
             unique_item: true,
             rare_item: true,
           )

--- a/spec/models/jewelry_item_spec.rb
+++ b/spec/models/jewelry_item_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe JewelryItem, type: :model do
         let(:canonical_jewelry_item) do
           create(
             :canonical_jewelry_item,
+            max_quantity: 1,
             unique_item: true,
             rare_item: true,
           )

--- a/spec/models/misc_item_spec.rb
+++ b/spec/models/misc_item_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe MiscItem, type: :model do
         let(:canonical_misc_item) do
           create(
             :canonical_misc_item,
+            max_quantity: 1,
             unique_item: true,
             rare_item: true,
           )

--- a/spec/models/potion_spec.rb
+++ b/spec/models/potion_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe Potion, type: :model do
         let(:canonical_potion) do
           create(
             :canonical_potion,
+            max_quantity: 1,
             unique_item: true,
             rare_item: true,
           )

--- a/spec/support/factories/canonical/misc_items.rb
+++ b/spec/support/factories/canonical/misc_items.rb
@@ -6,9 +6,12 @@ FactoryBot.define do
     sequence(:item_code) {|n| "xx123x#{n}" }
     unit_weight { 1.0 }
     item_types { %w[miscellaneous] }
+    add_on { 'base' }
+    collectible { true }
     purchasable { true }
     unique_item { false }
     rare_item { false }
     quest_item { false }
+    quest_reward { false }
   end
 end

--- a/spec/support/fixtures/canonical/sync/misc_items.json
+++ b/spec/support/fixtures/canonical/sync/misc_items.json
@@ -28,7 +28,7 @@
       ],
       "description": null,
       "add_on": "base",
-      "max_quantity": null,
+      "max_quantity": 1,
       "collectible": true,
       "purchasable": false,
       "unique_item": true,

--- a/spec/support/fixtures/canonical/sync/misc_items.json
+++ b/spec/support/fixtures/canonical/sync/misc_items.json
@@ -8,10 +8,14 @@
         "paragon"
       ],
       "description": null,
+      "add_on": "dawnguard",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
-      "unique_item": false,
+      "unique_item": true,
       "rare_item": true,
-      "quest_item": true
+      "quest_item": true,
+      "quest_reward": true
     }
   },
   {
@@ -23,10 +27,14 @@
         "animal part"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": null,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
-      "quest_item": false
+      "quest_item": false,
+      "quest_reward": false
     }
   },
   {
@@ -38,10 +46,14 @@
         "miscellaneous"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": true,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
-      "quest_item": true
+      "quest_item": true,
+      "quest_reward": true
     }
   },
   {
@@ -53,10 +65,14 @@
         "Dwemer artifact"
       ],
       "description": null,
+      "add_on": "base",
+      "max_quantity": 1,
+      "collectible": false,
       "purchasable": false,
       "unique_item": true,
       "rare_item": true,
-      "quest_item": true
+      "quest_item": true,
+      "quest_reward": false
     }
   }
 ]


### PR DESCRIPTION
## Context

[**Add new attributes to all canonical models**](https://trello.com/c/wQbjkOgB/353-add-new-attributes-to-all-canonical-models)

This PR adds the new fields, `add_on`, `max_quantity`, and `collectible` - to the `canonical_misc_items` table, updates JSON data, and  adds validations for the new attributes. We are adding these attributes to all canonical models.

Additionally, canonical models that have both a `unique_item` attribute and a `max_quantity` attribute have been updated to validate that the two must be in sync.

## Changes

* Add `add_on`, `max_quantity`, and `collectible` columns to the `canonical_misc_items` table
* Update JSON data to include new values
* Add validations for new columns
* Update tests

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [x] Added and updated API docs and developer docs as appropriate
