### PR TITLE
Add add_on field to Enchantment model

### DIFF
--- a/app/models/enchantment.rb
+++ b/app/models/enchantment.rb
@@ -42,7 +42,19 @@ class Enchantment < ApplicationRecord
               message: 'must be "point", "percentage", "second", or the "level" of affected targets',
               allow_blank: true,
             }
-  validates :school, inclusion: { in: Skyrim::MAGIC_SCHOOLS, message: 'must be a valid school of magic', allow_blank: true }
+  validates :school,
+            presence: false,
+            inclusion: {
+              in: Skyrim::MAGIC_SCHOOLS,
+              message: 'must be a valid school of magic',
+              allow_blank: true,
+            }
+  validates :add_on,
+            presence: true,
+            inclusion: {
+              in: Canonical::SUPPORTED_ADD_ONS,
+              message: Canonical::UNSUPPORTED_ADD_ON_MESSAGE,
+            }
   validate :validate_enchantable_items
 
   def self.unique_identifier

--- a/db/migrate/20240823103752_add_add_on_to_enchantments.rb
+++ b/db/migrate/20240823103752_add_add_on_to_enchantments.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddAddOnToEnchantments < ActiveRecord::Migration[7.2]
+  def change
+    add_column :enchantments,
+               :add_on,
+               :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_08_23_050136) do
+ActiveRecord::Schema[7.2].define(version: 2024_08_23_103752) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -373,6 +373,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_23_050136) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "school"
+    t.string "add_on"
     t.index ["name"], name: "index_enchantments_on_name", unique: true
   end
 

--- a/lib/tasks/canonical_models/enchantments.json
+++ b/lib/tasks/canonical_models/enchantments.json
@@ -15,7 +15,8 @@
         "crossbow",
         "other"
       ],
-      "strength_unit": "point"
+      "strength_unit": "point",
+      "add_on": "base"
     }
   },
   {
@@ -34,7 +35,8 @@
         "crossbow",
         "other"
       ],
-      "strength_unit": "point"
+      "strength_unit": "point",
+      "add_on": "base"
     }
   },
   {
@@ -53,7 +55,8 @@
         "crossbow",
         "other"
       ],
-      "strength_unit": "point"
+      "strength_unit": "point",
+      "add_on": "base"
     }
   },
   {
@@ -72,7 +75,8 @@
         "crossbow",
         "other"
       ],
-      "strength_unit": "level"
+      "strength_unit": "level",
+      "add_on": "base"
     }
   },
   {
@@ -91,7 +95,8 @@
         "crossbow",
         "other"
       ],
-      "strength_unit": "point"
+      "strength_unit": "point",
+      "add_on": "dragonborn"
     }
   },
   {
@@ -110,7 +115,8 @@
         "crossbow",
         "other"
       ],
-      "strength_unit": "second"
+      "strength_unit": "second",
+      "add_on": "base"
     }
   },
   {
@@ -129,7 +135,8 @@
         "crossbow",
         "other"
       ],
-      "strength_unit": "second"
+      "strength_unit": "second",
+      "add_on": "base"
     }
   },
   {
@@ -148,7 +155,8 @@
         "crossbow",
         "other"
       ],
-      "strength_unit": "point"
+      "strength_unit": "point",
+      "add_on": "base"
     }
   },
   {
@@ -162,7 +170,8 @@
         "amulet",
         "ring"
       ],
-      "strength_unit": "percentage"
+      "strength_unit": "percentage",
+      "add_on": "base"
     }
   },
   {
@@ -176,7 +185,8 @@
         "amulet",
         "ring"
       ],
-      "strength_unit": "percentage"
+      "strength_unit": "percentage",
+      "add_on": "base"
     }
   },
   {
@@ -186,7 +196,8 @@
       "enchantable_items": [
         "chest"
       ],
-      "strength_unit": "percentage"
+      "strength_unit": "percentage",
+      "add_on": "base"
     }
   },
   {
@@ -200,7 +211,8 @@
         "amulet",
         "ring"
       ],
-      "strength_unit": "percentage"
+      "strength_unit": "percentage",
+      "add_on": "base"
     }
   },
   {
@@ -210,7 +222,8 @@
       "enchantable_items": [
         "amulet"
       ],
-      "strength_unit": "percentage"
+      "strength_unit": "percentage",
+      "add_on": "base"
     }
   },
   {
@@ -223,7 +236,8 @@
         "amulet",
         "ring"
       ],
-      "strength_unit": "percentage"
+      "strength_unit": "percentage",
+      "add_on": "base"
     }
   },
   {
@@ -236,7 +250,8 @@
         "amulet",
         "ring"
       ],
-      "strength_unit": "point"
+      "strength_unit": "point",
+      "add_on": "base"
     }
   },
   {
@@ -250,7 +265,8 @@
         "amulet",
         "ring"
       ],
-      "strength_unit": "percentage"
+      "strength_unit": "percentage",
+      "add_on": "base"
     }
   },
   {
@@ -260,7 +276,8 @@
       "enchantable_items": [
         "chest"
       ],
-      "strength_unit": "percentage"
+      "strength_unit": "percentage",
+      "add_on": "base"
     }
   },
   {
@@ -274,7 +291,8 @@
         "amulet",
         "ring"
       ],
-      "strength_unit": "percentage"
+      "strength_unit": "percentage",
+      "add_on": "base"
     }
   },
   {
@@ -284,7 +302,8 @@
       "enchantable_items": [
         "chest"
       ],
-      "strength_unit": "percentage"
+      "strength_unit": "percentage",
+      "add_on": "base"
     }
   },
   {
@@ -296,7 +315,8 @@
         "amulet",
         "ring"
       ],
-      "strength_unit": "percentage"
+      "strength_unit": "percentage",
+      "add_on": "base"
     }
   },
   {
@@ -309,7 +329,8 @@
         "amulet",
         "ring"
       ],
-      "strength_unit": "point"
+      "strength_unit": "point",
+      "add_on": "base"
     }
   },
   {
@@ -322,7 +343,8 @@
         "amulet",
         "ring"
       ],
-      "strength_unit": "point"
+      "strength_unit": "point",
+      "add_on": "base"
     }
   },
   {
@@ -336,7 +358,8 @@
         "amulet",
         "ring"
       ],
-      "strength_unit": "percentage"
+      "strength_unit": "percentage",
+      "add_on": "base"
     }
   },
   {
@@ -346,7 +369,8 @@
       "enchantable_items": [
         "chest"
       ],
-      "strength_unit": "percentage"
+      "strength_unit": "percentage",
+      "add_on": "base"
     }
   },
   {
@@ -359,7 +383,8 @@
         "amulet",
         "ring"
       ],
-      "strength_unit": "point"
+      "strength_unit": "point",
+      "add_on": "base"
     }
   },
   {
@@ -372,7 +397,8 @@
         "amulet",
         "ring"
       ],
-      "strength_unit": "percentage"
+      "strength_unit": "percentage",
+      "add_on": "base"
     }
   },
   {
@@ -386,7 +412,8 @@
         "amulet",
         "ring"
       ],
-      "strength_unit": "point"
+      "strength_unit": "point",
+      "add_on": "base"
     }
   },
   {
@@ -398,7 +425,8 @@
         "chest",
         "ring"
       ],
-      "strength_unit": "percentage"
+      "strength_unit": "percentage",
+      "add_on": "base"
     }
   },
   {
@@ -412,7 +440,8 @@
         "amulet",
         "ring"
       ],
-      "strength_unit": "percentage"
+      "strength_unit": "percentage",
+      "add_on": "base"
     }
   },
   {
@@ -425,7 +454,8 @@
         "amulet",
         "ring"
       ],
-      "strength_unit": "percentage"
+      "strength_unit": "percentage",
+      "add_on": "base"
     }
   },
   {
@@ -439,7 +469,8 @@
         "amulet",
         "ring"
       ],
-      "strength_unit": "percentage"
+      "strength_unit": "percentage",
+      "add_on": "base"
     }
   },
   {
@@ -449,7 +480,8 @@
       "enchantable_items": [
         "chest"
       ],
-      "strength_unit": "percentage"
+      "strength_unit": "percentage",
+      "add_on": "base"
     }
   },
   {
@@ -462,7 +494,8 @@
         "amulet",
         "ring"
       ],
-      "strength_unit": "percentage"
+      "strength_unit": "percentage",
+      "add_on": "base"
     }
   },
   {
@@ -475,7 +508,8 @@
         "amulet",
         "ring"
       ],
-      "strength_unit": "percentage"
+      "strength_unit": "percentage",
+      "add_on": "base"
     }
   },
   {
@@ -489,7 +523,8 @@
         "amulet",
         "ring"
       ],
-      "strength_unit": "point"
+      "strength_unit": "point",
+      "add_on": "base"
     }
   },
   {
@@ -501,7 +536,8 @@
         "feet",
         "amulet"
       ],
-      "strength_unit": "percentage"
+      "strength_unit": "percentage",
+      "add_on": "base"
     }
   },
   {
@@ -515,7 +551,8 @@
         "amulet",
         "ring"
       ],
-      "strength_unit": "percentage"
+      "strength_unit": "percentage",
+      "add_on": "base"
     }
   },
   {
@@ -526,7 +563,8 @@
         "hands",
         "ring"
       ],
-      "strength_unit": "percentage"
+      "strength_unit": "percentage",
+      "add_on": "base"
     }
   },
   {
@@ -545,7 +583,8 @@
         "crossbow",
         "other"
       ],
-      "strength_unit": "point"
+      "strength_unit": "point",
+      "add_on": "base"
     }
   },
   {
@@ -564,7 +603,8 @@
         "crossbow",
         "other"
       ],
-      "strength_unit": "point"
+      "strength_unit": "point",
+      "add_on": "base"
     }
   },
   {
@@ -583,7 +623,8 @@
         "crossbow",
         "other"
       ],
-      "strength_unit": "point"
+      "strength_unit": "point",
+      "add_on": "base"
     }
   },
   {
@@ -593,7 +634,8 @@
       "enchantable_items": [
         "feet"
       ],
-      "strength_unit": "percentage"
+      "strength_unit": "percentage",
+      "add_on": "base"
     }
   },
   {
@@ -612,7 +654,8 @@
         "crossbow",
         "other"
       ],
-      "strength_unit": "second"
+      "strength_unit": "second",
+      "add_on": "base"
     }
   },
   {
@@ -625,7 +668,8 @@
         "amulet",
         "ring"
       ],
-      "strength_unit": "percentage"
+      "strength_unit": "percentage",
+      "add_on": "base"
     }
   },
   {
@@ -639,7 +683,8 @@
         "amulet",
         "ring"
       ],
-      "strength_unit": "percentage"
+      "strength_unit": "percentage",
+      "add_on": "base"
     }
   },
   {
@@ -653,7 +698,8 @@
         "amulet",
         "ring"
       ],
-      "strength_unit": "percentage"
+      "strength_unit": "percentage",
+      "add_on": "base"
     }
   },
   {
@@ -666,7 +712,8 @@
         "amulet",
         "ring"
       ],
-      "strength_unit": "percentage"
+      "strength_unit": "percentage",
+      "add_on": "base"
     }
   },
   {
@@ -679,7 +726,8 @@
         "amulet",
         "ring"
       ],
-      "strength_unit": "percentage"
+      "strength_unit": "percentage",
+      "add_on": "base"
     }
   },
   {
@@ -693,7 +741,8 @@
         "amulet",
         "ring"
       ],
-      "strength_unit": "percentage"
+      "strength_unit": "percentage",
+      "add_on": "base"
     }
   },
   {
@@ -712,7 +761,8 @@
         "crossbow",
         "other"
       ],
-      "strength_unit": "point"
+      "strength_unit": "point",
+      "add_on": "base"
     }
   },
   {
@@ -731,7 +781,8 @@
         "crossbow",
         "other"
       ],
-      "strength_unit": "point"
+      "strength_unit": "point",
+      "add_on": "base"
     }
   },
   {
@@ -750,7 +801,8 @@
         "crossbow",
         "other"
       ],
-      "strength_unit": "second"
+      "strength_unit": "second",
+      "add_on": "base"
     }
   },
   {
@@ -769,7 +821,8 @@
         "crossbow",
         "other"
       ],
-      "strength_unit": "point"
+      "strength_unit": "point",
+      "add_on": "base"
     }
   },
   {
@@ -788,7 +841,8 @@
         "crossbow",
         "other"
       ],
-      "strength_unit": "level"
+      "strength_unit": "level",
+      "add_on": "base"
     }
   },
   {
@@ -801,7 +855,8 @@
         "amulet",
         "ring"
       ],
-      "strength_unit": null
+      "strength_unit": null,
+      "add_on": "base"
     }
   }
 ]

--- a/spec/models/canonical/sync/weapons_spec.rb
+++ b/spec/models/canonical/sync/weapons_spec.rb
@@ -6,7 +6,17 @@ RSpec.describe Canonical::Sync::Weapons do
   # Use let! because if we wait to evaluate these until we've run the
   # examples, the stub in the before block will prevent `File.read` from
   # running.
-  let(:json_path) { Rails.root.join('spec', 'support', 'fixtures', 'canonical', 'sync', 'weapons.json') }
+  let(:json_path) do
+    Rails.root.join(
+      'spec',
+      'support',
+      'fixtures',
+      'canonical',
+      'sync',
+      'weapons.json',
+    )
+  end
+
   let!(:json_data) { File.read(json_path) }
 
   before do
@@ -91,6 +101,7 @@ RSpec.describe Canonical::Sync::Weapons do
         it "removes associations that don't exist in the JSON data" do
           item_in_json.enchantments.create!(
             name: 'Raise Hell',
+            add_on: 'dawnguard',
             enchantable_items: Enchantment::ENCHANTABLE_WEAPONS,
           )
           perform

--- a/spec/models/enchantment_spec.rb
+++ b/spec/models/enchantment_spec.rb
@@ -4,56 +4,67 @@ require 'rails_helper'
 
 RSpec.describe Enchantment, type: :model do
   describe 'validations' do
-    describe 'name' do
-      it 'is invalid without a name' do
-        enchantment = described_class.new(strength_unit: 'percentage', enchantable_items: %w[sword mace])
+    subject(:validate) { enchantment.validate }
 
-        enchantment.validate
+    let(:enchantment) { build(:enchantment) }
+
+    describe 'name' do
+      it "can't be blank" do
+        enchantment.name = nil
+        validate
         expect(enchantment.errors[:name]).to include "can't be blank"
       end
 
-      it 'requires a unique name' do
-        described_class.create!(name: 'Absorb Health', strength_unit: 'point', enchantable_items: %w[battleaxe warhammer])
+      it 'must be unique' do
+        create(:enchantment, name: 'My Enchantment')
+        enchantment.name = 'My Enchantment'
 
-        enchantment = described_class.new(name: 'Absorb Health', strength_unit: 'percentage', enchantable_items: %w[sword mace greatsword])
+        validate
 
-        enchantment.validate
         expect(enchantment.errors[:name]).to include 'must be unique'
       end
     end
 
     describe 'school' do
       it 'has to be a valid school of magic' do
-        enchantment = described_class.new(school: 'Foo')
-
-        enchantment.validate
+        enchantment.school = 'Foo'
+        validate
         expect(enchantment.errors[:school]).to include 'must be a valid school of magic'
       end
     end
 
     describe 'strength_unit' do
       it 'must be "point", "percentage", "second", or "level"' do
-        enchantment = described_class.new(strength_unit: 'foobar')
-
-        enchantment.validate
+        enchantment.strength_unit = 'foobar'
+        validate
         expect(enchantment.errors[:strength_unit]).to include 'must be "point", "percentage", "second", or the "level" of affected targets'
       end
 
       it 'can be blank' do
-        enchantment = described_class.new
-
-        enchantment.validate
-        expect(enchantment.errors[:strength_unit]).to be_blank
+        enchantment.strength_unit = nil
+        expect(enchantment).to be_valid
       end
     end
 
     describe 'enchantable_items' do
       it 'needs to be one of the valid enchantable items' do
-        enchantment = described_class.new(name: 'Fortify Archery', strength_unit: 'percentage', enchantable_items: %w[ring necklace foo])
-
-        enchantment.validate
-
+        enchantment.enchantable_items = %w[ring necklace foo]
+        validate
         expect(enchantment.errors[:enchantable_items]).to include 'must consist of valid enchantable item types'
+      end
+    end
+
+    describe 'add_on' do
+      it "can't be blank" do
+        enchantment.add_on = nil
+        validate
+        expect(enchantment.errors[:add_on]).to include "can't be blank"
+      end
+
+      it 'must be a supported add-on' do
+        enchantment.add_on = 'fishing'
+        validate
+        expect(enchantment.errors[:add_on]).to include 'must be a SIM-supported add-on or DLC'
       end
     end
   end

--- a/spec/support/factories/enchantments.rb
+++ b/spec/support/factories/enchantments.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
   factory :enchantment do
     sequence(:name) {|n| "Enchantment #{n}" }
     strength_unit { 'point' }
+    add_on { 'base' }
   end
 end

--- a/spec/support/fixtures/canonical/sync/enchantments.json
+++ b/spec/support/fixtures/canonical/sync/enchantments.json
@@ -15,7 +15,8 @@
         "crossbow",
         "other"
       ],
-      "strength_unit": "level"
+      "strength_unit": "level",
+      "add_on": "base"
     }
   },
   {
@@ -34,7 +35,8 @@
         "crossbow",
         "other"
       ],
-      "strength_unit": "point"
+      "strength_unit": "point",
+      "add_on": "base"
     }
   },
   {
@@ -53,7 +55,8 @@
         "crossbow",
         "other"
       ],
-      "strength_unit": "second"
+      "strength_unit": "second",
+      "add_on": "base"
     }
   },
   {
@@ -72,7 +75,8 @@
         "crossbow",
         "other"
       ],
-      "strength_unit": "second"
+      "strength_unit": "second",
+      "add_on": "base"
     }
   }
 ]


### PR DESCRIPTION
## Context

[**Add new attributes to all canonical models**](https://trello.com/c/wQbjkOgB/353-add-new-attributes-to-all-canonical-models)

We are updating most canonical and pseudo-canonical models to have three new fields. Of these, the only one that applies to the `Enchantment` model is `add_on`, the add-on or DLC that adds the enchantment.

## Changes

* Add new `add_on` field to the `enchantments` table
* Add model validations for the new field
* Update JSON data to include new field
* Add tests for new validations

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [ ] ~~Added and updated API docs and developer docs as appropriate~~