### PR TITLE
Add add_on attribute to Canonical::RawMaterial model

### DIFF
--- a/app/models/canonical/raw_material.rb
+++ b/app/models/canonical/raw_material.rb
@@ -40,6 +40,12 @@ module Canonical
               numericality: {
                 greater_than_or_equal_to: 0,
               }
+    validates :add_on,
+              presence: true,
+              inclusion: {
+                in: SUPPORTED_ADD_ONS,
+                message: UNSUPPORTED_ADD_ON_MESSAGE,
+              }
 
     before_validation :upcase_item_code, if: :item_code_changed?
 

--- a/db/migrate/20240823014425_add_add_on_to_canonical_raw_materials.rb
+++ b/db/migrate/20240823014425_add_add_on_to_canonical_raw_materials.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddAddOnToCanonicalRawMaterials < ActiveRecord::Migration[7.2]
+  def change
+    add_column :canonical_raw_materials,
+               :add_on,
+               :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_02_034625) do
+ActiveRecord::Schema[7.2].define(version: 2024_08_23_014425) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -280,6 +280,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_02_034625) do
     t.decimal "unit_weight", precision: 5, scale: 2, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "add_on"
     t.index ["item_code"], name: "index_canonical_raw_materials_on_item_code", unique: true
   end
 

--- a/lib/tasks/canonical_models/canonical_raw_materials.json
+++ b/lib/tasks/canonical_models/canonical_raw_materials.json
@@ -5,7 +5,8 @@
       "item_code": "XX003043",
       "building_material": true,
       "smithing_material": false,
-      "unit_weight": 1
+      "unit_weight": 1,
+      "add_on": "hearthfire"
     }
   },
   {
@@ -14,7 +15,8 @@
       "item_code": "XX005A69",
       "building_material": true,
       "smithing_material": false,
-      "unit_weight": 1
+      "unit_weight": 1,
+      "add_on": "hearthfire"
     }
   },
   {
@@ -23,7 +25,8 @@
       "item_code": "XX00303F",
       "building_material": true,
       "smithing_material": false,
-      "unit_weight": 1
+      "unit_weight": 1,
+      "add_on": "hearthfire"
     }
   },
   {
@@ -32,7 +35,8 @@
       "item_code": "XX003011",
       "building_material": true,
       "smithing_material": false,
-      "unit_weight": 0.5
+      "unit_weight": 0.5,
+      "add_on": "hearthfire"
     }
   },
   {
@@ -41,7 +45,8 @@
       "item_code": "XX003035",
       "building_material": true,
       "smithing_material": false,
-      "unit_weight": 1
+      "unit_weight": 1,
+      "add_on": "hearthfire"
     }
   },
   {
@@ -50,7 +55,8 @@
       "item_code": "XX003012",
       "building_material": true,
       "smithing_material": false,
-      "unit_weight": 0.5
+      "unit_weight": 0.5,
+      "add_on": "hearthfire"
     }
   },
   {
@@ -59,7 +65,8 @@
       "item_code": "XX00300F",
       "building_material": true,
       "smithing_material": false,
-      "unit_weight": 0.1
+      "unit_weight": 0.1,
+      "add_on": "hearthfire"
     }
   },
   {
@@ -68,7 +75,8 @@
       "item_code": "XX00306C",
       "building_material": true,
       "smithing_material": false,
-      "unit_weight": 1
+      "unit_weight": 1,
+      "add_on": "hearthfire"
     }
   },
   {
@@ -77,7 +85,8 @@
       "item_code": "XX00300E",
       "building_material": true,
       "smithing_material": false,
-      "unit_weight": 0
+      "unit_weight": 0,
+      "add_on": "hearthfire"
     }
   },
   {
@@ -86,7 +95,8 @@
       "item_code": "XX005A68",
       "building_material": true,
       "smithing_material": false,
-      "unit_weight": 1
+      "unit_weight": 1,
+      "add_on": "hearthfire"
     }
   },
   {
@@ -95,7 +105,8 @@
       "item_code": "000319E4",
       "building_material": true,
       "smithing_material": false,
-      "unit_weight": 3.5
+      "unit_weight": 3.5,
+      "add_on": "base"
     }
   },
   {
@@ -104,7 +115,8 @@
       "item_code": "0003AD52",
       "building_material": true,
       "smithing_material": true,
-      "unit_weight": 3
+      "unit_weight": 3,
+      "add_on": "base"
     }
   },
   {
@@ -113,7 +125,8 @@
       "item_code": "00063B46",
       "building_material": false,
       "smithing_material": true,
-      "unit_weight": 0.1
+      "unit_weight": 0.1,
+      "add_on": "base"
     }
   },
   {
@@ -122,7 +135,8 @@
       "item_code": "XX002994",
       "building_material": false,
       "smithing_material": true,
-      "unit_weight": 1
+      "unit_weight": 1,
+      "add_on": "dawnguard"
     }
   },
   {
@@ -131,7 +145,8 @@
       "item_code": "XX002993",
       "building_material": false,
       "smithing_material": true,
-      "unit_weight": 1
+      "unit_weight": 1,
+      "add_on": "dawnguard"
     }
   },
   {
@@ -140,7 +155,8 @@
       "item_code": "0003AD53",
       "building_material": false,
       "smithing_material": true,
-      "unit_weight": 3
+      "unit_weight": 3,
+      "add_on": "base"
     }
   },
   {
@@ -149,7 +165,8 @@
       "item_code": "0003AD57",
       "building_material": false,
       "smithing_material": true,
-      "unit_weight": 4
+      "unit_weight": 4,
+      "add_on": "base"
     }
   },
   {
@@ -158,7 +175,8 @@
       "item_code": "XX02B04E",
       "building_material": false,
       "smithing_material": true,
-      "unit_weight": 1
+      "unit_weight": 1,
+      "add_on": "dragonborn"
     }
   },
   {
@@ -167,7 +185,8 @@
       "item_code": "0005AD93",
       "building_material": true,
       "smithing_material": true,
-      "unit_weight": 1
+      "unit_weight": 1,
+      "add_on": "base"
     }
   },
   {
@@ -176,7 +195,8 @@
       "item_code": "0005acdb",
       "building_material": true,
       "smithing_material": true,
-      "unit_weight": 1
+      "unit_weight": 1,
+      "add_on": "base"
     }
   },
   {
@@ -185,7 +205,8 @@
       "item_code": "0003AD8F",
       "building_material": false,
       "smithing_material": true,
-      "unit_weight": 1
+      "unit_weight": 1,
+      "add_on": "base"
     }
   },
   {
@@ -194,7 +215,8 @@
       "item_code": "000D284D",
       "building_material": true,
       "smithing_material": true,
-      "unit_weight": 2
+      "unit_weight": 2,
+      "add_on": "base"
     }
   },
   {
@@ -203,7 +225,8 @@
       "item_code": "00063B47",
       "building_material": false,
       "smithing_material": true,
-      "unit_weight": 0.1
+      "unit_weight": 0.1,
+      "add_on": "base"
     }
   },
   {
@@ -212,7 +235,8 @@
       "item_code": "0006851F",
       "building_material": false,
       "smithing_material": true,
-      "unit_weight": 0.1
+      "unit_weight": 0.1,
+      "add_on": "base"
     }
   },
   {
@@ -221,7 +245,8 @@
       "item_code": "0003ADA4",
       "building_material": true,
       "smithing_material": true,
-      "unit_weight": 15
+      "unit_weight": 15,
+      "add_on": "base"
     }
   },
   {
@@ -230,7 +255,8 @@
       "item_code": "0003ADA3",
       "building_material": true,
       "smithing_material": true,
-      "unit_weight": 10
+      "unit_weight": 10,
+      "add_on": "base"
     }
   },
   {
@@ -239,7 +265,8 @@
       "item_code": "000DB8A2",
       "building_material": false,
       "smithing_material": true,
-      "unit_weight": 1
+      "unit_weight": 1,
+      "add_on": "base"
     }
   },
   {
@@ -248,7 +275,8 @@
       "item_code": "000c886c",
       "building_material": false,
       "smithing_material": true,
-      "unit_weight": 2
+      "unit_weight": 2,
+      "add_on": "base"
     }
   },
   {
@@ -257,7 +285,8 @@
       "item_code": "000c8878",
       "building_material": false,
       "smithing_material": true,
-      "unit_weight": 15
+      "unit_weight": 15,
+      "add_on": "base"
     }
   },
   {
@@ -266,7 +295,8 @@
       "item_code": "000c8864",
       "building_material": false,
       "smithing_material": true,
-      "unit_weight": 2
+      "unit_weight": 2,
+      "add_on": "base"
     }
   },
   {
@@ -275,7 +305,8 @@
       "item_code": "000c8872",
       "building_material": false,
       "smithing_material": true,
-      "unit_weight": 20
+      "unit_weight": 20,
+      "add_on": "base"
     }
   },
   {
@@ -284,7 +315,8 @@
       "item_code": "000c8866",
       "building_material": false,
       "smithing_material": true,
-      "unit_weight": 2
+      "unit_weight": 2,
+      "add_on": "base"
     }
   },
   {
@@ -293,7 +325,8 @@
       "item_code": "000c8874",
       "building_material": false,
       "smithing_material": true,
-      "unit_weight": 25
+      "unit_weight": 25,
+      "add_on": "base"
     }
   },
   {
@@ -302,7 +335,8 @@
       "item_code": "000c886a",
       "building_material": true,
       "smithing_material": false,
-      "unit_weight": 2
+      "unit_weight": 2,
+      "add_on": "base"
     }
   },
   {
@@ -311,7 +345,8 @@
       "item_code": "0005AD9D",
       "building_material": true,
       "smithing_material": true,
-      "unit_weight": 1
+      "unit_weight": 1,
+      "add_on": "base"
     }
   },
   {
@@ -320,7 +355,8 @@
       "item_code": "0005acdc",
       "building_material": false,
       "smithing_material": true,
-      "unit_weight": 1
+      "unit_weight": 1,
+      "add_on": "base"
     }
   },
   {
@@ -329,7 +365,8 @@
       "item_code": "00063B43",
       "building_material": false,
       "smithing_material": true,
-      "unit_weight": 0.1
+      "unit_weight": 0.1,
+      "add_on": "base"
     }
   },
   {
@@ -338,7 +375,8 @@
       "item_code": "00068520",
       "building_material": false,
       "smithing_material": true,
-      "unit_weight": 0.1
+      "unit_weight": 0.1,
+      "add_on": "base"
     }
   },
   {
@@ -347,7 +385,8 @@
       "item_code": "0006F993",
       "building_material": false,
       "smithing_material": true,
-      "unit_weight": 5
+      "unit_weight": 5,
+      "add_on": "base"
     }
   },
   {
@@ -356,7 +395,8 @@
       "item_code": "0006851E",
       "building_material": true,
       "smithing_material": true,
-      "unit_weight": 0.1
+      "unit_weight": 0.1,
+      "add_on": "base"
     }
   },
   {
@@ -365,7 +405,8 @@
       "item_code": "00068521",
       "building_material": false,
       "smithing_material": true,
-      "unit_weight": 0.1
+      "unit_weight": 0.1,
+      "add_on": "base"
     }
   },
   {
@@ -374,7 +415,8 @@
       "item_code": "00068522",
       "building_material": false,
       "smithing_material": true,
-      "unit_weight": 0.1
+      "unit_weight": 0.1,
+      "add_on": "base"
     }
   },
   {
@@ -383,7 +425,8 @@
       "item_code": "000D4B35",
       "building_material": false,
       "smithing_material": true,
-      "unit_weight": 0.5
+      "unit_weight": 0.5,
+      "add_on": "base"
     }
   },
   {
@@ -392,7 +435,8 @@
       "item_code": "00063B45",
       "building_material": false,
       "smithing_material": true,
-      "unit_weight": 0.1
+      "unit_weight": 0.1,
+      "add_on": "base"
     }
   },
   {
@@ -401,7 +445,8 @@
       "item_code": "0003AD8E",
       "building_material": true,
       "smithing_material": true,
-      "unit_weight": 1
+      "unit_weight": 1,
+      "add_on": "base"
     }
   },
   {
@@ -410,7 +455,8 @@
       "item_code": "0005AD9E",
       "building_material": true,
       "smithing_material": true,
-      "unit_weight": 1
+      "unit_weight": 1,
+      "add_on": "base"
     }
   },
   {
@@ -419,7 +465,8 @@
       "item_code": "0005acde",
       "building_material": false,
       "smithing_material": true,
-      "unit_weight": 1
+      "unit_weight": 1,
+      "add_on": "base"
     }
   },
   {
@@ -428,7 +475,8 @@
       "item_code": "XX011999",
       "building_material": false,
       "smithing_material": true,
-      "unit_weight": 2
+      "unit_weight": 2,
+      "add_on": "dawnguard"
     }
   },
   {
@@ -437,7 +485,8 @@
       "item_code": "0003AD93",
       "building_material": false,
       "smithing_material": true,
-      "unit_weight": 2
+      "unit_weight": 2,
+      "add_on": "base"
     }
   },
   {
@@ -446,7 +495,8 @@
       "item_code": "0003AD75",
       "building_material": false,
       "smithing_material": true,
-      "unit_weight": 1
+      "unit_weight": 1,
+      "add_on": "base"
     }
   },
   {
@@ -455,7 +505,8 @@
       "item_code": "0005ACE4",
       "building_material": true,
       "smithing_material": true,
-      "unit_weight": 1
+      "unit_weight": 1,
+      "add_on": "base"
     }
   },
   {
@@ -464,7 +515,8 @@
       "item_code": "00071cf3",
       "building_material": false,
       "smithing_material": true,
-      "unit_weight": 1
+      "unit_weight": 1,
+      "add_on": "base"
     }
   },
   {
@@ -473,7 +525,8 @@
       "item_code": "000DB5D2",
       "building_material": true,
       "smithing_material": true,
-      "unit_weight": 2
+      "unit_weight": 2,
+      "add_on": "base"
     }
   },
   {
@@ -482,7 +535,8 @@
       "item_code": "000800E4",
       "building_material": true,
       "smithing_material": true,
-      "unit_weight": 0.1
+      "unit_weight": 0.1,
+      "add_on": "base"
     }
   },
   {
@@ -491,7 +545,8 @@
       "item_code": "XX01CD7C",
       "building_material": false,
       "smithing_material": true,
-      "unit_weight": 2
+      "unit_weight": 2,
+      "add_on": "dragonborn"
     }
   },
   {
@@ -500,7 +555,8 @@
       "item_code": "0005AD99",
       "building_material": true,
       "smithing_material": true,
-      "unit_weight": 1
+      "unit_weight": 1,
+      "add_on": "base"
     }
   },
   {
@@ -509,7 +565,8 @@
       "item_code": "0005acdd",
       "building_material": false,
       "smithing_material": true,
-      "unit_weight": 1
+      "unit_weight": 1,
+      "add_on": "base"
     }
   },
   {
@@ -518,7 +575,8 @@
       "item_code": "00063B44",
       "building_material": false,
       "smithing_material": true,
-      "unit_weight": 0.1
+      "unit_weight": 0.1,
+      "add_on": "base"
     }
   },
   {
@@ -527,7 +585,8 @@
       "item_code": "00068523",
       "building_material": true,
       "smithing_material": true,
-      "unit_weight": 0.1
+      "unit_weight": 0.1,
+      "add_on": "base"
     }
   },
   {
@@ -536,7 +595,8 @@
       "item_code": "0005ADA0",
       "building_material": true,
       "smithing_material": true,
-      "unit_weight": 1
+      "unit_weight": 1,
+      "add_on": "base"
     }
   },
   {
@@ -545,7 +605,8 @@
       "item_code": "0005ace2",
       "building_material": false,
       "smithing_material": true,
-      "unit_weight": 1
+      "unit_weight": 1,
+      "add_on": "base"
     }
   },
   {
@@ -554,7 +615,8 @@
       "item_code": "0005ADA1",
       "building_material": true,
       "smithing_material": true,
-      "unit_weight": 1
+      "unit_weight": 1,
+      "add_on": "base"
     }
   },
   {
@@ -563,7 +625,8 @@
       "item_code": "0005ace1",
       "building_material": false,
       "smithing_material": true,
-      "unit_weight": 1
+      "unit_weight": 1,
+      "add_on": "base"
     }
   },
   {
@@ -572,7 +635,8 @@
       "item_code": "0005AD9F",
       "building_material": true,
       "smithing_material": true,
-      "unit_weight": 1
+      "unit_weight": 1,
+      "add_on": "base"
     }
   },
   {
@@ -581,7 +645,8 @@
       "item_code": "0005ace0",
       "building_material": false,
       "smithing_material": true,
-      "unit_weight": 1
+      "unit_weight": 1,
+      "add_on": "base"
     }
   },
   {
@@ -590,7 +655,8 @@
       "item_code": "00063B42",
       "building_material": false,
       "smithing_material": true,
-      "unit_weight": 0.1
+      "unit_weight": 0.1,
+      "add_on": "base"
     }
   },
   {
@@ -599,7 +665,8 @@
       "item_code": "0003AD6D",
       "building_material": true,
       "smithing_material": true,
-      "unit_weight": 2
+      "unit_weight": 2,
+      "add_on": "base"
     }
   },
   {
@@ -608,7 +675,8 @@
       "item_code": "0003AD6E",
       "building_material": true,
       "smithing_material": true,
-      "unit_weight": 2
+      "unit_weight": 2,
+      "add_on": "base"
     }
   },
   {
@@ -617,7 +685,8 @@
       "item_code": "XX0195AA",
       "building_material": false,
       "smithing_material": true,
-      "unit_weight": 4
+      "unit_weight": 4,
+      "add_on": "dawnguard"
     }
   },
   {
@@ -626,7 +695,8 @@
       "item_code": "0005ACE3",
       "building_material": true,
       "smithing_material": true,
-      "unit_weight": 1
+      "unit_weight": 1,
+      "add_on": "base"
     }
   },
   {
@@ -635,7 +705,8 @@
       "item_code": "0005ACDF",
       "building_material": false,
       "smithing_material": true,
-      "unit_weight": 1
+      "unit_weight": 1,
+      "add_on": "base"
     }
   },
   {
@@ -644,7 +715,8 @@
       "item_code": "0003AD54",
       "building_material": true,
       "smithing_material": true,
-      "unit_weight": 3
+      "unit_weight": 3,
+      "add_on": "base"
     }
   },
   {
@@ -653,7 +725,8 @@
       "item_code": "000D4BE7",
       "building_material": false,
       "smithing_material": true,
-      "unit_weight": 0.5
+      "unit_weight": 0.5,
+      "add_on": "base"
     }
   },
   {
@@ -662,7 +735,8 @@
       "item_code": "XX02B06B",
       "building_material": false,
       "smithing_material": false,
-      "unit_weight": 1
+      "unit_weight": 1,
+      "add_on": "dragonborn"
     }
   },
   {
@@ -671,7 +745,8 @@
       "item_code": "0005ACE5",
       "building_material": true,
       "smithing_material": true,
-      "unit_weight": 1
+      "unit_weight": 1,
+      "add_on": "base"
     }
   },
   {
@@ -680,7 +755,8 @@
       "item_code": "XX01199A",
       "building_material": false,
       "smithing_material": true,
-      "unit_weight": 2
+      "unit_weight": 2,
+      "add_on": "dawnguard"
     }
   },
   {
@@ -689,7 +765,8 @@
       "item_code": "0003AD74",
       "building_material": true,
       "smithing_material": true,
-      "unit_weight": 1
+      "unit_weight": 1,
+      "add_on": "base"
     }
   },
   {
@@ -698,7 +775,8 @@
       "item_code": "0003AD68",
       "building_material": true,
       "smithing_material": false,
-      "unit_weight": 1
+      "unit_weight": 1,
+      "add_on": "base"
     }
   }
 ]

--- a/spec/models/canonical/raw_material_spec.rb
+++ b/spec/models/canonical/raw_material_spec.rb
@@ -49,6 +49,20 @@ RSpec.describe Canonical::RawMaterial, type: :model do
         expect(material.errors[:unit_weight]).to include 'must be greater than or equal to 0'
       end
     end
+
+    describe 'add_on' do
+      it "can't be blank" do
+        material.add_on = nil
+        validate
+        expect(material.errors[:add_on]).to include "can't be blank"
+      end
+
+      it 'must be a supported add-on' do
+        material.add_on = 'fishing'
+        validate
+        expect(material.errors[:add_on]).to include 'must be a SIM-supported add-on or DLC'
+      end
+    end
   end
 
   describe 'default behavior' do

--- a/spec/support/factories/canonical/raw_materials.rb
+++ b/spec/support/factories/canonical/raw_materials.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     name { 'iron ingot' }
     sequence(:item_code) {|n| "xxx000#{n}" }
     unit_weight { 2.4 }
+    add_on { 'base' }
   end
 end

--- a/spec/support/fixtures/canonical/sync/raw_materials.json
+++ b/spec/support/fixtures/canonical/sync/raw_materials.json
@@ -5,7 +5,8 @@
       "item_code": "XX00300F",
       "building_material": true,
       "smithing_material": false,
-      "unit_weight": 0.1
+      "unit_weight": 0.1,
+      "add_on": "hearthfire"
     }
   },
   {
@@ -14,7 +15,8 @@
       "item_code": "XX00306C",
       "building_material": true,
       "smithing_material": false,
-      "unit_weight": 1
+      "unit_weight": 1,
+      "add_on": "hearthfire"
     }
   },
   {
@@ -23,7 +25,8 @@
       "item_code": "XX00300E",
       "building_material": true,
       "smithing_material": false,
-      "unit_weight": 0
+      "unit_weight": 0,
+      "add_on": "hearthfire"
     }
   },
   {
@@ -32,7 +35,8 @@
       "item_code": "XX005A68",
       "building_material": true,
       "smithing_material": false,
-      "unit_weight": 1
+      "unit_weight": 1,
+      "add_on": "base"
     }
   }
 ]


### PR DESCRIPTION
## Context

[**Add new attributes to all canonical models**](https://trello.com/c/wQbjkOgB/353-add-new-attributes-to-all-canonical-models)

We are adding new fields to each canonical model. For the `Canonical::RawMaterial` model, the only field being added is `add_on`, indicating if the material comes from the base game or from an add-on or DLC.

## Changes

* Add `add_on` field to `canonical_raw_materials` table
* Add field to JSON data
* Add model validations for new field

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [ ] ~~Added and updated API docs and developer docs as appropriate~~