### PR TITLE
Add add on field to Spell and AlchemicalProperty models

### DIFF
--- a/app/models/alchemical_property.rb
+++ b/app/models/alchemical_property.rb
@@ -40,6 +40,12 @@ class AlchemicalProperty < ApplicationRecord
               in: VALID_EFFECT_TYPES,
               message: 'must be "potion" or "poison"',
             }
+  validates :add_on,
+            presence: true,
+            inclusion: {
+              in: Canonical::SUPPORTED_ADD_ONS,
+              message: Canonical::UNSUPPORTED_ADD_ON_MESSAGE,
+            }
 
   def self.unique_identifier
     :name

--- a/app/models/spell.rb
+++ b/app/models/spell.rb
@@ -29,6 +29,12 @@ class Spell < ApplicationRecord
               allow_blank: true,
             }
   validates :description, presence: true
+  validates :add_on,
+            presence: true,
+            inclusion: {
+              in: Canonical::SUPPORTED_ADD_ONS,
+              message: Canonical::UNSUPPORTED_ADD_ON_MESSAGE,
+            }
   validate :strength_and_strength_unit_both_or_neither_present
 
   def self.unique_identifier

--- a/db/migrate/20240823222345_add_add_on_to_alchemical_properties_and_spells.rb
+++ b/db/migrate/20240823222345_add_add_on_to_alchemical_properties_and_spells.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddAddOnToAlchemicalPropertiesAndSpells < ActiveRecord::Migration[7.2]
+  def change
+    add_column :alchemical_properties,
+               :add_on,
+               :string
+    add_column :spells,
+               :add_on,
+               :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_08_23_103752) do
+ActiveRecord::Schema[7.2].define(version: 2024_08_23_222345) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,6 +22,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_23_103752) do
     t.datetime "updated_at", null: false
     t.string "description", null: false
     t.string "effect_type", null: false
+    t.string "add_on"
     t.index ["name"], name: "index_alchemical_properties_on_name", unique: true
   end
 
@@ -547,6 +548,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_23_103752) do
     t.string "school", null: false
     t.string "level", null: false
     t.string "strength_unit"
+    t.string "add_on"
     t.index ["name"], name: "index_spells_on_name", unique: true
   end
 

--- a/lib/tasks/canonical_models/alchemical_properties.json
+++ b/lib/tasks/canonical_models/alchemical_properties.json
@@ -5,7 +5,8 @@
       "description": "Cures all diseases.",
       "strength_unit": null,
       "effects_cumulative": false,
-      "effect_type": "potion"
+      "effect_type": "potion",
+      "add_on": "base"
     }
   },
   {
@@ -14,7 +15,8 @@
       "description": "Causes <strength> points of poison damage.",
       "strength_unit": "point",
       "effects_cumulative": false,
-      "effect_type": "poison"
+      "effect_type": "poison",
+      "add_on": "base"
     }
   },
   {
@@ -23,7 +25,8 @@
       "description": "Drains the target's Magicka by <strength> points.",
       "strength_unit": "point",
       "effects_cumulative": false,
-      "effect_type": "poison"
+      "effect_type": "poison",
+      "add_on": "base"
     }
   },
   {
@@ -32,7 +35,8 @@
       "description": "Decreases the target's Magicka regeneration by <strength>% for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false,
-      "effect_type": "poison"
+      "effect_type": "poison",
+      "add_on": "base"
     }
   },
   {
@@ -41,7 +45,8 @@
       "description": "Drains the target's Stamina by <strength> points.",
       "strength_unit": "point",
       "effects_cumulative": false,
-      "effect_type": "poison"
+      "effect_type": "poison",
+      "add_on": "base"
     }
   },
   {
@@ -50,7 +55,8 @@
       "description": "Decrease the target's Stamina regeneration by <strength>% for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false,
-      "effect_type": "poison"
+      "effect_type": "poison",
+      "add_on": "base"
     }
   },
   {
@@ -59,7 +65,8 @@
       "description": "Creatures and people up to level <strength> flee from combat for <duration> seconds.",
       "strength_unit": "level",
       "effects_cumulative": false,
-      "effect_type": "poison"
+      "effect_type": "poison",
+      "add_on": "base"
     }
   },
   {
@@ -68,7 +75,8 @@
       "description": "Alteration spells last <strength>% longer for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false,
-      "effect_type": "potion"
+      "effect_type": "potion",
+      "add_on": "base"
     }
   },
   {
@@ -77,7 +85,8 @@
       "description": "You haggle for <strength>% better prices for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false,
-      "effect_type": "potion"
+      "effect_type": "potion",
+      "add_on": "base"
     }
   },
   {
@@ -86,7 +95,8 @@
       "description": "Blocking absorbs <strength>% more damage for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false,
-      "effect_type": "potion"
+      "effect_type": "potion",
+      "add_on": "base"
     }
   },
   {
@@ -95,7 +105,8 @@
       "description": "Carrying capacity increases by <strength> for <duration> seconds.",
       "strength_unit": "point",
       "effects_cumulative": false,
-      "effect_type": "potion"
+      "effect_type": "potion",
+      "add_on": "base"
     }
   },
   {
@@ -104,7 +115,8 @@
       "description": "Conjuration spells last <strength>% longer for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false,
-      "effect_type": "potion"
+      "effect_type": "potion",
+      "add_on": "base"
     }
   },
   {
@@ -113,7 +125,8 @@
       "description": "Destruction spells are <strength>% stronger for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false,
-      "effect_type": "potion"
+      "effect_type": "potion",
+      "add_on": "base"
     }
   },
   {
@@ -122,7 +135,8 @@
       "description": "For <duration> seconds, items are enchanted <strength>% stronger.",
       "strength_unit": "percentage",
       "effects_cumulative": false,
-      "effect_type": "potion"
+      "effect_type": "potion",
+      "add_on": "base"
     }
   },
   {
@@ -131,7 +145,8 @@
       "description": "Health is increased by <strength> points for <duration> seconds.",
       "strength_unit": "point",
       "effects_cumulative": false,
-      "effect_type": "potion"
+      "effect_type": "potion",
+      "add_on": "base"
     }
   },
   {
@@ -140,7 +155,8 @@
       "description": "Increase Heavy Armor skill by <strength> points for <duration> seconds.",
       "strength_unit": "point",
       "effects_cumulative": false,
-      "effect_type": "potion"
+      "effect_type": "potion",
+      "add_on": "base"
     }
   },
   {
@@ -149,7 +165,8 @@
       "description": "Illusion spells are <strength>% stronger for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false,
-      "effect_type": "potion"
+      "effect_type": "potion",
+      "add_on": "base"
     }
   },
   {
@@ -158,7 +175,8 @@
       "description": "Increases Light Armor skill by <strength> points for <duration> seconds.",
       "strength_unit": "point",
       "effects_cumulative": false,
-      "effect_type": "potion"
+      "effect_type": "potion",
+      "add_on": "base"
     }
   },
   {
@@ -167,7 +185,8 @@
       "description": "Lockpicking is <strength>% easier for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false,
-      "effect_type": "potion"
+      "effect_type": "potion",
+      "add_on": "base"
     }
   },
   {
@@ -176,7 +195,8 @@
       "description": "Magicka is increased by <strength> points for <duration> seconds.",
       "strength_unit": "point",
       "effects_cumulative": false,
-      "effect_type": "potion"
+      "effect_type": "potion",
+      "add_on": "base"
     }
   },
   {
@@ -185,7 +205,8 @@
       "description": "Bows do <strength>% more damage for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false,
-      "effect_type": "potion"
+      "effect_type": "potion",
+      "add_on": "base"
     }
   },
   {
@@ -194,7 +215,8 @@
       "description": "One-handed weapons do <strength>% more damage for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false,
-      "effect_type": "potion"
+      "effect_type": "potion",
+      "add_on": "base"
     }
   },
   {
@@ -203,7 +225,8 @@
       "description": "Pickpocketing is <strength>% easier for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false,
-      "effect_type": "potion"
+      "effect_type": "potion",
+      "add_on": "base"
     }
   },
   {
@@ -212,7 +235,8 @@
       "description": "Restoration spells are <strength>% stronger for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false,
-      "effect_type": "potion"
+      "effect_type": "potion",
+      "add_on": "base"
     }
   },
   {
@@ -221,7 +245,8 @@
       "description": "For <duration> seconds, weapon and armor improving is <strength>% better.",
       "strength_unit": "percentage",
       "effects_cumulative": false,
-      "effect_type": "potion"
+      "effect_type": "potion",
+      "add_on": "base"
     }
   },
   {
@@ -230,7 +255,8 @@
       "description": "You are <strength>% harder to detect for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false,
-      "effect_type": "potion"
+      "effect_type": "potion",
+      "add_on": "base"
     }
   },
   {
@@ -239,7 +265,8 @@
       "description": "+<strength> Speechcraft for <duration> seconds.",
       "strength_unit": "point",
       "effects_cumulative": false,
-      "effect_type": "potion"
+      "effect_type": "potion",
+      "add_on": "base"
     }
   },
   {
@@ -248,7 +275,8 @@
       "description": "Stamina is increased by <strength> points for <duration> seconds.",
       "strength_unit": "point",
       "effects_cumulative": false,
-      "effect_type": "potion"
+      "effect_type": "potion",
+      "add_on": "base"
     }
   },
   {
@@ -257,7 +285,8 @@
       "description": "Two-handed weapons do <strength>% more damage for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false,
-      "effect_type": "potion"
+      "effect_type": "potion",
+      "add_on": "base"
     }
   },
   {
@@ -266,7 +295,8 @@
       "description": "Creatures and people up to level <strength> will attack anything nearby for <duration> seconds.",
       "strength_unit": "level",
       "effects_cumulative": false,
-      "effect_type": "poison"
+      "effect_type": "poison",
+      "add_on": "base"
     }
   },
   {
@@ -275,7 +305,8 @@
       "description": "Invisibility for <duration> seconds.",
       "strength_unit": null,
       "effects_cumulative": false,
-      "effect_type": "potion"
+      "effect_type": "potion",
+      "add_on": "base"
     }
   },
   {
@@ -284,7 +315,8 @@
       "description": "Causes <strength> points of poison damage for <duration> seconds.",
       "strength_unit": "point",
       "effects_cumulative": true,
-      "effect_type": "poison"
+      "effect_type": "poison",
+      "add_on": "base"
     }
   },
   {
@@ -293,7 +325,8 @@
       "description": "Drains the target's Magicka by <strength> points per second for <duration> seconds.",
       "strength_unit": "point",
       "effects_cumulative": true,
-      "effect_type": "poison"
+      "effect_type": "poison",
+      "add_on": "base"
     }
   },
   {
@@ -302,7 +335,8 @@
       "description": "Drain the target's Stamina by <strength> points per second for <duration> seconds.",
       "strength_unit": "point",
       "effects_cumulative": true,
-      "effect_type": "poison"
+      "effect_type": "poison",
+      "add_on": "base"
     }
   },
   {
@@ -311,7 +345,8 @@
       "description": "Target is paralyzed for <duration> seconds.",
       "strength_unit": null,
       "effects_cumulative": false,
-      "effect_type": "poison"
+      "effect_type": "poison",
+      "add_on": "base"
     }
   },
   {
@@ -320,7 +355,8 @@
       "description": "Causes <strength> points of concentrated poison damage.",
       "strength_unit": "point",
       "effects_cumulative": false,
-      "effect_type": "poison"
+      "effect_type": "poison",
+      "add_on": "base"
     }
   },
   {
@@ -329,7 +365,8 @@
       "description": "Concentrated poison damages maximum Magicka by <strength> points.",
       "strength_unit": "point",
       "effects_cumulative": false,
-      "effect_type": "poison"
+      "effect_type": "poison",
+      "add_on": "base"
     }
   },
   {
@@ -338,7 +375,8 @@
       "description": "Concentrated poison damages maximum Stamina by <strength> points.",
       "strength_unit": "point",
       "effects_cumulative": false,
-      "effect_type": "poison"
+      "effect_type": "poison",
+      "add_on": "base"
     }
   },
   {
@@ -347,7 +385,8 @@
       "description": "Health regenerates <strength>% faster for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false,
-      "effect_type": "potion"
+      "effect_type": "potion",
+      "add_on": "base"
     }
   },
   {
@@ -356,7 +395,8 @@
       "description": "Magicka regenerates <strength>% faster for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false,
-      "effect_type": "potion"
+      "effect_type": "potion",
+      "add_on": "base"
     }
   },
   {
@@ -365,7 +405,8 @@
       "description": "Stamina regenerates <strength>% faster for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false,
-      "effect_type": "potion"
+      "effect_type": "potion",
+      "add_on": "base"
     }
   },
   {
@@ -374,7 +415,8 @@
       "description": "Resist <strength>% of fire damage for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false,
-      "effect_type": "potion"
+      "effect_type": "potion",
+      "add_on": "base"
     }
   },
   {
@@ -383,7 +425,8 @@
       "description": "Resist <strength>% of frost damage for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false,
-      "effect_type": "potion"
+      "effect_type": "potion",
+      "add_on": "base"
     }
   },
   {
@@ -392,7 +435,8 @@
       "description": "Resist <strength>% of magic for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false,
-      "effect_type": "potion"
+      "effect_type": "potion",
+      "add_on": "base"
     }
   },
   {
@@ -401,7 +445,8 @@
       "description": "Resist <strength>% of poison for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false,
-      "effect_type": "potion"
+      "effect_type": "potion",
+      "add_on": "base"
     }
   },
   {
@@ -410,7 +455,8 @@
       "description": "Resist <strength>% of shock damage for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false,
-      "effect_type": "potion"
+      "effect_type": "potion",
+      "add_on": "base"
     }
   },
   {
@@ -419,7 +465,8 @@
       "description": "Restore <strength> points of Health.",
       "strength_unit": "point",
       "effects_cumulative": false,
-      "effect_type": "potion"
+      "effect_type": "potion",
+      "add_on": "base"
     }
   },
   {
@@ -428,7 +475,8 @@
       "description": "Restore <strength> points of Magicka.",
       "strength_unit": "point",
       "effects_cumulative": false,
-      "effect_type": "potion"
+      "effect_type": "potion",
+      "add_on": "base"
     }
   },
   {
@@ -437,7 +485,8 @@
       "description": "Restore <strength> Stamina.",
       "strength_unit": "point",
       "effects_cumulative": false,
-      "effect_type": "potion"
+      "effect_type": "potion",
+      "add_on": "base"
     }
   },
   {
@@ -446,7 +495,8 @@
       "description": "Target moves at 50% speed for <duration> seconds.",
       "strength_unit": null,
       "effects_cumulative": false,
-      "effect_type": "poison"
+      "effect_type": "poison",
+      "add_on": "base"
     }
   },
   {
@@ -455,7 +505,8 @@
       "description": "Can breathe underwater for <duration> seconds.",
       "strength_unit": null,
       "effects_cumulative": false,
-      "effect_type": "potion"
+      "effect_type": "potion",
+      "add_on": "base"
     }
   },
   {
@@ -464,7 +515,8 @@
       "description": "Target is <strength>% weaker to fire damage for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false,
-      "effect_type": "poison"
+      "effect_type": "poison",
+      "add_on": "base"
     }
   },
   {
@@ -473,7 +525,8 @@
       "description": "Target is <strength>% weaker to frost damage for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false,
-      "effect_type": "poison"
+      "effect_type": "poison",
+      "add_on": "base"
     }
   },
   {
@@ -482,7 +535,8 @@
       "description": "Target is <strength>% weaker to magic for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false,
-      "effect_type": "poison"
+      "effect_type": "poison",
+      "add_on": "base"
     }
   },
   {
@@ -491,7 +545,8 @@
       "description": "Target is <strength>% weaker to poison for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false,
-      "effect_type": "poison"
+      "effect_type": "poison",
+      "add_on": "base"
     }
   },
   {
@@ -500,7 +555,8 @@
       "description": "Target is <strength>% weaker to shock damage for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false,
-      "effect_type": "poison"
+      "effect_type": "poison",
+      "add_on": "base"
     }
   }
 ]

--- a/lib/tasks/canonical_models/spells.json
+++ b/lib/tasks/canonical_models/spells.json
@@ -8,7 +8,8 @@
       "strength": 1,
       "strength_unit": "point",
       "base_duration": null,
-      "effects_cumulative": true
+      "effects_cumulative": true,
+      "add_on": "base"
     }
   },
   {
@@ -20,7 +21,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": 30,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "dragonborn"
     }
   },
   {
@@ -32,7 +34,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": 30,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "dragonborn"
     }
   },
   {
@@ -44,7 +47,8 @@
       "strength": 30,
       "strength_unit": "level",
       "base_duration": 30,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -56,7 +60,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": null,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -68,7 +73,8 @@
       "strength": 20,
       "strength_unit": "point",
       "base_duration": 10,
-      "effects_cumulative": true
+      "effects_cumulative": true,
+      "add_on": "base"
     }
   },
   {
@@ -80,7 +86,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": 120,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -92,7 +99,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": 120,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -104,7 +112,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": 120,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -116,7 +125,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": 120,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -128,7 +138,8 @@
       "strength": 25,
       "strength_unit": "point",
       "base_duration": 600,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -140,7 +151,8 @@
       "strength": 9,
       "strength_unit": "level",
       "base_duration": 30,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -152,7 +164,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": 60,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -164,7 +177,8 @@
       "strength": 40,
       "strength_unit": "point",
       "base_duration": null,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -176,7 +190,8 @@
       "strength": 20,
       "strength_unit": "level",
       "base_duration": null,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -188,7 +203,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": null,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -200,7 +216,8 @@
       "strength": 100,
       "strength_unit": "point",
       "base_duration": null,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -212,7 +229,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": null,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -224,7 +242,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": null,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "dragonborn"
     }
   },
   {
@@ -236,7 +255,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": 60,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "dragonborn"
     }
   },
   {
@@ -248,7 +268,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": 60,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "dawnguard"
     }
   },
   {
@@ -260,7 +281,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": 60,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -272,7 +294,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": 60,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -284,7 +307,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": 60,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -296,7 +320,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": 60,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -308,7 +333,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": null,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -320,7 +346,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": 60,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -332,7 +359,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": 60,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "dawnguard"
     }
   },
   {
@@ -344,7 +372,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": 60,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "dragonborn"
     }
   },
   {
@@ -356,7 +385,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": 60,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -368,7 +398,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": 60,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "dawnguard"
     }
   },
   {
@@ -380,7 +411,8 @@
       "strength": 25,
       "strength_unit": "point",
       "base_duration": 60,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -392,7 +424,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": null,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -404,7 +437,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": null,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -416,7 +450,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": null,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -428,7 +463,8 @@
       "strength": 80,
       "strength_unit": "percentage",
       "base_duration": 30,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -440,7 +476,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": 60,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -452,7 +489,8 @@
       "strength": 100,
       "strength_unit": "point",
       "base_duration": 60,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -464,7 +502,8 @@
       "strength": 25,
       "strength_unit": "point",
       "base_duration": null,
-      "effects_cumulative": true
+      "effects_cumulative": true,
+      "add_on": "base"
     }
   },
   {
@@ -476,7 +515,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": null,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -488,7 +528,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": 30,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -500,7 +541,8 @@
       "strength": 50,
       "strength_unit": "point",
       "base_duration": null,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -512,7 +554,8 @@
       "strength": 9,
       "strength_unit": "level",
       "base_duration": 30,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -524,7 +567,8 @@
       "strength": 50,
       "strength_unit": "point",
       "base_duration": null,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -536,7 +580,8 @@
       "strength": 100,
       "strength_unit": "point",
       "base_duration": null,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -548,7 +593,8 @@
       "strength": 40,
       "strength_unit": "point",
       "base_duration": null,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -560,7 +606,8 @@
       "strength": 25,
       "strength_unit": "point",
       "base_duration": null,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -572,7 +619,8 @@
       "strength": 8,
       "strength_unit": "point",
       "base_duration": 60,
-      "effects_cumulative": true
+      "effects_cumulative": true,
+      "add_on": "base"
     }
   },
   {
@@ -584,7 +632,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": null,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -596,7 +645,8 @@
       "strength": 8,
       "strength_unit": "point",
       "base_duration": null,
-      "effects_cumulative": true
+      "effects_cumulative": true,
+      "add_on": "base"
     }
   },
   {
@@ -608,7 +658,8 @@
       "strength": 20,
       "strength_unit": "point",
       "base_duration": 15,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -620,7 +671,8 @@
       "strength": 14,
       "strength_unit": "level",
       "base_duration": 60,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -632,7 +684,8 @@
       "strength": 20,
       "strength_unit": "level",
       "base_duration": 30,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "dragonborn"
     }
   },
   {
@@ -644,7 +697,8 @@
       "strength": 8,
       "strength_unit": "point",
       "base_duration": 60,
-      "effects_cumulative": true
+      "effects_cumulative": true,
+      "add_on": "base"
     }
   },
   {
@@ -656,7 +710,8 @@
       "strength": 50,
       "strength_unit": "point",
       "base_duration": null,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -668,7 +723,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": null,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -680,7 +736,8 @@
       "strength": 8,
       "strength_unit": "point",
       "base_duration": null,
-      "effects_cumulative": true
+      "effects_cumulative": true,
+      "add_on": "base"
     }
   },
   {
@@ -692,7 +749,8 @@
       "strength": 6,
       "strength_unit": "level",
       "base_duration": 30,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -704,7 +762,8 @@
       "strength": 200,
       "strength_unit": "point",
       "base_duration": null,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -716,7 +775,8 @@
       "strength": 80,
       "strength_unit": "point",
       "base_duration": null,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -728,7 +788,8 @@
       "strength": 20,
       "strength_unit": "point",
       "base_duration": 60,
-      "effects_cumulative": true
+      "effects_cumulative": true,
+      "add_on": "base"
     }
   },
   {
@@ -740,7 +801,8 @@
       "strength": 25,
       "strength_unit": "level",
       "base_duration": 60,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -752,7 +814,8 @@
       "strength": 75,
       "strength_unit": "point",
       "base_duration": null,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -764,7 +827,8 @@
       "strength": 75,
       "strength_unit": "point",
       "base_duration": null,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "dawnguard"
     }
   },
   {
@@ -776,7 +840,8 @@
       "strength": 10,
       "strength_unit": "point",
       "base_duration": null,
-      "effects_cumulative": true
+      "effects_cumulative": true,
+      "add_on": "base"
     }
   },
   {
@@ -788,7 +853,8 @@
       "strength": 10,
       "strength_unit": "point",
       "base_duration": null,
-      "effects_cumulative": true
+      "effects_cumulative": true,
+      "add_on": "base"
     }
   },
   {
@@ -800,7 +866,8 @@
       "strength": 25,
       "strength_unit": "level",
       "base_duration": 60,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -812,7 +879,8 @@
       "strength": 25,
       "strength_unit": "point",
       "base_duration": null,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -824,7 +892,8 @@
       "strength": 40,
       "strength_unit": "point",
       "base_duration": null,
-      "effects_cumulative": true
+      "effects_cumulative": true,
+      "add_on": "base"
     }
   },
   {
@@ -836,7 +905,8 @@
       "strength": 60,
       "strength_unit": "point",
       "base_duration": null,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -848,7 +918,8 @@
       "strength": 4,
       "strength_unit": "point",
       "base_duration": 15,
-      "effects_cumulative": true
+      "effects_cumulative": true,
+      "add_on": "dragonborn"
     }
   },
   {
@@ -860,7 +931,8 @@
       "strength": 60,
       "strength_unit": "point",
       "base_duration": null,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -872,7 +944,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": 30,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -884,7 +957,8 @@
       "strength": 80,
       "strength_unit": "point",
       "base_duration": 60,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -896,7 +970,8 @@
       "strength": 40,
       "strength_unit": "point",
       "base_duration": null,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -908,7 +983,8 @@
       "strength": 25,
       "strength_unit": "point",
       "base_duration": null,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -920,7 +996,8 @@
       "strength": 8,
       "strength_unit": "point",
       "base_duration": 60,
-      "effects_cumulative": true
+      "effects_cumulative": true,
+      "add_on": "base"
     }
   },
   {
@@ -932,7 +1009,8 @@
       "strength": 50,
       "strength_unit": "point",
       "base_duration": null,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -944,7 +1022,8 @@
       "strength": 75,
       "strength_unit": "point",
       "base_duration": null,
-      "effects_cumulative": true
+      "effects_cumulative": true,
+      "add_on": "base"
     }
   },
   {
@@ -956,7 +1035,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": 60,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -968,7 +1048,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": 15,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -980,7 +1061,8 @@
       "strength": 25,
       "strength_unit": "level",
       "base_duration": 60,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -992,7 +1074,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": 180,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -1004,7 +1087,8 @@
       "strength": 10,
       "strength_unit": "point",
       "base_duration": null,
-      "effects_cumulative": true
+      "effects_cumulative": true,
+      "add_on": "dawnguard"
     }
   },
   {
@@ -1016,7 +1100,8 @@
       "strength": 40,
       "strength_unit": "point",
       "base_duration": 60,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -1028,7 +1113,8 @@
       "strength": 20,
       "strength_unit": "level",
       "base_duration": 60,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -1040,7 +1126,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": 10,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -1052,7 +1139,8 @@
       "strength": 3,
       "strength_unit": "point",
       "base_duration": 30,
-      "effects_cumulative": true
+      "effects_cumulative": true,
+      "add_on": "dragonborn"
     }
   },
   {
@@ -1064,7 +1152,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": 60,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -1076,7 +1165,8 @@
       "strength": 25,
       "strength_unit": "point",
       "base_duration": 60,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -1088,7 +1178,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": 60,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -1100,7 +1191,8 @@
       "strength": 8,
       "strength_unit": "level",
       "base_duration": 30,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -1112,7 +1204,8 @@
       "strength": 16,
       "strength_unit": "level",
       "base_duration": 30,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -1124,7 +1217,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": 60,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -1136,7 +1230,8 @@
       "strength": 20,
       "strength_unit": "level",
       "base_duration": 30,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -1148,7 +1243,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": 60,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -1160,7 +1256,8 @@
       "strength": 8,
       "strength_unit": "point",
       "base_duration": null,
-      "effects_cumulative": true
+      "effects_cumulative": true,
+      "add_on": "base"
     }
   },
   {
@@ -1172,7 +1269,8 @@
       "strength": 30,
       "strength_unit": "point",
       "base_duration": null,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -1184,7 +1282,8 @@
       "strength": 60,
       "strength_unit": "point",
       "base_duration": null,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -1196,7 +1295,8 @@
       "strength": 10,
       "strength_unit": "point",
       "base_duration": 60,
-      "effects_cumulative": true
+      "effects_cumulative": true,
+      "add_on": "dawnguard"
     }
   },
   {
@@ -1208,7 +1308,8 @@
       "strength": 60,
       "strength_unit": "point",
       "base_duration": 60,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -1220,7 +1321,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": null,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -1232,7 +1334,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": 60,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -1244,7 +1347,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": 60,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "dawnguard"
     }
   },
   {
@@ -1256,7 +1360,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": null,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -1268,7 +1373,8 @@
       "strength": 25,
       "strength_unit": "point",
       "base_duration": null,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "dawnguard"
     }
   },
   {
@@ -1280,7 +1386,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": null,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -1292,7 +1399,8 @@
       "strength": 60,
       "strength_unit": "point",
       "base_duration": null,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -1304,7 +1412,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": null,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -1316,7 +1425,8 @@
       "strength": 21,
       "strength_unit": "level",
       "base_duration": 30,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -1328,7 +1438,8 @@
       "strength": 6,
       "strength_unit": "level",
       "base_duration": 30,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -1340,7 +1451,8 @@
       "strength": 13,
       "strength_unit": "level",
       "base_duration": 30,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -1352,7 +1464,8 @@
       "strength": 40,
       "strength_unit": "point",
       "base_duration": null,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "dawnguard"
     }
   },
   {
@@ -1364,7 +1477,8 @@
       "strength": 10,
       "strength_unit": "level",
       "base_duration": 30,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -1376,7 +1490,8 @@
       "strength": 2,
       "strength_unit": "point",
       "base_duration": null,
-      "effects_cumulative": true
+      "effects_cumulative": true,
+      "add_on": "base"
     }
   },
   {
@@ -1388,7 +1503,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": 30,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -1400,7 +1516,8 @@
       "strength": 50,
       "strength_unit": "point",
       "base_duration": 30,
-      "effects_cumulative": true
+      "effects_cumulative": true,
+      "add_on": "base"
     }
   },
   {
@@ -1412,7 +1529,8 @@
       "strength": 50,
       "strength_unit": "point",
       "base_duration": 30,
-      "effects_cumulative": true
+      "effects_cumulative": true,
+      "add_on": "base"
     }
   },
   {
@@ -1424,7 +1542,8 @@
       "strength": 50,
       "strength_unit": "point",
       "base_duration": 30,
-      "effects_cumulative": true
+      "effects_cumulative": true,
+      "add_on": "base"
     }
   },
   {
@@ -1436,7 +1555,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": 60,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -1448,7 +1568,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": 60,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "dragonborn"
     }
   }
 ]

--- a/spec/models/alchemical_property_spec.rb
+++ b/spec/models/alchemical_property_spec.rb
@@ -4,71 +4,84 @@ require 'rails_helper'
 
 RSpec.describe AlchemicalProperty, type: :model do
   describe 'validations' do
-    describe 'name' do
-      it 'must be present' do
-        model = build(:alchemical_property, name: nil)
+    subject(:validate) { model.validate }
 
-        model.validate
+    let(:model) { build(:alchemical_property) }
+
+    describe 'name' do
+      it "can't be blank" do
+        model.name = nil
+        validate
         expect(model.errors[:name]).to include "can't be blank"
       end
 
       it 'must be unique' do
         create(:alchemical_property, name: 'Restore Health', strength_unit: 'point')
-        model = build(:alchemical_property, name: 'Restore Health')
+        model.name = 'Restore Health'
 
-        model.validate
+        validate
+
         expect(model.errors[:name]).to include 'must be unique'
       end
     end
 
     describe 'description' do
       it "can't be blank" do
-        model = build(:alchemical_property, description: nil)
-
-        model.validate
+        model.description = nil
+        validate
         expect(model.errors[:description]).to include "can't be blank"
       end
     end
 
     describe 'strength_unit' do
       it "isn't required" do
-        model = build(:alchemical_property, strength_unit: nil)
-
-        model.validate
+        model.strength_unit = nil
+        validate
         expect(model.errors[:strength_unit]).to be_empty
       end
 
       it 'must be one of "point" or "percentage"' do
-        model = build(:alchemical_property, strength_unit: 'Foobar')
-
-        model.validate
+        model.strength_unit = 'foobar'
+        validate
         expect(model.errors[:strength_unit]).to include 'must be "point", "percentage", or the "level" of affected targets'
       end
     end
 
-    describe 'effect type' do
+    describe 'effect_type' do
       it 'is valid if "potion"' do
-        model = build(:alchemical_property, effect_type: 'potion')
+        model.effect_type = 'potion'
         expect(model).to be_valid
       end
 
       it 'is valid if "poison"' do
-        model = build(:alchemical_property, effect_type: 'poison')
+        model.effect_type = 'poison'
         expect(model).to be_valid
       end
 
       it "can't be blank" do
-        model = build(:alchemical_property, effect_type: nil)
-
-        model.validate
+        model.effect_type = nil
+        validate
         expect(model.errors[:effect_type]).to include "can't be blank"
       end
 
       it "can't be another value" do
-        model = build(:alchemical_property, effect_type: 'mixed')
-
-        model.validate
+        model.effect_type = 'mixed'
+        validate
         expect(model.errors[:effect_type]).to include 'must be "potion" or "poison"'
+      end
+    end
+
+    describe 'add_on' do
+      it "can't be blank" do
+        model.add_on = nil
+        validate
+        expect(model.errors[:add_on]).to include "can't be blank"
+      end
+
+      it 'must be a SIM-supported add-on' do
+        model.add_on = 'fishing'
+        validate
+        expect(model.errors[:add_on]).to include 'must be a SIM-supported add-on or DLC'
       end
     end
   end

--- a/spec/models/spell_spec.rb
+++ b/spec/models/spell_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe Spell, type: :model do
 
       it 'must be unique' do
         create(:spell, name: 'Clairvoyance')
-        spell = described_class.new(name: 'Clairvoyance')
+        spell.name = 'Clairvoyance'
 
-        spell.validate
+        validate
         expect(spell.errors[:name]).to include 'must be unique'
       end
     end
@@ -89,7 +89,7 @@ RSpec.describe Spell, type: :model do
 
       it 'requires a valid strength_unit value' do
         spell.strength_unit = 'foo'
-        spell.validate
+        validate
         expect(spell.errors[:strength_unit]).to include 'must be "point", "percentage", or the "level" of affected targets'
       end
     end

--- a/spec/models/spell_spec.rb
+++ b/spec/models/spell_spec.rb
@@ -4,16 +4,19 @@ require 'rails_helper'
 
 RSpec.describe Spell, type: :model do
   describe 'validations' do
-    describe 'name' do
-      it 'must be present' do
-        spell = described_class.new
+    subject(:validate) { spell.validate }
 
-        spell.validate
+    let(:spell) { build(:spell) }
+
+    describe 'name' do
+      it "can't be blank" do
+        spell.name = nil
+        validate
         expect(spell.errors[:name]).to include "can't be blank"
       end
 
       it 'must be unique' do
-        described_class.create!(name: 'Clairvoyance', school: 'Illusion', level: 'Novice', description: 'Something')
+        create(:spell, name: 'Clairvoyance')
         spell = described_class.new(name: 'Clairvoyance')
 
         spell.validate
@@ -22,82 +25,86 @@ RSpec.describe Spell, type: :model do
     end
 
     describe 'school' do
-      it 'must be present' do
-        spell = described_class.new
-
-        spell.validate
+      it "can't be blank" do
+        spell.school = nil
+        validate
         expect(spell.errors[:school]).to include "can't be blank"
       end
 
       it 'must be a valid school of magic' do
-        spell = described_class.new(name: 'Alternation')
-
-        spell.validate
+        spell.school = 'Alternation'
+        validate
         expect(spell.errors[:school]).to include 'must be a valid school of magic'
       end
     end
 
     describe 'level' do
-      it 'must be present' do
-        spell = described_class.new
-
-        spell.validate
+      it "can't be blank" do
+        spell.level = nil
+        validate
         expect(spell.errors[:level]).to include "can't be blank"
       end
 
       it 'must be a valid level' do
-        spell = described_class.new
-
-        spell.validate
+        spell.level = 'Legendary'
+        validate
         expect(spell.errors[:level]).to include 'must be "Novice", "Apprentice", "Adept", "Expert", or "Master"'
       end
     end
 
     describe 'description' do
-      it 'must be present' do
-        spell = described_class.new
-
-        spell.validate
+      it "can't be blank" do
+        spell.description = nil
+        validate
         expect(spell.errors[:description]).to include "can't be blank"
       end
     end
 
     describe 'strength and strength_unit' do
       it 'is valid with both a strength and a strength_unit' do
-        spell = described_class.new(
-          strength: 50,
-          strength_unit: 'point',
-          name: 'Fire Rune',
-          level: 'Adept',
-          school: 'Destruction',
-          description: 'Hello world',
-        )
+        spell.strength = 50
+        spell.strength_unit = 'point'
 
         expect(spell).to be_valid
       end
 
       it 'is valid with neither a strength nor a strength_unit' do
-        spell = described_class.new(name: 'Clairvoyance', level: 'Novice', school: 'Illusion', description: 'Hello world')
+        spell.strength = nil
+        spell.strength_unit = nil
 
         expect(spell).to be_valid
       end
 
       it 'is invalid with a strength but no strength_unit' do
-        spell = described_class.new(strength: 50)
-        spell.validate
+        spell.strength = 50
+        validate
         expect(spell.errors[:strength_unit]).to include 'must be present if strength is given'
       end
 
       it 'is invalid with a strength_unit but no strength' do
-        spell = described_class.new(strength_unit: 'percentage')
-        spell.validate
+        spell.strength_unit = 'percentage'
+        validate
         expect(spell.errors[:strength]).to include 'must be present if strength unit is given'
       end
 
       it 'requires a valid strength_unit value' do
-        spell = described_class.new(strength: 50, strength_unit: 'foo')
+        spell.strength_unit = 'foo'
         spell.validate
         expect(spell.errors[:strength_unit]).to include 'must be "point", "percentage", or the "level" of affected targets'
+      end
+    end
+
+    describe 'add_on' do
+      it "can't be blank" do
+        spell.add_on = nil
+        validate
+        expect(spell.errors[:add_on]).to include "can't be blank"
+      end
+
+      it 'must be a supported add-on' do
+        spell.add_on = 'fishing'
+        validate
+        expect(spell.errors[:add_on]).to include 'must be a SIM-supported add-on or DLC'
       end
     end
   end

--- a/spec/support/factories/alchemical_properties.rb
+++ b/spec/support/factories/alchemical_properties.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     sequence(:name) {|n| "Alchemical Property #{n}" }
     description { 'Something magical' }
     effect_type { 'potion' }
+    add_on { 'base' }
   end
 end

--- a/spec/support/factories/spells.rb
+++ b/spec/support/factories/spells.rb
@@ -7,5 +7,6 @@ FactoryBot.define do
     level { 'Adept' }
     description { 'Destroys enemies on sight' }
     base_duration { 5 }
+    add_on { 'base' }
   end
 end

--- a/spec/support/fixtures/canonical/sync/alchemical_properties.json
+++ b/spec/support/fixtures/canonical/sync/alchemical_properties.json
@@ -5,7 +5,8 @@
       "description": "Cures all diseases.",
       "strength_unit": null,
       "effects_cumulative": false,
-      "effect_type": "potion"
+      "effect_type": "potion",
+      "add_on": "base"
     }
   },
   {
@@ -14,7 +15,8 @@
       "description": "Causes <strength> points of poison damage.",
       "strength_unit": "point",
       "effects_cumulative": false,
-      "effect_type": "poison"
+      "effect_type": "poison",
+      "add_on": "base"
     }
   },
   {
@@ -23,7 +25,8 @@
       "description": "Drains the target's Magicka by <strength> points.",
       "strength_unit": "point",
       "effects_cumulative": false,
-      "effect_type": "poison"
+      "effect_type": "poison",
+      "add_on": "base"
     }
   },
   {
@@ -32,7 +35,8 @@
       "description": "Decreases the target's Magicka regeneration by <strength>% for <duration> seconds.",
       "strength_unit": "percentage",
       "effects_cumulative": false,
-      "effect_type": "poison"
+      "effect_type": "poison",
+      "add_on": "base"
     }
   }
 ]

--- a/spec/support/fixtures/canonical/sync/spells.json
+++ b/spec/support/fixtures/canonical/sync/spells.json
@@ -8,7 +8,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": 120,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -20,7 +21,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": 120,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -32,7 +34,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": 120,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   },
   {
@@ -44,7 +47,8 @@
       "strength": null,
       "strength_unit": null,
       "base_duration": 120,
-      "effects_cumulative": false
+      "effects_cumulative": false,
+      "add_on": "base"
     }
   }
 ]


### PR DESCRIPTION
## Context

[**Add new fields to all canonical models**](https://trello.com/c/wQbjkOgB/353-add-new-attributes-to-all-canonical-models)

We are adding new fields to all canonical models, including pseudo-canonical models like `Spell` and `AlchemicalProperty`. The only field applying to these models is `add_on`, the add-on or DLC (including the `"base"` game) that includes the spell or alchemical property. (Note that, currently, all alchemical properties present in SIM JSON data come from the base game.)

## Changes

* Add `add_on` field to `spells` table
* Add `add_on` field to `alchemical_properties` table
* Add validations for the new fields
* Add tests for new validations
* Update JSON data for spells and alchemical properties to include `add_on`

### Required Changes

* [x] Added and updated RSpec tests as appropriate
* [ ] ~~Added and updated API docs and developer docs as appropriate~~
